### PR TITLE
Open first snap flow language details based on hash in URL

### DIFF
--- a/static/js/public/fsf-language-select.js
+++ b/static/js/public/fsf-language-select.js
@@ -10,51 +10,66 @@ function initFSFLanguageSelect(rootEl) {
   const closeDetails = () => {
     flowDetails.forEach(e => (e.style.display = "none"));
     flowLinks.forEach(l => l.classList.remove("is-open"));
+    window.location.hash = "";
   };
 
-  flowLinks.forEach(link => {
-    link.addEventListener("click", event => {
-      var link = event.target.closest(".p-flow-link");
+  const openDetails = link => {
+    if (link && link.dataset.flowLink) {
+      // find where the next row of links starts to insert details panel before
+      var top = link.offsetTop;
 
-      if (link && link.dataset.flowLink) {
-        // find where the next row of links starts to insert details panel before
-        var top = link.offsetTop;
-
-        var nextRow = null;
-        for (
-          var i = flowLinks.indexOf(link);
-          i < flowLinks.length && !nextRow;
-          i++
-        ) {
-          if (flowLinks[i].offsetTop > top) {
-            nextRow = flowLinks[i];
-          }
+      var nextRow = null;
+      for (
+        var i = flowLinks.indexOf(link);
+        i < flowLinks.length && !nextRow;
+        i++
+      ) {
+        if (flowLinks[i].offsetTop > top) {
+          nextRow = flowLinks[i];
         }
-        const isOpen = link.classList.contains("is-open");
-
-        closeDetails();
-
-        if (!isOpen) {
-          // find the end of the row of icons to place details panel properly
-          var details = rootEl.querySelector(
-            `[data-flow-details='${link.dataset.flowLink}'`
-          );
-          if (nextRow) {
-            nextRow.parentNode.insertBefore(details, nextRow);
-          } else {
-            rootEl.appendChild(details);
-          }
-          details.style.display = "block";
-          link.classList.add("is-open");
-        } else {
-          link.classList.remove("is-open");
-        }
-
-        window.scrollTo(0, link.offsetTop);
-        event.preventDefault();
       }
-    });
+      const isOpen = link.classList.contains("is-open");
+
+      closeDetails();
+
+      if (!isOpen) {
+        // find the end of the row of icons to place details panel properly
+        var details = rootEl.querySelector(
+          `[data-flow-details='${link.dataset.flowLink}'`
+        );
+        if (nextRow) {
+          nextRow.parentNode.insertBefore(details, nextRow);
+        } else {
+          rootEl.appendChild(details);
+        }
+        details.style.display = "block";
+        link.classList.add("is-open");
+        window.location.hash = link.dataset.flowLink;
+      } else {
+        link.classList.remove("is-open");
+        window.location.hash = "";
+      }
+
+      window.scrollTo(0, link.offsetTop);
+    }
+  };
+
+  rootEl.addEventListener("click", event => {
+    var link = event.target.closest(".p-flow-link");
+
+    if (link) {
+      openDetails(link);
+      event.preventDefault();
+    }
   });
+
+  // if there is a hash in URL that corresponds to one of the languages
+  // open given language section (for example /first-snap#python)
+  const hash = window.location.hash.slice(1);
+  const link = rootEl.querySelector(`[data-flow-link='${hash}'`);
+  if (link) {
+    openDetails(link);
+  }
 
   const onResize = debounce(closeDetails, 500);
   window.addEventListener("resize", onResize);


### PR DESCRIPTION
Fixes #1905

In first snap flow language selection page it opens the section corresponding to hash in the URL.

### QA
- ./run or https://snapcraft-io-canonical-web-and-design-pr-1916.run.demo.haus/
- go to first snap flow
- click on any language
- details should open and hash in URL should change
- see that it works for different languages
- reload the page with URL with hash (https://snapcraft-io-canonical-web-and-design-pr-1916.run.demo.haus/first-snap#c)
- page should load and language details from URL should open
- same should with language selector for first snap flow on home page