### PR TITLE
Fix first snap flow macOS test instructions

### DIFF
--- a/webapp/first_snap/content/c/test.yaml
+++ b/webapp/first_snap/content/c/test.yaml
@@ -3,15 +3,14 @@ macos:
   - action: Create a Linux virtual machine for testing snaps
     command: multipass launch -n testvm
   - action: Return to the directory containing the .snap file and copy it into the virtual machine
-    command: 'multipass copy-files dosbox*.snap testvm:'
+    command: 'multipass copy-files ${name}*.snap testvm:'
   - action: Connect to the virtual machine
     command: multipass shell testvm
   - action: Install the snap inside the virtual machine
-    command: sudo snap install --devmode --dangerous dosbox*.snap
+    command: sudo snap install --devmode --dangerous ${name}*.snap
   - action: Confirm the snap is installed by listing your installed snaps
     command: snap list
   - action: Run the snap inside the virtual machine
-    warning: You should change <code>dosbox</code> to <code>${name}</code>, as written into the snapcraft.yaml file earlier.
-    command: dosbox -h
+    command: ${name} -h
   - action: Exit the virtual machine
     command: exit

--- a/webapp/first_snap/content/golang/test.yaml
+++ b/webapp/first_snap/content/golang/test.yaml
@@ -3,15 +3,14 @@ macos:
   - action: Create a Linux virtual machine for testing snaps
     command: multipass launch -n testvm
   - action: Return to the directory containing the .snap file and copy it into the virtual machine
-    command: 'multipass copy-files *.snap testvm:'
+    command: 'multipass copy-files ${name}*.snap testvm:'
   - action: Connect to the virtual machine
     command: multipass shell testvm
   - action: Install the snap inside the virtual machine
-    command: sudo snap install --devmode --dangerous *.snap
+    command: sudo snap install --devmode --dangerous ${name}*.snap
   - action: Confirm the snap is installed by listing your installed snaps
     command: snap list
   - action: Run the snap inside the virtual machine
-    warning: You should change <code>httplab</code> to <code>${name}</code>, as written into the snapcraft.yaml file earlier.
-    command: httplab
+    command: ${name}
   - action: Exit the virtual machine
     command: exit

--- a/webapp/first_snap/content/java/test.yaml
+++ b/webapp/first_snap/content/java/test.yaml
@@ -3,15 +3,14 @@ macos:
   - action: Create a Linux virtual machine for testing snaps
     command: multipass launch -n testvm
   - action: Return to the directory containing the .snap file and copy it into the virtual machine
-    command: 'multipass copy-files freeplane*.snap testvm:'
+    command: 'multipass copy-files ${name}*.snap testvm:'
   - action: Connect to the virtual machine
     command: multipass shell testvm
   - action: Install the snap inside the virtual machine
-    command: sudo snap install --devmode --dangerous freeplane*.snap
+    command: sudo snap install --devmode --dangerous ${name}*.snap
   - action: Confirm the snap is installed by listing your installed snaps
     command: snap list
   - action: Run the snap inside the virtual machine
-    warning: You should change <code>freeplane</code> to <code>${name}</code>, as written into the snapcraft.yaml file earlier.
-    command: freeplane -h
+    command: ${name} -h
   - action: Exit the virtual machine
     command: exit

--- a/webapp/first_snap/content/moos/test.yaml
+++ b/webapp/first_snap/content/moos/test.yaml
@@ -3,15 +3,14 @@ macos:
   - action: Create a Linux virtual machine for testing snaps
     command: multipass launch -n testvm
   - action: Return to the directory containing the .snap file and copy it into the virtual machine
-    command: 'multipass copy-files moos*.snap testvm:'
+    command: 'multipass copy-files ${name}*.snap testvm:'
   - action: Connect to the virtual machine
     command: multipass shell testvm
   - action: Install the snap inside the virtual machine
-    command: sudo snap install --devmode --dangerous moos*.snap
+    command: sudo snap install --devmode --dangerous ${name}*.snap
   - action: Confirm the snap is installed by listing your installed snaps
     command: snap list
   - action: Run the snap inside the virtual machine
-    warning: You should change <code>moos</code> to <code>test-moos-{name}</code> (where <code>{name}</code> is your name), as written into the snapcraft.yaml file earlier.
-    command: test-moos-{name}.MOOSDB -h
+    command: ${name}.MOOSDB -h
   - action: Exit the virtual machine
     command: exit

--- a/webapp/first_snap/content/node/test.yaml
+++ b/webapp/first_snap/content/node/test.yaml
@@ -3,15 +3,14 @@ macos:
   - action: Create a Linux virtual machine for testing snaps
     command: multipass launch -n testvm
   - action: Return to the directory containing the .snap file and copy it into the virtual machine
-    command: 'multipass copy-files wethr*.snap testvm:'
+    command: 'multipass copy-files ${name}*.snap testvm:'
   - action: Connect to the virtual machine
     command: multipass shell testvm
   - action: Install the snap inside the virtual machine
-    command: sudo snap install --devmode --dangerous wethr*.snap
+    command: sudo snap install --devmode --dangerous ${name}*.snap
   - action: Confirm the snap is installed by listing your installed snaps
     command: snap list
   - action: Run the snap inside the virtual machine
-    warning: You should change <code>wethr</code> to <code>${name}</code>, as written into the snapcraft.yaml file earlier.
-    command: wethr -h
+    command: ${name} -h
   - action: Exit the virtual machine
     command: exit

--- a/webapp/first_snap/content/pre-built/test.yaml
+++ b/webapp/first_snap/content/pre-built/test.yaml
@@ -3,7 +3,7 @@ macos:
   - action: Create a Linux virtual machine for testing snaps
     command: multipass launch -n testvm
   - action: Return to the directory containing the snapcraft.yaml and map it into the virtual machine
-    command: 'multipass copy-files *.snap testvm:'
+    command: 'multipass copy-files ${name}*.snap testvm:'
   - action: Connect to the virtual machine using Multipass
     command: multipass shell testvm
   - action: Install the snap inside the virtual machine

--- a/webapp/first_snap/content/python/test.yaml
+++ b/webapp/first_snap/content/python/test.yaml
@@ -3,15 +3,14 @@ macos:
   - action: Create a Linux virtual machine for testing snaps
     command: multipass launch -n testvm
   - action: Return to the directory containing the .snap file and copy it into the virtual machine
-    command: 'multipass copy-files offlineimap*.snap testvm:'
+    command: 'multipass copy-files ${name}*.snap testvm:'
   - action: Connect to the virtual machine
     command: multipass shell testvm
   - action: Install the snap inside the virtual machine
-    command: sudo snap install --devmode --dangerous offlineimap*.snap
+    command: sudo snap install --devmode --dangerous ${name}*.snap
   - action: Confirm the snap is installed by listing your installed snaps
     command: snap list
   - action: Run the snap inside the virtual machine
-    warning: Make sure the name matches what has been used previously (i.e <code>${name}</code>).
     command: ${name} -h
   - action: Exit the virtual machine
     command: exit

--- a/webapp/first_snap/content/ros/test.yaml
+++ b/webapp/first_snap/content/ros/test.yaml
@@ -3,15 +3,14 @@ macos:
   - action: Create a Linux virtual machine for testing snaps
     command: multipass launch -n testvm
   - action: Return to the directory containing the .snap file and copy it into the virtual machine
-    command: 'multipass copy-files ros-talker-listener*.snap testvm:'
+    command: 'multipass copy-files ${name}*.snap testvm:'
   - action: Connect to the virtual machine
     command: multipass shell testvm
   - action: Install the snap inside the virtual machine
-    command: sudo snap install --devmode --dangerous ros-talker-listener*.snap
+    command: sudo snap install --devmode --dangerous ${name}*.snap
   - action: Confirm the snap is installed by listing your installed snaps
     command: snap list
   - action: Run the snap inside the virtual machine
-    warning: You should change <code>ros-talker-listener</code> to <code>${name}</code>, as written into the snapcraft.yaml file earlier.
     command: ${name} -h
   - action: Exit the virtual machine
     command: exit

--- a/webapp/first_snap/content/ros2/test.yaml
+++ b/webapp/first_snap/content/ros2/test.yaml
@@ -3,15 +3,14 @@ macos:
   - action: Create a Linux virtual machine for testing snaps
     command: multipass launch -n testvm
   - action: Return to the directory containing the .snap file and copy it into the virtual machine
-    command: 'multipass copy-files ros2-talker-listener*.snap testvm:'
+    command: 'multipass copy-files ${name}*.snap testvm:'
   - action: Connect to the virtual machine
     command: multipass shell testvm
   - action: Install the snap inside the virtual machine
-    command: sudo snap install --devmode --dangerous ros2-talker-listener*.snap
+    command: sudo snap install --devmode --dangerous ${name}*.snap
   - action: Confirm the snap is installed by listing your installed snaps
     command: snap list
   - action: Run the snap inside the virtual machine
-    warning: You should change <code>ros2-talker-listener</code> to <code>${name}</code>, as written into the snapcraft.yaml file earlier.
     command: ${name} -h
   - action: Exit the virtual machine
     command: exit

--- a/webapp/first_snap/content/ruby/test.yaml
+++ b/webapp/first_snap/content/ruby/test.yaml
@@ -3,15 +3,14 @@ macos:
   - action: Create a Linux virtual machine for testing snaps
     command: multipass launch -n testvm
   - action: Return to the directory containing the .snap file and copy it into the virtual machine
-    command: 'multipass copy-files mdl*.snap testvm:'
+    command: 'multipass copy-files ${name}*.snap testvm:'
   - action: Connect to the virtual machine
     command: multipass shell testvm
   - action: Install the snap inside the virtual machine
-    command: sudo snap install --devmode --dangerous mdl*.snap
+    command: sudo snap install --devmode --dangerous ${name}*.snap
   - action: Confirm the snap is installed by listing your installed snaps
     command: snap list
   - action: Run the snap inside the virtual machine
-    warning: You should change <code>mdl</code> to <code>${name}</code>, as written into the snapcraft.yaml file earlier.
     command: ${name} -h
   - action: Exit the virtual machine
     command: exit

--- a/webapp/first_snap/content/rust/test.yaml
+++ b/webapp/first_snap/content/rust/test.yaml
@@ -3,15 +3,14 @@ macos:
   - action: Create a Linux virtual machine for testing snaps
     command: multipass launch -n testvm
   - action: Return to the directory containing the .snap file and copy it into the virtual machine
-    command: 'multipass copy-files xsv*.snap testvm:'
+    command: 'multipass copy-files ${name}*.snap testvm:'
   - action: Connect to the virtual machine
     command: multipass shell testvm
   - action: Install the snap inside the virtual machine
-    command: sudo snap install --devmode --dangerous xsv*.snap
+    command: sudo snap install --devmode --dangerous ${name}*.snap
   - action: Confirm the snap is installed by listing your installed snaps
     command: snap list
   - action: Run the snap inside the virtual machine
-    warning: You should change <code>xsv</code> to <code>${name}</code>, as written into the snapcraft.yaml file earlier.
     command: ${name} -h
   - action: Exit the virtual machine
     command: exit


### PR DESCRIPTION
Fixes #1910 

Updates first snap flow macOS test instructions to correctly display user chosen snap name

### QA
- ./run or https://snapcraft-io-canonical-web-and-design-pr-1923.run.demo.haus/
- go to first snap flow, any language, choose mac OS
- go next, choose snap name
-  go to test step
- install instructions in all steps should correctly show entered snap name

<img width="728" alt="Screenshot 2019-05-16 at 17 10 34" src="https://user-images.githubusercontent.com/83575/57865267-8bf48580-77fd-11e9-8368-6222a6b7cb97.png">
