### PR TITLE
Fixed ordering on snaps with dotted version numbers

### DIFF
--- a/static/js/publisher/release/components/releasesHeading.js
+++ b/static/js/publisher/release/components/releasesHeading.js
@@ -1,5 +1,6 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
+import { sortAlphaNum } from "../../../libs/channels";
 
 class ReleasesHeading extends Component {
   onTrackChange(event) {
@@ -7,6 +8,8 @@ class ReleasesHeading extends Component {
   }
 
   renderTrackDropdown(tracks) {
+    tracks = sortAlphaNum(tracks, "latest");
+
     return (
       <form className="p-form p-form--inline u-float--right">
         <div className="p-form__group">


### PR DESCRIPTION
### QA Steps

Fixes #1411 

1. Pull the branch or run the demo service
2. Visit snaps with different version number systems dotted, just letters, numbers...: go, node, code, nextcloud, pycharm-community
3. Notice in the track selector that latest is always first and then all versions are displayed in alphanumeric descending order 
4. #winning

**Note:** I would like to take the opportunity to thank @Lukewh for the amazing library in `/js/lib/channels.js`