### PR TITLE
Update multipass link to new website

### DIFF
--- a/templates/first-snap/_install-macos.html
+++ b/templates/first-snap/_install-macos.html
@@ -13,7 +13,7 @@
         <li class="p-list-step__item">
             <h4 class="p-list-step__title">
               <span class="p-list-step__bullet">1</span>
-              <a href="https://github.com/CanonicalLtd/multipass/releases/" target="_blank" class="p-link--external">Install Multipass</a>, a virtualisation product from <br/>Canonical that can set up a complete Linux environment <br/>in a couple of minutes
+              <a href="https://multipass.run/install" target="_blank" class="p-link--external">Install Multipass</a>, a virtualisation product from <br/>Canonical that can set up a complete Linux environment <br/>in a couple of minutes
             </h4>
           </li>
         <li class="p-list-step__item">


### PR DESCRIPTION
Fixes #1903

### QA

- ./run or https://snapcraft-io-canonical-web-and-design-pr-1904.run.demo.haus
- go to [first snap flow](https://snapcraft-io-canonical-web-and-design-pr-1904.run.demo.haus/first-snap/python), choose MacOS
- in the Multipass install instructions link should link to new Multipass site instead of the repo