### PR TITLE
Embedded channels fix

### DIFF
--- a/static/sass/styles-embedded.scss
+++ b/static/sass/styles-embedded.scss
@@ -38,6 +38,13 @@ $color-navigation-background: #252525;
   z-index: 10;
 }
 
+// utility to make ellipsis
+.u-ellipsis {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 // make max-width of the layout smaller for embedded view
 .row {
   max-width: 40rem;

--- a/templates/store/snap-embedded-card.html
+++ b/templates/store/snap-embedded-card.html
@@ -69,12 +69,14 @@
           </tr>
         </thead>
         <tbody>
-          {% for release in channel_map[default_architecture][default_track] %}
-          <tr>
-            <td>{% if default_track == "latest"%}{{ default_track }}/{% endif %}{{ release.channel }}</td>
-            <td>{{ release.version }}</td>
-            <td>{{ release["created-at"] }}</td>
-          </tr>
+          {% for track in channel_map[default_architecture] %}
+            {% for release in channel_map[default_architecture][track] %}
+            <tr>
+              <td>{% if track == "latest"%}{{ track }}/{% endif %}{{ release.channel }}</td>
+              <td>{{ release.version }}</td>
+              <td>{{ release["created-at"] }}</td>
+            </tr>
+            {% endfor %}
           {% endfor %}
         </tbody>
       </table>

--- a/templates/store/snap-embedded-card.html
+++ b/templates/store/snap-embedded-card.html
@@ -73,7 +73,7 @@
             {% for release in channel_map[default_architecture][track] %}
             <tr>
               <td>{% if track == "latest"%}{{ track }}/{% endif %}{{ release.channel }}</td>
-              <td>{{ release.version }}</td>
+              <td class="u-ellipsis">{{ release.version }}</td>
               <td>{{ release["created-at"] }}</td>
             </tr>
             {% endfor %}


### PR DESCRIPTION
Fixes #1825

Makes sure all released channels are shown in embedded card.

### QA

- ./run or https://snapcraft-io-canonical-web-and-design-pr-1874.run.demo.haus/
- go to publicise page of any snap with multiple tracks
- show embedded card
- if 'Show all channels' option is enabled all channels (from different tracks) should be visible

<img width="580" alt="Screenshot 2019-04-29 at 15 28 00" src="https://user-images.githubusercontent.com/83575/56899464-c935e500-6a93-11e9-8a02-f138f994145c.png">
