### PR TITLE
Increase timeout on wordpress API

### DIFF
--- a/webapp/api/blog.py
+++ b/webapp/api/blog.py
@@ -9,7 +9,8 @@ API_URL = os.getenv(
 TAGS = [2996]  # 'snapcraft.io'
 
 
-api_session = api.requests.CachedSession(expire_after=3600, timeout=(1, 5))
+# 10 seconds is a bit high but we have ocasional spikes in response times
+api_session = api.requests.CachedSession(expire_after=3600, timeout=(1, 10))
 
 
 def process_response(response):


### PR DESCRIPTION
## Done
Wordpress response times ocasionally spike, we are increasing the
timeout times to avoid bad gateways when this happens

## QA

- ./run
- Make sure blog still works
