### PR TITLE
Error message on banner

### DIFF
--- a/static/js/libs/fileValidation.js
+++ b/static/js/libs/fileValidation.js
@@ -142,18 +142,20 @@ function imageRestrictions(file, restrictions) {
             Math.round((aspectRatioMax[0] / aspectRatioMax[1]) * 100) / 100;
 
           const message = [
-            `(${width}x${height} pixels) is not the correct aspect ratio:`
+            `(${width}x${height} pixels) is not the correct aspect ratio.`
           ];
 
           if (min === max) {
             message.push(
-              `The image must be ${min}:1. (e.g.,
-                ${height * min}x${height})`
+              `The image must be ${min}:1 (e.g.,
+                ${height * min}x${height}) or a maximum of
+              ${restrictions.width.max}x${restrictions.height.max}.`
             );
           } else {
             message.push(
               `The width must be between ${min}x (${height * min} pixels) and
-              ${max}x the height (${height * max} pixels).`
+              ${max}x the height (${height * max} pixels) or a maximum of
+              ${restrictions.width.max}x${restrictions.height.max}.`
             );
           }
 

--- a/static/js/libs/fileValidation.js
+++ b/static/js/libs/fileValidation.js
@@ -140,17 +140,20 @@ function imageRestrictions(file, restrictions) {
             Math.round((aspectRatioMin[0] / aspectRatioMin[1]) * 100) / 100;
           const max =
             Math.round((aspectRatioMax[0] / aspectRatioMax[1]) * 100) / 100;
-          const actual = Math.round(aspectRatio * 100) / 100;
 
           const message = [
-            `has a width (${width} pixels) that is ${actual}x its height (${height} pixels).`
+            `(${width}x${height} pixels) is not the correct aspect ratio:`
           ];
 
           if (min === max) {
-            message.push(`Its width needs to be ${min}x the height.`);
+            message.push(
+              `The image must be ${min}:1. (e.g.,
+                ${height * min}x${height})`
+            );
           } else {
             message.push(
-              `Its width needs to be between ${min}x and ${max}x the height.`
+              `The width must be between ${min}x (${height * min} pixels) and
+              ${max}x the height (${height * max} pixels).`
             );
           }
 

--- a/static/js/publisher/form/banner.js
+++ b/static/js/publisher/form/banner.js
@@ -170,7 +170,7 @@ class Banner extends React.Component {
                 <br />
                 Max resolution: <b>4320 x 1440 pixels</b>
                 <br />
-                Aspect ratio: <b>3:1</b>
+                Allowed aspect ratio: <b>3:1</b>
                 <br />
                 File size limit: <b>2MB</b>
               </small>

--- a/static/js/publisher/form/media.js
+++ b/static/js/publisher/form/media.js
@@ -108,7 +108,7 @@ class Media extends React.Component {
               <br />
               Max resolution: <b>3840 x 2160 pixels</b>
               <br />
-              Aspect ratio: <b>Between 1:2 and 2:1</b>
+              Allowed aspect ratio: <b>Between 1:2 and 2:1</b>
               <br />
               File size limit: <b>2MB</b>
               <br />


### PR DESCRIPTION
Fixes https://github.com/canonical-web-and-design/snapcraft.io/issues/1936

### QA Steps

1. Pull the branch or open the demo service
2. Open edit listing page for a snap you own
3. Try to upload this image 1444x482.png as a Featured Banner:
![1444x482](https://user-images.githubusercontent.com/8167677/58270126-fb7bef00-7d80-11e9-87be-2e5e11b25c4a.png)
4. You should get an error message: `banner3to1.png (1444x482 pixels) is not the correct aspect ratio: The image needs to be 3:1 (e.g., 1446x482 pixels)`
4. #winning