### PR TITLE
First snap flow - choose snap name

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,10 @@
     "relative": true
   },
   "jest": {
-    "collectCoverage": true
+    "collectCoverage": true,
+    "setupFiles": [
+      "<rootDir>/static/js/test/setup/polyfill.js"
+    ]
   },
   "author": "Canonical webteam",
   "dependencies": {

--- a/static/js/public/accordion.js
+++ b/static/js/public/accordion.js
@@ -36,3 +36,24 @@ export default function initAccordion(accordionContainerSelector) {
       }
     });
 }
+
+/**
+  Attaches click event to a button to close current accordion tab and open next one.
+*/
+export function initAccordionButtons(continueButton) {
+  continueButton.addEventListener("click", event => {
+    event.preventDefault();
+
+    const currentPanel = continueButton.closest(".p-accordion__group");
+    const currentToggle = currentPanel.querySelector(".p-accordion__tab");
+    const currentSuccess = currentPanel.querySelector(".p-icon--success");
+    const nextPanel = currentPanel.nextElementSibling;
+    const nextToggle = nextPanel.querySelector(".p-accordion__tab");
+
+    toggleAccordion(currentToggle, false);
+    if (currentSuccess) {
+      currentSuccess.classList.remove("u-hide");
+    }
+    toggleAccordion(nextToggle, true);
+  });
+}

--- a/static/js/public/accordion.js
+++ b/static/js/public/accordion.js
@@ -2,23 +2,24 @@
 // https://github.com/vanilla-framework/vanilla-framework/blob/develop/examples/patterns/accordion.html
 
 /**
+  Toggles the necessary values on the accordion panels and handles to show or
+  hide depending on the supplied values.
+  @param {HTMLElement} element The tab that acts as the handles for the
+    accordion panes.
+  @param {Boolean} show Whether to show or hide the accordion panel.
+*/
+export const toggleAccordion = (element, show) => {
+  element.setAttribute("aria-expanded", show);
+  document
+    .querySelector(element.getAttribute("aria-controls"))
+    .setAttribute("aria-hidden", !show);
+};
+
+/**
   Attaches event listeners for the accordion open and close click events.
   @param {String} accordionContainerSelector The selector of the accordion container.
 */
 export default function initAccordion(accordionContainerSelector) {
-  /**
-    Toggles the necessary values on the accordion panels and handles to show or
-    hide depending on the supplied values.
-    @param {HTMLElement} element The tab that acts as the handles for the
-      accordion panes.
-    @param {Boolean} show Whether to show or hide the accordion panel.
-  */
-  const toggle = (element, show) => {
-    element.setAttribute("aria-expanded", show);
-    document
-      .querySelector(element.getAttribute("aria-controls"))
-      .setAttribute("aria-hidden", !show);
-  };
   // Set up an event listener on the container so that panels can be added
   // and removed and events do not need to be managed separately.
   document
@@ -29,9 +30,9 @@ export default function initAccordion(accordionContainerSelector) {
         // Find any open panels within the container and close them.
         e.currentTarget
           .querySelectorAll("[aria-expanded=true]")
-          .forEach(element => toggle(element, false));
+          .forEach(element => toggleAccordion(element, false));
         // Open the target.
-        toggle(target, true);
+        toggleAccordion(target, true);
       }
     });
 }

--- a/static/js/public/accordion.test.js
+++ b/static/js/public/accordion.test.js
@@ -1,18 +1,5 @@
 import initAccordion, { initAccordionButtons } from "./accordion";
 
-// jsdom (in version that comes with jest) doesn't support .closest
-// so we need to polyfill that
-// shouldn't be needed when jsdom used by jest is updated to v11.12.0
-window.Element.prototype.closest = function(selector) {
-  var el = this;
-  while (el) {
-    if (el.matches(selector)) {
-      return el;
-    }
-    el = el.parentElement;
-  }
-};
-
 describe("accordion", () => {
   let button1;
   let button2;

--- a/static/js/public/accordion.test.js
+++ b/static/js/public/accordion.test.js
@@ -1,0 +1,142 @@
+import initAccordion, { initAccordionButtons } from "./accordion";
+
+// jsdom (in version that comes with jest) doesn't support .closest
+// so we need to polyfill that
+// shouldn't be needed when jsdom used by jest is updated to v11.12.0
+window.Element.prototype.closest = function(selector) {
+  var el = this;
+  while (el) {
+    if (el.matches(selector)) {
+      return el;
+    }
+    el = el.parentElement;
+  }
+};
+
+describe("accordion", () => {
+  let button1;
+  let button2;
+  let button3;
+  let panel1;
+  let panel2;
+  let panel3;
+
+  function setupAccordion() {
+    const accordionHTML = `
+    <div class="p-accordion" role="tablist" aria-multiselect="true">
+      <ul class="p-accordion__list">
+        <li class="p-accordion__group">
+          <button type="button" class="p-accordion__tab" id="tab1" role="tab" aria-controls="#tab1-section" aria-expanded="true">Owner</button>
+          <section class="p-accordion__panel" id="tab1-section" role="tabpanel" aria-hidden="false" aria-labelledby="tab1-section">
+            <p>Open panel</p>
+          </section>
+        </li>
+        <li class="p-accordion__group">
+          <button type="button" class="p-accordion__tab" id="tab2" role="tab" aria-controls="#tab2-section" aria-expanded="false">Status</button>
+          <section class="p-accordion__panel" id="tab2-section" role="tabpanel" aria-hidden="true" aria-labelledby="tab2-section">
+            <p>Closed panel</p>
+          </section>
+        </li>
+        <li class="p-accordion__group">
+          <button type="button" class="p-accordion__tab" id="tab3" role="tab" aria-controls="#tab3-section" aria-expanded="false">Tags</button>
+          <section class="p-accordion__panel" id="tab3-section" role="tabpanel" aria-hidden="true" aria-labelledby="tab3-section">
+            <p>Closed panel</p>
+          </section>
+        </li>
+      </ul>
+    </div>
+  `;
+
+    const wrapper = document.createElement("div");
+    wrapper.innerHTML = accordionHTML;
+
+    button1 = wrapper.querySelector("#tab1");
+    button2 = wrapper.querySelector("#tab2");
+    button3 = wrapper.querySelector("#tab3");
+
+    panel1 = wrapper.querySelector("#tab1-section");
+    panel2 = wrapper.querySelector("#tab2-section");
+    panel3 = wrapper.querySelector("#tab3-section");
+
+    document.body.appendChild(wrapper);
+  }
+
+  describe("initAccordion", () => {
+    beforeEach(() => {
+      setupAccordion();
+      initAccordion(".p-accordion");
+    });
+
+    afterEach(() => {
+      document.body.innerHTML = "";
+    });
+
+    it("should do nothing when clicked on open tab", () => {
+      button1.click();
+
+      expect(button1.getAttribute("aria-expanded")).toBe("true");
+      expect(panel1.getAttribute("aria-hidden")).toBe("false");
+      expect(button2.getAttribute("aria-expanded")).toBe("false");
+      expect(panel2.getAttribute("aria-hidden")).toBe("true");
+      expect(button3.getAttribute("aria-expanded")).toBe("false");
+      expect(panel3.getAttribute("aria-hidden")).toBe("true");
+    });
+
+    it("should open panel when clicked on closed tab", () => {
+      button2.click();
+
+      expect(button1.getAttribute("aria-expanded")).toBe("false");
+      expect(panel1.getAttribute("aria-hidden")).toBe("true");
+      expect(button2.getAttribute("aria-expanded")).toBe("true");
+      expect(panel2.getAttribute("aria-hidden")).toBe("false");
+      expect(button3.getAttribute("aria-expanded")).toBe("false");
+      expect(panel3.getAttribute("aria-hidden")).toBe("true");
+    });
+
+    it("should do nothing when clicked on disabled tab", () => {
+      button3.disabled = true;
+      button3.click();
+
+      expect(button1.getAttribute("aria-expanded")).toBe("true");
+      expect(panel1.getAttribute("aria-hidden")).toBe("false");
+      expect(button2.getAttribute("aria-expanded")).toBe("false");
+      expect(panel2.getAttribute("aria-hidden")).toBe("true");
+      expect(button3.getAttribute("aria-expanded")).toBe("false");
+      expect(panel3.getAttribute("aria-hidden")).toBe("true");
+    });
+  });
+
+  describe("initAccordionButtons", () => {
+    let continueButton;
+    let successEl;
+
+    beforeEach(() => {
+      setupAccordion();
+      continueButton = document.createElement("button");
+      successEl = document.createElement("i");
+      successEl.className = "p-icon--success u-hide";
+      panel1.appendChild(continueButton);
+      panel1.appendChild(successEl);
+      initAccordionButtons(continueButton);
+    });
+
+    afterEach(() => {
+      document.body.innerHTML = "";
+    });
+
+    it("should close current panel and open next one", () => {
+      continueButton.click();
+
+      expect(button1.getAttribute("aria-expanded")).toBe("false");
+      expect(panel1.getAttribute("aria-hidden")).toBe("true");
+      expect(button2.getAttribute("aria-expanded")).toBe("true");
+      expect(panel2.getAttribute("aria-hidden")).toBe("false");
+    });
+
+    it("should close current panel and open next one", () => {
+      continueButton.click();
+
+      expect(successEl.classList.contains("u-hide")).toBe(false);
+    });
+  });
+});

--- a/static/js/public/first-snap-flow.js
+++ b/static/js/public/first-snap-flow.js
@@ -200,6 +200,30 @@ function validateSnapName(name) {
   return /^[a-z0-9-]*[a-z][a-z0-9-]*$/.test(name) && !/^-|-$/.test(name);
 }
 
+function initChooseName(formEl) {
+  const snapNameInput = formEl.querySelector("[name=snap-name]");
+
+  snapNameInput.addEventListener("keyup", () => {
+    const isValid = validateSnapName(snapNameInput.value);
+
+    if (!isValid) {
+      snapNameInput.parentNode.classList.add("is-error");
+      formEl.querySelector("button").disabled = true;
+    } else {
+      snapNameInput.parentNode.classList.remove("is-error");
+      formEl.querySelector("button").disabled = false;
+    }
+  });
+
+  formEl.addEventListener("submit", event => {
+    event.preventDefault();
+
+    // set value in cookie an reload (to render with a new name)
+    document.cookie = `fsf_snap_name=${snapNameInput.value};`;
+    window.location.reload();
+  });
+}
+
 function initRegisterName(formEl, notificationEl, successEl) {
   const initialNotificationClassName = notificationEl.className;
   const initialNotificationHtml = notificationEl.querySelector(
@@ -263,6 +287,7 @@ function initRegisterName(formEl, notificationEl, successEl) {
 }
 
 export default {
+  initChooseName,
   initRegisterName,
   install,
   push

--- a/static/js/public/first-snap-flow.js
+++ b/static/js/public/first-snap-flow.js
@@ -2,6 +2,8 @@
 
 import "whatwg-fetch";
 
+import { toggleAccordion } from "./accordion";
+
 function install(language) {
   const osPickers = document.querySelectorAll(".js-os-select");
   const osWrappers = document.querySelectorAll(".js-os-wrapper");
@@ -224,6 +226,22 @@ function initChooseName(formEl, language) {
   });
 }
 
+function initAccordionButtons(continueButton) {
+  continueButton.addEventListener("click", event => {
+    event.preventDefault();
+
+    const currentPanel = continueButton.closest(".p-accordion__group");
+    const currentToggle = currentPanel.querySelector(".p-accordion__tab");
+    const currentSuccess = currentPanel.querySelector(".p-icon--success");
+    const nextPanel = currentPanel.nextElementSibling;
+    const nextToggle = nextPanel.querySelector(".p-accordion__tab");
+
+    toggleAccordion(currentToggle, false);
+    currentSuccess.classList.remove("u-hide");
+    toggleAccordion(nextToggle, true);
+  });
+}
+
 function initRegisterName(formEl, notificationEl, successEl) {
   const initialNotificationClassName = notificationEl.className;
   const initialNotificationHtml = notificationEl.querySelector(
@@ -288,6 +306,7 @@ function initRegisterName(formEl, notificationEl, successEl) {
 
 export default {
   initChooseName,
+  initAccordionButtons,
   initRegisterName,
   install,
   push

--- a/static/js/public/first-snap-flow.js
+++ b/static/js/public/first-snap-flow.js
@@ -200,7 +200,7 @@ function validateSnapName(name) {
   return /^[a-z0-9-]*[a-z][a-z0-9-]*$/.test(name) && !/^-|-$/.test(name);
 }
 
-function initChooseName(formEl) {
+function initChooseName(formEl, language) {
   const snapNameInput = formEl.querySelector("[name=snap-name]");
 
   snapNameInput.addEventListener("keyup", () => {
@@ -219,7 +219,7 @@ function initChooseName(formEl) {
     event.preventDefault();
 
     // set value in cookie an reload (to render with a new name)
-    document.cookie = `fsf_snap_name=${snapNameInput.value};`;
+    document.cookie = `fsf_snap_name_${language}=${snapNameInput.value};`;
     window.location.reload();
   });
 }

--- a/static/js/public/first-snap-flow.js
+++ b/static/js/public/first-snap-flow.js
@@ -2,8 +2,6 @@
 
 import "whatwg-fetch";
 
-import { toggleAccordion } from "./accordion";
-
 function install(language) {
   const osPickers = document.querySelectorAll(".js-os-select");
   const osWrappers = document.querySelectorAll(".js-os-wrapper");
@@ -226,22 +224,6 @@ function initChooseName(formEl, language) {
   });
 }
 
-function initAccordionButtons(continueButton) {
-  continueButton.addEventListener("click", event => {
-    event.preventDefault();
-
-    const currentPanel = continueButton.closest(".p-accordion__group");
-    const currentToggle = currentPanel.querySelector(".p-accordion__tab");
-    const currentSuccess = currentPanel.querySelector(".p-icon--success");
-    const nextPanel = currentPanel.nextElementSibling;
-    const nextToggle = nextPanel.querySelector(".p-accordion__tab");
-
-    toggleAccordion(currentToggle, false);
-    currentSuccess.classList.remove("u-hide");
-    toggleAccordion(nextToggle, true);
-  });
-}
-
 function initRegisterName(formEl, notificationEl, successEl) {
   const initialNotificationClassName = notificationEl.className;
   const initialNotificationHtml = notificationEl.querySelector(
@@ -306,7 +288,6 @@ function initRegisterName(formEl, notificationEl, successEl) {
 
 export default {
   initChooseName,
-  initAccordionButtons,
   initRegisterName,
   install,
   push

--- a/static/js/public/first-snap-flow.test.js
+++ b/static/js/public/first-snap-flow.test.js
@@ -1,0 +1,69 @@
+import firstSnapFlow from "./first-snap-flow";
+
+describe("initChooseName", () => {
+  let formEl;
+  let validationEl;
+  let nameInput;
+  let submitButton;
+
+  function setupForm() {
+    formEl = document.createElement("form");
+    formEl.id = "test-form";
+
+    validationEl = document.createElement("div");
+
+    nameInput = document.createElement("input");
+    nameInput.type = "text";
+    nameInput.name = "snap-name";
+
+    submitButton = document.createElement("button");
+    submitButton.disabled = true;
+
+    validationEl.appendChild(nameInput);
+    formEl.appendChild(validationEl);
+    formEl.appendChild(submitButton);
+
+    document.body.appendChild(formEl);
+  }
+
+  beforeEach(() => {
+    setupForm();
+    firstSnapFlow.initChooseName(formEl, "python");
+  });
+
+  afterEach(() => {
+    formEl.parentNode.removeChild(formEl);
+  });
+
+  it("should mark field invalid", () => {
+    nameInput.click();
+    nameInput.value = "-invalid";
+    nameInput.dispatchEvent(new Event("keyup", { bubbles: true }));
+
+    expect(submitButton.disabled).toBe(true);
+    expect(validationEl.classList.contains("is-error")).toBe(true);
+  });
+
+  it("should mark field valid", () => {
+    nameInput.click();
+    nameInput.value = "valid-name";
+    nameInput.dispatchEvent(new Event("keyup", { bubbles: true }));
+
+    expect(submitButton.disabled).toBe(false);
+    expect(validationEl.classList.contains("is-error")).toBe(false);
+  });
+
+  it("should set cookie on submit", () => {
+    Object.defineProperty(window.location, "reload", {
+      configurable: true
+    });
+    window.location.reload = jest.fn();
+
+    nameInput.click();
+    nameInput.value = "valid-name";
+
+    formEl.dispatchEvent(new Event("submit", { bubbles: true }));
+    expect(document.cookie).toContain("fsf_snap_name_python=valid-name");
+    expect(window.location.reload).toHaveBeenCalled();
+  });
+});

--- a/static/js/public/public.js
+++ b/static/js/public/public.js
@@ -2,7 +2,7 @@ import map from "./snap-details/map";
 import screenshots from "./snap-details/screenshots";
 import channelMap from "./snap-details/channelMap";
 import videos from "./snap-details/videos";
-import initAccordion from "./accordion";
+import initAccordion, { initAccordionButtons } from "./accordion";
 import initReportSnap from "./snap-details/reportSnap";
 import initEmbeddedCardModal from "./snap-details/embeddedCard";
 import { snapDetailsPosts, seriesPosts } from "./snap-details/blog-posts";
@@ -20,6 +20,7 @@ export {
   snapDetailsPosts,
   seriesPosts,
   initAccordion,
+  initAccordionButtons,
   initEmbeddedCardModal,
   initFSFLanguageSelect,
   initReportSnap,

--- a/static/js/test/setup/polyfill.js
+++ b/static/js/test/setup/polyfill.js
@@ -1,0 +1,12 @@
+// jsdom (in version that comes with jest) doesn't support .closest
+// so we need to polyfill that
+// shouldn't be needed when jsdom used by jest is updated to v11.12.0
+window.Element.prototype.closest = function(selector) {
+  var el = this;
+  while (el) {
+    if (el.matches(selector)) {
+      return el;
+    }
+    el = el.parentElement;
+  }
+};

--- a/static/sass/_snapcraft_p-list-step.scss
+++ b/static/sass/_snapcraft_p-list-step.scss
@@ -7,6 +7,19 @@
       content: "." counter(li);
     }
 
+    &.is-alpha .p-list-step__item::before {
+      content: "(" counter(li, lower-alpha);
+    }
+
+    &.is-nested {
+      margin-left: 0;
+
+      .p-list-step__item::before {
+        margin-left: -3rem;
+        text-align: left;
+      }
+    }
+
     // Override max-width of 25em
     .p-list-step__title {
       max-width: 100%;

--- a/templates/first-snap/build.html
+++ b/templates/first-snap/build.html
@@ -12,7 +12,7 @@
                 {{ step.action }}
               </h4>
               {% if step.command %}
-                {% set snippet_value = step.command %}
+                {% set snippet_value = step.command|replace("${name}", snap_name) %}
                 {% set snippet_id = loop.index %}
                 {% if snippet_value.count('\n') == 0 %}
                   {% include "/partials/_code-snippet.html" %}
@@ -26,7 +26,7 @@
           {% if loop.last and step.warning %}
             <div class="p-notification--caution">
               <p class="p-notification__response">
-                {{ step.warning|safe }}
+                {{ step.warning|replace("${name}", snap_name)|safe }}
               </p>
             </div>
           {% endif %}

--- a/templates/first-snap/package.html
+++ b/templates/first-snap/package.html
@@ -201,7 +201,8 @@
   <script>
     Raven.context(function() {
       snapcraft.public.firstSnapFlow.initChooseName(
-        document.getElementById("choose-name-form")
+        document.getElementById("choose-name-form"),
+         "{{language}}"
       );
       snapcraft.public.initAccordion('.p-accordion__list');
     });

--- a/templates/first-snap/package.html
+++ b/templates/first-snap/package.html
@@ -53,10 +53,9 @@
           </button>
           <section class="p-accordion__panel" id="tab3-section" role="tabpanel" aria-hidden="true" aria-labelledby="tab3-section">
             <div class="col-8">
-              <ol class="p-list-step has-margin">
+              <ol class="p-list-step has-margin is-nested is-alpha">
                 <li class="p-list-step__item">
                   <h4 class="p-list-step__title">
-                    <span class="p-list-step__bullet">2</span>
                     Open the snapcraft.yaml file in the root of the project
                   </h4>
                   {% set snippet_value = steps.createDir %}
@@ -65,7 +64,6 @@
                 </li>
                 <li class="p-list-step__item">
                   <h4 class="p-list-step__title">
-                    <span class="p-list-step__bullet">3</span>
                     The snapcraft.yaml file starts with a small amount of human-readable metadata.
                   </h4>
                   <div class="p-list-step__content">
@@ -89,7 +87,6 @@
                 </li>
                 <li class="p-list-step__item">
                   <h4 class="p-list-step__title">
-                    <span class="p-list-step__bullet">4</span>
                     Security model
                   </h4>
                   <div class="p-list-step__content">
@@ -111,7 +108,6 @@
                 {% if steps.explain.base %}
                 <li class="p-list-step__item">
                   <h4 class="p-list-step__title">
-                    <span class="p-list-step__bullet">5</span>
                     Base
                   </h4>
                   <div class="p-list-step__content">
@@ -133,7 +129,6 @@
                 {% endif %}
                 <li class="p-list-step__item">
                   <h4 class="p-list-step__title">
-                    <span class="p-list-step__bullet">6</span>
                     Parts
                   </h4>
                   <div class="p-list-step__content">
@@ -154,7 +149,6 @@
                 </li>
                 <li class="p-list-step__item">
                   <h4 class="p-list-step__title">
-                    <span class="p-list-step__bullet">7</span>
                     Apps
                   </h4>
                   <div class="p-list-step__content">

--- a/templates/first-snap/package.html
+++ b/templates/first-snap/package.html
@@ -38,6 +38,7 @@
             <h4 class="u-no-margin--bottom">
               <span class="p-accordion__step">2.</span>
               Download an example app
+              <i class="p-icon--success u-hide"></i>
             </h4>
           </button>
           <section class="p-accordion__panel" id="tab2-section" role="tabpanel" {% if has_user_chosen_name %}aria-hidden="false"{% else %}aria-hidden="true"{% endif %} aria-labelledby="tab2-section">
@@ -48,6 +49,7 @@
                   {% set snippet_value = steps.download %}
                   {% set snippet_id = "download" %}
                   {% include "/partials/_code-snippet.html" %}
+                  <button id="js-clone-continue-button" class="p-button--positive">Continue</button>
                 </div>
               </div>
             </div>
@@ -214,6 +216,9 @@
          "{{language}}"
       );
       snapcraft.public.initAccordion('.p-accordion__list');
+      snapcraft.public.firstSnapFlow.initAccordionButtons(
+        document.getElementById("js-clone-continue-button")
+      );
     });
   </script>
   {{ super() }}

--- a/templates/first-snap/package.html
+++ b/templates/first-snap/package.html
@@ -3,6 +3,25 @@
 
 {% block fsf_content %}
   <div class="row">
+    <div class="col-8">
+      <h4 class="p-list-step__title">
+        Choose snap name
+      </h4>
+      <form id="choose-name-form">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+        <label>Please pick a snap name for the purpose of this tutorial:</label>
+        <div class="p-form-validation">
+          <input class="p-form-validation__input" type="text" name="snap-name" value="{{ snap_name }}" />
+          <p class="p-form-validation__message" id="input-error-message-inline" role="alert">
+            Name should only have lowercase letters, numbers, and hyphens, must have at least one letter, and cannot start or end with a hyphen.
+          </p>
+        </div>
+        <button class="p-button--positive" disabled>Choose snap name</button>
+      </form>
+    </div>
+  </div>
+
+  <div class="row">
     <p>Now we'll take a real world app, and package it as a snap</p>
   </div>
 
@@ -151,4 +170,17 @@
     <span class="p-pagination__label">Next</span>
     <span class="p-pagination__title">Build snap</span>
   </a>
+{% endblock %}
+
+{% block scripts %}
+  <script src="{{ static_url('js/dist/public.js') }}"></script>
+  <script>
+    Raven.context(function() {
+      snapcraft.public.firstSnapFlow.initChooseName(
+        document.getElementById("choose-name-form")
+      );
+      // snapcraft.public.initAccordion('.p-accordion__list');
+    });
+  </script>
+  {{ super() }}
 {% endblock %}

--- a/templates/first-snap/package.html
+++ b/templates/first-snap/package.html
@@ -3,160 +3,190 @@
 
 {% block fsf_content %}
   <div class="row">
-    <div class="col-8">
-      <h4 class="p-list-step__title">
-        Choose snap name
-      </h4>
-      <form id="choose-name-form">
-        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
-        <label>Please pick a snap name for the purpose of this tutorial:</label>
-        <div class="p-form-validation">
-          <input class="p-form-validation__input" type="text" name="snap-name" value="{{ snap_name }}" />
-          <p class="p-form-validation__message" id="input-error-message-inline" role="alert">
-            Name should only have lowercase letters, numbers, and hyphens, must have at least one letter, and cannot start or end with a hyphen.
-          </p>
-        </div>
-        <button class="p-button--positive" disabled>Choose snap name</button>
-      </form>
+    <div class="p-accordion" role="tablist" aria-multiselect="true">
+      <ol class="p-accordion__list">
+        <li class="p-accordion__group">
+          <button aria-expanded="true" type="button" class="p-accordion__tab" id="tab1" role="tab" aria-controls="#tab1-section" >
+            <h4 class="u-no-margin--bottom">
+              <span class="p-accordion__step">1.</span>
+              Choose snap name
+            </h4>
+          </button>
+          <section class="p-accordion__panel" id="tab1-section" role="tabpanel" aria-hidden="false" aria-labelledby="tab1-section">
+            <div class="col-8">
+              <form id="choose-name-form">
+                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+                <label>Please pick a snap name for the purpose of this tutorial:</label>
+                <div class="p-form-validation">
+                  <input class="p-form-validation__input" type="text" name="snap-name" value="{{ snap_name }}" />
+                  <p class="p-form-validation__message" id="input-error-message-inline" role="alert">
+                    Name should only have lowercase letters, numbers, and hyphens, must have at least one letter, and cannot start or end with a hyphen.
+                  </p>
+                </div>
+                <button class="p-button--positive" disabled>Choose snap name</button>
+              </form>
+            </div>
+          </section>
+        </li>
+        <li class="p-accordion__group">
+          <button aria-expanded="false" type="button" class="p-accordion__tab" id="tab2" role="tab" aria-controls="#tab2-section" >
+            <h4 class="u-no-margin--bottom">
+              <span class="p-accordion__step">2.</span>
+              Download an example app
+            </h4>
+          </button>
+          <section class="p-accordion__panel" id="tab2-section" role="tabpanel" aria-hidden="true" aria-labelledby="tab2-section">
+            <div class="col-8">
+              <p>Clone the following application to use for the purpose of this tutorial</p>
+              {% set snippet_value = steps.download %}
+              {% set snippet_id = "download" %}
+              {% include "/partials/_code-snippet.html" %}
+            </div>
+          </section>
+        </li>
+        <li class="p-accordion__group">
+          <button aria-expanded="false" type="button" class="p-accordion__tab" id="tab3" role="tab" aria-controls="#tab3-section" >
+            <h4 class="u-no-margin--bottom">
+              <span class="p-accordion__step">3.</span>
+              Update your snapcraft.yaml
+            </h4>
+          </button>
+          <section class="p-accordion__panel" id="tab3-section" role="tabpanel" aria-hidden="true" aria-labelledby="tab3-section">
+            <div class="col-8">
+              <ol class="p-list-step has-margin">
+                <li class="p-list-step__item">
+                  <h4 class="p-list-step__title">
+                    <span class="p-list-step__bullet">2</span>
+                    Open the snapcraft.yaml file in the root of the project
+                  </h4>
+                  {% set snippet_value = steps.createDir %}
+                  {% set snippet_id = "createdir" %}
+                  {% include "/partials/_code-snippet-multi.html" %}
+                </li>
+                <li class="p-list-step__item">
+                  <h4 class="p-list-step__title">
+                    <span class="p-list-step__bullet">3</span>
+                    The snapcraft.yaml file starts with a small amount of human-readable metadata.
+                  </h4>
+                  <div class="p-list-step__content">
+                    {% set snippet_value = steps.metadata %}
+                    {% set snippet_id = "metadata" %}
+                    {% include "/partials/_code.html" %}
+                    {% for item in steps.explain.metadata %}
+                      {% if item.text %}
+                        <p>{{ item.text|safe }}</p>
+                      {% elif item.code %}
+                        <pre><code>{{ item.code }}</code></pre>
+                      {% elif item.warning %}
+                        <div class="p-notification--caution">
+                          <p class="p-notification__response">
+                            {{ item.warning|replace("${name}", snap_name)|safe }}
+                          </p>
+                        </div>
+                      {% endif %}
+                    {% endfor %}
+                  </div>
+                </li>
+                <li class="p-list-step__item">
+                  <h4 class="p-list-step__title">
+                    <span class="p-list-step__bullet">4</span>
+                    Security model
+                  </h4>
+                  <div class="p-list-step__content">
+                    {% for item in steps.explain.security %}
+                      {% if item.text %}
+                        <p>{{ item.text|safe }}</p>
+                      {% elif item.code %}
+                        <pre><code>{{ item.code }}</code></pre>
+                      {% elif item.warning %}
+                        <div class="p-notification--caution">
+                          <p class="p-notification__response">
+                            {{ item.warning|replace("${name}", snap_name)|safe }}
+                          </p>
+                        </div>
+                      {% endif %}
+                    {% endfor %}
+                  </div>
+                </li>
+                {% if steps.explain.base %}
+                <li class="p-list-step__item">
+                  <h4 class="p-list-step__title">
+                    <span class="p-list-step__bullet">5</span>
+                    Base
+                  </h4>
+                  <div class="p-list-step__content">
+                    {% for item in steps.explain.base %}
+                      {% if item.text %}
+                        <p>{{ item.text|safe }}</p>
+                      {% elif item.code %}
+                        <pre><code>{{ item.code }}</code></pre>
+                      {% elif item.warning %}
+                        <div class="p-notification--caution">
+                          <p class="p-notification__response">
+                            {{ item.warning|replace("${name}", snap_name)|safe }}
+                          </p>
+                        </div>
+                      {% endif %}
+                    {% endfor %}
+                  </div>
+                </li>
+                {% endif %}
+                <li class="p-list-step__item">
+                  <h4 class="p-list-step__title">
+                    <span class="p-list-step__bullet">6</span>
+                    Parts
+                  </h4>
+                  <div class="p-list-step__content">
+                    {% for item in steps.explain.parts %}
+                      {% if item.text %}
+                        <p>{{ item.text|safe }}</p>
+                      {% elif item.code %}
+                        <pre><code>{{ item.code }}</code></pre>
+                      {% elif item.warning %}
+                        <div class="p-notification--caution">
+                          <p class="p-notification__response">
+                            {{ item.warning|replace("${name}", snap_name)|safe }}
+                          </p>
+                        </div>
+                      {% endif %}
+                    {% endfor %}
+                  </div>
+                </li>
+                <li class="p-list-step__item">
+                  <h4 class="p-list-step__title">
+                    <span class="p-list-step__bullet">7</span>
+                    Apps
+                  </h4>
+                  <div class="p-list-step__content">
+                    {% for item in steps.explain.apps %}
+                    {% if item.text %}
+                    <p>{{ item.text|safe }}</p>
+                    {% elif item.code %}
+                    <pre><code>{{ item.code }}</code></pre>
+                    {% elif item.warning %}
+                    <div class="p-notification--caution">
+                      <p class="p-notification__response">
+                        {{ item.warning|replace("${name}", snap_name)|safe }}
+                      </p>
+                    </div>
+                    {% endif %}
+                    {% endfor %}
+                  </div>
+                </li>
+              </ol>
+            </div>
+          </section>
+        </li>
+      </ol>
     </div>
   </div>
-
   <div class="row">
     <p>Now we'll take a real world app, and package it as a snap</p>
   </div>
 
   <div class="row">
     <div class="col-8">
-      <ol class="p-list-step has-margin">
-        <li class="p-list-step__item">
-          <h4 class="p-list-step__title">
-            <span class="p-list-step__bullet">1</span>
-            Download a copy of the app
-          </h4>
-          {% set snippet_value = steps.download %}
-          {% set snippet_id = "download" %}
-          {% include "/partials/_code-snippet.html" %}
-        </li>
-        <li class="p-list-step__item">
-          <h4 class="p-list-step__title">
-            <span class="p-list-step__bullet">2</span>
-            Open the snapcraft.yaml file in the root of the project
-          </h4>
-          {% set snippet_value = steps.createDir %}
-          {% set snippet_id = "createdir" %}
-          {% include "/partials/_code-snippet-multi.html" %}
-        </li>
-        <li class="p-list-step__item">
-          <h4 class="p-list-step__title">
-            <span class="p-list-step__bullet">3</span>
-            The snapcraft.yaml file starts with a small amount of human-readable metadata.
-          </h4>
-          <div class="p-list-step__content">
-            {% set snippet_value = steps.metadata %}
-            {% set snippet_id = "metadata" %}
-            {% include "/partials/_code.html" %}
-            {% for item in steps.explain.metadata %}
-              {% if item.text %}
-                <p>{{ item.text|safe }}</p>
-              {% elif item.code %}
-                <pre><code>{{ item.code }}</code></pre>
-              {% elif item.warning %}
-                <div class="p-notification--caution">
-                  <p class="p-notification__response">
-                    {{ item.warning|replace("${name}", snap_name)|safe }}
-                  </p>
-                </div>
-              {% endif %}
-            {% endfor %}
-          </div>
-        </li>
-        <li class="p-list-step__item">
-          <h4 class="p-list-step__title">
-            <span class="p-list-step__bullet">4</span>
-            Security model
-          </h4>
-          <div class="p-list-step__content">
-            {% for item in steps.explain.security %}
-              {% if item.text %}
-                <p>{{ item.text|safe }}</p>
-              {% elif item.code %}
-                <pre><code>{{ item.code }}</code></pre>
-              {% elif item.warning %}
-                <div class="p-notification--caution">
-                  <p class="p-notification__response">
-                    {{ item.warning|replace("${name}", snap_name)|safe }}
-                  </p>
-                </div>
-              {% endif %}
-            {% endfor %}
-          </div>
-        </li>
-        {% if steps.explain.base %}
-        <li class="p-list-step__item">
-          <h4 class="p-list-step__title">
-            <span class="p-list-step__bullet">5</span>
-            Base
-          </h4>
-          <div class="p-list-step__content">
-            {% for item in steps.explain.base %}
-              {% if item.text %}
-                <p>{{ item.text|safe }}</p>
-              {% elif item.code %}
-                <pre><code>{{ item.code }}</code></pre>
-              {% elif item.warning %}
-                <div class="p-notification--caution">
-                  <p class="p-notification__response">
-                    {{ item.warning|replace("${name}", snap_name)|safe }}
-                  </p>
-                </div>
-              {% endif %}
-            {% endfor %}
-          </div>
-        </li>
-        {% endif %}
-        <li class="p-list-step__item">
-          <h4 class="p-list-step__title">
-            <span class="p-list-step__bullet">6</span>
-            Parts
-          </h4>
-          <div class="p-list-step__content">
-            {% for item in steps.explain.parts %}
-              {% if item.text %}
-                <p>{{ item.text|safe }}</p>
-              {% elif item.code %}
-                <pre><code>{{ item.code }}</code></pre>
-              {% elif item.warning %}
-                <div class="p-notification--caution">
-                  <p class="p-notification__response">
-                    {{ item.warning|replace("${name}", snap_name)|safe }}
-                  </p>
-                </div>
-              {% endif %}
-            {% endfor %}
-          </div>
-        </li>
-        <li class="p-list-step__item">
-          <h4 class="p-list-step__title">
-            <span class="p-list-step__bullet">7</span>
-            Apps
-          </h4>
-          <div class="p-list-step__content">
-            {% for item in steps.explain.apps %}
-            {% if item.text %}
-            <p>{{ item.text|safe }}</p>
-            {% elif item.code %}
-            <pre><code>{{ item.code }}</code></pre>
-            {% elif item.warning %}
-            <div class="p-notification--caution">
-              <p class="p-notification__response">
-                {{ item.warning|replace("${name}", snap_name)|safe }}
-              </p>
-            </div>
-            {% endif %}
-            {% endfor %}
-          </div>
-        </li>
-      </ol>
+
     </div>
   </div>
 {% endblock %}
@@ -179,7 +209,7 @@
       snapcraft.public.firstSnapFlow.initChooseName(
         document.getElementById("choose-name-form")
       );
-      // snapcraft.public.initAccordion('.p-accordion__list');
+      snapcraft.public.initAccordion('.p-accordion__list');
     });
   </script>
   {{ super() }}

--- a/templates/first-snap/package.html
+++ b/templates/first-snap/package.html
@@ -26,7 +26,7 @@
                         Name should only have lowercase letters, numbers, and hyphens, must have at least one letter, and cannot start or end with a hyphen.
                       </p>
                     </div>
-                    <button class="p-button--positive u-no-margin--bottom" disabled>Choose snap name</button>
+                    <button class="p-button--positive" disabled>Choose snap name</button>
                   </form>
                 </div>
               </div>

--- a/templates/first-snap/package.html
+++ b/templates/first-snap/package.html
@@ -14,18 +14,22 @@
             </h4>
           </button>
           <section class="p-accordion__panel" id="tab1-section" role="tabpanel" {% if has_user_chosen_name %}aria-hidden="true"{% else %}aria-hidden="false"{% endif %} aria-labelledby="tab1-section">
-            <div class="col-8">
-              <form id="choose-name-form">
-                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
-                <label>Please pick a snap name for the purpose of this tutorial:</label>
-                <div class="p-form-validation">
-                  <input class="p-form-validation__input" type="text" name="snap-name" value="{{ snap_name }}" />
-                  <p class="p-form-validation__message" id="input-error-message-inline" role="alert">
-                    Name should only have lowercase letters, numbers, and hyphens, must have at least one letter, and cannot start or end with a hyphen.
-                  </p>
+            <div class="p-strip is-shallow">
+              <div class="row">
+                <div class="col-8">
+                  <form id="choose-name-form">
+                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+                    <label>Please pick a snap name for the purpose of this tutorial:</label>
+                    <div class="p-form-validation">
+                      <input class="p-form-validation__input" type="text" name="snap-name" value="{{ snap_name }}" />
+                      <p class="p-form-validation__message" id="input-error-message-inline" role="alert">
+                        Name should only have lowercase letters, numbers, and hyphens, must have at least one letter, and cannot start or end with a hyphen.
+                      </p>
+                    </div>
+                    <button class="p-button--positive u-no-margin--bottom" disabled>Choose snap name</button>
+                  </form>
                 </div>
-                <button class="p-button--positive" disabled>Choose snap name</button>
-              </form>
+              </div>
             </div>
           </section>
         </li>
@@ -37,11 +41,15 @@
             </h4>
           </button>
           <section class="p-accordion__panel" id="tab2-section" role="tabpanel" {% if has_user_chosen_name %}aria-hidden="false"{% else %}aria-hidden="true"{% endif %} aria-labelledby="tab2-section">
-            <div class="col-8">
-              <p>Clone the following application to use for the purpose of this tutorial</p>
-              {% set snippet_value = steps.download %}
-              {% set snippet_id = "download" %}
-              {% include "/partials/_code-snippet.html" %}
+            <div class="p-strip is-shallow">
+              <div class="row">
+                <div class="col-8">
+                  <p>Clone the following application to use for the purpose of this tutorial</p>
+                  {% set snippet_value = steps.download %}
+                  {% set snippet_id = "download" %}
+                  {% include "/partials/_code-snippet.html" %}
+                </div>
+              </div>
             </div>
           </section>
         </li>

--- a/templates/first-snap/package.html
+++ b/templates/first-snap/package.html
@@ -6,13 +6,14 @@
     <div class="p-accordion" role="tablist" aria-multiselect="true">
       <ol class="p-accordion__list">
         <li class="p-accordion__group">
-          <button aria-expanded="true" type="button" class="p-accordion__tab" id="tab1" role="tab" aria-controls="#tab1-section" >
+          <button {% if has_user_chosen_name %}aria-expanded="false"{% else %}aria-expanded="true"{% endif %} type="button" class="p-accordion__tab" id="tab1" role="tab" aria-controls="#tab1-section" >
             <h4 class="u-no-margin--bottom">
               <span class="p-accordion__step">1.</span>
               Choose snap name
+              {% if has_user_chosen_name %}<i class="p-icon--success"></i>{% endif %}
             </h4>
           </button>
-          <section class="p-accordion__panel" id="tab1-section" role="tabpanel" aria-hidden="false" aria-labelledby="tab1-section">
+          <section class="p-accordion__panel" id="tab1-section" role="tabpanel" {% if has_user_chosen_name %}aria-hidden="true"{% else %}aria-hidden="false"{% endif %} aria-labelledby="tab1-section">
             <div class="col-8">
               <form id="choose-name-form">
                 <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
@@ -29,13 +30,13 @@
           </section>
         </li>
         <li class="p-accordion__group">
-          <button aria-expanded="false" type="button" class="p-accordion__tab" id="tab2" role="tab" aria-controls="#tab2-section" >
+          <button {% if has_user_chosen_name %}aria-expanded="true"{% else %}aria-expanded="false"{% endif %} type="button" class="p-accordion__tab" id="tab2" role="tab" aria-controls="#tab2-section" >
             <h4 class="u-no-margin--bottom">
               <span class="p-accordion__step">2.</span>
               Download an example app
             </h4>
           </button>
-          <section class="p-accordion__panel" id="tab2-section" role="tabpanel" aria-hidden="true" aria-labelledby="tab2-section">
+          <section class="p-accordion__panel" id="tab2-section" role="tabpanel" {% if has_user_chosen_name %}aria-hidden="false"{% else %}aria-hidden="true"{% endif %} aria-labelledby="tab2-section">
             <div class="col-8">
               <p>Clone the following application to use for the purpose of this tutorial</p>
               {% set snippet_value = steps.download %}

--- a/templates/first-snap/package.html
+++ b/templates/first-snap/package.html
@@ -216,7 +216,7 @@
          "{{language}}"
       );
       snapcraft.public.initAccordion('.p-accordion__list');
-      snapcraft.public.firstSnapFlow.initAccordionButtons(
+      snapcraft.public.initAccordionButtons(
         document.getElementById("js-clone-continue-button")
       );
     });

--- a/templates/first-snap/package.html
+++ b/templates/first-snap/package.html
@@ -63,7 +63,7 @@
               {% elif item.warning %}
                 <div class="p-notification--caution">
                   <p class="p-notification__response">
-                    {{ item.warning|safe }}
+                    {{ item.warning|replace("${name}", snap_name)|safe }}
                   </p>
                 </div>
               {% endif %}
@@ -84,7 +84,7 @@
               {% elif item.warning %}
                 <div class="p-notification--caution">
                   <p class="p-notification__response">
-                    {{ item.warning|safe }}
+                    {{ item.warning|replace("${name}", snap_name)|safe }}
                   </p>
                 </div>
               {% endif %}
@@ -106,7 +106,7 @@
               {% elif item.warning %}
                 <div class="p-notification--caution">
                   <p class="p-notification__response">
-                    {{ item.warning|safe }}
+                    {{ item.warning|replace("${name}", snap_name)|safe }}
                   </p>
                 </div>
               {% endif %}
@@ -128,7 +128,7 @@
               {% elif item.warning %}
                 <div class="p-notification--caution">
                   <p class="p-notification__response">
-                    {{ item.warning|safe }}
+                    {{ item.warning|replace("${name}", snap_name)|safe }}
                   </p>
                 </div>
               {% endif %}
@@ -149,7 +149,7 @@
             {% elif item.warning %}
             <div class="p-notification--caution">
               <p class="p-notification__response">
-                {{ item.warning|safe }}
+                {{ item.warning|replace("${name}", snap_name)|safe }}
               </p>
             </div>
             {% endif %}

--- a/templates/first-snap/push.html
+++ b/templates/first-snap/push.html
@@ -69,7 +69,7 @@
                     Make sure the name matches what has been used previously (i.e <code>{{ snap_name }}</code>)
                   </p>
                 </div>
-                <button class="p-button--positive" disabled>Register snap name</button>
+                <button class="p-button--positive" {% if not has_user_chosen_name %}disabled{% endif %}>Register snap name</button>
               </form>
             </div>
           </section>

--- a/templates/first-snap/push.html
+++ b/templates/first-snap/push.html
@@ -33,14 +33,18 @@
             </h4>
           </button>
           <section class="p-accordion__panel" id="tab1-section" role="tabpanel" {% if user %}aria-hidden="true"{% else %}aria-hidden="false"{% endif %} aria-labelledby="tab1-section">
-            <div class="col-8">
-              <p>This lets you make releases, alter your store listing and see usage metrics.</p>
+            <div class="p-strip is-shallow">
               <div class="row">
-                <p class="col-5">
-                  <img src="https://assets.ubuntu.com/v1/cd588a80-ubuntu-one.png" />
-                </p>
+                <div class="col-8">
+                  <p>This lets you make releases, alter your store listing and see usage metrics.</p>
+                  <div class="row">
+                    <p class="col-5">
+                      <img src="https://assets.ubuntu.com/v1/cd588a80-ubuntu-one.png" />
+                    </p>
+                  </div>
+                  <a href="/login" class="p-button--positive p-link--external">Register / Sign in...</a>
+                </div>
               </div>
-              <a href="/login" class="p-button--positive p-link--external">Register / Sign in...</a>
             </div>
           </section>
         </li>
@@ -53,24 +57,28 @@
             </h4>
           </button>
           <section class="p-accordion__panel" id="tab2-section" role="tabpanel" {% if not user %}aria-hidden="true"{% else %}aria-hidden="false"{% endif %} aria-labelledby="tab2-section">
-            <div class="col-8">
-              <form id="register-name-form">
-                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
-                <label>You must register snap name to be able to push your snap to the store.</label>
-                <div class="p-form-validation">
-                  <input class="p-form-validation__input" type="text" name="snap-name" value="{{ snap_name }}" />
-                  <p class="p-form-validation__message" id="input-error-message-inline" role="alert">
-                    Name should only have lowercase letters, numbers, and hyphens, must have at least one letter, and cannot start or end with a hyphen.
-                  </p>
+            <div class="p-strip is-shallow">
+              <div class="row">
+                <div class="col-8">
+                  <form id="register-name-form">
+                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+                    <label>You must register snap name to be able to push your snap to the store.</label>
+                    <div class="p-form-validation">
+                      <input class="p-form-validation__input" type="text" name="snap-name" value="{{ snap_name }}" />
+                      <p class="p-form-validation__message" id="input-error-message-inline" role="alert">
+                        Name should only have lowercase letters, numbers, and hyphens, must have at least one letter, and cannot start or end with a hyphen.
+                      </p>
+                    </div>
+                    <div id="register-name-notification" class="p-notification--caution">
+                      <p class="p-notification__response">
+                        <span class="p-notification__status"></span>
+                        Make sure the name matches what has been used previously (i.e <code>{{ snap_name }}</code>)
+                      </p>
+                    </div>
+                    <button class="p-button--positive" {% if not has_user_chosen_name %}disabled{% endif %}>Register snap name</button>
+                  </form>
                 </div>
-                <div id="register-name-notification" class="p-notification--caution">
-                  <p class="p-notification__response">
-                    <span class="p-notification__status"></span>
-                    Make sure the name matches what has been used previously (i.e <code>{{ snap_name }}</code>)
-                  </p>
-                </div>
-                <button class="p-button--positive" {% if not has_user_chosen_name %}disabled{% endif %}>Register snap name</button>
-              </form>
+              </div>
             </div>
           </section>
         </li>
@@ -82,25 +90,29 @@
             </h4>
           </button>
           <section class="p-accordion__panel" id="tab3-section" role="tabpanel" aria-hidden="true" aria-labelledby="tab3-section">
-            <div class="col-8">
-              <p>Log in to snapcraft using your Ubuntu One account credentials:</p>
-              {% set snippet_value = "snapcraft login" %}
-              {% set snippet_id = "snapcraft-login" %}
-              {% include "/partials/_code-snippet.html" %}
+            <div class="p-strip is-shallow">
+              <div class="row">
+                <div class="col-8">
+                  <p>Log in to snapcraft using your Ubuntu One account credentials:</p>
+                  {% set snippet_value = "snapcraft login" %}
+                  {% set snippet_id = "snapcraft-login" %}
+                  {% include "/partials/_code-snippet.html" %}
 
-              <p>
-                Once logged, you can push your snap to the store with following command:
-              </p>
-              {% set snippet_value = "snapcraft push --release edge *.snap" %}
-              {% set snippet_id = "snapcraft-push" %}
-              {% include "/partials/_code-snippet.html" %}
+                  <p>
+                    Once logged, you can push your snap to the store with following command:
+                  </p>
+                  {% set snippet_value = "snapcraft push --release edge *.snap" %}
+                  {% set snippet_id = "snapcraft-push" %}
+                  {% include "/partials/_code-snippet.html" %}
 
-              <p>
-                Once you've pushed to the Snap store, edit your snap public presentation.
-              </p>
-              <a class="p-button--neutral js-continue is--disabled">
-                <i class="p-icon--spinner u-animation--spin"></i>
-                &nbsp;Waiting for push...</a>
+                  <p>
+                    Once you've pushed to the Snap store, edit your snap public presentation.
+                  </p>
+                  <a class="p-button--neutral js-continue is--disabled">
+                    <i class="p-icon--spinner u-animation--spin"></i>
+                    &nbsp;Waiting for push...</a>
+                </div>
+              </div>
             </div>
           </section>
         </li>

--- a/templates/first-snap/test.html
+++ b/templates/first-snap/test.html
@@ -12,7 +12,7 @@
               {{ step.action|safe }}
             </h4>
             {% if step.command %}
-              {% set snippet_value = step.command %}
+              {% set snippet_value = step.command|replace("${name}", snap_name) %}
               {% set snippet_id = loop.index %}
               {% if snippet_value.count('\n') == 0 %}
                 {% include "/partials/_code-snippet.html" %}
@@ -23,7 +23,7 @@
             {% if step.warning %}
                 <div class="p-notification--caution">
                   <p class="p-notification__response">
-                    {{ step.warning|safe }}
+                    {{ step.warning|replace("${name}", snap_name)|safe }}
                   </p>
                 </div>
               {% endif %}

--- a/tests/first_snap/tests_views.py
+++ b/tests/first_snap/tests_views.py
@@ -49,6 +49,18 @@ class FirstSnap(TestCase):
         assert response.status_code == 200
         self.assert_context("language", "python")
         self.assert_context("os", "linux-auto")
+        self.assert_context("has_user_chosen_name", False)
+        self.assert_template_used("first-snap/package.html")
+
+    def test_get_package_snap_name(self):
+        response = self.client.get(
+            "/first-snap/python/linux-auto/package",
+            headers={"Cookie": "fsf_snap_name_python=test-snap-name-python"},
+        )
+        assert response.status_code == 200
+        self.assert_context("language", "python")
+        self.assert_context("snap_name", "test-snap-name-python")
+        self.assert_context("has_user_chosen_name", True)
         self.assert_template_used("first-snap/package.html")
 
     def test_get_package_404_language(self):
@@ -61,6 +73,17 @@ class FirstSnap(TestCase):
         assert response.status_code == 200
         self.assert_context("language", "python")
         self.assert_context("os", "linux-auto")
+        self.assert_template_used("first-snap/build.html")
+
+    def test_get_build_snap_name(self):
+        response = self.client.get(
+            "/first-snap/python/linux-auto/build",
+            headers={"Cookie": "fsf_snap_name_python=test-snap-name-python"},
+        )
+        assert response.status_code == 200
+        self.assert_context("language", "python")
+        self.assert_context("os", "linux-auto")
+        self.assert_context("snap_name", "test-snap-name-python")
         self.assert_template_used("first-snap/build.html")
 
     def test_get_build_404_language(self):
@@ -78,6 +101,17 @@ class FirstSnap(TestCase):
         assert response.status_code == 200
         self.assert_context("language", "python")
         self.assert_context("os", "macos-auto")
+        self.assert_template_used("first-snap/test.html")
+
+    def test_get_test_snap_name(self):
+        response = self.client.get(
+            "/first-snap/python/macos-auto/test",
+            headers={"Cookie": "fsf_snap_name_python=test-snap-name-python"},
+        )
+        assert response.status_code == 200
+        self.assert_context("language", "python")
+        self.assert_context("os", "macos-auto")
+        self.assert_context("snap_name", "test-snap-name-python")
         self.assert_template_used("first-snap/test.html")
 
     def test_get_test_404_language(self):
@@ -99,6 +133,19 @@ class FirstSnap(TestCase):
         self.assert_context("os", "linux")
         self.assert_context("user", None)
         self.assert_context("snap_name", "test-offlineimap-{name}")
+
+    def test_get_push_snap_name(self):
+        response = self.client.get(
+            "/first-snap/python/linux/push",
+            headers={"Cookie": "fsf_snap_name_python=test-snap-name-python"},
+        )
+        assert response.status_code == 200
+        self.assert_context("language", "python")
+        self.assert_context("os", "linux")
+        self.assert_context("snap_name", "test-snap-name-python")
+        self.assert_context("has_user_chosen_name", True)
+        self.assert_context("user", None)
+        self.assert_template_used("first-snap/push.html")
 
     def test_get_push_logged_in(self):
         user_expected = {

--- a/webapp/first_snap/content/c/build.yaml
+++ b/webapp/first_snap/content/c/build.yaml
@@ -1,3 +1,4 @@
+name: test-dosbox-{name}
 linux:
   auto:
     - action: Return to the root directory of the project containing your snapcraft.yaml and run snapcraft
@@ -9,9 +10,9 @@ linux:
     - action: List your installed snaps to confirm
       command: snap list
     - action: Run the snap
-      command: test-dosbox-{name} -h
+      command: ${name} -h
     - warning: |
-        Make sure the name matches what has been used previously (i.e <code>test-dosbox-{name}</code>)
+        Make sure the name matches what has been used previously (i.e <code>${name}</code>)
   manual:
     - action: Return to the root directory of the project containing your snapcraft.yaml and run the snapcraft Docker image
       command: docker run -v $PWD:$PWD -w $PWD snapcore/snapcraft snapcraft
@@ -22,9 +23,9 @@ linux:
     - action: List your installed snaps to confirm
       command: snap list
     - action: Run the snap
-      command: test-dosbox-{name} -h
+      command: ${name} -h
     - warning: |
-        Make sure the name matches what has been used previously (i.e <code>test-dosbox-{name}</code>)
+        Make sure the name matches what has been used previously (i.e <code>${name}</code>)
 macos:
   auto:
     - action: Return to the root directory of the project containing your snapcraft.yaml and run snapcraft

--- a/webapp/first_snap/content/c/package.yaml
+++ b/webapp/first_snap/content/c/package.yaml
@@ -1,16 +1,16 @@
 name: test-dosbox-{name}
 download: git clone https://github.com/snapcraft-docs/dosbox
 createDir: |
-  cd dosbox 
+  cd dosbox
   $EDITOR snapcraft.yaml
 metadata: |
   name: DOSBox is an x86 emulator
   version: 0.74-svn
-  summary: 
+  summary:
   description: |
     DOSBox is an x86 emulator with Tandy/Hercules/
-    CGA/EGA/VGA/SVGA graphics sound and DOS. It's 
-    been designed to run old DOS games under 
+    CGA/EGA/VGA/SVGA graphics sound and DOS. It's
+    been designed to run old DOS games under
     platforms that don't support it.
 explain:
   metadata:
@@ -18,7 +18,7 @@ explain:
     - code: |
         name: dosbox
     - warning: |
-        <span class="p-notification__status">Snap names are globally unique.</span> You should change any instance of <code>dosbox</code> to <code>test-dosbox-{name}</code> (where <code>{name}</code> is your name) before continuing to avoid conflicting with the official DOSBox snap.
+        <span class="p-notification__status">Snap names are globally unique.</span> You should change any instance of <code>dosbox</code> to <code>${name}</code> before continuing to avoid conflicting with the official DOSBox snap.
     - text: |
         Versions carry no semantic meaning in snaps. Use text that best identifies that release, it won't be used to compare against the preceding or following one.
     - code: |
@@ -116,9 +116,9 @@ explain:
     - text: Apps are the commands you want to expose to users and any background services your application provides.
     - code: |
         apps:
-          test-dosbox-{name}:
+          dosbox:
             command: bin/dosbox
     - warning: |
-        <span class="p-notification__status"></span>As before, remember to change this instance of <code>dosbox</code> to <code>test-dosbox-{name}</code> (where <code>{name}</code> is your name) before continuing to avoid conflicting with the official DOSBox snap.
+        <span class="p-notification__status"></span>As before, remember to change this instance of <code>dosbox</code> to <code>${name}</code> before continuing to avoid conflicting with the official DOSBox snap.
     - text: The <code>command</code> specifies the path to the binary to be run. This is resolved relative to the root of your snap contents and automatically searches in the usr/sbin, usr/bin, sbin, and bin subdirectories of your snap.
     - text: If your command name matches the snap name, users will be able run the command directly.

--- a/webapp/first_snap/content/c/test.yaml
+++ b/webapp/first_snap/content/c/test.yaml
@@ -1,3 +1,4 @@
+name: test-dosbox-{name}
 macos:
   - action: Create a Linux virtual machine for testing snaps
     command: multipass launch -n testvm
@@ -10,7 +11,7 @@ macos:
   - action: Confirm the snap is installed by listing your installed snaps
     command: snap list
   - action: Run the snap inside the virtual machine
-    warning: You should change <code>dosbox</code> to <code>test-dosbox-{name}</code> (where <code>{name}</code> is your name), as written into the snapcraft.yaml file earlier.
+    warning: You should change <code>dosbox</code> to <code>${name}</code>, as written into the snapcraft.yaml file earlier.
     command: dosbox -h
   - action: Exit the virtual machine
     command: exit

--- a/webapp/first_snap/content/golang/build.yaml
+++ b/webapp/first_snap/content/golang/build.yaml
@@ -1,3 +1,4 @@
+name: test-httplab-{name}
 linux:
   auto:
     - action: Return to the root directory of the project containing your snapcraft.yaml and run snapcraft
@@ -9,9 +10,9 @@ linux:
     - action: List your installed snaps to confirm
       command: snap list
     - action: Run the snap
-      command: test-httplab-{name} -h
+      command: ${name} -h
     - warning: |
-        Make sure the name matches what has been used previously (i.e <code>test-httplab-{name}</code>)
+        Make sure the name matches what has been used previously (i.e <code>${name}</code>)
   manual:
     - action: Return to the root directory of the project containing your snapcraft.yaml and run the snapcraft Docker image
       command: docker run -v $PWD:$PWD -w $PWD snapcore/snapcraft snapcraft
@@ -22,9 +23,9 @@ linux:
     - action: List your installed snaps to confirm
       command: snap list
     - action: Run the snap
-      command: test-httplab-{name} -h
+      command: ${name} -h
     - warning: |
-        Make sure the name matches what has been used previously (i.e <code>test-httplab-{name}</code>)
+        Make sure the name matches what has been used previously (i.e <code>${name}</code>)
 macos:
   auto:
     - action: Return to the root directory of the project containing your snapcraft.yaml and run snapcraft

--- a/webapp/first_snap/content/golang/package.yaml
+++ b/webapp/first_snap/content/golang/package.yaml
@@ -15,7 +15,7 @@ explain:
     - code: |
         name: httplab
     - warning: |
-        <span class="p-notification__status">Snap names are globally unique.</span> You should change any instance of <code>httplab</code> to <code>test-httplab-{name}</code> (where <code>{name}</code> is your name) before continuing to avoid conflicting with the official httplab snap.
+        <span class="p-notification__status">Snap names are globally unique.</span> You should change any instance of <code>httplab</code> to <code>${name}</code> before continuing to avoid conflicting with the official httplab snap.
     - text: By specifying git for the version, the current git tag or commit will be used as the version string. Versions carry no semantic meaning in snaps.
     - code: |
         version: git
@@ -56,9 +56,9 @@ explain:
     - text: Apps are the commands you want to expose to users and any background services your application provides.
     - code: |
         apps:
-          test-httplab-{name}:
+          httplab:
             command: bin/httplab
     - warning: |
-        <span class="p-notification__status"></span>As before, remember to change this instance of <code>httplab</code> to <code>test-httplab-{name}</code> (where <code>{name}</code> is your name) before continuing to avoid conflicting with the official httplab snap.
+        <span class="p-notification__status"></span>As before, remember to change this instance of <code>httplab</code> to <code>${name}</code> before continuing to avoid conflicting with the official httplab snap.
     - text: The <code>command</code> specifies the path to the binary to be run. This is resolved relative to the root of your snap contents and automatically searches in the usr/sbin, usr/bin, sbin, and bin subdirectories of your snap.
     - text: If your command name matches the snap name, users will be able run the command directly.

--- a/webapp/first_snap/content/golang/test.yaml
+++ b/webapp/first_snap/content/golang/test.yaml
@@ -1,3 +1,4 @@
+name: test-httplab-{name}
 macos:
   - action: Create a Linux virtual machine for testing snaps
     command: multipass launch -n testvm
@@ -10,7 +11,7 @@ macos:
   - action: Confirm the snap is installed by listing your installed snaps
     command: snap list
   - action: Run the snap inside the virtual machine
-    warning: You should change <code>httplab</code> to <code>test-httplab-{name}</code> (where <code>{name}</code> is your name), as written into the snapcraft.yaml file earlier.
+    warning: You should change <code>httplab</code> to <code>${name}</code>, as written into the snapcraft.yaml file earlier.
     command: httplab
   - action: Exit the virtual machine
     command: exit

--- a/webapp/first_snap/content/java/build.yaml
+++ b/webapp/first_snap/content/java/build.yaml
@@ -1,3 +1,4 @@
+name: test-freeplane-{name}
 linux:
   auto:
     - action: Return to the root directory of the project containing your snapcraft.yaml and run snapcraft
@@ -9,9 +10,9 @@ linux:
     - action: List your installed snaps to confirm
       command: snap list
     - action: Run the snap
-      command: test-freeplane-{name} -h
+      command: ${name} -h
     - warning: |
-        Make sure the name matches what has been used previously (i.e <code>test-freeplane-{name}</code>)
+        Make sure the name matches what has been used previously (i.e <code>${name}</code>)
   manual:
     - action: Return to the root directory of the project containing your snapcraft.yaml and run the snapcraft Docker image
       command: docker run -v $PWD:$PWD -w $PWD snapcore/snapcraft snapcraft
@@ -22,9 +23,9 @@ linux:
     - action: List your installed snaps to confirm
       command: snap list
     - action: Run the snap
-      command: test-freeplane-{name} -h
+      command: ${name} -h
     - warning: |
-        Make sure the name matches what has been used previously (i.e <code>test-freeplane-{name}</code>)
+        Make sure the name matches what has been used previously (i.e <code>${name}</code>)
 macos:
   auto:
     - action: Return to the root directory of the project containing your snapcraft.yaml and run snapcraft

--- a/webapp/first_snap/content/java/package.yaml
+++ b/webapp/first_snap/content/java/package.yaml
@@ -1,4 +1,4 @@
-name: freeplane-{name}
+name: test-freeplane-{name}
 download: git clone https://github.com/snapcraft-docs/freeplane
 createDir: |
   cd freeplane
@@ -6,13 +6,13 @@ createDir: |
 metadata: |
   name: freeplane
   version: '1.6.10'
-  summary: Application for Mind Mapping, Knowledge and Project 
+  summary: Application for Mind Mapping, Knowledge and Project
   Management
   description: |
-    Freeplane is a free and open source software application that 
-    supports thinking, sharing information and getting things done 
-    at work, in school and at home. The core of the software is tools 
-    for mind mapping (also known as concept mapping or information 
+    Freeplane is a free and open source software application that
+    supports thinking, sharing information and getting things done
+    at work, in school and at home. The core of the software is tools
+    for mind mapping (also known as concept mapping or information
     mapping) and using mapped information.
 explain:
   metadata:
@@ -20,11 +20,11 @@ explain:
     - code: |
         name: freeplane
     - warning: |
-        <span class="p-notification__status">Snap names are globally unique.</span> You should change any instance of <code>freeplane</code> to <code>freeplane-{name}</code> (where <code>{name}</code> is your name) before continuing to avoid conflicting with the official freeplane snap.
+        <span class="p-notification__status">Snap names are globally unique.</span> You should change any instance of <code>freeplane</code> to <code>${name}</code> before continuing to avoid conflicting with the official freeplane snap.
     - text: |
         Versions carry no semantic meaning in snaps. Use text that best identifies that release, it won't be used to compare against the preceding or following one.
     - code: |
-        version: '1.6.10' 
+        version: '1.6.10'
     - text: The summary can not exceed 79 characters. You can use a pipe ‘|’ in the description key to declare a multi-line description.
     - code: |
         description: |
@@ -37,7 +37,7 @@ explain:
     - text: Once an app is working well in devmode, you can review confinement violations, add appropriate interfaces, and switch to strict confinement.
   parts:
     - text: |
-        Parts define how to build your app. Parts can be anything: programs, libraries, or other assets needed to create and run your application. Parts can point to local directories, remote git repositories, or tarballs. 
+        Parts define how to build your app. Parts can be anything: programs, libraries, or other assets needed to create and run your application. Parts can point to local directories, remote git repositories, or tarballs.
     - code: |
         parts:
           freeplane:
@@ -56,7 +56,7 @@ explain:
         The gradle plugin can build the application using standard parameters. However, in this case, we have overridden some gradle parameters (to disable testing, and prevent a new git tag being created), and set an appropriate JAVA_HOME in a build: script snippet.
     - text: |
         In the install: script snippet we’re unpacking the built application into a directory which later gets incorporated into the final snap, defined by the $SNAPCRAFT_PART_INSTALL variable.
-    - text: |    
+    - text: |
         The build requires an appropriate JDK/JRE and the install step requires the addition of the unzip command, so these are specified as build-packages.
   apps:
     - text: |
@@ -66,5 +66,5 @@ explain:
             freeplane:
                 command: desktop-launch $SNAP/freeplane-1.6.10/freeplane.sh
     - warning: |
-        <span class="p-notification__status"></span>As before, remember to change this instance of <code>freeplane</code> to <code>freeplane-{name}</code> (where <code>{name}</code> is your name) before continuing to avoid conflicting with the official freeplane snap.
+        <span class="p-notification__status"></span>As before, remember to change this instance of <code>freeplane</code> to <code>${name}</code> before continuing to avoid conflicting with the official freeplane snap.
     - text: The <code>command</code> specifies the path to the binary to be run. This is resolved relative to the root of your snap contents and automatically searches in the usr/sbin, usr/bin, sbin, and bin subdirectories of your snap.

--- a/webapp/first_snap/content/java/test.yaml
+++ b/webapp/first_snap/content/java/test.yaml
@@ -1,3 +1,4 @@
+name: test-freeplane-{name}
 macos:
   - action: Create a Linux virtual machine for testing snaps
     command: multipass launch -n testvm
@@ -10,7 +11,7 @@ macos:
   - action: Confirm the snap is installed by listing your installed snaps
     command: snap list
   - action: Run the snap inside the virtual machine
-    warning: You should change <code>freeplane</code> to <code>test-freeplane-{name}</code> (where <code>{name}</code> is your name), as written into the snapcraft.yaml file earlier.
+    warning: You should change <code>freeplane</code> to <code>${name}</code>, as written into the snapcraft.yaml file earlier.
     command: freeplane -h
   - action: Exit the virtual machine
     command: exit

--- a/webapp/first_snap/content/node/build.yaml
+++ b/webapp/first_snap/content/node/build.yaml
@@ -1,3 +1,4 @@
+name: test-wethr-{name}
 linux:
   auto:
     - action: Return to the root directory of the project containing your snapcraft.yaml and run snapcraft
@@ -9,9 +10,9 @@ linux:
     - action: List your installed snaps to confirm
       command: snap list
     - action: Run the snap
-      command: test-wethr-{name} -h
+      command: ${name} -h
     - warning: |
-        Make sure the name matches what has been used previously (i.e <code>test-wethr-{name}</code>)
+        Make sure the name matches what has been used previously (i.e <code>${name}</code>)
   manual:
     - action: Return to the root directory of the project containing your snapcraft.yaml and run the snapcraft Docker image
       command: docker run -v $PWD:$PWD -w $PWD snapcore/snapcraft snapcraft
@@ -22,9 +23,9 @@ linux:
     - action: List your installed snaps to confirm
       command: snap list
     - action: Run the snap
-      command: test-wethr-{name} -h
+      command: ${name} -h
     - warning: |
-        Make sure the name matches what has been used previously (i.e <code>test-wethr-{name}</code>)
+        Make sure the name matches what has been used previously (i.e <code>${name}</code>)
 macos:
   auto:
     - action: Return to the root directory of the project containing your snapcraft.yaml and run snapcraft

--- a/webapp/first_snap/content/node/package.yaml
+++ b/webapp/first_snap/content/node/package.yaml
@@ -20,7 +20,7 @@ explain:
     - code: |
         name: wethr
     - warning: |
-        <span class="p-notification__status">Snap names are globally unique.</span> You should change any instance of <code>wethr</code> to <code>test-wethr-{name}</code> (where <code>{name}</code> is your name) before continuing to avoid conflicting with the official wethr snap.
+        <span class="p-notification__status">Snap names are globally unique.</span> You should change any instance of <code>wethr</code> to <code>${name}</code> before continuing to avoid conflicting with the official wethr snap.
     - text: By specifying git for the version, the current git tag or commit will be used as the version string. Versions carry no semantic meaning in snaps.
     - code: |
         version: git
@@ -53,9 +53,9 @@ explain:
     - text: Apps are the commands you want to expose to users and any background services your application provides.
     - code: |
         apps:
-          test-wethr-{name}:
+          wethr:
             command: bin/wethr
     - warning: |
-        <span class="p-notification__status"></span>As before, remember to change this instance of <code>wethr</code> to <code>test-wethr-{name}</code> (where <code>{name}</code> is your name) before continuing to avoid conflicting with the official wethr snap.
+        <span class="p-notification__status"></span>As before, remember to change this instance of <code>wethr</code> to <code>${name}</code> before continuing to avoid conflicting with the official wethr snap.
     - text: The <code>command</code> specifies the path to the binary to be run. This is resolved relative to the root of your snap contents and automatically searches in the usr/sbin, usr/bin, sbin, and bin subdirectories of your snap.
     - text: If your command name matches the snap name, users will be able run the command directly.

--- a/webapp/first_snap/content/node/test.yaml
+++ b/webapp/first_snap/content/node/test.yaml
@@ -1,3 +1,4 @@
+name: test-wethr-{name}
 macos:
   - action: Create a Linux virtual machine for testing snaps
     command: multipass launch -n testvm
@@ -10,7 +11,7 @@ macos:
   - action: Confirm the snap is installed by listing your installed snaps
     command: snap list
   - action: Run the snap inside the virtual machine
-    warning: You should change <code>wethr</code> to <code>test-wethr-{name}</code> (where <code>{name}</code> is your name), as written into the snapcraft.yaml file earlier.
+    warning: You should change <code>wethr</code> to <code>${name}</code>, as written into the snapcraft.yaml file earlier.
     command: wethr -h
   - action: Exit the virtual machine
     command: exit

--- a/webapp/first_snap/content/pre-built/build.yaml
+++ b/webapp/first_snap/content/pre-built/build.yaml
@@ -1,3 +1,4 @@
+name: test-geekbench4-{name}
 linux:
   auto:
     - action: Return to the root directory of the project containing your snapcraft.yaml and run snapcraft
@@ -9,9 +10,9 @@ linux:
     - action: List your installed snaps to confirm
       command: snap list
     - action: Run the snap
-      command: test-geekbench4-{name} -h
+      command: ${name} -h
     - warning: |
-        Make sure the name matches what has been used previously (i.e <code>test-geekbench4-{name}</code>)
+        Make sure the name matches what has been used previously (i.e <code>${name}</code>)
   manual:
     - action: Return to the root directory of the project containing your snapcraft.yaml and run the snapcraft Docker image
       command: docker run -v $PWD:$PWD -w $PWD snapcore/snapcraft snapcraft
@@ -22,9 +23,9 @@ linux:
     - action: List your installed snaps to confirm
       command: snap list
     - action: Run the snap
-      command: test-geekbench4-{name} -h
+      command: ${name} -h
     - warning: |
-        Make sure the name matches what has been used previously (i.e <code>test-geekbench4-{name}</code>)
+        Make sure the name matches what has been used previously (i.e <code>${name}</code>)
 macos:
   auto:
     - action: Return to the root directory of the project containing your snapcraft.yaml and run snapcraft

--- a/webapp/first_snap/content/pre-built/package.yaml
+++ b/webapp/first_snap/content/pre-built/package.yaml
@@ -19,7 +19,7 @@ explain:
     - code: |
         name: geekbench4
     - warning: |
-        <span class="p-notification__status">Snap names are globally unique.</span> You should change any instance of <code>geekbench4</code> to <code>test-geekbench4-{name}</code> (where <code>{name}</code> is your name) before continuing to avoid conflicting with the official geekbench4 snap.
+        <span class="p-notification__status">Snap names are globally unique.</span> You should change any instance of <code>geekbench4</code> to <code>${name}</code> before continuing to avoid conflicting with the official geekbench4 snap.
     - text: Versions carry no semantic meaning in snaps. You can move end user installs from 4.1.0 to 4.2.0, and back to 4.1.0 in the event of a premature release.
     - code: |
         version: 4.2.0
@@ -53,9 +53,9 @@ explain:
     - text: Apps are the commands you want to expose to users and any background services your application provides.
     - code: |
         apps:
-          test-geekbench4-{name}:
+          geekbench4:
             command: geekbench4
     - warning: |
-        <span class="p-notification__status"></span>As before, remember to change this instance of <code>geekbench4</code> to <code>test-geekbench4-{name}</code> (where <code>{name}</code> is your name) before continuing to avoid conflicting with the official geekbench4 snap.
+        <span class="p-notification__status"></span>As before, remember to change this instance of <code>geekbench4</code> to <code>${name}</code> before continuing to avoid conflicting with the official geekbench4 snap.
     - text: The <code>command</code> specifies the path to the binary to be run. This is resolved relative to the root of your snap contents and automatically searches in the usr/sbin, usr/bin, sbin, and bin subdirectories of your snap.
     - text: If your command name matches the snap name, users will be able run the command directly.

--- a/webapp/first_snap/content/pre-built/test.yaml
+++ b/webapp/first_snap/content/pre-built/test.yaml
@@ -1,3 +1,4 @@
+name: test-geekbench4-{name}
 macos:
   - action: Create a Linux virtual machine for testing snaps
     command: multipass launch -n testvm
@@ -10,4 +11,4 @@ macos:
   - action: Confirm the snap is installed by listing your installed snaps
     command: snap list
   - action: Run the snap inside the virtual machine
-    command: test-geekbench4-{name}
+    command: ${name}

--- a/webapp/first_snap/content/python/build.yaml
+++ b/webapp/first_snap/content/python/build.yaml
@@ -1,3 +1,4 @@
+name: test-offlineimap-{name}
 linux:
   auto:
     - action: Return to the root directory of the project containing your snapcraft.yaml and run snapcraft
@@ -9,9 +10,9 @@ linux:
     - action: List your installed snaps to confirm
       command: snap list
     - action: Run the snap
-      command: test-offlineimap-{name} -h
+      command: ${name} -h
     - warning: |
-        Make sure the name matches what has been used previously (i.e <code>test-offlineimap-{name}</code>)
+        Make sure the name matches what has been used previously (i.e <code>${name}</code>)
   manual:
     - action: Return to the root directory of the project containing your snapcraft.yaml and run the snapcraft Docker image
       command: docker run -v $PWD:$PWD -w $PWD snapcore/snapcraft snapcraft
@@ -22,9 +23,9 @@ linux:
     - action: List your installed snaps to confirm
       command: snap list
     - action: Run the snap
-      command: test-offlineimap-{name} -h
+      command: ${name} -h
     - warning: |
-        Make sure the name matches what has been used previously (i.e <code>test-offlineimap-{name}</code>)
+        Make sure the name matches what has been used previously (i.e <code>${name}</code>)
 macos:
   auto:
     - action: Return to the root directory of the project containing your snapcraft.yaml and run snapcraft

--- a/webapp/first_snap/content/python/package.yaml
+++ b/webapp/first_snap/content/python/package.yaml
@@ -17,7 +17,7 @@ explain:
     - code: |
         name: offlineimap
     - warning: |
-        <span class="p-notification__status">Snap names are globally unique.</span> You should change any instance of <code>offlineimap</code> to <code>test-offlineimap-{name}</code> (where <code>{name}</code> is your name) before continuing to avoid conflicting with the official offlineimap snap.
+        <span class="p-notification__status">Snap names are globally unique.</span> You should change any instance of <code>offlineimap</code> to <code>${name}</code> before continuing to avoid conflicting with the official offlineimap snap.
     - text: By specifying git for the version, the current git tag or commit will be used as the version string. Versions carry no semantic meaning in snaps.
     - code: |
         version: git
@@ -56,9 +56,9 @@ explain:
     - text: Apps are the commands you want to expose to users and any background services your application provides.
     - code: |
         apps:
-          test-offlineimap-{name}:
+          offlineimap:
             command: bin/offlineimap
     - warning: |
-        <span class="p-notification__status"></span>As before, remember to change this instance of <code>offlineimap</code> to <code>test-offlineimap-{name}</code> (where <code>{name}</code> is your name) before continuing to avoid conflicting with the official offlineimap snap.
+        <span class="p-notification__status"></span>As before, remember to change this instance of <code>offlineimap</code> to <code>${name}</code> before continuing to avoid conflicting with the official offlineimap snap.
     - text: The <code>command</code> specifies the path to the binary to be run. This is resolved relative to the root of your snap contents and automatically searches in the usr/sbin, usr/bin, sbin, and bin subdirectories of your snap.
     - text: If your command name matches the snap name, users will be able run the command directly.

--- a/webapp/first_snap/content/python/test.yaml
+++ b/webapp/first_snap/content/python/test.yaml
@@ -1,3 +1,4 @@
+name: test-offlineimap-{name}
 macos:
   - action: Create a Linux virtual machine for testing snaps
     command: multipass launch -n testvm
@@ -10,7 +11,7 @@ macos:
   - action: Confirm the snap is installed by listing your installed snaps
     command: snap list
   - action: Run the snap inside the virtual machine
-    warning: You should change <code>offlineimap</code> to <code>test-offlineimap-{name}</code> (where <code>{name}</code> is your name), as written into the snapcraft.yaml file earlier.
-    command: offlineimap -h
+    warning: Make sure the name matches what has been used previously (i.e <code>${name}</code>).
+    command: ${name} -h
   - action: Exit the virtual machine
     command: exit

--- a/webapp/first_snap/content/ros/build.yaml
+++ b/webapp/first_snap/content/ros/build.yaml
@@ -1,3 +1,4 @@
+name: test-ros-talker-listener-{name}
 linux:
   auto:
     - action: Return to the root directory of the project containing your snapcraft.yaml and run snapcraft
@@ -9,9 +10,9 @@ linux:
     - action: List your installed snaps to confirm
       command: snap list
     - action: Run the snap
-      command: test-ros-talker-listener-{name} -h
+      command: ${name} -h
     - warning: |
-        Make sure the name matches what has been used previously (i.e <code>test-ros-talker-listener-{name}</code>)
+        Make sure the name matches what has been used previously (i.e <code>${name}</code>)
   manual:
     - action: Return to the root directory of the project containing your snapcraft.yaml and run the snapcraft Docker image
       command: docker run -v $PWD:$PWD -w $PWD snapcore/snapcraft snapcraft
@@ -22,9 +23,9 @@ linux:
     - action: List your installed snaps to confirm
       command: snap list
     - action: Run the snap
-      command: test-ros-talker-listener-{name} -h
+      command: ${name} -h
     - warning: |
-        Make sure the name matches what has been used previously (i.e <code>test-ros-talker-listener-{name}</code>)
+        Make sure the name matches what has been used previously (i.e <code>${name}</code>)
 macos:
   auto:
     - action: Return to the root directory of the project containing your snapcraft.yaml and run snapcraft

--- a/webapp/first_snap/content/ros/package.yaml
+++ b/webapp/first_snap/content/ros/package.yaml
@@ -15,7 +15,7 @@ explain:
     - code: |
         name: ros-talker-listener
     - warning: |
-        <span class="p-notification__status">Snap names are globally unique.</span> You should change any instance of <code>ros-talker-listener</code> to <code>test-ros-talker-listener-{name}</code> (where <code>{name}</code> is your name) before continuing to avoid conflicting with the official ros-talker-listener snap.
+        <span class="p-notification__status">Snap names are globally unique.</span> You should change any instance of <code>ros-talker-listener</code> to <code>${name}</code> before continuing to avoid conflicting with the official ros-talker-listener snap.
     - text: Versions carry no semantic meaning in snaps. Use text that best identifies that release, it won't be used to compare against the preceding or following one.
     - code: |
         version: '0.1'
@@ -54,6 +54,6 @@ explain:
           ros-talker-listener:
             command: roslaunch roscpp_tutorials talker_listener.launch
     - warning: |
-        <span class="p-notification__status">Snap names are globally unique.</span> As before, remember to change this instance of ros-talker-listener to test-ros-talker-listener-{name} (where {name} is your name).
+        <span class="p-notification__status">Snap names are globally unique.</span> As before, remember to change this instance of ros-talker-listener to <code>${name}</code>.
     - text: The <code>command</code> specifies the path to the binary to be run. This is resolved relative to the root of your snap contents and automatically searches in the usr/sbin, usr/bin, sbin, and bin subdirectories of your snap.
     - text: If your command name matches the snap name, users will be able run the command directly.

--- a/webapp/first_snap/content/ros/test.yaml
+++ b/webapp/first_snap/content/ros/test.yaml
@@ -1,3 +1,4 @@
+name: test-ros-talker-listener-{name}
 macos:
   - action: Create a Linux virtual machine for testing snaps
     command: multipass launch -n testvm
@@ -10,7 +11,7 @@ macos:
   - action: Confirm the snap is installed by listing your installed snaps
     command: snap list
   - action: Run the snap inside the virtual machine
-    warning: You should change <code>ros-talker-listener</code> to <code>test-ros-talker-listener-{name}</code> (where <code>{name}</code> is your name), as written into the snapcraft.yaml file earlier.
-    command: test-ros-talker-listener-{name} -h
+    warning: You should change <code>ros-talker-listener</code> to <code>${name}</code>, as written into the snapcraft.yaml file earlier.
+    command: ${name} -h
   - action: Exit the virtual machine
     command: exit

--- a/webapp/first_snap/content/ros2/build.yaml
+++ b/webapp/first_snap/content/ros2/build.yaml
@@ -1,3 +1,4 @@
+name: test-ros2-talker-listener-{name}
 linux:
   auto:
     - action: Return to the root directory of the project containing your snapcraft.yaml and run snapcraft
@@ -9,9 +10,9 @@ linux:
     - action: List your installed snaps to confirm
       command: snap list
     - action: Run the snap
-      command: test-ros2-talker-listener-{name} -h
+      command: ${name} -h
     - warning: |
-        Make sure the name matches what has been used previously (i.e <code>test-ros2-talker-listener-{name}</code>)
+        Make sure the name matches what has been used previously (i.e <code>${name}</code>)
   manual:
     - action: Return to the root directory of the project containing your snapcraft.yaml and run the snapcraft Docker image
       command: docker run -v $PWD:$PWD -w $PWD snapcore/snapcraft snapcraft
@@ -22,9 +23,9 @@ linux:
     - action: List your installed snaps to confirm
       command: snap list
     - action: Run the snap
-      command: test-ros2-talker-listener-{name} -h
+      command: ${name} -h
     - warning: |
-        Make sure the name matches what has been used previously (i.e <code>test-ros2-talker-listener-{name}</code>)
+        Make sure the name matches what has been used previously (i.e <code>${name}</code>)
 macos:
   auto:
     - action: Return to the root directory of the project containing your snapcraft.yaml and run snapcraft

--- a/webapp/first_snap/content/ros2/package.yaml
+++ b/webapp/first_snap/content/ros2/package.yaml
@@ -15,7 +15,7 @@ explain:
     - code: |
         name: ros2-talker-listener
     - warning: |
-        <span class="p-notification__status">Snap names are globally unique.</span> You should change any instance of <code>ros2-talker-listener</code> to <code>test-ros2-talker-listener-{name}</code> (where <code>{name}</code> is your name) before continuing to avoid conflicting with the official ros2-talker-listener snap.
+        <span class="p-notification__status">Snap names are globally unique.</span> You should change any instance of <code>ros2-talker-listener</code> to <code>${name}</code> before continuing to avoid conflicting with the official ros2-talker-listener snap.
     - text: Versions carry no semantic meaning in snaps. Use text that best identifies that release, it won't be used to compare against the preceding or following one.
     - code: |
         version: '0.1'
@@ -62,6 +62,6 @@ explain:
           ros2-talker-listener:
             command: opt/ros/crystal/bin/ros2 launch demo_nodes_cpp talker_listener.launch.py
     - warning: |
-        <span class="p-notification__status"></span>As before, remember to change this instance of <code>ros2-talker-listener</code> to <code>test-ros2-talker-listener-{name}</code> (where <code>{name}</code> is your name) before continuing to avoid conflicting with the official ros2-talker-listener snap.
+        <span class="p-notification__status"></span>As before, remember to change this instance of <code>ros2-talker-listener</code> to <code>${name}</code> before continuing to avoid conflicting with the official ros2-talker-listener snap.
     - text: The <code>command</code> specifies the path to the binary to be run. This is resolved relative to the root of your snap contents and automatically searches in the usr/sbin, usr/bin, sbin, and bin subdirectories of your snap.
     - text: If your command name matches the snap name, users will be able run the command directly.

--- a/webapp/first_snap/content/ros2/test.yaml
+++ b/webapp/first_snap/content/ros2/test.yaml
@@ -1,3 +1,4 @@
+name: test-ros2-talker-listener-{name}
 macos:
   - action: Create a Linux virtual machine for testing snaps
     command: multipass launch -n testvm
@@ -10,7 +11,7 @@ macos:
   - action: Confirm the snap is installed by listing your installed snaps
     command: snap list
   - action: Run the snap inside the virtual machine
-    warning: You should change <code>ros2-talker-listener</code> to <code>test-ros2-talker-listener-{name}</code> (where <code>{name}</code> is your name), as written into the snapcraft.yaml file earlier.
-    command: test-ros2-talker-listener-{name} -h
+    warning: You should change <code>ros2-talker-listener</code> to <code>${name}</code>, as written into the snapcraft.yaml file earlier.
+    command: ${name} -h
   - action: Exit the virtual machine
     command: exit

--- a/webapp/first_snap/content/ruby/build.yaml
+++ b/webapp/first_snap/content/ruby/build.yaml
@@ -1,3 +1,4 @@
+name: test-mdl-{name}
 linux:
   auto:
     - action: Return to the root directory of the project containing your snapcraft.yaml and run snapcraft
@@ -9,9 +10,9 @@ linux:
     - action: List your installed snaps to confirm
       command: snap list
     - action: Run the snap
-      command: test-mdl-{name} -h
+      command: ${name} -h
     - warning: |
-        Make sure the name matches what has been used previously (i.e <code>test-mdl-{name}</code>)
+        Make sure the name matches what has been used previously (i.e <code>${name}</code>)
   manual:
     - action: Return to the root directory of the project containing your snapcraft.yaml and run the snapcraft Docker image
       command: docker run -v $PWD:$PWD -w $PWD snapcore/snapcraft snapcraft
@@ -22,9 +23,9 @@ linux:
     - action: List your installed snaps to confirm
       command: snap list
     - action: Run the snap
-      command: test-mdl-{name} -h
+      command: ${name} -h
     - warning: |
-        Make sure the name matches what has been used previously (i.e <code>test-mdl-{name}</code>)
+        Make sure the name matches what has been used previously (i.e <code>${name}</code>)
 macos:
   auto:
     - action: Return to the root directory of the project containing your snapcraft.yaml and run snapcraft

--- a/webapp/first_snap/content/ruby/package.yaml
+++ b/webapp/first_snap/content/ruby/package.yaml
@@ -15,7 +15,7 @@ explain:
     - code: |
         name: mdl
     - warning: |
-        <span class="p-notification__status">Snap names are globally unique.</span> You should change any instance of <code>mdl</code> to <code>test-mdl-{name}</code> (where <code>{name}</code> is your name) before continuing to avoid conflicting with the official mdl snap.
+        <span class="p-notification__status">Snap names are globally unique.</span> You should change any instance of <code>mdl</code> to <code>${name}</code> before continuing to avoid conflicting with the official mdl snap.
     - text: Versions carry no semantic meaning in snaps. Use text that best identifies that release, it won't be used to compare against the preceding or following one.
     - code: |
         version: "0.5.0"
@@ -62,6 +62,6 @@ explain:
           mdl:
             command: bin/mdl
     - warning: |
-        <span class="p-notification__status"></span>As before, remember to change this instance of <code>mdl</code> to <code>test-mdl-{name}</code> (where <code>{name}</code> is your name) before continuing to avoid conflicting with the official mdl snap.
+        <span class="p-notification__status"></span>As before, remember to change this instance of <code>mdl</code> to <code>${name}</code> before continuing to avoid conflicting with the official mdl snap.
     - text: The <code>command</code> specifies the path to the binary to be run. This is resolved relative to the root of your snap contents and automatically searches in the usr/sbin, usr/bin, sbin, and bin subdirectories of your snap.
     - text: If your command name matches the snap name, users will be able run the command directly.

--- a/webapp/first_snap/content/ruby/test.yaml
+++ b/webapp/first_snap/content/ruby/test.yaml
@@ -1,3 +1,4 @@
+name: test-mdl-{name}
 macos:
   - action: Create a Linux virtual machine for testing snaps
     command: multipass launch -n testvm
@@ -10,7 +11,7 @@ macos:
   - action: Confirm the snap is installed by listing your installed snaps
     command: snap list
   - action: Run the snap inside the virtual machine
-    warning: You should change <code>mdl</code> to <code>test-mdl-{name}</code> (where <code>{name}</code> is your name), as written into the snapcraft.yaml file earlier.
-    command: mdl -h
+    warning: You should change <code>mdl</code> to <code>${name}</code>, as written into the snapcraft.yaml file earlier.
+    command: ${name} -h
   - action: Exit the virtual machine
     command: exit

--- a/webapp/first_snap/content/rust/build.yaml
+++ b/webapp/first_snap/content/rust/build.yaml
@@ -1,3 +1,4 @@
+name: test-xsv-{name}
 linux:
   auto:
     - action: Return to the root directory of the project containing your snapcraft.yaml and run snapcraft
@@ -9,9 +10,9 @@ linux:
     - action: List your installed snaps to confirm
       command: snap list
     - action: Run the snap
-      command: test-xsv-{name} -h
+      command: ${name} -h
     - warning: |
-        Make sure the name matches what has been used previously (i.e <code>test-xsv-{name}</code>)
+        Make sure the name matches what has been used previously (i.e <code>${name}</code>)
   manual:
     - action: Return to the root directory of the project containing your snapcraft.yaml and run the snapcraft Docker image
       command: docker run -v $PWD:$PWD -w $PWD snapcore/snapcraft snapcraft
@@ -22,9 +23,9 @@ linux:
     - action: List your installed snaps to confirm
       command: snap list
     - action: Run the snap
-      command: test-xsv-{name} -h
+      command: ${name} -h
     - warning: |
-        Make sure the name matches what has been used previously (i.e <code>test-xsv-{name}</code>)
+        Make sure the name matches what has been used previously (i.e <code>${name}</code>)
 macos:
   auto:
     - action: Return to the root directory of the project containing your snapcraft.yaml and run snapcraft

--- a/webapp/first_snap/content/rust/package.yaml
+++ b/webapp/first_snap/content/rust/package.yaml
@@ -8,8 +8,8 @@ metadata: |
   version: git
   summary: A fast CSV command line toolkit written in Rust
   description: |
-    xsv is a command line program for indexing, slicing, analyzing, 
-    splitting and joining CSV files. Commands should be simple, 
+    xsv is a command line program for indexing, slicing, analyzing,
+    splitting and joining CSV files. Commands should be simple,
     fast and composable:
     - Simple tasks should be easy.
     - Performance trade offs should be exposed in the CLI interface.
@@ -20,7 +20,7 @@ explain:
     - code: |
         name: xsv
     - warning: |
-        <span class="p-notification__status">Snap names are globally unique.</span> You should change any instance of <code>xsv</code> to <code>test-xsv-{name}</code> (where <code>{name}</code> is your name) before continuing to avoid conflicting with the official xsv snap.
+        <span class="p-notification__status">Snap names are globally unique.</span> You should change any instance of <code>xsv</code> to <code>${name}</code> before continuing to avoid conflicting with the official xsv snap.
     - text: By specifying git for the version, the current git tag or commit will be used as the version string. Versions carry no semantic meaning in snaps.
     - code: |
         version: git
@@ -55,6 +55,6 @@ explain:
           xsv:
             command: xsv
     - warning: |
-        <span class="p-notification__status"></span>As before, remember to change this instance of <code>xsv</code> to <code>test-xsv-{name}</code> (where <code>{name}</code> is your name) before continuing to avoid conflicting with the official xsv snap.
+        <span class="p-notification__status"></span>As before, remember to change this instance of <code>xsv</code> to <code>${name}</code> before continuing to avoid conflicting with the official xsv snap.
     - text: The <code>command</code> specifies the path to the binary to be run. This is resolved relative to the root of your snap contents and automatically searches in the usr/sbin, usr/bin, sbin, and bin subdirectories of your snap.
     - text: If your command name matches the snap name, users will be able run the command directly.

--- a/webapp/first_snap/content/rust/test.yaml
+++ b/webapp/first_snap/content/rust/test.yaml
@@ -1,3 +1,4 @@
+name: test-xsv-{name}
 macos:
   - action: Create a Linux virtual machine for testing snaps
     command: multipass launch -n testvm
@@ -10,7 +11,7 @@ macos:
   - action: Confirm the snap is installed by listing your installed snaps
     command: snap list
   - action: Run the snap inside the virtual machine
-    warning: You should change <code>xsv</code> to <code>test-xsv-{name}</code> (where <code>{name}</code> is your name), as written into the snapcraft.yaml file earlier.
-    command: xsv -h
+    warning: You should change <code>xsv</code> to <code>${name}</code>, as written into the snapcraft.yaml file earlier.
+    command: ${name} -h
   - action: Exit the virtual machine
     command: exit

--- a/webapp/first_snap/views.py
+++ b/webapp/first_snap/views.py
@@ -159,9 +159,11 @@ def get_push(language, operating_system):
         return flask.abort(404)
 
     snap_name = data["name"]
+    has_user_chosen_name = False
 
     if snap_name_cookie in flask.request.cookies:
         snap_name = flask.request.cookies.get(snap_name_cookie)
+        has_user_chosen_name = True
 
     flask_user = flask.session.get("openid", {})
 
@@ -180,6 +182,7 @@ def get_push(language, operating_system):
         "os": operating_system,
         "user": user,
         "snap_name": snap_name,
+        "has_user_chosen_name": has_user_chosen_name,
     }
 
     return flask.render_template("first-snap/push.html", **context)

--- a/webapp/first_snap/views.py
+++ b/webapp/first_snap/views.py
@@ -51,11 +51,20 @@ def get_language(language):
 def get_package(language, operating_system):
     filename = f"first_snap/content/{language}/package.yaml"
     steps = get_file(filename)
-
     if not steps:
         return flask.abort(404)
 
-    context = {"language": language, "os": operating_system, "steps": steps}
+    snap_name = steps["name"]
+
+    if "fsf_snap_name" in flask.request.cookies:
+        snap_name = flask.request.cookies.get("fsf_snap_name")
+
+    context = {
+        "language": language,
+        "os": operating_system,
+        "steps": steps,
+        "snap_name": snap_name,
+    }
 
     return flask.render_template("first-snap/package.html", **context)
 

--- a/webapp/first_snap/views.py
+++ b/webapp/first_snap/views.py
@@ -50,14 +50,15 @@ def get_language(language):
 @first_snap.route("/<language>/<operating_system>/package")
 def get_package(language, operating_system):
     filename = f"first_snap/content/{language}/package.yaml"
+    snap_name_cookie = f"fsf_snap_name_{language}"
     steps = get_file(filename)
     if not steps:
         return flask.abort(404)
 
     snap_name = steps["name"]
 
-    if "fsf_snap_name" in flask.request.cookies:
-        snap_name = flask.request.cookies.get("fsf_snap_name")
+    if snap_name_cookie in flask.request.cookies:
+        snap_name = flask.request.cookies.get(snap_name_cookie)
 
     context = {
         "language": language,
@@ -72,6 +73,7 @@ def get_package(language, operating_system):
 @first_snap.route("/<language>/<operating_system>/build")
 def get_build(language, operating_system):
     filename = f"first_snap/content/{language}/build.yaml"
+    snap_name_cookie = f"fsf_snap_name_{language}"
     steps = get_file(filename)
 
     operating_system_parts = operating_system.split("-")
@@ -92,8 +94,8 @@ def get_build(language, operating_system):
 
     snap_name = steps["name"]
 
-    if "fsf_snap_name" in flask.request.cookies:
-        snap_name = flask.request.cookies.get("fsf_snap_name")
+    if snap_name_cookie in flask.request.cookies:
+        snap_name = flask.request.cookies.get(snap_name_cookie)
 
     context = {
         "language": language,
@@ -108,6 +110,7 @@ def get_build(language, operating_system):
 @first_snap.route("/<language>/<operating_system>/test")
 def get_test(language, operating_system):
     filename = f"first_snap/content/{language}/test.yaml"
+    snap_name_cookie = f"fsf_snap_name_{language}"
     steps = get_file(filename)
 
     operating_system_only = operating_system.split("-")[0]
@@ -117,8 +120,8 @@ def get_test(language, operating_system):
 
     snap_name = steps["name"]
 
-    if "fsf_snap_name" in flask.request.cookies:
-        snap_name = flask.request.cookies.get("fsf_snap_name")
+    if snap_name_cookie in flask.request.cookies:
+        snap_name = flask.request.cookies.get(snap_name_cookie)
 
     converted_steps = []
 
@@ -145,6 +148,8 @@ def get_test(language, operating_system):
 @first_snap.route("/<language>/<operating_system>/push")
 def get_push(language, operating_system):
     filename = f"first_snap/content/{language}/package.yaml"
+    snap_name_cookie = f"fsf_snap_name_{language}"
+
     data = get_file(filename)
 
     if not data:
@@ -152,8 +157,8 @@ def get_push(language, operating_system):
 
     snap_name = data["name"]
 
-    if "fsf_snap_name" in flask.request.cookies:
-        snap_name = flask.request.cookies.get("fsf_snap_name")
+    if snap_name_cookie in flask.request.cookies:
+        snap_name = flask.request.cookies.get(snap_name_cookie)
 
     flask_user = flask.session.get("openid", {})
 

--- a/webapp/first_snap/views.py
+++ b/webapp/first_snap/views.py
@@ -90,10 +90,16 @@ def get_build(language, operating_system):
     ):
         return flask.abort(404)
 
+    snap_name = steps["name"]
+
+    if "fsf_snap_name" in flask.request.cookies:
+        snap_name = flask.request.cookies.get("fsf_snap_name")
+
     context = {
         "language": language,
         "os": operating_system,
         "steps": steps[operating_system_only][install_type],
+        "snap_name": snap_name,
     }
 
     return flask.render_template("first-snap/build.html", **context)
@@ -108,6 +114,11 @@ def get_test(language, operating_system):
 
     if not steps or operating_system_only not in steps:
         return flask.abort(404)
+
+    snap_name = steps["name"]
+
+    if "fsf_snap_name" in flask.request.cookies:
+        snap_name = flask.request.cookies.get("fsf_snap_name")
 
     converted_steps = []
 
@@ -125,6 +136,7 @@ def get_test(language, operating_system):
         "language": language,
         "os": operating_system,
         "steps": converted_steps,
+        "snap_name": snap_name,
     }
 
     return flask.render_template("first-snap/test.html", **context)
@@ -137,6 +149,11 @@ def get_push(language, operating_system):
 
     if not data:
         return flask.abort(404)
+
+    snap_name = data["name"]
+
+    if "fsf_snap_name" in flask.request.cookies:
+        snap_name = flask.request.cookies.get("fsf_snap_name")
 
     flask_user = flask.session.get("openid", {})
 
@@ -154,7 +171,7 @@ def get_push(language, operating_system):
         "language": language,
         "os": operating_system,
         "user": user,
-        "snap_name": data["name"],
+        "snap_name": snap_name,
     }
 
     return flask.render_template("first-snap/push.html", **context)

--- a/webapp/first_snap/views.py
+++ b/webapp/first_snap/views.py
@@ -56,15 +56,18 @@ def get_package(language, operating_system):
         return flask.abort(404)
 
     snap_name = steps["name"]
+    has_user_chosen_name = False
 
     if snap_name_cookie in flask.request.cookies:
         snap_name = flask.request.cookies.get(snap_name_cookie)
+        has_user_chosen_name = True
 
     context = {
         "language": language,
         "os": operating_system,
         "steps": steps,
         "snap_name": snap_name,
+        "has_user_chosen_name": has_user_chosen_name,
     }
 
     return flask.render_template("first-snap/package.html", **context)


### PR DESCRIPTION
Fixes #1786

Adds a form to choose snap name at the beginning of the package step of first snap flow

### QA

- ./run or demo
- go to first snap flow
- in the beginning of the Package snap there should be a 'Choose a snap name' form
- choose a snap name, try using invalid name to see if validation works
- 'Choose' button should be disabled until valid name is used
- Click 'Choose snap name' button, page should reload, first step should be marked done, second step should be open
- Make sure that name chosen by user is used in next steps (in some warning notifications and commands)
- Chosen snap name should be used in the register name form on the last step of first snap flow
- Go back and choose different language for first snap flow
- Snap name chosen in different language should not be used

#### Check different language/OS configurations to see all is fine

<img width="1023" alt="Screenshot 2019-04-24 at 14 51 22" src="https://user-images.githubusercontent.com/83575/56661286-b8572f00-66a1-11e9-95b9-3910aa53cf7c.png">
