### PR TITLE
Don't init store-categories on search page

### DIFF
--- a/static/js/public/store-categories.js
+++ b/static/js/public/store-categories.js
@@ -9,6 +9,10 @@ function getColour(holder) {
     parent.classList.add(colour.isDark ? "is-dark" : "is-light");
   }
 
+  if (!holder) {
+    return;
+  }
+
   const images = holder.querySelectorAll(".p-featured-snap__icon img");
   if (images.length > 0) {
     for (let i = 0, ii = images.length; i < ii; i += 1) {

--- a/templates/store/search.html
+++ b/templates/store/search.html
@@ -87,12 +87,3 @@
   </section>
   {% endif %}
 {% endblock %}
-
-{% block scripts %}
-  <script src="{{ static_url('js/dist/public.js') }}"></script>
-  <script>
-    Raven.context(function () {
-      snapcraft.public.storeCategories();
-    });
-  </script>
-{% endblock %}


### PR DESCRIPTION
Fixes the waterfall of sentry issues related to `Cannot read property 'querySelectorAll' of null` since the last release

## QA

- Pull the branch
- `./run`
- Visit http://0.0.0.0:8004/search?category=&q=asdasdasda
- There should be no errors in console