### PR TITLE
Improve speed on blog pages

### DIFF
--- a/tests/blog/tests_index.py
+++ b/tests/blog/tests_index.py
@@ -34,6 +34,10 @@ class BlogPage(TestCase):
                 "date_gmt": "2018-06-11T11:11:11",
                 "author": 321,
                 "categories": [123],
+                "_embedded": {
+                    "author": [{"name": "Toto"}],
+                    "wp:featuredmedia": [{"url": "url"}],
+                },
             }
         ]
 
@@ -71,9 +75,13 @@ class BlogPage(TestCase):
                     "date": "11 June 2018",
                     "date_gmt": "2018-06-11T11:11:11",
                     "featured_media": 123,
-                    "image": None,
-                    "author": None,
+                    "image": {"url": "url"},
+                    "author": {"name": "Toto"},
                     "categories": [123],
+                    "_embedded": {
+                        "author": [{"name": "Toto"}],
+                        "wp:featuredmedia": [{"url": "url"}],
+                    },
                 }
             ],
         )
@@ -427,12 +435,6 @@ class BlogPage(TestCase):
             json=payload,
             status=200,
             headers=posts_headers,
-        )
-
-        url = "".join([self.api_url, "/users/321"])
-
-        responses.add(
-            responses.GET, url, body=requests.exceptions.Timeout(), status=504
         )
 
         categories_url = "".join([self.api_url, "/categories?per_page=100"])

--- a/webapp/api/blog.py
+++ b/webapp/api/blog.py
@@ -9,7 +9,7 @@ API_URL = os.getenv(
 TAGS = [2996]  # 'snapcraft.io'
 
 
-api_session = api.requests.CachedSession(expire_after=3600)
+api_session = api.requests.CachedSession(expire_after=3600, timeout=(1, 5))
 
 
 def process_response(response):
@@ -40,6 +40,7 @@ def get_articles(
         str(page),
         "&offset=",
         str(offset),
+        "&_embed",
     ]
 
     if exclude:
@@ -64,6 +65,7 @@ def get_article(slug):
             slug,
             "&tags=",
             "".join(str(tag) for tag in TAGS),
+            "&_embed",
         ]
     )
 


### PR DESCRIPTION
## Done
Improve speed of blog pages and reduce the number of HTTP calls to the wordpress API made to render these pages.

## QA

- ./run
- Make sure /blog and /blog/<slug> endpoints work as in production.