### PR TITLE
Check if user is snap collaborator for snap details editing

### DIFF
--- a/tests/publisher/snaps/test_logic.py
+++ b/tests/publisher/snaps/test_logic.py
@@ -1,0 +1,44 @@
+import unittest
+
+from webapp.publisher.snaps import logic
+
+
+class LogicTest(unittest.TestCase):
+    def test_get_snap_names_by_ownership(self):
+        account_info = {
+            "username": "toto",
+            "snaps": {
+                "16": {
+                    "test": {
+                        "status": "Approved",
+                        "snap-id": "1",
+                        "snap-name": "test",
+                        "publisher": {"username": "toto"},
+                        "latest_revisions": [
+                            {
+                                "test": "test",
+                                "since": "2018-01-01T00:00:00Z",
+                                "channels": [],
+                            }
+                        ],
+                    },
+                    "test2": {
+                        "status": "Approved",
+                        "snap-id": "2",
+                        "snap-name": "test2",
+                        "publisher": {"username": "titi"},
+                        "latest_revisions": [
+                            {
+                                "test": "test",
+                                "since": "2018-01-01T00:00:00Z",
+                                "channels": [],
+                            }
+                        ],
+                    },
+                }
+            },
+        }
+
+        owned, shared = logic.get_snap_names_by_ownership(account_info)
+        self.assertListEqual(owned, ["test"])
+        self.assertListEqual(shared, ["test2"])

--- a/tests/store/tests_details.py
+++ b/tests/store/tests_details.py
@@ -110,7 +110,7 @@ class GetDetailsPageTest(TestCase):
     def test_user_connected(self):
         payload = {
             "snap-id": "id",
-            "name": "snapName",
+            "name": "toto",
             "snap": {
                 "title": "Snap Title",
                 "summary": "This is a summary",
@@ -155,11 +155,16 @@ class GetDetailsPageTest(TestCase):
         )
 
         with self.client.session_transaction() as s:
-            s["openid"] = {"nickname": "toto"}
+            # make test session 'authenticated'
+            s["openid"] = {"nickname": "toto", "fullname": "Totinio"}
+            s["macaroon_root"] = "test"
+            s["macaroon_discharge"] = "test"
+            # mock test user snaps list
+            s["user_snaps"] = {"toto": {"snap-id": "test"}}
 
         response = self.client.get(self.endpoint_url)
 
-        assert response.status_code == 200
+        self.assert200(response)
         self.assert_context("is_users_snap", True)
 
     @responses.activate

--- a/webapp/authentication.py
+++ b/webapp/authentication.py
@@ -37,6 +37,7 @@ def empty_session(session):
     session.pop("macaroon_root", None)
     session.pop("macaroon_discharge", None)
     session.pop("openid", None)
+    session.pop("user_shared_snaps", None)
 
 
 def get_caveat_id(root):

--- a/webapp/login/views.py
+++ b/webapp/login/views.py
@@ -8,6 +8,7 @@ from webapp.api import dashboard
 from webapp.api.exceptions import ApiCircuitBreaker, ApiError, ApiResponseError
 from webapp.extensions import csrf
 from webapp.login.macaroon import MacaroonRequest, MacaroonResponse
+from webapp.publisher.snaps import logic
 
 login = flask.Blueprint(
     "login", __name__, template_folder="/templates", static_folder="/static"
@@ -70,6 +71,9 @@ def after_login(resp):
             "image": resp.image,
             "email": account["email"],
         }
+        snaps, names = logic.get_snaps_account_info(account)
+        flask.session["user_snaps"] = snaps
+
     except ApiCircuitBreaker:
         flask.abort(503)
     except Exception:

--- a/webapp/login/views.py
+++ b/webapp/login/views.py
@@ -72,7 +72,7 @@ def after_login(resp):
             "email": account["email"],
         }
         snaps, names = logic.get_snaps_account_info(account)
-        flask.session["user_snaps"] = snaps
+        flask.session["user_snaps"] = list(snaps.keys())
 
     except ApiCircuitBreaker:
         flask.abort(503)

--- a/webapp/login/views.py
+++ b/webapp/login/views.py
@@ -71,8 +71,8 @@ def after_login(resp):
             "image": resp.image,
             "email": account["email"],
         }
-        snaps, names = logic.get_snaps_account_info(account)
-        flask.session["user_snaps"] = list(snaps.keys())
+        owned, shared = logic.get_snap_names_by_ownership(account)
+        flask.session["user_shared_snaps"] = shared
 
     except ApiCircuitBreaker:
         flask.abort(503)

--- a/webapp/publisher/snaps/logic.py
+++ b/webapp/publisher/snaps/logic.py
@@ -7,10 +7,10 @@ from json import dumps
 def get_snaps_account_info(account_info):
     """Get snaps from the account information of a user
 
-    :param account_info The account informations
+    :param account_info: The account informations
 
-    :return A list of snaps
-    :return A list of registred snaps
+    :return: A list of snaps
+    :return: A list of registred snaps
     """
     user_snaps = {}
     registered_snaps = {}
@@ -50,13 +50,36 @@ def get_snaps_account_info(account_info):
     return user_snaps, registered_snaps
 
 
+def get_snap_names_by_ownership(account_info):
+    """Get list of snaps names user is collaborator of
+
+    :param account_info: The account informations
+
+    :return: A list of owned snaps names
+    :return: A list of shared snaps names
+    """
+
+    snaps, registered_names = get_snaps_account_info(account_info)
+
+    owned_snaps_names = []
+    shared_snaps_names = []
+
+    for snap in snaps:
+        if snaps[snap]["publisher"]["username"] == account_info["username"]:
+            owned_snaps_names.append(snap)
+        else:
+            shared_snaps_names.append(snap)
+
+    return owned_snaps_names, shared_snaps_names
+
+
 def verify_base_metrics(active_devices):
     """Verify that the base metric exists in the list of available
     metrics
 
-    :param active_devices The base metric
+    :param active_devices: The base metric
 
-    :return The base metric if it's available, 'version' if not
+    :return: The base metric if it's available, 'version' if not
     """
     if active_devices not in ("version", "os", "channel"):
         return "version"
@@ -79,9 +102,9 @@ def extract_metrics_period(metric_period):
         'bucket': 30
       }
 
-    :param metric_period The metric period requested
+    :param metric_period: The metric period requested
 
-    :returns A dictionnary with the differents values of the period
+    :returns: A dictionnary with the differents values of the period
     """
     allowed_periods = ["d", "m", "y"]
 

--- a/webapp/store/snap_details_views.py
+++ b/webapp/store/snap_details_views.py
@@ -16,6 +16,7 @@ from webapp.api.exceptions import (
     ApiTimeoutError,
 )
 from webapp.markdown import parse_markdown_description
+from webapp import authentication
 
 
 def snap_details_views(store, api, handle_errors):
@@ -116,10 +117,10 @@ def snap_details_views(store, api, handle_errors):
         )
 
         is_users_snap = False
-        if flask.session and "openid" in flask.session:
+        if authentication.is_authenticated(flask.session):
             if (
-                flask.session.get("openid").get("nickname")
-                == details["snap"]["publisher"]["username"]
+                "user_snaps" in flask.session
+                and snap_name in flask.session.get("user_snaps")
             ):
                 is_users_snap = True
 

--- a/webapp/store/snap_details_views.py
+++ b/webapp/store/snap_details_views.py
@@ -119,8 +119,11 @@ def snap_details_views(store, api, handle_errors):
         is_users_snap = False
         if authentication.is_authenticated(flask.session):
             if (
-                "user_snaps" in flask.session
-                and snap_name in flask.session.get("user_snaps")
+                flask.session.get("openid").get("nickname")
+                == details["snap"]["publisher"]["username"]
+            ) or (
+                "user_shared_snaps" in flask.session
+                and snap_name in flask.session.get("user_shared_snaps")
             ):
                 is_users_snap = True
 


### PR DESCRIPTION
Fixes #1813

Show notification on snap details page for snap owners and collaborators with a link to editing details of listing page.

### QA

- ./run or https://snapcraft-io-canonical-web-and-design-pr-1919.run.demo.haus/
- go to snap details page of a snap shared with you (that you didn't create yourself)
- snap details page should show notification about editing the snap listing
- go to snap details page of snap you don't own (and are not a collaborator of) - no notification should be on the page

<img width="1022" alt="Screenshot 2019-05-17 at 09 37 06" src="https://user-images.githubusercontent.com/83575/57911191-5dbb8800-7887-11e9-91e2-f684542b1032.png">
