### PR TITLE
Semi-automate snapcraft live

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -36,6 +36,8 @@
       </div>
     {% endif %}
 
+    {% include 'partials/livestream-notification.html' %}
+
     <div class="col-12">
       <h2>The app store for Linux</h2>
       <p class="u-no-padding--top p-heading--four">Publish your app for Linux users &mdash;<br class="u-hide--small" /> for desktop, cloud, and Internet of Things.</p>

--- a/templates/partials/livestream-notification.html
+++ b/templates/partials/livestream-notification.html
@@ -2,7 +2,7 @@
     <div class="col-12">
         <div class="p-notification--information p-snapcraft-nps-banner">
             <p class="p-notification__response">
-                <span class="p-notification__status">📺 LIVE</span>
+                <span class="p-notification__status">LIVE</span>
                 <a href="{{ livestream.url }}" target="_blank" class="p-link--external">Watch our Snapcraft Live Stream </a>&nbsp;{{ livestream.text }}
             </p>
         </div>

--- a/templates/partials/livestream-notification.html
+++ b/templates/partials/livestream-notification.html
@@ -1,0 +1,10 @@
+{% if livestream %}
+    <div class="col-12">
+        <div class="p-notification--information p-snapcraft-nps-banner">
+            <p class="p-notification__response">
+                <span class="p-notification__status">📺 LIVE</span>
+                <a href="{{ livestream.url }}" target="_blank" class="p-link--external">Watch our Snapcraft Live Stream </a>&nbsp;{{ livestream.text }}
+            </p>
+        </div>
+    </div>
+{% endif %}

--- a/templates/partials/search-bar.html
+++ b/templates/partials/search-bar.html
@@ -6,6 +6,7 @@
 {% endif %}">
   <div class="row">
     {% if not IS_BRAND_STORE %}
+      {% include 'partials/livestream-notification.html' %}
       <h1 class="p-heading--two">Search thousands of snaps used by millions of people across 41 Linux distributions</h1>
     {% endif %}
     {% if webapp_config['STORE_SEARCH_INTRO'] %}

--- a/webapp/helpers.py
+++ b/webapp/helpers.py
@@ -42,6 +42,12 @@ def get_default_track(snap_name):
     return default_track
 
 
+def get_livestreams():
+    content = _get_file("snapcraft/content/snapcraft_live.yaml")
+
+    return content
+
+
 def _get_file(yaml_file):
     try:
         with open(

--- a/webapp/snapcraft/content/snapcraft_live.yaml
+++ b/webapp/snapcraft/content/snapcraft_live.yaml
@@ -1,0 +1,3 @@
+- text: Building snaps - version management & parallel snap installs
+  time: 2019-05-17T13:00:00Z
+  url: https://www.youtube.com/watch?v=ZtAzeoA0UgE

--- a/webapp/snapcraft/logic.py
+++ b/webapp/snapcraft/logic.py
@@ -1,21 +1,21 @@
-from webapp import helpers
 from datetime import datetime, timedelta
+
+from webapp import helpers
 
 
 def get_livestreams():
     """
     Get available livestreams and decide whether they should be shown
-    :return: Dictionary of livestream details
+    :returns: Dictionary of livestream details
     """
-    lead_time = 4  # 4 days
-    cooldown_time = 2  # 2 days
+    livestream_to_show = None
     livestreams = helpers.get_livestreams()
 
-    now = datetime.now()
-
-    livestream_to_show = None
-
     if livestreams:
+        now = datetime.now()
+        lead_time = 4  # 4 days
+        cooldown_time = 2  # 2 days
+
         for livestream in livestreams:
             instance_lead_time = lead_time
             if "lead_time" in livestream:

--- a/webapp/snapcraft/logic.py
+++ b/webapp/snapcraft/logic.py
@@ -1,0 +1,36 @@
+from webapp import helpers
+from datetime import datetime, timedelta
+
+
+def get_livestreams():
+    """
+    Get available livestreams and decide whether they should be shown
+    :return: Dictionary of livestream details
+    """
+    lead_time = 4  # 4 days
+    cooldown_time = 2  # 2 days
+    livestreams = helpers.get_livestreams()
+
+    now = datetime.now()
+
+    livestream_to_show = None
+
+    if livestreams:
+        for livestream in livestreams:
+            instance_lead_time = lead_time
+            if "lead_time" in livestream:
+                instance_lead_time = livestream["lead_time"]
+
+            instance_cooldown_time = cooldown_time
+            if "lead_time" in livestream:
+                instance_cooldown_time = livestream["cooldown_time"]
+
+            show_from = livestream["time"] - timedelta(days=instance_lead_time)
+            show_until = livestream["time"] + timedelta(
+                days=instance_cooldown_time
+            )
+
+            if show_from < now and show_until > now:
+                livestream_to_show = livestream
+
+    return livestream_to_show

--- a/webapp/snapcraft/logic.py
+++ b/webapp/snapcraft/logic.py
@@ -22,7 +22,7 @@ def get_livestreams():
                 instance_lead_time = livestream["lead_time"]
 
             instance_cooldown_time = cooldown_time
-            if "lead_time" in livestream:
+            if "cooldown_time" in livestream:
                 instance_cooldown_time = livestream["cooldown_time"]
 
             show_from = livestream["time"] - timedelta(days=instance_lead_time)

--- a/webapp/snapcraft/views.py
+++ b/webapp/snapcraft/views.py
@@ -1,4 +1,5 @@
 import flask
+from webapp.snapcraft import logic
 
 
 def snapcraft_blueprint():
@@ -13,7 +14,11 @@ def snapcraft_blueprint():
     def homepage():
         nps = flask.request.args.get("nps")
 
-        return flask.render_template("index.html", nps=nps)
+        livestream = logic.get_livestreams()
+
+        return flask.render_template(
+            "index.html", nps=nps, livestream=livestream
+        )
 
     @snapcraft.route("/iot")
     def iot():

--- a/webapp/snapcraft/views.py
+++ b/webapp/snapcraft/views.py
@@ -1,4 +1,5 @@
 import flask
+
 from webapp.snapcraft import logic
 
 

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -15,8 +15,8 @@ from webapp.api.exceptions import (
     ApiTimeoutError,
 )
 from webapp.api.store import StoreApi
-from webapp.store.snap_details_views import snap_details_views
 from webapp.snapcraft import logic as snapcraft_logic
+from webapp.store.snap_details_views import snap_details_views
 
 
 def store_blueprint(store_query=None, testing=False):

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -16,6 +16,7 @@ from webapp.api.exceptions import (
 )
 from webapp.api.store import StoreApi
 from webapp.store.snap_details_views import snap_details_views
+from webapp.snapcraft import logic as snapcraft_logic
 
 
 def store_blueprint(store_query=None, testing=False):
@@ -82,6 +83,8 @@ def store_blueprint(store_query=None, testing=False):
         if len(featured_snaps) == 10 and featured_snaps[0]["icon_url"] == "":
             featured_snaps = featured_snaps[:-1]
 
+        livestream = snapcraft_logic.get_livestreams()
+
         return (
             flask.render_template(
                 "store/store.html",
@@ -89,6 +92,7 @@ def store_blueprint(store_query=None, testing=False):
                 has_featured=True,
                 featured_snaps=featured_snaps,
                 error_info=error_info,
+                livestream=livestream,
             ),
             status_code,
         )


### PR DESCRIPTION
Semi fixes: https://github.com/canonical-web-and-design/snapcraft.io/issues/1854

## QA
- Pull the branch
- `./run`
- Visit http://0.0.0.0:8004/ and http://0.0.0.0:8004/store
- See the notification atop the page

## BONUS QA
- Edit `webapp/snapcraft/content/snapcraft_live.yaml`
- Set a different time to ensure that the default `lead_time` of 4 days is honoured
- Set a different time to ensure that the default `cooldown_time` of 2 days is honoured
- Set `lead_time` in the yaml to ensure that the local lead time override works
- set `cooldown_time` in the yaml to ensure that the local cooldown time override works