### PR TITLE
Annotated snapcraft yaml

### DIFF
--- a/static/js/public/first-snap-flow.js
+++ b/static/js/public/first-snap-flow.js
@@ -219,7 +219,7 @@ function initChooseName(formEl, language) {
     event.preventDefault();
 
     // set value in cookie an reload (to render with a new name)
-    document.cookie = `fsf_snap_name_${language}=${snapNameInput.value};`;
+    document.cookie = `fsf_snap_name_${language}=${snapNameInput.value};path=/`;
     window.location.reload();
   });
 }

--- a/static/sass/_patterns_annotated_code.scss
+++ b/static/sass/_patterns_annotated_code.scss
@@ -1,0 +1,34 @@
+@mixin p-annotated-code {
+  .p-annotated-code {
+    background-color: $color-light;
+    border: 1px solid $color-mid-light;
+    border-radius: .125rem;
+    color: $color-dark;
+    display: block;
+    margin-bottom: 1.5rem;
+    margin-top: 0;
+    text-align: left;
+    text-shadow: none;
+  }
+
+  .p-annotated-code__block {
+    border-bottom: 1px solid transparent;
+    border-top: 1px solid transparent;
+    padding: .25rem 1rem;
+  }
+
+  .p-annotated-code__block:first-child {
+    border-top: 0;
+    padding-top: .5rem;
+  }
+
+  .p-annotated-code__block:last-child {
+    border-bottom: 0;
+    padding-bottom: .5rem;
+  }
+
+  .p-annotated-code__block:hover {
+    background: $color-x-light;
+    border-color: $color-mid-light;
+  }
+}

--- a/static/sass/_patterns_annotated_code.scss
+++ b/static/sass/_patterns_annotated_code.scss
@@ -9,6 +9,19 @@
     margin-top: 0;
     text-align: left;
     text-shadow: none;
+
+    code b {
+      color: $color-positive;
+      font-weight: bold;
+    }
+
+    &:hover .p-annotated-code__block {
+      opacity: .5;
+
+      &:hover {
+        opacity: 1;
+      }
+    }
   }
 
   .p-annotated-code__block {

--- a/static/sass/_patterns_first-snap-flow.scss
+++ b/static/sass/_patterns_first-snap-flow.scss
@@ -16,6 +16,13 @@
     }
   }
 
+  // workaround for bringing back default p styles in accordion
+  // before this vanilla bug is fixed:
+  // https://github.com/canonical-web-and-design/vanilla-framework/issues/2301
+  .p-accordion p {
+    margin-bottom: map-get($sp-after, p) - map-get($nudges, nudge--p);
+  }
+
   .p-accordion__step {
     display: block;
     float: left;

--- a/static/sass/_patterns_first-snap-flow.scss
+++ b/static/sass/_patterns_first-snap-flow.scss
@@ -23,6 +23,7 @@
   }
 
   .p-accordion__panel {
+    overflow: visible;
     padding-left: 4rem;
   }
 

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -71,6 +71,9 @@ $color-navigation-background: #252525;
 @import 'patterns_button_spinner';
 @include p-button-spinner;
 
+@import 'patterns_annotated_code';
+@include p-annotated-code;
+
 @import 'map';
 @include snap-details-map;
 

--- a/templates/first-snap/package-deprecated.html
+++ b/templates/first-snap/package-deprecated.html
@@ -1,0 +1,225 @@
+{% set fsf_step = "package" %}
+{% extends "first-snap/_layout_fsf.html" %}
+
+{% block fsf_content %}
+  <div class="row">
+    <div class="p-accordion" role="tablist" aria-multiselect="true">
+      <ol class="p-accordion__list">
+        <li class="p-accordion__group">
+          <button {% if has_user_chosen_name %}aria-expanded="false"{% else %}aria-expanded="true"{% endif %} type="button" class="p-accordion__tab" id="tab1" role="tab" aria-controls="#tab1-section" >
+            <h4 class="u-no-margin--bottom">
+              <span class="p-accordion__step">1.</span>
+              Choose snap name
+              {% if has_user_chosen_name %}<i class="p-icon--success"></i>{% endif %}
+            </h4>
+          </button>
+          <section class="p-accordion__panel" id="tab1-section" role="tabpanel" {% if has_user_chosen_name %}aria-hidden="true"{% else %}aria-hidden="false"{% endif %} aria-labelledby="tab1-section">
+            <div class="p-strip is-shallow">
+              <div class="row">
+                <div class="col-8">
+                  <form id="choose-name-form">
+                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+                    <label>Please pick a snap name for the purpose of this tutorial:</label>
+                    <div class="p-form-validation">
+                      <input class="p-form-validation__input" type="text" name="snap-name" value="{{ snap_name }}" />
+                      <p class="p-form-validation__message" id="input-error-message-inline" role="alert">
+                        Name should only have lowercase letters, numbers, and hyphens, must have at least one letter, and cannot start or end with a hyphen.
+                      </p>
+                    </div>
+                    <button class="p-button--positive" disabled>Choose snap name</button>
+                  </form>
+                </div>
+              </div>
+            </div>
+          </section>
+        </li>
+        <li class="p-accordion__group">
+          <button {% if has_user_chosen_name %}aria-expanded="true"{% else %}aria-expanded="false"{% endif %} type="button" class="p-accordion__tab" id="tab2" role="tab" aria-controls="#tab2-section" >
+            <h4 class="u-no-margin--bottom">
+              <span class="p-accordion__step">2.</span>
+              Download an example app
+              <i class="p-icon--success u-hide"></i>
+            </h4>
+          </button>
+          <section class="p-accordion__panel" id="tab2-section" role="tabpanel" {% if has_user_chosen_name %}aria-hidden="false"{% else %}aria-hidden="true"{% endif %} aria-labelledby="tab2-section">
+            <div class="p-strip is-shallow">
+              <div class="row">
+                <div class="col-8">
+                  <p>Clone the following application to use for the purpose of this tutorial</p>
+                  {% set snippet_value = steps.download %}
+                  {% set snippet_id = "download" %}
+                  {% include "/partials/_code-snippet.html" %}
+                  <button id="js-clone-continue-button" class="p-button--positive">Continue</button>
+                </div>
+              </div>
+            </div>
+          </section>
+        </li>
+        <li class="p-accordion__group">
+          <button aria-expanded="false" type="button" class="p-accordion__tab" id="tab3" role="tab" aria-controls="#tab3-section" >
+            <h4 class="u-no-margin--bottom">
+              <span class="p-accordion__step">3.</span>
+              Update your snapcraft.yaml
+            </h4>
+          </button>
+          <section class="p-accordion__panel" id="tab3-section" role="tabpanel" aria-hidden="true" aria-labelledby="tab3-section">
+            <div class="col-8">
+              <ol class="p-list-step has-margin is-nested is-alpha">
+                <li class="p-list-step__item">
+                  <h4 class="p-list-step__title">
+                    Open the snapcraft.yaml file in the root of the project
+                  </h4>
+                  {% set snippet_value = steps.createDir %}
+                  {% set snippet_id = "createdir" %}
+                  {% include "/partials/_code-snippet-multi.html" %}
+                </li>
+                <li class="p-list-step__item">
+                  <h4 class="p-list-step__title">
+                    The snapcraft.yaml file starts with a small amount of human-readable metadata.
+                  </h4>
+                  <div class="p-list-step__content">
+                    {% set snippet_value = steps.metadata %}
+                    {% set snippet_id = "metadata" %}
+                    {% include "/partials/_code.html" %}
+                    {% for item in steps.explain.metadata %}
+                      {% if item.text %}
+                        <p>{{ item.text|safe }}</p>
+                      {% elif item.code %}
+                        <pre><code>{{ item.code }}</code></pre>
+                      {% elif item.warning %}
+                        <div class="p-notification--caution">
+                          <p class="p-notification__response">
+                            {{ item.warning|replace("${name}", snap_name)|safe }}
+                          </p>
+                        </div>
+                      {% endif %}
+                    {% endfor %}
+                  </div>
+                </li>
+                <li class="p-list-step__item">
+                  <h4 class="p-list-step__title">
+                    Security model
+                  </h4>
+                  <div class="p-list-step__content">
+                    {% for item in steps.explain.security %}
+                      {% if item.text %}
+                        <p>{{ item.text|safe }}</p>
+                      {% elif item.code %}
+                        <pre><code>{{ item.code }}</code></pre>
+                      {% elif item.warning %}
+                        <div class="p-notification--caution">
+                          <p class="p-notification__response">
+                            {{ item.warning|replace("${name}", snap_name)|safe }}
+                          </p>
+                        </div>
+                      {% endif %}
+                    {% endfor %}
+                  </div>
+                </li>
+                {% if steps.explain.base %}
+                <li class="p-list-step__item">
+                  <h4 class="p-list-step__title">
+                    Base
+                  </h4>
+                  <div class="p-list-step__content">
+                    {% for item in steps.explain.base %}
+                      {% if item.text %}
+                        <p>{{ item.text|safe }}</p>
+                      {% elif item.code %}
+                        <pre><code>{{ item.code }}</code></pre>
+                      {% elif item.warning %}
+                        <div class="p-notification--caution">
+                          <p class="p-notification__response">
+                            {{ item.warning|replace("${name}", snap_name)|safe }}
+                          </p>
+                        </div>
+                      {% endif %}
+                    {% endfor %}
+                  </div>
+                </li>
+                {% endif %}
+                <li class="p-list-step__item">
+                  <h4 class="p-list-step__title">
+                    Parts
+                  </h4>
+                  <div class="p-list-step__content">
+                    {% for item in steps.explain.parts %}
+                      {% if item.text %}
+                        <p>{{ item.text|safe }}</p>
+                      {% elif item.code %}
+                        <pre><code>{{ item.code }}</code></pre>
+                      {% elif item.warning %}
+                        <div class="p-notification--caution">
+                          <p class="p-notification__response">
+                            {{ item.warning|replace("${name}", snap_name)|safe }}
+                          </p>
+                        </div>
+                      {% endif %}
+                    {% endfor %}
+                  </div>
+                </li>
+                <li class="p-list-step__item">
+                  <h4 class="p-list-step__title">
+                    Apps
+                  </h4>
+                  <div class="p-list-step__content">
+                    {% for item in steps.explain.apps %}
+                    {% if item.text %}
+                    <p>{{ item.text|safe }}</p>
+                    {% elif item.code %}
+                    <pre><code>{{ item.code }}</code></pre>
+                    {% elif item.warning %}
+                    <div class="p-notification--caution">
+                      <p class="p-notification__response">
+                        {{ item.warning|replace("${name}", snap_name)|safe }}
+                      </p>
+                    </div>
+                    {% endif %}
+                    {% endfor %}
+                  </div>
+                </li>
+              </ol>
+            </div>
+          </section>
+        </li>
+      </ol>
+    </div>
+  </div>
+  <div class="row">
+    <p>Now we'll take a real world app, and package it as a snap</p>
+  </div>
+
+  <div class="row">
+    <div class="col-8">
+
+    </div>
+  </div>
+{% endblock %}
+
+{% block fsf_pagination %}
+  <a class="p-pagination__link--previous" href="/first-snap/{{ language }}">
+    <span class="p-pagination__label">Previous</span>
+    <span class="p-pagination__title">Install Snapcraft</span>
+  </a>
+  <a class="p-pagination__link--next" href="/first-snap/{{ language }}/{{ os }}/build">
+    <span class="p-pagination__label">Next</span>
+    <span class="p-pagination__title">Build snap</span>
+  </a>
+{% endblock %}
+
+{% block scripts %}
+  <script src="{{ static_url('js/dist/public.js') }}"></script>
+  <script>
+    Raven.context(function() {
+      snapcraft.public.firstSnapFlow.initChooseName(
+        document.getElementById("choose-name-form"),
+         "{{language}}"
+      );
+      snapcraft.public.initAccordion('.p-accordion__list');
+      snapcraft.public.initAccordionButtons(
+        document.getElementById("js-clone-continue-button")
+      );
+    });
+  </script>
+  {{ super() }}
+{% endblock %}

--- a/templates/first-snap/package.html
+++ b/templates/first-snap/package.html
@@ -59,24 +59,30 @@
           <button aria-expanded="false" type="button" class="p-accordion__tab" id="tab3" role="tab" aria-controls="#tab3-section" >
             <h4 class="u-no-margin--bottom">
               <span class="p-accordion__step">3.</span>
-              Generate and download snapcraft.yaml
+              Download your snapcraft.yaml
             </h4>
           </button>
           <section class="p-accordion__panel" id="tab3-section" role="tabpanel" aria-hidden="true" aria-labelledby="tab3-section">
-            <div class="row">
-            <div class="col-9">
-              <p>A <a href="https://docs.snapcraft.io/snapcraft-format">snapcraft.yaml file</a> holds the basic meta data for the snap.</p>
-              <p>You can edit the meta data later on. For now we have generated an example snapcraft.yaml for you using the snap name you have chosen.</p>
-              <div class="p-annotated-code">
-                {% for key in snapcraft_yaml %}
-                  <div class="p-annotated-code__block p-tooltip p-tooltip--btm-center">
-                    <code>{{ snapcraft_yaml[key]|safe }}</code>
-                    <span class="p-tooltip__message">{{ annotations[key]|safe }}</span>
+            <div class="p-strip is-shallow">
+              <div class="row">
+                <div class="col-9">
+                  <p>A <a href="https://docs.snapcraft.io/snapcraft-format">snapcraft.yaml file</a> holds the basic meta data for the snap.</p>
+                  <p>You can edit the meta data later on. For now we have generated an example snapcraft.yaml for you using the snap name you have chosen.</p>
+                  <p>To discover more about the <code>snapcraft.yaml</code>, mouse over each piece of metadata in the interactive <code>.yaml</code> viewer below.</p>
+                  <div class="p-annotated-code">
+                    {% for key in snapcraft_yaml %}
+                      <div class="p-annotated-code__block p-tooltip p-tooltip--btm-center">
+                        <code>{{ snapcraft_yaml[key]|safe }}</code>
+                        <span class="p-tooltip__message">{{ annotations[key]|safe }}</span>
+                      </div>
+                    {% endfor %}
                   </div>
-                {% endfor %}
+                  <p>In order for your snap to build using the name you have chosen you'll need to replace the example application's <code>snapcraft.yaml</code> file.</p>
+                  <p>First download new <code>snapcraft.yaml</code> file that contains your chosen name:</p>
+                  <p><a class="p-button--positive" href="/first-snap/{{ language }}/snapcraft.yaml" download>Download snapcraft.yaml file</a>
+                  <p>Next move or copy it to project folder making sure to override the old file.</p>
+                </div>
               </div>
-              <p><a class="p-button--positive" href="/first-snap/{{ language }}/snapcraft.yaml" download>Download snapcraft.yaml file</a>
-            </div>
             </div>
           </section>
         </li>

--- a/templates/first-snap/package.html
+++ b/templates/first-snap/package.html
@@ -70,7 +70,7 @@
               <div class="p-annotated-code">
                 {% for key in snapcraft_yaml %}
                   <div class="p-annotated-code__block p-tooltip p-tooltip--btm-center">
-                    <code>{{ snapcraft_yaml[key]|replace("${name}", snap_name) }}</code>
+                    <code>{{ snapcraft_yaml[key]|safe }}</code>
                     <span class="p-tooltip__message">{{ annotations[key]|safe }}</span>
                   </div>
                 {% endfor %}

--- a/templates/first-snap/package.html
+++ b/templates/first-snap/package.html
@@ -64,7 +64,7 @@
           </button>
           <section class="p-accordion__panel" id="tab3-section" role="tabpanel" aria-hidden="true" aria-labelledby="tab3-section">
             <div class="row">
-            <div class="col-8">
+            <div class="col-9">
               <p>A <a href="https://docs.snapcraft.io/snapcraft-format">snapcraft.yaml file</a> holds the basic meta data for the snap.</p>
               <p>You can edit the meta data later on. For now we have generated an example snapcraft.yaml for you using the snap name you have chosen.</p>
               <div class="p-annotated-code">

--- a/templates/first-snap/package.html
+++ b/templates/first-snap/package.html
@@ -59,13 +59,13 @@
           <button aria-expanded="false" type="button" class="p-accordion__tab" id="tab3" role="tab" aria-controls="#tab3-section" >
             <h4 class="u-no-margin--bottom">
               <span class="p-accordion__step">3.</span>
-              Update your snapcraft.yaml
+              Generate and download snapcraft.yaml
             </h4>
           </button>
           <section class="p-accordion__panel" id="tab3-section" role="tabpanel" aria-hidden="true" aria-labelledby="tab3-section">
             <div class="row">
             <div class="col-8">
-              <p>A snapcraft.yaml file holds the basic meta data for the snap.</p>
+              <p>A <a href="https://docs.snapcraft.io/snapcraft-format">snapcraft.yaml file</a> holds the basic meta data for the snap.</p>
               <p>You can edit the meta data later on. For now we have generated an example snapcraft.yaml for you using the snap name you have chosen.</p>
               <div class="p-annotated-code">
                 {% for key in snapcraft_yaml %}
@@ -75,6 +75,7 @@
                   </div>
                 {% endfor %}
               </div>
+              <p><a class="p-button--positive" href="/first-snap/{{ language }}/snapcraft.yaml" download>Download snapcraft.yaml file</a>
             </div>
             </div>
           </section>

--- a/templates/first-snap/package.html
+++ b/templates/first-snap/package.html
@@ -63,122 +63,19 @@
             </h4>
           </button>
           <section class="p-accordion__panel" id="tab3-section" role="tabpanel" aria-hidden="true" aria-labelledby="tab3-section">
+            <div class="row">
             <div class="col-8">
-              <ol class="p-list-step has-margin is-nested is-alpha">
-                <li class="p-list-step__item">
-                  <h4 class="p-list-step__title">
-                    Open the snapcraft.yaml file in the root of the project
-                  </h4>
-                  {% set snippet_value = steps.createDir %}
-                  {% set snippet_id = "createdir" %}
-                  {% include "/partials/_code-snippet-multi.html" %}
-                </li>
-                <li class="p-list-step__item">
-                  <h4 class="p-list-step__title">
-                    The snapcraft.yaml file starts with a small amount of human-readable metadata.
-                  </h4>
-                  <div class="p-list-step__content">
-                    {% set snippet_value = steps.metadata %}
-                    {% set snippet_id = "metadata" %}
-                    {% include "/partials/_code.html" %}
-                    {% for item in steps.explain.metadata %}
-                      {% if item.text %}
-                        <p>{{ item.text|safe }}</p>
-                      {% elif item.code %}
-                        <pre><code>{{ item.code }}</code></pre>
-                      {% elif item.warning %}
-                        <div class="p-notification--caution">
-                          <p class="p-notification__response">
-                            {{ item.warning|replace("${name}", snap_name)|safe }}
-                          </p>
-                        </div>
-                      {% endif %}
-                    {% endfor %}
+              <p>A snapcraft.yaml file holds the basic meta data for the snap.</p>
+              <p>You can edit the meta data later on. For now we have generated an example snapcraft.yaml for you using the snap name you have chosen.</p>
+              <div class="p-annotated-code">
+                {% for key in snapcraft_yaml %}
+                  <div class="p-annotated-code__block p-tooltip p-tooltip--btm-center">
+                    <code>{{ snapcraft_yaml[key]|replace("${name}", snap_name) }}</code>
+                    <span class="p-tooltip__message">{{ annotations[key]|safe }}</span>
                   </div>
-                </li>
-                <li class="p-list-step__item">
-                  <h4 class="p-list-step__title">
-                    Security model
-                  </h4>
-                  <div class="p-list-step__content">
-                    {% for item in steps.explain.security %}
-                      {% if item.text %}
-                        <p>{{ item.text|safe }}</p>
-                      {% elif item.code %}
-                        <pre><code>{{ item.code }}</code></pre>
-                      {% elif item.warning %}
-                        <div class="p-notification--caution">
-                          <p class="p-notification__response">
-                            {{ item.warning|replace("${name}", snap_name)|safe }}
-                          </p>
-                        </div>
-                      {% endif %}
-                    {% endfor %}
-                  </div>
-                </li>
-                {% if steps.explain.base %}
-                <li class="p-list-step__item">
-                  <h4 class="p-list-step__title">
-                    Base
-                  </h4>
-                  <div class="p-list-step__content">
-                    {% for item in steps.explain.base %}
-                      {% if item.text %}
-                        <p>{{ item.text|safe }}</p>
-                      {% elif item.code %}
-                        <pre><code>{{ item.code }}</code></pre>
-                      {% elif item.warning %}
-                        <div class="p-notification--caution">
-                          <p class="p-notification__response">
-                            {{ item.warning|replace("${name}", snap_name)|safe }}
-                          </p>
-                        </div>
-                      {% endif %}
-                    {% endfor %}
-                  </div>
-                </li>
-                {% endif %}
-                <li class="p-list-step__item">
-                  <h4 class="p-list-step__title">
-                    Parts
-                  </h4>
-                  <div class="p-list-step__content">
-                    {% for item in steps.explain.parts %}
-                      {% if item.text %}
-                        <p>{{ item.text|safe }}</p>
-                      {% elif item.code %}
-                        <pre><code>{{ item.code }}</code></pre>
-                      {% elif item.warning %}
-                        <div class="p-notification--caution">
-                          <p class="p-notification__response">
-                            {{ item.warning|replace("${name}", snap_name)|safe }}
-                          </p>
-                        </div>
-                      {% endif %}
-                    {% endfor %}
-                  </div>
-                </li>
-                <li class="p-list-step__item">
-                  <h4 class="p-list-step__title">
-                    Apps
-                  </h4>
-                  <div class="p-list-step__content">
-                    {% for item in steps.explain.apps %}
-                    {% if item.text %}
-                    <p>{{ item.text|safe }}</p>
-                    {% elif item.code %}
-                    <pre><code>{{ item.code }}</code></pre>
-                    {% elif item.warning %}
-                    <div class="p-notification--caution">
-                      <p class="p-notification__response">
-                        {{ item.warning|replace("${name}", snap_name)|safe }}
-                      </p>
-                    </div>
-                    {% endif %}
-                    {% endfor %}
-                  </div>
-                </li>
-              </ol>
+                {% endfor %}
+              </div>
+            </div>
             </div>
           </section>
         </li>

--- a/tests/first_snap/tests_views.py
+++ b/tests/first_snap/tests_views.py
@@ -16,8 +16,8 @@ class FirstSnap(TestCase):
         return app
 
     @patch("builtins.open", new_callable=mock_open, read_data="test: test")
-    def test_get_file(self, mock_open_file):
-        yaml_read = views.get_file("filename.yaml")
+    def test_get_yaml(self, mock_open_file):
+        yaml_read = views.get_yaml("filename.yaml")
         self.assertEqual(yaml_read, {"test": "test"})
         mock_open_file.assert_called_with(
             os.path.join(self.app.root_path, "filename.yaml"), "r"
@@ -26,8 +26,8 @@ class FirstSnap(TestCase):
     @patch(
         "builtins.open", new_callable=mock_open, read_data="test: test: test"
     )
-    def test_get_file_error(self, mock_open_file):
-        yaml_read = views.get_file("filename.yaml")
+    def test_get_yaml_error(self, mock_open_file):
+        yaml_read = views.get_yaml("filename.yaml")
         self.assertEqual(yaml_read, None)
         mock_open_file.assert_called_with(
             os.path.join(self.app.root_path, "filename.yaml"), "r"
@@ -67,6 +67,16 @@ class FirstSnap(TestCase):
         response = self.client.get("/first-snap/toto-lang/linux/package")
 
         assert response.status_code == 404
+
+    @patch("builtins.open", new_callable=mock_open, read_data="name: test")
+    def test_get_snapcraft_yaml(self, mock_open_file):
+        response = self.client.get("/first-snap/python/snapcraft.yaml")
+        self.assert200(response)
+        self.assertEqual(response.get_data(as_text=True), "name: test")
+
+    def test_get_snapcraft_yaml_404(self):
+        response = self.client.get("/first-snap/toto-lang/snapcraft.yaml")
+        self.assert404(response)
 
     def test_get_build(self):
         response = self.client.get("/first-snap/python/linux-auto/build")

--- a/webapp/first_snap/content/python/snapcraft.yaml
+++ b/webapp/first_snap/content/python/snapcraft.yaml
@@ -17,4 +17,4 @@ parts:
 
 apps:
   ${name}:
-    command: bin/${name}
+    command: bin/offlineimap

--- a/webapp/first_snap/content/python/snapcraft.yaml
+++ b/webapp/first_snap/content/python/snapcraft.yaml
@@ -1,0 +1,26 @@
+# This file is based on contents of:
+# https://github.com/snapcraft-docs/offlineimap/blob/master/snapcraft.yaml
+#
+# Contents of this YAML template and snapcraft.yaml in GitHub repo should
+# be kept in sync to make sure tutotials work as expected.
+
+name: ${name}
+version: git
+summary: OfflineIMAP
+description: |
+  OfflineIMAP is software that downloads your email mailbox(es) as local
+  Maildirs. OfflineIMAP will synchronize both sides via IMAP.
+confinement: devmode
+base: core18
+
+parts:
+  ${name}:
+    plugin: python
+    python-version: python2
+    source: .
+    stage-packages:
+      - python-six
+
+apps:
+  ${name}:
+    command: bin/${name}

--- a/webapp/first_snap/content/python/snapcraft.yaml
+++ b/webapp/first_snap/content/python/snapcraft.yaml
@@ -1,9 +1,3 @@
-# This file is based on contents of:
-# https://github.com/snapcraft-docs/offlineimap/blob/master/snapcraft.yaml
-#
-# Contents of this YAML template and snapcraft.yaml in GitHub repo should
-# be kept in sync to make sure tutotials work as expected.
-
 name: ${name}
 version: git
 summary: OfflineIMAP

--- a/webapp/first_snap/content/snapcraft_yaml_annotations.yaml
+++ b/webapp/first_snap/content/snapcraft_yaml_annotations.yaml
@@ -1,0 +1,29 @@
+name: |
+  The name must be unique in the Snap Store. Valid snap names consist of at
+  least two lower-case alphanumeric characters and can contain hyphens.
+  They cannot consist of only numbers and cannot start or end with a hyphen.
+version: |
+  The version is a string that is assigned to the project by its developers,
+  according to their development practices. It is a free text field that should
+  be human readable and tell the user what content to expect from a snap.
+summary: |
+  A sentence summarising the snap in short and simple terms.
+description: |
+  A multi-line description of the snap. This should be a more in-depth look at
+  what your snap does and who may find it most useful.
+confinement: |
+  Confinement determines if the snap should be restricted in access or not.
+  Possible values are <b>strict</b> (for no access outside of declared interfaces through plugs),
+  <b>devmode</b> (for unrestricted access) or <b>classic</b>.
+base: |
+  A base is a special kind of snap that provides a minimal set of libraries
+  common to most applications. A base snap mounts itself as the root filesystem
+  within your snap so that when your application runs, the base’s library paths
+  are searched directly after the paths for your specific snap.
+parts: |
+  Parts are a set of building blocks which are usually independent. These
+  building blocks consist of either code, pre-built packages or other assets.
+  At times some blocks depend on another and as such may be built in a defined
+  sequence.
+apps: |
+  A map of app-names representing entry points to run for the snap.

--- a/webapp/first_snap/views.py
+++ b/webapp/first_snap/views.py
@@ -85,6 +85,36 @@ def get_language(language):
     )
 
 
+@first_snap.route("/<language>/snapcraft.yaml")
+def get_language_snapcraft_yaml(language):
+    filename = f"first_snap/content/{language}/package.yaml"
+    snapcraft_yaml_filename = f"first_snap/content/{language}/snapcraft.yaml"
+    snap_name_cookie = f"fsf_snap_name_{language}"
+    steps = get_file(filename)
+
+    if not steps:
+        return flask.abort(404)
+
+    snap_name = steps["name"]
+
+    if snap_name_cookie in flask.request.cookies:
+        snap_name = flask.request.cookies.get(snap_name_cookie)
+
+    snapcraft_yaml = get_file(snapcraft_yaml_filename, {"${name}": snap_name})
+
+    if not snapcraft_yaml:
+        return flask.abort(404)
+
+    content = StringIO()
+    yaml.dump(snapcraft_yaml, content)
+
+    resp = flask.Response(content.getvalue(), mimetype="text/yaml")
+    resp.headers.extend(
+        {"Content-Disposition": "attachment;filename=snaprcaft.yaml"}
+    )
+    return resp
+
+
 @first_snap.route("/<language>/<operating_system>/package")
 def get_package(language, operating_system):
     filename = f"first_snap/content/{language}/package.yaml"


### PR DESCRIPTION
Fixes #1896

Adds annotated snapcraft.yaml viewer to Python tutorial in first snap flow (Package step).
Allows to download snapcraft.yaml file generated with a snap name chosen by user.

### QA
- ./run or https://snapcraft-io-canonical-web-and-design-pr-1891.run.demo.haus/
- go to Package step of Python first snap flow
- choose name, go to third step (Download your snapcraft.yaml)
- annotated yaml should be shown (with a name chosen before)
- tooltips should be shown when hovering over different sections of the file
- button below it should download the snapcraft.yaml file with a name chosen by user

**Please make sure to read the copy text of "Downloa your snapcraft.yaml" section. My "D" key is misbehaving recently an I may have mae some typos ;)**

<img width="1013" alt="Screenshot 2019-05-09 at 15 56 28" src="https://user-images.githubusercontent.com/83575/57459531-b54c6900-7273-11e9-9f94-af37845bec11.png">
