### PR TITLE
WIP: Remove hardcoded snap names from first snap flow content

### DIFF
--- a/tests/first_snap/tests_views.py
+++ b/tests/first_snap/tests_views.py
@@ -142,7 +142,7 @@ class FirstSnap(TestCase):
         self.assert_context("language", "python")
         self.assert_context("os", "linux")
         self.assert_context("user", None)
-        self.assert_context("snap_name", "test-offlineimap-{name}")
+        self.assert_context("snap_name", "test-python-[yourname]")
 
     def test_get_push_snap_name(self):
         response = self.client.get(
@@ -178,7 +178,7 @@ class FirstSnap(TestCase):
         self.assert_context("language", "python")
         self.assert_context("os", "linux")
         self.assert_context("user", user_expected)
-        self.assert_context("snap_name", "test-offlineimap-{name}")
+        self.assert_context("snap_name", "test-python-[yourname]")
 
     def test_get_push_404(self):
         response = self.client.get("/first-snap/toto-lang/linux/push")

--- a/webapp/first_snap/content/c/build.yaml
+++ b/webapp/first_snap/content/c/build.yaml
@@ -1,4 +1,3 @@
-name: test-dosbox-{name}
 linux:
   auto:
     - action: Return to the root directory of the project containing your snapcraft.yaml and run snapcraft

--- a/webapp/first_snap/content/c/package.yaml
+++ b/webapp/first_snap/content/c/package.yaml
@@ -1,2 +1,1 @@
-name: test-dosbox-{name}
 download: git clone https://github.com/snapcraft-docs/dosbox

--- a/webapp/first_snap/content/c/test.yaml
+++ b/webapp/first_snap/content/c/test.yaml
@@ -1,4 +1,3 @@
-name: test-dosbox-{name}
 macos:
   - action: Create a Linux virtual machine for testing snaps
     command: multipass launch -n testvm

--- a/webapp/first_snap/content/golang/build.yaml
+++ b/webapp/first_snap/content/golang/build.yaml
@@ -1,4 +1,3 @@
-name: test-httplab-{name}
 linux:
   auto:
     - action: Return to the root directory of the project containing your snapcraft.yaml and run snapcraft

--- a/webapp/first_snap/content/golang/package.yaml
+++ b/webapp/first_snap/content/golang/package.yaml
@@ -1,2 +1,1 @@
-name: test-httplab-{name}
 download: git clone https://github.com/snapcraft-docs/httplab

--- a/webapp/first_snap/content/golang/test.yaml
+++ b/webapp/first_snap/content/golang/test.yaml
@@ -1,4 +1,3 @@
-name: test-httplab-{name}
 macos:
   - action: Create a Linux virtual machine for testing snaps
     command: multipass launch -n testvm

--- a/webapp/first_snap/content/java/build.yaml
+++ b/webapp/first_snap/content/java/build.yaml
@@ -1,4 +1,3 @@
-name: test-freeplane-{name}
 linux:
   auto:
     - action: Return to the root directory of the project containing your snapcraft.yaml and run snapcraft

--- a/webapp/first_snap/content/java/package.yaml
+++ b/webapp/first_snap/content/java/package.yaml
@@ -1,2 +1,1 @@
-name: test-freeplane-{name}
 download: git clone https://github.com/snapcraft-docs/freeplane

--- a/webapp/first_snap/content/java/test.yaml
+++ b/webapp/first_snap/content/java/test.yaml
@@ -1,4 +1,3 @@
-name: test-freeplane-{name}
 macos:
   - action: Create a Linux virtual machine for testing snaps
     command: multipass launch -n testvm

--- a/webapp/first_snap/content/moos/build.yaml
+++ b/webapp/first_snap/content/moos/build.yaml
@@ -1,4 +1,3 @@
-name: test-moos-{name}
 linux:
   auto:
     - action: Return to the root directory of the project containing your snapcraft.yaml and run snapcraft

--- a/webapp/first_snap/content/moos/package.yaml
+++ b/webapp/first_snap/content/moos/package.yaml
@@ -1,2 +1,1 @@
-name: test-moos-{name}
 download: git clone https://github.com/snapcraft-docs/moos

--- a/webapp/first_snap/content/moos/test.yaml
+++ b/webapp/first_snap/content/moos/test.yaml
@@ -1,4 +1,3 @@
-name: test-moos-{name}
 macos:
   - action: Create a Linux virtual machine for testing snaps
     command: multipass launch -n testvm

--- a/webapp/first_snap/content/node/build.yaml
+++ b/webapp/first_snap/content/node/build.yaml
@@ -1,4 +1,3 @@
-name: test-wethr-{name}
 linux:
   auto:
     - action: Return to the root directory of the project containing your snapcraft.yaml and run snapcraft

--- a/webapp/first_snap/content/node/package.yaml
+++ b/webapp/first_snap/content/node/package.yaml
@@ -1,2 +1,1 @@
-name: test-wethr-{name}
 download: git clone https://github.com/snapcraft-docs/wethr

--- a/webapp/first_snap/content/node/test.yaml
+++ b/webapp/first_snap/content/node/test.yaml
@@ -1,4 +1,3 @@
-name: test-wethr-{name}
 macos:
   - action: Create a Linux virtual machine for testing snaps
     command: multipass launch -n testvm

--- a/webapp/first_snap/content/pre-built/build.yaml
+++ b/webapp/first_snap/content/pre-built/build.yaml
@@ -1,4 +1,3 @@
-name: test-geekbench4-{name}
 linux:
   auto:
     - action: Return to the root directory of the project containing your snapcraft.yaml and run snapcraft

--- a/webapp/first_snap/content/pre-built/package.yaml
+++ b/webapp/first_snap/content/pre-built/package.yaml
@@ -1,2 +1,1 @@
-name: test-geekbench4-{name}
 download: git clone https://github.com/snapcraft-docs/geekbench4

--- a/webapp/first_snap/content/pre-built/test.yaml
+++ b/webapp/first_snap/content/pre-built/test.yaml
@@ -1,4 +1,3 @@
-name: test-geekbench4-{name}
 macos:
   - action: Create a Linux virtual machine for testing snaps
     command: multipass launch -n testvm

--- a/webapp/first_snap/content/python/build.yaml
+++ b/webapp/first_snap/content/python/build.yaml
@@ -1,4 +1,3 @@
-name: test-offlineimap-{name}
 linux:
   auto:
     - action: Return to the root directory of the project containing your snapcraft.yaml and run snapcraft

--- a/webapp/first_snap/content/python/package.yaml
+++ b/webapp/first_snap/content/python/package.yaml
@@ -1,2 +1,1 @@
-name: test-offlineimap-{name}
 download: git clone https://github.com/snapcraft-docs/offlineimap

--- a/webapp/first_snap/content/python/test.yaml
+++ b/webapp/first_snap/content/python/test.yaml
@@ -1,4 +1,3 @@
-name: test-offlineimap-{name}
 macos:
   - action: Create a Linux virtual machine for testing snaps
     command: multipass launch -n testvm

--- a/webapp/first_snap/content/ros/build.yaml
+++ b/webapp/first_snap/content/ros/build.yaml
@@ -1,4 +1,3 @@
-name: test-ros-talker-listener-{name}
 linux:
   auto:
     - action: Return to the root directory of the project containing your snapcraft.yaml and run snapcraft

--- a/webapp/first_snap/content/ros/package.yaml
+++ b/webapp/first_snap/content/ros/package.yaml
@@ -1,2 +1,1 @@
-name: test-ros-talker-listener-{name}
 download: git clone https://github.com/snapcraft-docs/ros-talker-listener

--- a/webapp/first_snap/content/ros/test.yaml
+++ b/webapp/first_snap/content/ros/test.yaml
@@ -1,4 +1,3 @@
-name: test-ros-talker-listener-{name}
 macos:
   - action: Create a Linux virtual machine for testing snaps
     command: multipass launch -n testvm

--- a/webapp/first_snap/content/ros2/build.yaml
+++ b/webapp/first_snap/content/ros2/build.yaml
@@ -1,4 +1,3 @@
-name: test-ros2-talker-listener-{name}
 linux:
   auto:
     - action: Return to the root directory of the project containing your snapcraft.yaml and run snapcraft

--- a/webapp/first_snap/content/ros2/package.yaml
+++ b/webapp/first_snap/content/ros2/package.yaml
@@ -1,2 +1,1 @@
-name: test-ros2-talker-listener-{name}
 download: git clone https://github.com/snapcraft-docs/ros2-talker-listener

--- a/webapp/first_snap/content/ros2/test.yaml
+++ b/webapp/first_snap/content/ros2/test.yaml
@@ -1,4 +1,3 @@
-name: test-ros2-talker-listener-{name}
 macos:
   - action: Create a Linux virtual machine for testing snaps
     command: multipass launch -n testvm

--- a/webapp/first_snap/content/ruby/build.yaml
+++ b/webapp/first_snap/content/ruby/build.yaml
@@ -1,4 +1,3 @@
-name: test-mdl-{name}
 linux:
   auto:
     - action: Return to the root directory of the project containing your snapcraft.yaml and run snapcraft

--- a/webapp/first_snap/content/ruby/package.yaml
+++ b/webapp/first_snap/content/ruby/package.yaml
@@ -1,2 +1,1 @@
-name: test-mdl-{name}
 download: git clone https://github.com/snapcraft-docs/mdl

--- a/webapp/first_snap/content/ruby/test.yaml
+++ b/webapp/first_snap/content/ruby/test.yaml
@@ -1,4 +1,3 @@
-name: test-mdl-{name}
 macos:
   - action: Create a Linux virtual machine for testing snaps
     command: multipass launch -n testvm

--- a/webapp/first_snap/content/rust/build.yaml
+++ b/webapp/first_snap/content/rust/build.yaml
@@ -1,4 +1,3 @@
-name: test-xsv-{name}
 linux:
   auto:
     - action: Return to the root directory of the project containing your snapcraft.yaml and run snapcraft

--- a/webapp/first_snap/content/rust/package.yaml
+++ b/webapp/first_snap/content/rust/package.yaml
@@ -1,2 +1,1 @@
-name: test-xsv-{name}
 download: git clone https://github.com/snapcraft-docs/xsv

--- a/webapp/first_snap/content/rust/test.yaml
+++ b/webapp/first_snap/content/rust/test.yaml
@@ -1,4 +1,3 @@
-name: test-xsv-{name}
 macos:
   - action: Create a Linux virtual machine for testing snaps
     command: multipass launch -n testvm

--- a/webapp/first_snap/views.py
+++ b/webapp/first_snap/views.py
@@ -83,6 +83,10 @@ def directory_exists(file):
     return os.path.isdir(os.path.join(flask.current_app.root_path, file))
 
 
+def get_default_snap_name(language):
+    return f"test-{language}-[yourname]"
+
+
 @first_snap.route("/")
 def get_pick_language():
     return flask.render_template("first-snap/language.html")
@@ -110,7 +114,7 @@ def get_language_snapcraft_yaml(language):
     if not steps:
         return flask.abort(404)
 
-    snap_name = steps["name"]
+    snap_name = get_default_snap_name(language)
 
     if snap_name_cookie in flask.request.cookies:
         snap_name = flask.request.cookies.get(snap_name_cookie)
@@ -139,7 +143,7 @@ def get_package(language, operating_system):
     if not steps:
         return flask.abort(404)
 
-    snap_name = steps["name"]
+    snap_name = get_default_snap_name(language)
     has_user_chosen_name = False
 
     if snap_name_cookie in flask.request.cookies:
@@ -186,7 +190,7 @@ def get_build(language, operating_system):
     ):
         return flask.abort(404)
 
-    snap_name = steps["name"]
+    snap_name = get_default_snap_name(language)
 
     if snap_name_cookie in flask.request.cookies:
         snap_name = flask.request.cookies.get(snap_name_cookie)
@@ -212,7 +216,7 @@ def get_test(language, operating_system):
     if not steps or operating_system_only not in steps:
         return flask.abort(404)
 
-    snap_name = steps["name"]
+    snap_name = get_default_snap_name(language)
 
     if snap_name_cookie in flask.request.cookies:
         snap_name = flask.request.cookies.get(snap_name_cookie)
@@ -249,7 +253,7 @@ def get_push(language, operating_system):
     if not data:
         return flask.abort(404)
 
-    snap_name = data["name"]
+    snap_name = get_default_snap_name(language)
     has_user_chosen_name = False
 
     if snap_name_cookie in flask.request.cookies:

--- a/webapp/first_snap/views.py
+++ b/webapp/first_snap/views.py
@@ -106,13 +106,8 @@ def get_language(language):
 
 @first_snap.route("/<language>/snapcraft.yaml")
 def get_language_snapcraft_yaml(language):
-    filename = f"first_snap/content/{language}/package.yaml"
     snapcraft_yaml_filename = f"first_snap/content/{language}/snapcraft.yaml"
     snap_name_cookie = f"fsf_snap_name_{language}"
-    steps = get_yaml(filename)
-
-    if not steps:
-        return flask.abort(404)
 
     snap_name = get_default_snap_name(language)
 
@@ -245,13 +240,11 @@ def get_test(language, operating_system):
 
 @first_snap.route("/<language>/<operating_system>/push")
 def get_push(language, operating_system):
-    filename = f"first_snap/content/{language}/package.yaml"
-    snap_name_cookie = f"fsf_snap_name_{language}"
-
-    data = get_yaml(filename)
-
-    if not data:
+    filename = f"first_snap/content/{language}"
+    if not directory_exists(filename):
         return flask.abort(404)
+
+    snap_name_cookie = f"fsf_snap_name_{language}"
 
     snap_name = get_default_snap_name(language)
     has_user_chosen_name = False


### PR DESCRIPTION
In order to simplify first snap flow views and content .yaml files this PR removes hardcoded snap names from each language content (like `test-offlineimap-{name}`) and replaces them with generated names based on language name (like `test-python-[yourname]`).

### QA
- ./run or demo
- go to first snap flow, any language
- if you haven't chosen any snap name before default snap name based on language should be used

<img width="1031" alt="Screenshot 2019-05-17 at 11 57 06" src="https://user-images.githubusercontent.com/83575/57920256-eb54a300-789a-11e9-8cf8-05f9188ad50b.png">
