### PR TITLE
Moved devmode icon to right hand side

### DIFF
--- a/static/js/publisher/release/components/releasesTableCell.js
+++ b/static/js/publisher/release/components/releasesTableCell.js
@@ -31,13 +31,13 @@ class ReleasesTableCell extends Component {
   renderRevision(revision, isPending) {
     return (
       <Fragment>
-        {isInDevmode(revision) && (
-          <span className="p-release-data__icon">
-            <DevmodeIcon revision={revision} showTooltip={false} />
-          </span>
-        )}
         <span className="p-release-data__info">
           <span className="p-release-data__title">{revision.revision}</span>
+          {isInDevmode(revision) && (
+            <span className="p-release-data__icon u-float-right">
+              <DevmodeIcon revision={revision} showTooltip={false} />
+            </span>
+          )}
           <span className="p-release-data__meta">{revision.version}</span>
         </span>
         <span className="p-tooltip__message">

--- a/static/sass/_snapcraft_release.scss
+++ b/static/sass/_snapcraft_release.scss
@@ -145,12 +145,8 @@
     padding-right: .6rem; // give it a bit more space for version ellipsis
   }
 
-  .p-release-data__icon {
-    margin-right: 4px;
-  }
-
   .p-release-data__info {
-    max-width: 100%;
+    width: 100%;
     white-space: nowrap;
 
     &.is-pending {


### PR DESCRIPTION
### QA Steps

Fixes #1911 Moving devmode icon to right hand side

1. Pull the branch or open the demo service
2. Go to `htop/releases` to see revisions with devmode where the icon is on the right-hand side
3. #winning