### PR TITLE
Remove broken verified publisher tooltip from snaps grid

### DIFF
--- a/templates/store/_media-object-snap-partial.html
+++ b/templates/store/_media-object-snap-partial.html
@@ -1,4 +1,8 @@
-<a class="p-media-object p-media-object--snap{% if media_object_classname %} {{ media_object_classname }}{% endif %}" href="/{{ snap.package_name }}" title="{{ snap.title }} – {{ snap.summary }}">
+<a
+  class="p-media-object p-media-object--snap{% if media_object_classname %} {{ media_object_classname }}{% endif %}"
+  href="/{{ snap.package_name }}"
+  title="{{ snap.title }}{% if snap.summary %} – {{ snap.summary }}{% endif %}"
+>
   {% if snap.icon_url %}
   <img src="{{ snap.icon_url }}" class="p-media-object__image" alt="">
   {% else %}
@@ -14,10 +18,9 @@
         <p>
           <span class="u-off-screen">Publisher: </span>{{ snap.origin }}
           {% if snap.developer_validation and snap.developer_validation == VERIFIED_PUBLISHER %}
-          <span class="p-verified p-tooltip p-tooltip--top-center" aria-describedby="{{ snap.package_name }}-tooltip">
-                        <img src="https://assets.ubuntu.com/v1/75654c90-rosette.svg" />
-                        <span class="p-tooltip__message u-align--center" role="tooltip" id="{{ snap.package_name }}-tooltip">Verified account</span>
-                      </span>
+          <span class="p-verified" title="Verified account">
+            <img src="https://assets.ubuntu.com/v1/75654c90-rosette.svg" />
+          </span>
           {% endif %}
         </p>
       {% endif %}


### PR DESCRIPTION
Fixes https://github.com/CanonicalLtd/snap-squad/issues/985

Removes broken verified publisher tooltip.

### QA

- ./run or https://snapcraft-io-canonical-web-and-design-pr-1925.run.demo.haus/
- go to Store page
- find snap of verified publisher, hover over the verified icon
- Vanilla black tooltip should not appear
- small browser tooltip should appear
- click on a snap (to go to snap page)
- hover over verified publisher, black vanilla tooltip should normally appear

<img width="1048" alt="Screenshot 2019-05-17 at 15 23 52" src="https://user-images.githubusercontent.com/83575/57931206-3d57f180-78b8-11e9-9483-1ee4acc6f7e2.png">
