### PR TITLE
Reduce number of requests for getSnapCount in fsf

### DIFF
--- a/static/js/public/first-snap-flow.js
+++ b/static/js/public/first-snap-flow.js
@@ -161,7 +161,7 @@ function push() {
     });
 
     if (!ready) {
-      timer = setTimeout(getCount.bind(this, cb), 2500);
+      timer = setTimeout(getCount.bind(this, cb), 5000);
     }
   }
 


### PR DESCRIPTION
To reduce the number of idle requests to check if a snap has been uploaded.