### PR TITLE
MOOS FSF changes after old pr closed and Kyle approved moosdb example

### DIFF
--- a/templates/home/_fsf_moos.html
+++ b/templates/home/_fsf_moos.html
@@ -2,15 +2,46 @@
   <div class='col-6'>
     <h4>Why are snaps good for MOOS projects?</h4>
     <ul>
-      <li>Snaps are easy to discover and install. Millions of users can browse and install snaps graphically in the Snap Store or from the command-line.</li>
-      <li>Snaps install and run the same across Linux. They bundle the exact version of MOOS/MOOS-IvP required and your app’s library dependencies.</li>
-      <li>Snaps automatically update to the latest version. Four times a day, users’ systems will check for new versions and upgrade in the background.</li>
-      <li>Upgrades are not disruptive. Because upgrades are not in-place, users can keep your app open as it’s upgraded in the background.</li>
-      <li>Upgrades are safe. If your app fails to upgrade, users automatically roll back to the previous revision.</li>
+      <li>Bundle all the runtime requirements, including the exact version of MOOS/MOOS-IvP and system libraries you need.</li>
+      <li>Expand the distributions supported beyond just Ubuntu.</li>
+      <li>Directly and reliably control the delivery of application updates using existing infrastructure.</li>
+	  <li>Upgrades are safe. If your app fails to upgrade, users automatically roll back to the previous revision.</li>
+      <li>Extremely simple creation of daemons.</li>
     </ul>
-    <div class="p-flow-details__continue">
-      <p>In just a few steps, you’ll have an example MOOS app in the Snap Store.</p>
-      <a class="p-button--positive" href="https://docs.snapcraft.io/build-snaps/moos">Continue</a>
-    </div>
+  </div>
+
+  <div class='col-6'>
+    <h4>Here's an example snapcraft.yaml that uses MOOS:</h4>
+    <code class="p-code-yaml"><pre>
+<b>name</b>: moos-ping
+<b>version</b>: '0.1'
+<b>summary</b>: MOOS Ping Example
+<b>description</b>: |
+  The main communication mechanism for all 
+  MOOS apps.
+
+<b>confinement</b>: devmode
+<b>base</b>: core18
+
+<b>parts</b>:
+  <b>moos</b>:
+    <b>source</b>: https://github.com/themoos/core-moos/archive/10.0.2.a-release.tar.gz
+    <b>build-packages</b>:
+      - gcc
+      - g++
+      - make
+    <b>plugin</b>: cmake
+    <b>configflags</b>:
+      - -DCMAKE_INSTALL_PREFIX=/
+
+<b>apps</b>:
+  <b>MOOSDB</b>:
+    <b>command</b>: MOOSDB
+</pre></code>
+  </div>
+
+  <div class="p-flow-details__continue">
+    In just a few steps, you’ll have an example MOOS app in the Snap Store.
+    <a class="p-button--positive is-inline" href="/first-snap/moos">Continue</a>
   </div>
 </div>

--- a/templates/partials/fsf_language.html
+++ b/templates/partials/fsf_language.html
@@ -54,7 +54,7 @@
       </header>
       <span>Rust</span>
     </a>
-    <a class="p-logo-link p-fluid-grid__item--small p-card p-flow-link" href="https://docs.snapcraft.io/build-snaps/moos" data-flow-link="moos">
+    <a class="p-logo-link p-fluid-grid__item--small p-card p-flow-link" href="/first-snap/moos" data-flow-link="moos">
       <header class="p-card__header">
         <img src="https://assets.ubuntu.com/v1/4c371ff8-logo-moos.svg" alt="">
       </header>

--- a/webapp/first_snap/content/moos/build.yaml
+++ b/webapp/first_snap/content/moos/build.yaml
@@ -1,0 +1,54 @@
+linux:
+  auto:
+    - action: Return to the root directory of the project containing your snapcraft.yaml and run snapcraft
+      command: snapcraft
+    - action: You will find a .snap file in the same directory that you ran the snapcraft command. You can inspect the contents to ensure it contains all of the application's assets
+      command: unsquashfs -l *.snap
+    - action: Install the snap
+      command: sudo snap install --devmode --dangerous *.snap
+    - action: List your installed snaps to confirm
+      command: snap list
+    - action: Run the snap
+      command: test-moos-ping-{name}.MOOSDB -h
+    - warning: |
+        Make sure the name matches what has been used previously (i.e <code>test-moos-ping-{name}</code>)
+  manual:
+    - action: Return to the root directory of the project containing your snapcraft.yaml and run the snapcraft Docker image
+      command: docker run -v $PWD:$PWD -w $PWD snapcore/snapcraft snapcraft
+    - action: You will find a .snap file in the same directory that you ran the snapcraft command. You can inspect the contents to ensure it contains all of the application's assets
+      command: unsquashfs -l *.snap
+    - action: Install the snap
+      command: sudo snap install --devmode --dangerous *.snap
+    - action: List your installed snaps to confirm
+      command: snap list
+    - action: Run the snap
+      command: test-moos-ping-{name}.MOOSDB -h
+    - warning: |
+        Make sure the name matches what has been used previously (i.e <code>test-moos-ping-{name}</code>)
+macos:
+  auto:
+    - action: Return to the root directory of the project containing your snapcraft.yaml and run snapcraft
+      command: snapcraft
+    - action: You will find a .snap file in the same directory that you ran the snapcraft command. You can inspect the contents to ensure it contains all of the application's assets
+      command: |
+        brew install squashfs
+        unsquashfs -l *.snap
+  manual:
+    - action: Return to the root directory of the project containing your snapcraft.yaml and run the snapcraft Docker image
+      command: docker run -v $PWD:$PWD -w $PWD snapcore/snapcraft snapcraft
+    - action: You will find a .snap file in the same directory that you ran the snapcraft command. You can inspect the contents to ensure it contains all of the application's assets
+      command: |
+        brew install squashfs
+        unsquashfs -l *.snap
+windows:
+  auto:
+    - action: Run Windows Subsystem for Linux from the Windows Start menu
+    - action: Return to the root directory of the project containing your snapcraft.yaml and run snapcraft
+      command: snapcraft
+    - action: You will find a .snap file in the same directory that you ran the snapcraft command. You can inspect the contents to ensure it contains all of the application's assets
+      command: unsquashfs -l *.snap
+  manual:
+    - action: Return to the root directory of the project containing your snapcraft.yaml and run the snapcraft Docker image
+      command: docker run -v $PWD:$PWD -w $PWD snapcore/snapcraft snapcraft
+    - action: You will find a .snap file in the same directory that you ran the snapcraft command. You can inspect the contents to ensure it contains all of the application's assets
+      command: unsquashfs -l *.snap

--- a/webapp/first_snap/content/moos/package.yaml
+++ b/webapp/first_snap/content/moos/package.yaml
@@ -1,0 +1,63 @@
+name: test-moos-ping-{name}
+download: git clone https://github.com/snapcraft-docs/moos-ping
+createDir: |
+  cd moos-ping
+  $EDITOR snapcraft.yaml
+metadata: |
+  name: moos-ping
+  version: '0.1'
+  summary: MOOS Ping Example
+  description: |
+    The main communication mechanism for all MOOS apps.
+explain:
+  metadata:
+    - text: The name must be unique in the Snap Store. Valid snap names consist of lower-case alphanumeric characters and hyphens. They cannot be all numbers. They also cannot start or end with a hyphen.
+    - code: |
+        name: moos-ping
+    - warning: |
+        <span class="p-notification__status">Snap names are globally unique.</span> You should change any instance of <code>moos-ping</code> to <code>test-moos-ping-{name}</code> (where <code>{name}</code> is your name) before continuing to avoid conflicting with the official moos-ping snap.
+    - text: Versions carry no semantic meaning in snaps. Use text that best identifies that release, it won't be used to compare against the preceding or following one.
+    - code: |
+        version: '0.1'
+    - text: The summary can not exceed 79 characters. You can use a pipe ‘|’ in the description key to declare a multi-line description.
+    - code: |
+        description: |
+  security:
+    - text: The next section describes the level of confinement applied to your app.
+    - code: |
+        confinement: devmode
+    - text: Snaps are containerised to ensure more predictable application behaviour and greater security.
+    - text: It’s best to start a snap with the confinement in warning mode, rather than strictly applied. This is indicated through the <code>devmode</code> keyword.
+    - text: Once an app is working well in devmode, you can review confinement violations, add appropriate interfaces, and switch to strict confinement.
+  base:
+    - text: In general, snaps cannot see the root filesystem on end user systems. This prevents conflict with other applications and increases security. However, applications still need some location to act as the root filesystem. They would also benefit from common libraries (e.g. libc) being in this root filesystem rather than bundled into each application.
+    - text: The base keyword specifies a special kind of snap that provides a minimal set of libraries common to most applications. It will be mounted as the root filesystem for your application.
+    - code: |
+        base: core18
+    - text: The <code>core18</code> base is recommended.
+  parts:
+    - text: |
+        Parts define what sources are needed to assemble your app. Parts can be anything: programs, libraries, or other needed assets. The <code>cmake</code> plugin builds CMake-based parts. You can pass flags using the common cmake semantics through the optional <code>configflags</code> keyword.
+    - code: |
+        parts:
+          moos:
+            source: https://github.com/themoos/core-moos/archive/10.0.2.a-release.tar.gz  
+            build-packages:
+              - gcc
+              - g++
+              - make
+            plugin: cmake
+            configflags:
+              - -DCMAKE_INSTALL_PREFIX=/
+    - text: |
+        The <code>build-packages</code> section lists the library dependencies that will be used by snapcraft to build the part.                                                                                                                                                                        
+  apps:
+    - text: Apps are the commands you want to expose to users and any background services your application provides.
+    - code: |
+        apps:
+          MOOSDB:
+            command: MOOSDB
+    - warning: |
+        <span class="p-notification__status">Snap names are globally unique.</span> You should change any instance of <code>moos-ping</code> to <code>test-moos-ping-{name}</code> (where <code>{name}</code> is your name) before continuing to avoid conflicting with the official moos-ping snap.
+    - text: The <code>command</code> specifies the path to the binary to be run. This is resolved relative to the root of your snap contents and automatically searches in the usr/sbin, usr/bin, sbin, and bin subdirectories of your snap.
+    - text: If your command name matches the snap name, users will be able run the command directly.

--- a/webapp/first_snap/content/moos/test.yaml
+++ b/webapp/first_snap/content/moos/test.yaml
@@ -1,0 +1,16 @@
+macos:
+  - action: Create a Linux virtual machine for testing snaps
+    command: multipass launch -n testvm
+  - action: Return to the directory containing the .snap file and copy it into the virtual machine
+    command: 'multipass copy-files moos-ping*.snap testvm:'
+  - action: Connect to the virtual machine
+    command: multipass shell testvm
+  - action: Install the snap inside the virtual machine
+    command: sudo snap install --devmode --dangerous moos-ping*.snap
+  - action: Confirm the snap is installed by listing your installed snaps
+    command: snap list
+  - action: Run the snap inside the virtual machine
+    warning: You should change <code>moos-ping</code> to <code>test-moos-ping-{name}</code> (where <code>{name}</code> is your name), as written into the snapcraft.yaml file earlier.
+    command: test-moos-ping-{name}.MOOSDB -h
+  - action: Exit the virtual machine
+    command: exit


### PR DESCRIPTION
This is the new "old" PR for MOOS. Initially we wanted to add code example, but this will be a basic main comms mechanism snap.

The PR includes:

- Changes to build, package and test to reflect MOOSDB command invocation.
- Partials change to point to FSF.
- Template change with the new yaml (separate PR for docs).