### PR TITLE
Register name in first snap flow

### DIFF
--- a/static/js/public/first-snap-flow.js
+++ b/static/js/public/first-snap-flow.js
@@ -183,7 +183,67 @@ function push() {
   });
 }
 
+function updateNotification(notificationEl, className, message) {
+  notificationEl.className = className;
+  notificationEl.querySelector(".p-notification__response").innerHTML = message;
+}
+
+function successNotification(notificationEl, message) {
+  updateNotification(notificationEl, "p-notification--positive", message);
+}
+
+function errorNotification(notificationEl, message) {
+  updateNotification(notificationEl, "p-notification--negative", message);
+}
+
+function initRegisterName(formEl, notificationEl) {
+  const initialNotificationClassName = notificationEl.className;
+  const initialNotificationHtml = notificationEl.querySelector(
+    ".p-notification__response"
+  ).innerHTML;
+
+  const snapNameInput = formEl.querySelector("[name=snap-name]");
+
+  snapNameInput.addEventListener("keyup", () => {
+    updateNotification(
+      notificationEl,
+      initialNotificationClassName,
+      initialNotificationHtml
+    );
+  });
+
+  formEl.addEventListener("submit", event => {
+    event.preventDefault();
+    let formData = new FormData(formEl);
+
+    fetch("/register-snap/json", {
+      method: "POST",
+      body: formData
+    })
+      .then(response => response.json())
+      .then(json => {
+        if (json.errors) {
+          const error = json.errors[0];
+          if (error.code == "already_owned") {
+            successNotification(notificationEl, error.message);
+          } else {
+            errorNotification(notificationEl, error.message);
+          }
+        } else if (json.success) {
+          successNotification(notificationEl, "Name registered successfully.");
+        }
+      })
+      .catch(() => {
+        errorNotification(
+          notificationEl,
+          "There was some problem registering name. Please try again."
+        );
+      });
+  });
+}
+
 export default {
+  initRegisterName,
   install,
   push
 };

--- a/static/js/public/first-snap-flow.js
+++ b/static/js/public/first-snap-flow.js
@@ -196,6 +196,10 @@ function errorNotification(notificationEl, message) {
   updateNotification(notificationEl, "p-notification--negative", message);
 }
 
+function validateSnapName(name) {
+  return /^[a-z0-9-]*[a-z][a-z0-9-]*$/.test(name) && !/^-|-$/.test(name);
+}
+
 function initRegisterName(formEl, notificationEl) {
   const initialNotificationClassName = notificationEl.className;
   const initialNotificationHtml = notificationEl.querySelector(
@@ -205,6 +209,16 @@ function initRegisterName(formEl, notificationEl) {
   const snapNameInput = formEl.querySelector("[name=snap-name]");
 
   snapNameInput.addEventListener("keyup", () => {
+    const isValid = validateSnapName(snapNameInput.value);
+
+    if (!isValid) {
+      snapNameInput.parentNode.classList.add("is-error");
+      formEl.querySelector("button").disabled = true;
+    } else {
+      snapNameInput.parentNode.classList.remove("is-error");
+      formEl.querySelector("button").disabled = false;
+    }
+
     updateNotification(
       notificationEl,
       initialNotificationClassName,
@@ -224,13 +238,17 @@ function initRegisterName(formEl, notificationEl) {
       .then(json => {
         if (json.errors) {
           const error = json.errors[0];
-          if (error.code == "already_owned") {
-            successNotification(notificationEl, error.message);
-          } else {
-            errorNotification(notificationEl, error.message);
-          }
-        } else if (json.success) {
-          successNotification(notificationEl, "Name registered successfully.");
+          errorNotification(notificationEl, error.message);
+        } else if (json.code == "created") {
+          successNotification(
+            notificationEl,
+            `Name "${json.snap_name}" registered successfully.`
+          );
+        } else if (json.code == "already_owned") {
+          successNotification(
+            notificationEl,
+            `You already own "${json.snap_name}"".`
+          );
         }
       })
       .catch(() => {

--- a/static/js/public/first-snap-flow.js
+++ b/static/js/public/first-snap-flow.js
@@ -200,7 +200,7 @@ function validateSnapName(name) {
   return /^[a-z0-9-]*[a-z][a-z0-9-]*$/.test(name) && !/^-|-$/.test(name);
 }
 
-function initRegisterName(formEl, notificationEl) {
+function initRegisterName(formEl, notificationEl, successEl) {
   const initialNotificationClassName = notificationEl.className;
   const initialNotificationHtml = notificationEl.querySelector(
     ".p-notification__response"
@@ -226,6 +226,15 @@ function initRegisterName(formEl, notificationEl) {
     );
   });
 
+  function showSuccess(message) {
+    successEl.classList.remove("u-hide");
+    successNotification(notificationEl, message);
+  }
+
+  function showError(message) {
+    errorNotification(notificationEl, message);
+  }
+
   formEl.addEventListener("submit", event => {
     event.preventDefault();
     let formData = new FormData(formEl);
@@ -237,18 +246,11 @@ function initRegisterName(formEl, notificationEl) {
       .then(response => response.json())
       .then(json => {
         if (json.errors) {
-          const error = json.errors[0];
-          errorNotification(notificationEl, error.message);
+          showError(json.errors[0].message);
         } else if (json.code == "created") {
-          successNotification(
-            notificationEl,
-            `Name "${json.snap_name}" registered successfully.`
-          );
+          showSuccess(`Name "${json.snap_name}" registered successfully.`);
         } else if (json.code == "already_owned") {
-          successNotification(
-            notificationEl,
-            `You already own "${json.snap_name}"".`
-          );
+          showSuccess(`You already own "${json.snap_name}"".`);
         }
       })
       .catch(() => {

--- a/static/sass/_patterns_first-snap-flow.scss
+++ b/static/sass/_patterns_first-snap-flow.scss
@@ -25,4 +25,13 @@
   .p-accordion__panel {
     padding-left: 4rem;
   }
+
+  .p-form-validation__message {
+    display: none;
+
+    .is-error & {
+      color: $color-negative;
+      display: block;
+    }
+  }
 }

--- a/templates/first-snap/push.html
+++ b/templates/first-snap/push.html
@@ -56,14 +56,19 @@
               <form id="register-name-form">
                 <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
                 <label>You must register snap name to be able to push your snap to the store.</label>
-                <input type="text" name="snap-name" value="{{ snap_name }}" />
+                <div class="p-form-validation">
+                  <input class="p-form-validation__input" type="text" name="snap-name" value="{{ snap_name }}" />
+                  <p class="p-form-validation__message" id="input-error-message-inline" role="alert">
+                    Name should only have lowercase letters, numbers, and hyphens, must have at least one letter, and cannot start or end with a hyphen.
+                  </p>
+                </div>
                 <div id="register-name-notification" class="p-notification--caution">
                   <p class="p-notification__response">
                     <span class="p-notification__status"></span>
                     Make sure the name matches what has been used previously (i.e <code>{{ snap_name }}</code>)
                   </p>
                 </div>
-                <button class="p-button--positive">Register snap name</button>
+                <button class="p-button--positive" disabled>Register snap name</button>
               </form>
             </div>
           </section>

--- a/templates/first-snap/push.html
+++ b/templates/first-snap/push.html
@@ -49,6 +49,7 @@
             <h4 class="u-no-margin--bottom">
               <span class="p-accordion__step">2.</span>
               Register your snap name
+              <i id="register-name-success" class="p-icon--success u-hide"></i>
             </h4>
           </button>
           <section class="p-accordion__panel" id="tab2-section" role="tabpanel" {% if not user %}aria-hidden="true"{% else %}aria-hidden="false"{% endif %} aria-labelledby="tab2-section">
@@ -135,6 +136,7 @@
         snapcraft.public.firstSnapFlow.initRegisterName(
           document.getElementById("register-name-form"),
           document.getElementById("register-name-notification"),
+          document.getElementById("register-name-success")
         );
         snapcraft.public.firstSnapFlow.push({{ language|tojson }});
       {% endif %}

--- a/templates/first-snap/push.html
+++ b/templates/first-snap/push.html
@@ -53,23 +53,18 @@
           </button>
           <section class="p-accordion__panel" id="tab2-section" role="tabpanel" {% if not user %}aria-hidden="true"{% else %}aria-hidden="false"{% endif %} aria-labelledby="tab2-section">
             <div class="col-8">
-              <p>Okay {{ user.display_name }}, now log in with the same account at the terminal</p>
-
-              {% set snippet_value = "snapcraft login" %}
-              {% set snippet_id = "snapcraft-login" %}
-              {% include "/partials/_code-snippet.html" %}
-
-              <p>And register your snap name</p>
-              {% set snippet_value = "snapcraft register " + snap_name %}
-              {% set snippet_id = "snapcraft-login" %}
-              {% set snippet_id = "snapcraft-register" %}
-              {% include "/partials/_code-snippet.html" %}
-              <div class="p-notification--caution">
-                <p class="p-notification__response">
-                  <span class="p-notification__status"></span>
-                  Make sure the name matches what has been used previously (i.e <code>{{ snap_name }}</code>)
-                </p>
-              </div>
+              <form id="register-name-form">
+                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+                <label>You must register snap name to be able to push your snap to the store.</label>
+                <input type="text" name="snap-name" value="{{ snap_name }}" />
+                <div id="register-name-notification" class="p-notification--caution">
+                  <p class="p-notification__response">
+                    <span class="p-notification__status"></span>
+                    Make sure the name matches what has been used previously (i.e <code>{{ snap_name }}</code>)
+                  </p>
+                </div>
+                <button class="p-button--positive">Register snap name</button>
+              </form>
             </div>
           </section>
         </li>
@@ -82,8 +77,13 @@
           </button>
           <section class="p-accordion__panel" id="tab3-section" role="tabpanel" aria-hidden="true" aria-labelledby="tab3-section">
             <div class="col-8">
+              <p>Log in to snapcraft using your Ubuntu One account credentials:</p>
+              {% set snippet_value = "snapcraft login" %}
+              {% set snippet_id = "snapcraft-login" %}
+              {% include "/partials/_code-snippet.html" %}
+
               <p>
-                You can push your snap to the store with following command:
+                Once logged, you can push your snap to the store with following command:
               </p>
               {% set snippet_value = "snapcraft push --release edge *.snap" %}
               {% set snippet_id = "snapcraft-push" %}
@@ -127,6 +127,10 @@
   <script>
     Raven.context(function() {
       {% if user %}
+        snapcraft.public.firstSnapFlow.initRegisterName(
+          document.getElementById("register-name-form"),
+          document.getElementById("register-name-notification"),
+        );
         snapcraft.public.firstSnapFlow.push({{ language|tojson }});
       {% endif %}
       snapcraft.public.initAccordion('.p-accordion__list');


### PR DESCRIPTION
Fixes #1787

Adds registering name form to "Publish snap" step of first snap flow.

###

- ./run or demo
- go through first snap flow to the last step
- sign in
- register name form should appear for registering a name
- try typing invalid name (validation should show error, submit should be disabled)
- try registering reserved name, name that you already own, new name etc (proper error or success message should appear)

<img width="1012" alt="Screenshot 2019-04-17 at 17 16 28" src="https://user-images.githubusercontent.com/83575/56299557-91927900-6134-11e9-974e-0aba39254350.png">
