### PR TITLE
Updated index homepage with links to relevant snaps from logos

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -51,7 +51,7 @@
   <div class="row">
     <div class="p-fluid-grid--centered">
       <span class="p-logo-image p-fluid-grid__item--small u-align--center">
-        <img src="https://assets.ubuntu.com/v1/aae93857-logo-mozilla--snapcraft-homepage.svg" alt="Mozilla" />
+          <a href="/firefox"><img src="https://assets.ubuntu.com/v1/aae93857-logo-mozilla--snapcraft-homepage.svg" alt="Mozilla" /></a>
       </span>
       <span class="p-logo-image p-fluid-grid__item--small u-align--center">
         <a href="/publisher/kde"><img src="https://assets.ubuntu.com/v1/6958a93e-kde-logo-snapcraft-homepage.svg" alt="KDE" /></a>
@@ -60,13 +60,13 @@
         <a href="/publisher/jetbrains"><img src="https://assets.ubuntu.com/v1/55f6dae7-logo-jetbrains--snapcraft-homepage.svg" alt="JetBrains" /></a>
       </span>
       <span class="p-logo-image p-fluid-grid__item--small u-align--center">
-        <img src="https://assets.ubuntu.com/v1/63d5fd3f-logo-spotify--snapcraft-homepage.svg" alt="Spotify" />
+          <a href="/spotify"><img src="https://assets.ubuntu.com/v1/63d5fd3f-logo-spotify--snapcraft-homepage.svg" alt="Spotify" /></a>
       </span>
       <span class="p-logo-image p-fluid-grid__item--small u-align--center">
-        <img src="https://assets.ubuntu.com/v1/2d54fa27-logo-google--snapcraft-homepage.svg" alt="Google" />
+          <a href="/google-cloud-sdk"><img src="https://assets.ubuntu.com/v1/2d54fa27-logo-google--snapcraft-homepage.svg" alt="Google" /></a>
       </span>
       <span class="p-logo-image p-fluid-grid__item--small u-align--center">
-        <img src="https://assets.ubuntu.com/v1/7b03d4b8-logo-microsoft--snapcraft-homepage.svg" alt="Microsoft" />
+          <a href="/code"><img src="https://assets.ubuntu.com/v1/7b03d4b8-logo-microsoft--snapcraft-homepage.svg" alt="Microsoft" /></a>
       </span>
     </div>
   </div>
@@ -95,7 +95,7 @@
     <div class="col-4">
       <blockquote class="p-testimonial">
         <div class="p-testimonial__logo">
-          <img src="https://assets.ubuntu.com/v1/53b1b835-logo-heroku.svg" alt="Heroku logo" />
+            <a href="/heroku"><img src="https://assets.ubuntu.com/v1/53b1b835-logo-heroku.svg" alt="Heroku logo" /></a>
         </div>
         <h4 class="p-testimonial__title">“The auto-updating feature is huge”</h4>
         <p class="p-testimonial__content">Due to the nature of our platform, we release updates more than daily which admittedly can be annoying for our users to constantly update.</p>
@@ -108,7 +108,7 @@
     <div class="col-4">
       <blockquote class="p-testimonial">
         <div class="p-testimonial__logo">
-          <img src="https://assets.ubuntu.com/v1/e4c220b3-logo-microsoft.svg" alt="Microsoft logo" />
+            <a href="/code"><img src="https://assets.ubuntu.com/v1/e4c220b3-logo-microsoft.svg" alt="Microsoft logo" /></a>
         </div>
         <h4 class="p-testimonial__title">“Starting with snaps is easy”</h4>
         <p class="p-testimonial__content">We definitely find Snapcraft easier as it is yaml based and provides details of what artifacts are needed. Debian packaging has things that need to be followed which can be distribution specific, which creates complication.
@@ -121,7 +121,7 @@
     <div class="col-4">
       <blockquote class="p-testimonial">
         <div class="p-testimonial__logo">
-          <a href="https://www.jetbrains.com/"><img src="https://assets.ubuntu.com/v1/a82ec61c-logo-jetbrains.svg" alt="JetBrains logo" /></a>
+          <a href="/publisher/jetbrains"><img src="https://assets.ubuntu.com/v1/a82ec61c-logo-jetbrains.svg" alt="JetBrains logo" /></a>
         </div>
         <h4 class="p-testimonial__title">“A major software discovery tool”</h4>
         <p class="p-testimonial__content">The Snap store provides additional exposure to our tools for many of our existing and potential users. The decision to use it came quite naturally. We believe the store will be a major software discovery tool on Linux, so the more people find out about our tools naturally and install them more easily, the better for everyone.</p>


### PR DESCRIPTION
Proposal fix for #1860 

### QA Steps
1. Pull the branch or run the demo service
2. Open the homepage
3. Check all logos from different vendors have a link somewhere.

- Mozilla -> Firefox snap
- KDE -> Publisher page from KDE
- JetBrains -> Publisher page from JetBrains
- Spotify -> Spotify snap
- Google -> Google Cloud SDK snap
- Microsoft -> VSCode temporarily
- Heroku -> Heroku snap

Ideally, we would like to have a link to all publisher pages but in the meantime redirecting users from the homepage to relevant snaps seems like a quick fix meanwhile we gather all content and have the right conversations.
