### PR TITLE
more snaps on brand store

### DIFF
--- a/static/sass/_snapcraft-p_grid.scss
+++ b/static/sass/_snapcraft-p_grid.scss
@@ -1,0 +1,8 @@
+@mixin snapcraft-p-grid {
+  .snapcraft-p-grid {
+    column-gap: $sph-inter;
+    display: grid;
+    grid-template-columns: repeat(4, auto);
+    row-gap: $spv-inter--regular;
+  }
+}

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -237,6 +237,9 @@ $color-navigation-background: #252525;
 @import 'patterns_pagination';
 @include snapcraft-p-pagination;
 
+@import 'snapcraft-p_grid';
+@include snapcraft-p-grid;
+
 
 html,
 body {

--- a/templates/brand-store/store.html
+++ b/templates/brand-store/store.html
@@ -46,9 +46,9 @@ sudo service snapd restart</code></pre>
     {% endif %}
 
     <div class="row">
-      <div class="col-12 p-fluid-grid">
+      <div class="col-12 snapcraft-p-grid">
         {% for snap in snaps %}
-          <a class="p-fluid-grid__item p-media-object" href="/{{ snap.package_name }}">
+          <a class="p-media-object" href="/{{ snap.package_name }}">
             <span class="p-media-object__image">
               {% if snap.icon_url %}
                 <img class="p-heading-icon__img" src="{{ snap.icon_url }}" alt="">

--- a/webapp/configs/limenet.py
+++ b/webapp/configs/limenet.py
@@ -13,7 +13,7 @@ WEBAPP_CONFIG = {
      .p-navigation__link a:focus {color: #000;}\
      .p-navigation__link a:hover {color: #049619; background: transparent;}",
     "STORE_INSTALL_INSTRUCTIONS": True,
-    "FOOTER_TEXT": "Copyright 2018  Canonical Ltd.<br/>\
+    "FOOTER_TEXT": "Copyright 2019  Canonical Ltd.<br/>\
       Ubuntu and Canonical are registered trademarks of Canonical Ltd.",
     "STORE_QUERY": "LimeNET",
 }

--- a/webapp/configs/sdrsatcom.py
+++ b/webapp/configs/sdrsatcom.py
@@ -16,7 +16,7 @@ WEBAPP_CONFIG = {
      .p-navigation__link a:focus {color: #000;}\
      .p-navigation__link a:hover {color: #002568; background: transparent;}",
     "STORE_INSTALL_INSTRUCTIONS": True,
-    "FOOTER_TEXT": "Copyright 2018  Canonical Ltd.<br/>\
+    "FOOTER_TEXT": "Copyright 2019  Canonical Ltd.<br/>\
       Ubuntu and Canonical are registered trademarks of Canonical Ltd.",
     "STORE_QUERY": "SDR_Satcom",
 }

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -95,7 +95,7 @@ def store_blueprint(store_query=None, testing=False):
         status_code = 200
 
         try:
-            snaps_results = api.get_all_snaps(size=12)
+            snaps_results = api.get_all_snaps(size=16)
         except ApiError as api_error:
             snaps_results = []
             status_code, error_info = _handle_errors(api_error)


### PR DESCRIPTION
Fixes https://github.com/canonicalltd/snap-squad/issues/962

## Done
- Bumped number of snaps shown on homepage to 16
- Updated copyright notice to 2019

## QA
- Pull the branch
- Change `WEBAPP` to `limenet` in `.env`
- `./run`
- visit http://0.0.0.0:8004
- SDRangel should be shown in the list of snaps
- The copyright footer should be 2019