### PR TITLE
Force image sizes to prevent load-jumping

### DIFF
--- a/static/sass/_patterns_media-object--snap.scss
+++ b/static/sass/_patterns_media-object--snap.scss
@@ -44,8 +44,6 @@
 
     .p-media-object__image {
       height: 3rem;
-      max-height: 3rem;
-      max-width: 3rem;
       width: 3rem;
     }
 
@@ -93,14 +91,10 @@
     .p-media-object--snap {
       .p-media-object__image {
         height: 3rem;
-        max-height: 3rem;
-        max-width: 3rem;
         width: 3rem;
 
         @media screen and (min-width: $breakpoint-small) {
           height: 5rem;
-          max-height: 5rem;
-          max-width: 5rem;
           width: 5rem;
         }
       }

--- a/static/sass/_patterns_media-object--snap.scss
+++ b/static/sass/_patterns_media-object--snap.scss
@@ -43,8 +43,10 @@
     }
 
     .p-media-object__image {
+      height: 3rem;
       max-height: 3rem;
       max-width: 3rem;
+      width: 3rem;
     }
 
     &.is-placeholder {
@@ -52,8 +54,6 @@
         background: $color-mid-light;
         border-radius: 2px;
         display: block;
-        height: 3rem;
-        width: 3rem;
       }
 
       .p-media-object__title {
@@ -91,14 +91,17 @@
 
   .snapcraft-p-grid--featured {
     .p-media-object--snap {
-
       .p-media-object__image {
+        height: 3rem;
         max-height: 3rem;
         max-width: 3rem;
+        width: 3rem;
 
         @media screen and (min-width: $breakpoint-small) {
+          height: 5rem;
           max-height: 5rem;
           max-width: 5rem;
+          width: 5rem;
         }
       }
     }


### PR DESCRIPTION
Fixes https://github.com/canonical-web-and-design/snapcraft.io/pull/1878#issuecomment-487961744

To get around https://github.com/canonical-web-and-design/vanilla-framework/issues/2175 this set's specific image sizes for media-object images.

## QA

- Pull the branch
- `./run`
- Visit http://0.0.0.0:8004/store and http://0.0.0.0:8004/publisher/kde
- Throttle your connection/ browser [chrome](https://css-tricks.com/throttling-the-network/) [firefox](https://blog.nightly.mozilla.org/2016/11/07/simulate-slow-connections-with-the-network-throttling-tool/)
- See that the area icons should be aren't collapsed before the page loads