### PR TITLE
Skip featured colouring if parent can't be found

### DIFF
--- a/static/js/libs/colours.js
+++ b/static/js/libs/colours.js
@@ -17,13 +17,15 @@ function getColour(holder, imageSelector, imageParentSelector) {
   if (images.length > 0) {
     for (let i = 0, ii = images.length; i < ii; i += 1) {
       const parent = images[i].closest(imageParentSelector);
-      const image = images[i];
-      if (image.complete) {
-        extractAndSet(image, parent);
-      } else {
-        image.addEventListener("load", () => {
+      if (parent) {
+        const image = images[i];
+        if (image.complete) {
           extractAndSet(image, parent);
-        });
+        } else {
+          image.addEventListener("load", () => {
+            extractAndSet(image, parent);
+          });
+        }
       }
     }
   }


### PR DESCRIPTION
Fixes various sentry errors relating to `t is null` `Cannot read property 'style' of null` etc.

## QA

- Pull the branch
- Visit http://0.0.0.0:8004/store
- Make sure the featured background colours still load
- Do the same on some category pages