### PR TITLE
Only show pagination if there are search results

### DIFF
--- a/templates/store/search.html
+++ b/templates/store/search.html
@@ -78,7 +78,7 @@
     {% endif %}
   </section>
 
-  {% if links %}
+  {% if (searched_snaps or featured_snaps) and links %}
   <section class="p-strip is-shallow u-no-padding--top">
     <nav class="row">
       <div class="u-float--left u-align--left">


### PR DESCRIPTION
Fixes https://github.com/CanonicalLtd/snap-squad/issues/986

No results no pagination

### QA

- ./run or demo
- search for something that doesn't exist
- there should be no pagination
- make sure pagination works fine when there are search results, on category pages, etc