### PR TITLE
Make sure to warn users when leaving page during upload/post

### DIFF
--- a/static/js/publisher/market/market.js
+++ b/static/js/publisher/market/market.js
@@ -6,6 +6,14 @@ import { publicMetrics } from './publicMetrics';
 const URL_REGEXP = /^(?:(?:https?|ftp):\/\/)(?:\S+(?::\S*)?@)?(?:(?!(?:10|127)(?:\.\d{1,3}){3})(?!(?:169\.254|192\.168)(?:\.\d{1,3}){2})(?!172\.(?:1[6-9]|2\d|3[0-1])(?:\.\d{1,3}){2})(?:[1-9]\d?|1\d\d|2[01]\d|22[0-3])(?:\.(?:1?\d{1,2}|2[0-4]\d|25[0-5])){2}(?:\.(?:[1-9]\d?|1\d\d|2[0-4]\d|25[0-4]))|(?:(?:[a-z\u00a1-\uffff0-9]-*)*[a-z\u00a1-\uffff0-9]+)(?:\.(?:[a-z\u00a1-\uffff0-9]-*)*[a-z\u00a1-\uffff0-9]+)*(?:\.(?:[a-z\u00a1-\uffff]{2,}))\.?)(?::\d{2,5})?(?:[/?#]\S*)?$/i;
 const MAILTO_REGEXP = /^mailto:/;
 
+// check if browser is on chromium engine, based on:
+// https://stackoverflow.com/questions/4565112/javascript-how-to-find-out-if-the-user-browser-is-chrome
+const IS_CHROMIUM = (
+  window.chrome !== null &&
+  typeof window.chrome !== "undefined" &&
+  window.navigator.userAgent.indexOf("Edge") === -1 // Edge pretends to have window.chrome
+);
+
 function initSnapIconEdit(iconElId, iconInputId, state) {
   const snapIconInput = document.getElementById(iconInputId);
   const snapIconEl = document.getElementById(iconElId);
@@ -130,7 +138,12 @@ function initForm(config, initialState, errors) {
       return confirmationMessage;              // Gecko, WebKit, Chrome <34
     }
 
-    ignoreChangesOnUnload = false;
+    // make sure to show unload warning dialog during submit in progress
+    // but because of Chrome bug don't show it in Chrome:
+    // https://bugs.chromium.org/p/chromium/issues/detail?id=152649
+    if (!IS_CHROMIUM) {
+      ignoreChangesOnUnload = false;
+    }
   });
 
   revertButton.addEventListener('click', () => {


### PR DESCRIPTION
Fixes #603 

Warn users that they are leaving a page when there is upload/post in progress (after clicking on Save on Listing page).

### Note:

There is a [bug in Chrome](https://bugs.chromium.org/p/chromium/issues/detail?id=152649) that causes upload/post to be canceled regardless of the choice user makes in the warning dialog.
So in Chrome we **don't** show warning dialog when user tries to leave during upload, because it would be canceled anyway.

### QA

Use Firefox:

- ./run or  http://snapcraft.io-pr-633.run.demo.haus/
- go to Listing page of any snap
- be on a slow network, or throttle the network speed in developer tools, or choose a large screenshot to upload
- click Save
- while browser is uploading click on any other link on the page (to Measures, main nav)
- warning dialog should be shown that you are leaving page with unsaved changes
- you can choose to leave the page (and cancel ongoing upload/post) or stay on the page (and continue upload)
