### PR TITLE
Add publisher snaps metrics endpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "test": "yarn run test-python && yarn run test-js-all && yarn run lint-scss",
     "test-js": "jest",
     "test-js-all": "yarn run lint-js && yarn run test-js",
-    "test-python": "yarn run lint-py && python3 -m unittest discover tests",
+    "test-python": "yarn run lint-py && FLASK_DEBUG=0 python3 -m unittest discover tests",
     "get-licenses": "if [ ! -f webapp/licenses.json ] ; then curl https://raw.githubusercontent.com/spdx/license-list-data/master/json/licenses.json -o webapp/licenses.json; fi",
     "build": "yarn run get-licenses && yarn run build-js && yarn run build-css",
     "build-css": "node-sass --include-path node_modules static/sass --output-style compressed --output static/css && postcss --use autoprefixer --no-map --replace 'static/css/**/*.css'",

--- a/tests/publisher/tests_account_snaps.py
+++ b/tests/publisher/tests_account_snaps.py
@@ -54,6 +54,7 @@ class AccountSnapsPage(BaseTestCases.EndpointLoggedInErrorHandling):
                 "16": {
                     "test": {
                         "status": "Approved",
+                        "snap-id": "1",
                         "snap-name": "test",
                         "latest_revisions": [],
                     }
@@ -86,6 +87,7 @@ class AccountSnapsPage(BaseTestCases.EndpointLoggedInErrorHandling):
                 "16": {
                     "test": {
                         "status": "Approved",
+                        "snap-id": "1",
                         "snap-name": "test",
                         "latest_revisions": [
                             {
@@ -124,6 +126,7 @@ class AccountSnapsPage(BaseTestCases.EndpointLoggedInErrorHandling):
                 "16": {
                     "test": {
                         "status": "Approved",
+                        "snap-id": "1",
                         "snap-name": "test",
                         "latest_revisions": [
                             {
@@ -167,6 +170,7 @@ class AccountSnapsPage(BaseTestCases.EndpointLoggedInErrorHandling):
                 "16": {
                     "test": {
                         "status": "Approved",
+                        "snap-id": "1",
                         "snap-name": "test",
                         "latest_revisions": [
                             {
@@ -178,6 +182,7 @@ class AccountSnapsPage(BaseTestCases.EndpointLoggedInErrorHandling):
                     },
                     "test2": {
                         "status": "Approved",
+                        "snap-id": "2",
                         "snap-name": "test2",
                         "latest_revisions": [],
                     },
@@ -200,6 +205,7 @@ class AccountSnapsPage(BaseTestCases.EndpointLoggedInErrorHandling):
         registered_snaps = {
             "test2": {
                 "status": "Approved",
+                "snap-id": "2",
                 "snap-name": "test2",
                 "latest_revisions": [],
             }
@@ -208,6 +214,7 @@ class AccountSnapsPage(BaseTestCases.EndpointLoggedInErrorHandling):
         uploaded_snaps = {
             "test": {
                 "status": "Approved",
+                "snap-id": "1",
                 "snap-name": "test",
                 "latest_revisions": [
                     {
@@ -232,6 +239,7 @@ class AccountSnapsPage(BaseTestCases.EndpointLoggedInErrorHandling):
                 "16": {
                     "test": {
                         "status": "Approved",
+                        "snap-id": "1",
                         "snap-name": "test",
                         "latest_revisions": [
                             {
@@ -243,11 +251,13 @@ class AccountSnapsPage(BaseTestCases.EndpointLoggedInErrorHandling):
                     },
                     "test2": {
                         "status": "Approved",
+                        "snap-id": "2",
                         "snap-name": "test2",
                         "latest_revisions": [],
                     },
                     "test3": {
                         "status": "Revoked",
+                        "snap-id": "3",
                         "snap-name": "test",
                         "latest_revisions": [
                             {
@@ -259,6 +269,7 @@ class AccountSnapsPage(BaseTestCases.EndpointLoggedInErrorHandling):
                     },
                     "test4": {
                         "status": "Revoked",
+                        "snap-id": "4",
                         "snap-name": "test2",
                         "latest_revisions": [],
                     },
@@ -281,6 +292,7 @@ class AccountSnapsPage(BaseTestCases.EndpointLoggedInErrorHandling):
         registered_snaps = {
             "test2": {
                 "status": "Approved",
+                "snap-id": "2",
                 "snap-name": "test2",
                 "latest_revisions": [],
             }
@@ -289,6 +301,7 @@ class AccountSnapsPage(BaseTestCases.EndpointLoggedInErrorHandling):
         uploaded_snaps = {
             "test": {
                 "status": "Approved",
+                "snap-id": "1",
                 "snap-name": "test",
                 "latest_revisions": [
                     {

--- a/tests/publisher/tests_account_snaps_metrics.py
+++ b/tests/publisher/tests_account_snaps_metrics.py
@@ -1,0 +1,105 @@
+import json
+import responses
+from tests.publisher.endpoint_testing import BaseTestCases
+
+# Make sure tests fail on stray responses.
+responses.mock.assert_all_requests_are_fired = True
+
+
+class AccountSnapsMetricsNotAuth(BaseTestCases.EndpointLoggedOut):
+    def setUp(self):
+        endpoint_url = "/snaps/metrics/json"
+        super().setUp(
+            snap_name=None, endpoint_url=endpoint_url, method_endpoint="POST"
+        )
+
+
+class AccountSnapsMetrics(BaseTestCases.BaseAppTesting):
+    def setUp(self):
+        api_url = "https://dashboard.snapcraft.io/dev/api/snaps/metrics"
+        endpoint_url = "/snaps/metrics/json"
+        super().setUp(
+            snap_name=None, endpoint_url=endpoint_url, api_url=api_url
+        )
+        self.authorization = self._log_in(self.client)
+
+    @responses.activate
+    def test_metrics(self):
+        metrics_payload = {
+            "metrics": [
+                {
+                    "snap_id": "1",
+                    "status": "OK",
+                    "series": [
+                        {"values": [0, 3], "name": "new"},
+                        {"values": [2, 3], "name": "lost"},
+                        {"values": [9, 6], "name": "continued"},
+                    ],
+                    "buckets": ["2018-04-13", "2018-04-20"],
+                },
+                {
+                    "snap_id": "2",
+                    "status": "NODATA",
+                    "series": [],
+                    "buckets": [],
+                },
+            ]
+        }
+
+        responses.add(
+            responses.POST, self.api_url, json=metrics_payload, status=200
+        )
+
+        payload = ["1", "2"]
+        headers = {"content-type": "application/json"}
+        response = self.client.post(
+            self.endpoint_url, data=json.dumps(payload), headers=headers
+        )
+
+        expected_response = {
+            "buckets": ["2018-04-13", "2018-04-20"],
+            "snaps": [
+                {
+                    "id": "1",
+                    "series": [
+                        {"name": "new", "values": [0, 3]},
+                        {"name": "lost", "values": [2, 3]},
+                        {"name": "continued", "values": [9, 6]},
+                    ],
+                }
+            ],
+        }
+
+        self.assertEqual(200, response.status_code)
+        self.assertEqual(expected_response, response.json)
+        self.assertEqual(1, len(responses.calls))
+        called = responses.calls[0]
+        self.assertEqual(self.api_url, called.request.url)
+        self.assertEqual(
+            self.authorization, called.request.headers.get("Authorization")
+        )
+
+    @responses.activate
+    def test_metrics_no_payload(self):
+        headers = {"content-type": "application/json"}
+        response = self.client.post(self.endpoint_url, headers=headers)
+
+        expected_response = {"error": "Please provide a list of snap ID's"}
+
+        self.assertEqual(500, response.status_code)
+        self.assertEqual(expected_response, response.json)
+
+    @responses.activate
+    def test_metrics_bad_id_payload(self):
+        headers = {"content-type": "application/json"}
+        payload = ["badid"]
+        response = self.client.post(
+            self.endpoint_url, data=json.dumps(payload), headers=headers
+        )
+
+        expected_response = {
+            "error": "An error occured while fetching metrics"
+        }
+
+        self.assertEqual(500, response.status_code)
+        self.assertEqual(expected_response, response.json)

--- a/webapp/publisher/snaps/views.py
+++ b/webapp/publisher/snaps/views.py
@@ -110,6 +110,30 @@ def get_account_snaps():
     return flask.render_template("publisher/account-snaps.html", **context)
 
 
+@publisher_snaps.route("/snaps/metrics/json", methods=["POST"])
+@login_required
+def get_account_snaps_metrics():
+    if not flask.request.data:
+        error = {"error": "Please provide a list of snap ID's"}
+        return flask.jsonify(error), 500
+
+    try:
+        metrics = {"buckets": [], "snaps": []}
+
+        snaps = loads(flask.request.data)
+        metrics_query = metrics_helper.build_snap_installs_metrics_query(snaps)
+
+        if metrics_query:
+            snap_metrics = api.get_publisher_metrics(
+                flask.session, json=metrics_query
+            )
+            metrics = metrics_helper.transform_metrics(metrics, snap_metrics)
+        return flask.jsonify(metrics), 200
+    except Exception:
+        error = {"error": "An error occured while fetching metrics"}
+        return flask.jsonify(error), 500
+
+
 @publisher_snaps.route("/account/snaps/<snap_name>/measure")
 @publisher_snaps.route("/account/snaps/<snap_name>/metrics")
 @login_required


### PR DESCRIPTION
Adds an endpoint to retrieve metrics of snaps of a certain publisher
that can be used to render graphs on the publisher snaps page

Fixes https://github.com/CanonicalLtd/snap-squad/issues/971