### PR TITLE
Snap distro install page prototype (for Debian)

### DIFF
--- a/static/js/base/ga.js
+++ b/static/js/base/ga.js
@@ -65,6 +65,26 @@ if (typeof dataLayer !== "undefined") {
         break;
       }
     }
+
+    // clicking on copy clipboard button
+    if (target.matches(".js-clipboard-copy")) {
+      e.stopImmediatePropagation();
+      const clipboardTarget = target.dataset.clipboardTarget;
+
+      const clipboardTargetEl = document.querySelector(clipboardTarget);
+      const copiedValue = clipboardTargetEl.value
+        ? clipboardTargetEl.value.trim()
+        : clipboardTargetEl.text
+          ? clipboardTargetEl.text.trim()
+          : clipboardTargetEl.innerText.trim();
+
+      triggerEvent(
+        "clipboard-copy",
+        origin,
+        clipboardTarget,
+        `Copied code: ${copiedValue}`
+      );
+    }
   });
 }
 

--- a/templates/store/snap-distro-install.html
+++ b/templates/store/snap-distro-install.html
@@ -44,9 +44,19 @@
 {% endblock %}
 
 {% block content %}
-  <div class="p-strip--light is-shallow snapcraft-banner-background">
+  <div class="p-strip--light is-shallow distro-background">
+    <style>
+      .distro-background {
+        background-image: linear-gradient(-90deg, {{ distro_color_1 }}, {{ distro_color_2 }});
+      }
+    </style>
     <div class="row">
-      <h1 class="u-no-margin">How to install {{ snap_title }} on {{ distro_name }}</h1>
+      <div class="col-8">
+        <h1 class="p-heading--two" style="color: #f7f7f7">How to install {{ snap_title }}<br/> on <b>{{ distro_name }}</b></h1>
+      </div>
+      <div class="col-3">
+        <img src="{{ distro_logo }}" />
+      </div>
     </div>
   </div>
   <div class="p-strip is-shallow">
@@ -137,20 +147,24 @@
     <div class="row">
       <h3>Instructions to enable snapd support</h3>
     </div>
+    {% for step in distro_install_steps %}
     <div class="row">
       <div class="col-7">
-        <p>{{ distro_install_instruction }}</p>
+        <p>{{ step.action|safe }}</p>
       </div>
+      {% if step.command %}
       <div class="col-5">
-        {% set snippet_value = distro_install_command %}
-        {% set snippet_id = "distro-install-command" %}
-        {% if distro_install_command.count('\n') == 0 %}
+        {% set snippet_value = step.command %}
+        {% set snippet_id = "distro-install-command-" + loop.index|string %}
+        {% if step.command.count('\n') == 0 %}
           {% include "/partials/_code-snippet.html" %}
         {% else %}
           {% include "/partials/_code-snippet-multi.html" %}
         {% endif %}
       </div>
+      {% endif %}
     </div>
+    {% endfor %}
     <div class="row">
       <h3>How to install a snap</h3>
     </div>

--- a/templates/store/snap-distro-install.html
+++ b/templates/store/snap-distro-install.html
@@ -46,7 +46,7 @@
 {% block content %}
   <div class="p-strip--light is-shallow snapcraft-banner-background">
     <div class="row">
-      <h1>How to install {{ snap_title }} on {{ distro_name }}</h1>
+      <h1 class="u-no-margin">How to install {{ snap_title }} on {{ distro_name }}</h1>
     </div>
   </div>
   <div class="p-strip is-shallow">
@@ -73,13 +73,9 @@
         </div>
 
         <div class="p-snap-install-buttons">
-          <button
-            class="p-button--positive p-snap-install-buttons__install"
-            data-js="open-channel-map"
-            data-controls="channel-map-install"
-            aria-controls="channel-map-install">
-              Install
-          </button>
+          <a class="p-button--positive p-snap-install-buttons__install" href="#install">
+            Install
+          </a>
         </div>
 
       </div>
@@ -116,47 +112,6 @@
     </div>
   </div>
 
-  {% if countries or normalized_os %}
-    <div data-live="public_metrics_live">
-      <div class="row">
-        <div class="col-12">
-          <hr />
-        </div>
-      </div>
-
-      <div class="p-strip is-shallow">
-        <div class="row {% if normalized_os %}u-equal-height{% endif %}">
-          {% if countries %}
-            <div class="{% if normalized_os %}col-8{% else %}col-12{% endif %} js-snap-map-holder" data-live="installed_base_by_country_percent">
-              <h4>Where people are using {{ snap_title }}</h4>
-              <div id="js-snap-map" class="snapcraft-territories"></div>
-            </div>
-          {% endif %}
-          {% if normalized_os %}
-            <div class="col-4 js-snap-distro-chart-holder" data-live="weekly_installed_base_by_operating_system_normalized">
-              <h4>Users by distribution (log)</h4>
-              <div class="snapcraft-distro-chart">
-                <div class="snapcraft-distro-chart__names">
-                  {% for distro in normalized_os %}
-                  <div class="snapcraft-distro-chart__name" title="{{ distro.name }}">{{ distro.name }}</div>
-                  {% endfor %}
-                </div>
-                <div class="snapcraft-distro-chart__bars">
-                  {% for distro in normalized_os %}
-                    <div
-                      class="snapcraft-distro-chart__bar"
-                      style="width: {{ distro.value * 100 }}%"
-                    ></div>
-                  {% endfor %}
-                </div>
-              </div>
-            </div>
-          {% endif %}
-        </div>
-      </div>
-    </div>
-  {% endif %}
-
   {% if api_error %}
     <div class="row">
       <div class="col-12">
@@ -169,8 +124,13 @@
     </div>
   {% endif %}
 
-  <div class="p-strip is-shallow">
-    <hr />
+  <section class="p-strip is-shallow">
+    <div class="row">
+      <hr />
+    </div>
+  </section>
+
+  <div id="install" class="p-strip is-shallow">
     <div class="row">
       <h2>Snap install instructions for {{ distro_name }}</h2>
     </div>
@@ -218,6 +178,48 @@
       </div>
     </div>
   </div>
+
+
+  <section class="p-strip is-shallow">
+    <div class="row">
+      <hr />
+    </div>
+  </section>
+
+  <section class="p-strip is-shallow">
+    <div class="row">
+        <h2 class="u-float--left">Find more popular snaps</h2>
+        <a href="/search?category=featured" class="p-button--neutral u-float--right u-hide--small p-featured-snap__see-more">See more...</a>
+    </div>
+    <div class="row">
+      {% set snaps = featured_snaps %}
+      {% set category = "featured" %}
+      {% set show_summary = True %}
+      {% include "store/_category-partial.html" %}
+    </div>
+    <div class="row u-hide--medium u-hide--large">
+      <a href="/search?category=featured" class="p-button--neutral u-float--right">See more in Featured</a>
+    </div>
+  </section>
+
+
+  <section class="p-strip--image is-deep is-dark p-strip--snap-store">
+    <div class="row u-vertically-center">
+      <div class="col-7 u-fade-left--medium">
+        <p class="u-hide--large u-hide--medium u-align--center">
+          <img src="https://assets.ubuntu.com/v1/08af835e-Snap+Store+shopping+icon.svg" alt="Get the Snap Store snap" class="p-icon--snap-store u-fade-up">
+        </p>
+        <h1 class="p-heading--two">Access the App Store for Linux <br class="u-hide--small u-hide--medium">from your desktop</h1>
+        <p class="u-no-padding--top p-heading--four">Easily find and install new applications or remove existing installed applications with the Snap Store snap.</p>
+        <p>
+          <a href="/snap-store" class="p-button--positive">Get the Snap Store</a>
+        </p>
+      </div>
+      <div class="col-4 u-hide--small prefix-1">
+          <img src="https://assets.ubuntu.com/v1/08af835e-Snap+Store+shopping+icon.svg" alt="Get the Snap Store snap" class="p-icon--snap-store u-fade-up">
+      </div>
+    </div>
+  </section>
 
   {# templates #}
   {% set video = {'type': 'youtube', 'url': '${url}', 'id': '${id}'} %}

--- a/templates/store/snap-distro-install.html
+++ b/templates/store/snap-distro-install.html
@@ -1,0 +1,262 @@
+{% extends webapp_config['LAYOUT'] %}
+
+{% block meta_copydoc %}{% endblock %}
+
+{% block meta_title %}Install {{ snap_title }} on {{ distro_name }} using the Snap Store | Snapcraft{% endblock %}
+
+{% block meta_description %}Get the latest version of {{ snap_title }} for on {{ distro_name }} - {{ summary }}{% endblock %}
+
+{% if icon_url %}
+  {% block meta_image %}
+    {{ icon_url }}
+  {% endblock %}
+{% endif %}
+
+{% block meta_schema %}
+  <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "SoftwareApplication",
+      "name": "{{ snap_title }}",
+      "description": "{{ summary }}",
+      "datePublished": "{{ last_updated_raw }}",
+      {% if screenhots and screenshots|length > 0 %}
+      "screenshot": "{{ screenshots[0] }}",
+      {% endif %}
+      "image": "{{ icon_url }}",
+      "operatingSystem": "linux",
+      "offers": {
+        "price": {% if prices and prices['USD'] %}{{ prices['USD'] }}{% else %}0.00{% endif %},
+        "priceCurrency": "USD"
+      },
+      "author": {
+        "@type": "Person",
+        "name": "{{ publisher }}"
+        {% if website %}, {# the , is within the if to avoid parsing errors #}
+        "url": "{{ website }}"
+        {% endif %}
+      },
+      "softwareVersion": "{{ version }}",
+      "fileSize": "{{ filesize }}",
+      "license": "{{ license }}"
+    }
+  </script>
+{% endblock %}
+
+{% block content %}
+  <div class="p-strip--light is-shallow snapcraft-banner-background">
+    <div class="row">
+      <h1>How to install {{ snap_title }} on {{ distro_name }}</h1>
+    </div>
+  </div>
+  <div class="p-strip is-shallow">
+    <div class="row">
+      <div class="p-snap-heading">
+        {% if icon_url %}
+          <img class="p-snap-heading__icon" src="{{ icon_url }}" alt="{{ snap_title }} snap" data-live="icon" />
+        {% else %}
+          <img class="p-snap-heading__icon" src="https://assets.ubuntu.com/v1/be6eb412-snapcraft-missing-icon.svg" alt="" data-live="icon" />
+        {% endif %}
+        <div class="p-snap-heading__title">
+          <h1 class="p-heading--two p-snap-heading__name" data-live="title">{{ snap_title }}</h1>
+          <div class="u-hide u-show--small">
+            {% include 'store/_snap-header-information.html' %}
+          </div>
+          <ul class="p-inline-list--middot">
+            <li class="p-inline-list__item u-hide--small">
+              {% include 'store/_snap-header-information.html' %}
+            </li>
+            {% for category in categories %}<li class="p-inline-list__item">
+              <a href="/search?category={{category.slug}}">{{ category.name }}</a>
+            </li>{% endfor %}
+          </ul>
+        </div>
+
+        <div class="p-snap-install-buttons">
+          <button
+            class="p-button--positive p-snap-install-buttons__install"
+            data-js="open-channel-map"
+            data-controls="channel-map-install"
+            aria-controls="channel-map-install">
+              Install
+          </button>
+        </div>
+
+      </div>
+    </div>
+  </div>
+
+  {% if screenshots or videos %}
+    <div class="p-strip--light is-shallow">
+      <div class="row" id="js-snap-screenshots" data-live="screenshots">
+        {% if videos %}
+          {% include "partials/_snap-details-video-layout.html" %}
+        {% elif screenshots %}
+          {% include "partials/_snap-details-image-layout.html" %}
+        {% endif %}
+      </div>
+    </div>
+  {% endif %}
+
+  <div class="p-strip is-shallow">
+    <div class="row">
+      <div class="col-8">
+        {% if summary %}<h4 data-live="summary">{{ summary }}</h4>{% endif %}
+        <div data-live="description">{{ description | safe }}</div>
+      </div>
+      <div class="col-4">
+        <h4>Details for {{ snap_title }}</h4>
+        <dl>
+          <dt>License</dt>
+          <dd data-live="license">{{ license }}</dd>
+          <dt>Last updated</dt>
+          <dd>{{ last_updated }}</dd>
+        </dl>
+      </div>
+    </div>
+  </div>
+
+  {% if countries or normalized_os %}
+    <div data-live="public_metrics_live">
+      <div class="row">
+        <div class="col-12">
+          <hr />
+        </div>
+      </div>
+
+      <div class="p-strip is-shallow">
+        <div class="row {% if normalized_os %}u-equal-height{% endif %}">
+          {% if countries %}
+            <div class="{% if normalized_os %}col-8{% else %}col-12{% endif %} js-snap-map-holder" data-live="installed_base_by_country_percent">
+              <h4>Where people are using {{ snap_title }}</h4>
+              <div id="js-snap-map" class="snapcraft-territories"></div>
+            </div>
+          {% endif %}
+          {% if normalized_os %}
+            <div class="col-4 js-snap-distro-chart-holder" data-live="weekly_installed_base_by_operating_system_normalized">
+              <h4>Users by distribution (log)</h4>
+              <div class="snapcraft-distro-chart">
+                <div class="snapcraft-distro-chart__names">
+                  {% for distro in normalized_os %}
+                  <div class="snapcraft-distro-chart__name" title="{{ distro.name }}">{{ distro.name }}</div>
+                  {% endfor %}
+                </div>
+                <div class="snapcraft-distro-chart__bars">
+                  {% for distro in normalized_os %}
+                    <div
+                      class="snapcraft-distro-chart__bar"
+                      style="width: {{ distro.value * 100 }}%"
+                    ></div>
+                  {% endfor %}
+                </div>
+              </div>
+            </div>
+          {% endif %}
+        </div>
+      </div>
+    </div>
+  {% endif %}
+
+  {% if api_error %}
+    <div class="row">
+      <div class="col-12">
+        <div class="p-notification--negative">
+          <p class="p-notification__response">
+            <span class="p-notification__status">Error:</span> API request failed
+          </p>
+        </div>
+      </div>
+    </div>
+  {% endif %}
+
+  <div class="p-strip is-shallow">
+    <hr />
+    <div class="row">
+      <h2>Snap install instructions for {{ distro_name }}</h2>
+    </div>
+    <div class="row">
+      <h3>Instructions to enable snapd support</h3>
+    </div>
+    <div class="row">
+      <div class="col-7">
+        <p>{{ distro_install_instruction }}</p>
+      </div>
+      <div class="col-5">
+        {% set snippet_value = distro_install_command %}
+        {% set snippet_id = "distro-install-command" %}
+        {% if distro_install_command.count('\n') == 0 %}
+          {% include "/partials/_code-snippet.html" %}
+        {% else %}
+          {% include "/partials/_code-snippet-multi.html" %}
+        {% endif %}
+      </div>
+    </div>
+    <div class="row">
+      <h3>How to install a snap</h3>
+    </div>
+    <div class="row">
+      <div class="col-7">
+        <p>To install a snap, simply use the following command:</p>
+      </div>
+      <div class="col-5">
+        {% set snippet_value = "sudo snap install " + package_name %}
+        {% set snippet_id =  "snap-install-stable" %}
+        {% include "/partials/_code-snippet.html" %}
+      </div>
+    </div>
+    <div class="row">
+      <h3>Find more software in snapcraft.io</h3>
+    </div>
+    <div class="row">
+      <div class="col-7">
+        <p>Search for more snaps from the command line:</p>
+      </div>
+      <div class="col-5">
+        {% set snippet_value = 'sudo snap find "search query"' %}
+        {% set snippet_id =  "snap-search" %}
+        {% include "/partials/_code-snippet.html" %}
+      </div>
+    </div>
+  </div>
+
+  {# templates #}
+  {% set video = {'type': 'youtube', 'url': '${url}', 'id': '${id}'} %}
+  <script type="text/template" id="video-youtube-template">
+    {% include 'partials/_video.html' %}
+  </script>
+  {% set video = {'type': 'vimeo', 'url': '${url}', 'id': '${id}'} %}
+  <script type="text/template" id="video-vimeo-template">
+    {% include 'partials/_video.html' %}
+  </script>
+  {% set video = {'type': 'asciinema', 'url': '${url}', 'id': '${id}'} %}
+  <script type="text/template" id="video-asciinema-template">
+    {% include 'partials/_video.html' %}
+  </script>
+{% endblock %}
+
+{% block scripts_modules %}
+  <script src="{{ static_url('js/modules/clipboard.min.js') }}"></script>
+{% endblock %}
+
+{% block scripts %}
+  <script src="{{ static_url('js/dist/public.js') }}"></script>
+  <script>
+    Raven.context(function () {
+      try {
+        snapcraft.public.screenshots('#js-snap-screenshots');
+      } catch(e) {
+        Raven.captureException(e);
+      }
+
+      try {
+        snapcraft.public.videos('.js-video-slide');
+      } catch(e) {
+        Raven.captureException(e);
+      }
+
+      if (typeof ClipboardJS !== 'undefined') {
+        new ClipboardJS('.js-clipboard-copy');
+      }
+    });
+  </script>
+{% endblock %}

--- a/tests/store/tests_distro_page.py
+++ b/tests/store/tests_distro_page.py
@@ -1,0 +1,132 @@
+import responses
+from flask_testing import TestCase
+from webapp.app import create_app
+
+
+class GetDistroPageTest(TestCase):
+    render_templates = False
+
+    snap_payload = {
+        "snap-id": "id",
+        "name": "snapName",
+        "snap": {
+            "title": "Snap Title",
+            "summary": "This is a summary",
+            "description": "this is a description",
+            "media": [],
+            "license": "license",
+            "prices": 0,
+            "publisher": {
+                "display-name": "Toto",
+                "username": "toto",
+                "validation": True,
+            },
+            "categories": [{"name": "test"}],
+        },
+        "channel-map": [
+            {
+                "channel": {
+                    "architecture": "amd64",
+                    "name": "stable",
+                    "risk": "stable",
+                    "track": "latest",
+                },
+                "created-at": "2018-09-18T14:45:28.064633+00:00",
+                "version": "1.0",
+                "confinement": "conf",
+                "download": {"size": 100000},
+            }
+        ],
+    }
+
+    def setUp(self):
+        self.snap_name = "toto"
+        self.api_url = "".join(
+            [
+                "https://api.snapcraft.io/v2/",
+                "snaps/info/",
+                self.snap_name,
+                "?fields=title,summary,description,license,contact,website,",
+                "publisher,prices,media,download,version,created-at,"
+                "confinement,categories",
+            ]
+        )
+        self.featured_snaps_api_url = "".join(
+            [
+                "https://api.snapcraft.io/api/v1/",
+                "snaps/search",
+                "?confinement=strict,classic&section=featured&scope=wide",
+                "&fields=package_name,title,icon_url",
+            ]
+        )
+        self.endpoint_url = "/install/" + self.snap_name + "/debian"
+
+    def create_app(self):
+        app = create_app(testing=True)
+        app.secret_key = "secret_key"
+        app.config["WTF_CSRF_METHODS"] = []
+
+        return app
+
+    @responses.activate
+    def test_api_404(self):
+        payload = {"error-list": []}
+        responses.add(
+            responses.Response(
+                method="GET", url=self.api_url, json=payload, status=404
+            )
+        )
+
+        response = self.client.get(self.endpoint_url)
+
+        self.assertEqual(len(responses.calls), 1)
+        called = responses.calls[0]
+        self.assertEqual(called.request.url, self.api_url)
+
+        self.assert404(response)
+
+    @responses.activate
+    def test_api_500(self):
+        payload = {"error-list": []}
+        responses.add(
+            responses.Response(
+                method="GET", url=self.api_url, json=payload, status=500
+            )
+        )
+
+        response = self.client.get(self.endpoint_url)
+
+        self.assertEqual(len(responses.calls), 1)
+        called = responses.calls[0]
+        self.assertEqual(called.request.url, self.api_url)
+
+        self.assertStatus(response, 502)
+
+    def test_no_distro_data(self):
+        response = self.client.get("/install/" + self.snap_name + "/noname")
+
+        self.assert404(response)
+
+    @responses.activate
+    def test_get_page(self):
+        payload = self.snap_payload
+
+        responses.add(
+            responses.Response(
+                method="GET", url=self.api_url, json=payload, status=200
+            )
+        )
+
+        responses.add(
+            responses.Response(
+                method="GET",
+                url=self.featured_snaps_api_url,
+                json={},
+                status=200,
+            )
+        )
+
+        response = self.client.get(self.endpoint_url)
+
+        self.assert200(response)
+        self.assert_context("snap_title", "Snap Title")

--- a/webapp/store/content/distros/arch.yaml
+++ b/webapp/store/content/distros/arch.yaml
@@ -1,0 +1,24 @@
+name: Arch Linux
+color-1: "#5ebeed"
+color-2: "#1271a1"
+logo: https://assets.ubuntu.com/v1/feca0fc0-Distro_Logo_ArchLinux.svg
+install:
+  -
+    action: |
+      On Arch Linux, snap can be installed from the <a href="https://aur.archlinux.org/packages/snapd/" class="p-link--external">Arch User Repository (AUR).</a>
+      The <a href="https://wiki.archlinux.org/index.php/Arch_User_Repository#Installing_packages" class="p-link--external">manual build process</a> is the Arch-supported
+      install method for AUR packages, and you’ll need the <a href="https://wiki.archlinux.org/index.php/Arch_User_Repository#Prerequisites" class="p-link--external">prerequisites</a>
+      installed before you can install any AUR package. You can then install snap with the following:
+    command: |
+      git clone https://aur.archlinux.org/snapd.git
+      cd snapd
+      makepkg -si
+  -
+    action: |
+      Once installed, the <em>systemd</em> unit that manages the main snap communication socket needs to be enabled:
+    command: sudo systemctl enable --now snapd.socket
+  -
+    action: |
+      To enable <em>classic</em> snap support, enter the following to create a symbolic link between <code>/var/lib/snapd/snap</code> and <code>/snap</code>:
+    command: sudo ln -s /var/lib/snapd/snap /snap
+  - action: Either log out and back in again, or restart your system, to ensure snap’s paths are updated correctly.

--- a/webapp/store/content/distros/debian.yaml
+++ b/webapp/store/content/distros/debian.yaml
@@ -1,6 +1,11 @@
 name: Debian
-instruction: |
-    On Debian 9 (Stretch), snap can be installed directly from the command line:
-command: |
-    sudo apt update
-    sudo apt install snapd
+color-1: "#db003e"
+color-2: "#750021"
+logo: https://assets.ubuntu.com/v1/cfdc1144-Distro_Logo_Debian.svg
+install:
+  -
+    action: |
+      On Debian 9 (Stretch), snap can be installed directly from the command line:
+    command: |
+      sudo apt update
+      sudo apt install snapd

--- a/webapp/store/content/distros/debian.yaml
+++ b/webapp/store/content/distros/debian.yaml
@@ -1,0 +1,6 @@
+name: Debian
+instruction: |
+    On Debian 9 (Stretch), snap can be installed directly from the command line:
+command: |
+    sudo apt update
+    sudo apt install snapd

--- a/webapp/store/snap_details_views.py
+++ b/webapp/store/snap_details_views.py
@@ -395,6 +395,16 @@ def snap_details_views(store, api, handle_errors):
             }
         )
 
+        try:
+            featured_snaps_results = api.get_searched_snaps(
+                snap_searched="", category="featured", size=10, page=1
+            )
+        except ApiError:
+            featured_snaps_results = []
+
+        featured_snaps = logic.get_searched_snaps(featured_snaps_results)
+
+        context.update({"featured_snaps": featured_snaps})
         return flask.render_template(
             "store/snap-distro-install.html", **context
         )

--- a/webapp/store/snap_details_views.py
+++ b/webapp/store/snap_details_views.py
@@ -378,14 +378,13 @@ def snap_details_views(store, api, handle_errors):
 
     @store.route('/install/<regex("' + snap_regex + '"):snap_name>/<distro>')
     def snap_distro_install(snap_name, distro):
-        context = _get_context_snap_details(snap_name)
         filename = f"store/content/distros/{distro}.yaml"
-
         distro_data = get_yaml(filename)
 
         if not distro_data:
             flask.abort(404)
 
+        context = _get_context_snap_details(snap_name)
         context.update(
             {
                 "distro": distro,

--- a/webapp/store/snap_details_views.py
+++ b/webapp/store/snap_details_views.py
@@ -389,8 +389,10 @@ def snap_details_views(store, api, handle_errors):
             {
                 "distro": distro,
                 "distro_name": distro_data["name"],
-                "distro_install_instruction": distro_data["instruction"],
-                "distro_install_command": distro_data["command"],
+                "distro_logo": distro_data["logo"],
+                "distro_color_1": distro_data["color-1"],
+                "distro_color_2": distro_data["color-2"],
+                "distro_install_steps": distro_data["install"],
             }
         )
 


### PR DESCRIPTION
Fixes #1932 
Fixes #1933

Adds simple snap distro page template with example content for Debian.

### QA
- ./run or https://snapcraft-io-canonical-web-and-design-pr-1938.run.demo.haus/
- go to /install/SNAPNAME/debian or /arch for any public snap: https://snapcraft-io-canonical-web-and-design-pr-1938.run.demo.haus/install/spotify/debian
https://snapcraft-io-canonical-web-and-design-pr-1938.run.demo.haus/install/slack/arch
- basic template for distro page with install instructions should be shown

<img width="1147" alt="Screenshot 2019-05-31 at 11 12 02" src="https://user-images.githubusercontent.com/83575/58695199-0e03b300-8395-11e9-9c91-6c3fbab584c5.png">

<img width="1019" alt="Screenshot 2019-05-31 at 11 12 13" src="https://user-images.githubusercontent.com/83575/58695198-0e03b300-8395-11e9-8f18-cef70f28cb64.png">
