### PR TITLE
Make embedded card indexed by search engines as snap details page

### DIFF
--- a/templates/store/snap-embedded-card.html
+++ b/templates/store/snap-embedded-card.html
@@ -1,5 +1,13 @@
 {% extends "_layout-embedded.html" %}
 
+{% block meta_title %}Install {{ snap_title }} for Linux using the Snap Store | Snapcraft{% endblock %}
+
+{% block meta_path %}/{{ package_name }}{% endblock %}
+
+{% block extra_meta %}
+  <link rel="canonical" href="https://snapcraft.io/{{ package_name }}" />
+{% endblock %}
+
 {% block content %}
 <div class="p-strip--light is-shallow snapcraft-banner-background">
   <div class="row">


### PR DESCRIPTION
Fixes #1928

Adds "canonical" link URL to embedded card meta data to make it indexed as a snaps details page by search engines.

### QA

- ./run or https://snapcraft-io-canonical-web-and-design-pr-1929.run.demo.haus/
- go to embedded card page of any https://snapcraft-io-canonical-web-and-design-pr-1929.run.demo.haus/code/embedded
- check the source, `<head>` should contain rel="canonical" link with snap details page URL