### PR TITLE
Add updated privacy notification

### DIFF
--- a/static/js/base/base.js
+++ b/static/js/base/base.js
@@ -1,2 +1,3 @@
 import './polyfills';
 import './dropdown-menu-toggle';
+import './notification-dismiss';

--- a/static/js/base/notification-dismiss.js
+++ b/static/js/base/notification-dismiss.js
@@ -1,0 +1,54 @@
+(function() {
+  /**
+   * Find notification dismiss elements and make them interactive
+   *
+   * data-ispermanent will set localStorage, using data-name as the localStorages's key
+   *
+   * @example
+   * <div class="js-notification-holder">
+   *   <div class="p-notification">
+   *     <p class="p-notification__response">
+   *        <a href="#"
+   *            class="p-notification__action"
+   *            data-ispermanent="true"
+   *            data-name="privacy-update-06-2018">
+   *          Dismiss
+   *        </a>
+   *      </p>
+   *    </div>
+   * </div>
+   */
+  function dismissNotifications() {
+    const links = document.querySelectorAll('.p-notification__action');
+
+    for (let i = 0; i < links.length; i++) {
+      dismissNotification(links[i]);
+    }
+  }
+
+  function dismissNotification(ele) {
+    const notificationHolder = ele.closest('.js-notification-holder');
+    const isPermanent = ele.dataset.ispermanent;
+    const name = ele.dataset.name;
+
+    if (window.localStorage && window.localStorage.getItem(name) === 'suppress') {
+      notificationHolder.parentNode.removeChild(notificationHolder);
+    }
+
+    const removeNotification = function() {
+      return function (e) {
+        e.preventDefault();
+        if (isPermanent) {
+          if (window.localStorage) {
+            window.localStorage.setItem(name, 'suppress');
+          }
+        }
+        notificationHolder.parentNode.removeChild(notificationHolder);
+      };
+    }();
+
+    ele.addEventListener('click', removeNotification);
+  }
+
+  dismissNotifications();
+})();

--- a/templates/publisher/_header.html
+++ b/templates/publisher/_header.html
@@ -1,4 +1,5 @@
 {% include "publisher/_beta-notification.html" %}
+{% include "publisher/_privacy-notification.html" %}
 
 <section class="p-strip is-shallow u-no-padding--bottom">
   <nav class="p-tabs-bordered">

--- a/templates/publisher/_privacy-notification.html
+++ b/templates/publisher/_privacy-notification.html
@@ -1,0 +1,12 @@
+<div class="p-strip is-shallow u-no-padding--bottom js-notification-holder">
+  <div class="row">
+    <div class="p-notification--information u-no-margin--bottom">
+      <p class="p-notification__response">
+        <span class="p-notification__status">Information:</span> We have updated our
+        <a href="https://www.ubuntu.com/legal/terms-and-policies/developer-terms-and-conditions" class="p-link--external">developer terms and conditions</a>
+        and <a href="https://www.ubuntu.com/legal/dataprivacy/snap-store" class="p-link--external">privacy notice</a>.
+        <a href="#" class="p-notification__action" data-ispermanent="true" data-name="privacy-update-06-2018">Dismiss</a>
+      </p>
+    </div>
+  </div>
+</div>

--- a/templates/publisher/account-details.html
+++ b/templates/publisher/account-details.html
@@ -6,6 +6,7 @@ Account details — Linux software in the Snap Store
 
 {% block content %}
 {% include "publisher/_beta-notification.html" %}
+{% include "publisher/_privacy-notification.html" %}
 <section class="p-strip">
   <div class="row">
     <div class="col-12">

--- a/templates/publisher/account-snaps.html
+++ b/templates/publisher/account-snaps.html
@@ -6,6 +6,7 @@ My published snaps — Linux software in the Snap Store
 
 {% block content %}
 {% include "publisher/_beta-notification.html" %}
+{% include "publisher/_privacy-notification.html" %}
 <section class="p-strip is-shallow">
   {% with messages = get_flashed_messages() %}
     {% if messages %}


### PR DESCRIPTION
# Done
Partially fixes https://github.com/canonicalltd/snap-squad/issues/568

- Added notification to publisher pages
- Added small bit of JS that persists dismissed notifications, based on `data` attributes

# QA

- Pull the branch
- `./run`
- Visit http://0.0.0.0:8004/account/*
- Check the notification links
- Click the dismiss link
- Reload the page, make sure the notification doesn't appear again
- If you fancy, open the browsers console and remove the entry from localStorage
- Reload the page and see the notification again

# Screenshot

![screenshot-2018-6-26 my published snaps linux software in the snap store](https://user-images.githubusercontent.com/479384/41919053-82beaace-7955-11e8-8671-ab33506b129b.png)
