### PR TITLE
MOOS FSF: Remove "ping" references

### DIFF
--- a/templates/home/_fsf_moos.html
+++ b/templates/home/_fsf_moos.html
@@ -3,9 +3,8 @@
     <h4>Why are snaps good for MOOS projects?</h4>
     <ul>
       <li>Bundle all the runtime requirements, including the exact version of MOOS/MOOS-IvP and system libraries you need.</li>
-      <li>Expand the distributions supported beyond just Ubuntu.</li>
       <li>Directly and reliably control the delivery of application updates using existing infrastructure.</li>
-	  <li>Upgrades are safe. If your app fails to upgrade, users automatically roll back to the previous revision.</li>
+      <li>Upgrades are safe. If your app fails to upgrade, users automatically roll back to the previous revision.</li>
       <li>Extremely simple creation of daemons.</li>
     </ul>
   </div>
@@ -13,30 +12,25 @@
   <div class='col-6'>
     <h4>Here's an example snapcraft.yaml that uses MOOS:</h4>
     <code class="p-code-yaml"><pre>
-<b>name</b>: moos-ping
+<b>name</b>: moos
 <b>version</b>: '0.1'
-<b>summary</b>: MOOS Ping Example
+<b>summary</b>: MOOS Example
 <b>description</b>: |
-  The main communication mechanism for all 
-  MOOS apps.
+  This example includes MOOSDB, the main communication mechanism for all MOOS
+  apps.
 
 <b>confinement</b>: devmode
 <b>base</b>: core18
 
 <b>parts</b>:
   <b>moos</b>:
-    <b>source</b>: https://github.com/themoos/core-moos/archive/10.0.2.a-release.tar.gz
-    <b>build-packages</b>:
-      - gcc
-      - g++
-      - make
+    <b>source</b>: https://github.com/themoos/core-moos/archive/v10.4.0.tar.gz
     <b>plugin</b>: cmake
-    <b>configflags</b>:
-      - -DCMAKE_INSTALL_PREFIX=/
+    <b>build-packages</b>: [g++]
 
 <b>apps</b>:
   <b>MOOSDB</b>:
-    <b>command</b>: MOOSDB
+    <b>command</b>: bin/MOOSDB
 </pre></code>
   </div>
 

--- a/webapp/first_snap/content/moos/build.yaml
+++ b/webapp/first_snap/content/moos/build.yaml
@@ -9,9 +9,9 @@ linux:
     - action: List your installed snaps to confirm
       command: snap list
     - action: Run the snap
-      command: test-moos-ping-{name}.MOOSDB -h
+      command: test-moos-{name}.MOOSDB -h
     - warning: |
-        Make sure the name matches what has been used previously (i.e <code>test-moos-ping-{name}</code>)
+        Make sure the name matches what has been used previously (i.e <code>test-moos-{name}</code>)
   manual:
     - action: Return to the root directory of the project containing your snapcraft.yaml and run the snapcraft Docker image
       command: docker run -v $PWD:$PWD -w $PWD snapcore/snapcraft snapcraft
@@ -22,9 +22,9 @@ linux:
     - action: List your installed snaps to confirm
       command: snap list
     - action: Run the snap
-      command: test-moos-ping-{name}.MOOSDB -h
+      command: test-moos-{name}.MOOSDB -h
     - warning: |
-        Make sure the name matches what has been used previously (i.e <code>test-moos-ping-{name}</code>)
+        Make sure the name matches what has been used previously (i.e <code>test-moos-{name}</code>)
 macos:
   auto:
     - action: Return to the root directory of the project containing your snapcraft.yaml and run snapcraft

--- a/webapp/first_snap/content/moos/package.yaml
+++ b/webapp/first_snap/content/moos/package.yaml
@@ -1,21 +1,22 @@
-name: test-moos-ping-{name}
-download: git clone https://github.com/snapcraft-docs/moos-ping
+name: test-moos-{name}
+download: git clone https://github.com/snapcraft-docs/moos
 createDir: |
-  cd moos-ping
+  cd moos
   $EDITOR snapcraft.yaml
 metadata: |
-  name: moos-ping
+  name: moos
   version: '0.1'
-  summary: MOOS Ping Example
+  summary: MOOS Example
   description: |
-    The main communication mechanism for all MOOS apps.
+    This example includes MOOSDB, the main communication mechanism for all MOOS
+    apps.
 explain:
   metadata:
     - text: The name must be unique in the Snap Store. Valid snap names consist of lower-case alphanumeric characters and hyphens. They cannot be all numbers. They also cannot start or end with a hyphen.
     - code: |
-        name: moos-ping
+        name: moos
     - warning: |
-        <span class="p-notification__status">Snap names are globally unique.</span> You should change any instance of <code>moos-ping</code> to <code>test-moos-ping-{name}</code> (where <code>{name}</code> is your name) before continuing to avoid conflicting with the official moos-ping snap.
+        <span class="p-notification__status">Snap names are globally unique.</span> You should change any instance of <code>moos</code> to <code>test-moos-{name}</code> (where <code>{name}</code> is your name) before continuing to avoid conflicts.
     - text: Versions carry no semantic meaning in snaps. Use text that best identifies that release, it won't be used to compare against the preceding or following one.
     - code: |
         version: '0.1'
@@ -37,18 +38,13 @@ explain:
     - text: The <code>core18</code> base is recommended.
   parts:
     - text: |
-        Parts define what sources are needed to assemble your app. Parts can be anything: programs, libraries, or other needed assets. The <code>cmake</code> plugin builds CMake-based parts. You can pass flags using the common cmake semantics through the optional <code>configflags</code> keyword.
+        Parts define what sources are needed to assemble your app. Parts can be anything: programs, libraries, or other needed assets. The <code>cmake</code> plugin builds CMake-based parts.
     - code: |
         parts:
           moos:
-            source: https://github.com/themoos/core-moos/archive/10.0.2.a-release.tar.gz  
-            build-packages:
-              - gcc
-              - g++
-              - make
+            source: https://github.com/themoos/core-moos/archive/v10.4.0.tar.gz
             plugin: cmake
-            configflags:
-              - -DCMAKE_INSTALL_PREFIX=/
+            build-packages: [g++]
     - text: |
         The <code>build-packages</code> section lists the library dependencies that will be used by snapcraft to build the part.                                                                                                                                                                        
   apps:
@@ -56,8 +52,8 @@ explain:
     - code: |
         apps:
           MOOSDB:
-            command: MOOSDB
+            command: bin/MOOSDB
     - warning: |
-        <span class="p-notification__status">Snap names are globally unique.</span> You should change any instance of <code>moos-ping</code> to <code>test-moos-ping-{name}</code> (where <code>{name}</code> is your name) before continuing to avoid conflicting with the official moos-ping snap.
+        <span class="p-notification__status">Snap names are globally unique.</span> You should change any instance of <code>moos</code> to <code>test-moos-{name}</code> (where <code>{name}</code> is your name) before continuing to avoid conflicts.
     - text: The <code>command</code> specifies the path to the binary to be run. This is resolved relative to the root of your snap contents and automatically searches in the usr/sbin, usr/bin, sbin, and bin subdirectories of your snap.
     - text: If your command name matches the snap name, users will be able run the command directly.

--- a/webapp/first_snap/content/moos/test.yaml
+++ b/webapp/first_snap/content/moos/test.yaml
@@ -2,15 +2,15 @@ macos:
   - action: Create a Linux virtual machine for testing snaps
     command: multipass launch -n testvm
   - action: Return to the directory containing the .snap file and copy it into the virtual machine
-    command: 'multipass copy-files moos-ping*.snap testvm:'
+    command: 'multipass copy-files moos*.snap testvm:'
   - action: Connect to the virtual machine
     command: multipass shell testvm
   - action: Install the snap inside the virtual machine
-    command: sudo snap install --devmode --dangerous moos-ping*.snap
+    command: sudo snap install --devmode --dangerous moos*.snap
   - action: Confirm the snap is installed by listing your installed snaps
     command: snap list
   - action: Run the snap inside the virtual machine
-    warning: You should change <code>moos-ping</code> to <code>test-moos-ping-{name}</code> (where <code>{name}</code> is your name), as written into the snapcraft.yaml file earlier.
-    command: test-moos-ping-{name}.MOOSDB -h
+    warning: You should change <code>moos</code> to <code>test-moos-{name}</code> (where <code>{name}</code> is your name), as written into the snapcraft.yaml file earlier.
+    command: test-moos-{name}.MOOSDB -h
   - action: Exit the virtual machine
     command: exit


### PR DESCRIPTION
Also update to use the latest MOOS, and stop referring to the "official" moos snap.