### PR TITLE
Move all the YAML logic into helpers

### DIFF
--- a/tests/first_snap/tests_views.py
+++ b/tests/first_snap/tests_views.py
@@ -1,8 +1,9 @@
 import os
-from unittest.mock import mock_open, patch
 
-import webapp.first_snap.views as views
+from unittest.mock import mock_open, patch
 from flask_testing import TestCase
+
+from webapp import helpers
 from webapp.app import create_app
 
 
@@ -17,7 +18,7 @@ class FirstSnap(TestCase):
 
     @patch("builtins.open", new_callable=mock_open, read_data="test: test")
     def test_get_yaml(self, mock_open_file):
-        yaml_read = views.get_yaml("filename.yaml")
+        yaml_read = helpers.get_yaml("filename.yaml", typ="rt")
         self.assertEqual(yaml_read, {"test": "test"})
         mock_open_file.assert_called_with(
             os.path.join(self.app.root_path, "filename.yaml"), "r"
@@ -27,7 +28,7 @@ class FirstSnap(TestCase):
         "builtins.open", new_callable=mock_open, read_data="test: test: test"
     )
     def test_get_yaml_error(self, mock_open_file):
-        yaml_read = views.get_yaml("filename.yaml")
+        yaml_read = helpers.get_yaml("filename.yaml", typ="rt")
         self.assertEqual(yaml_read, None)
         mock_open_file.assert_called_with(
             os.path.join(self.app.root_path, "filename.yaml"), "r"

--- a/webapp/snapcraft/logic.py
+++ b/webapp/snapcraft/logic.py
@@ -9,7 +9,9 @@ def get_livestreams():
     :returns: Dictionary of livestream details
     """
     livestream_to_show = None
-    livestreams = helpers.get_livestreams()
+    livestreams = helpers.get_yaml(
+        "snapcraft/content/snapcraft_live.yaml", typ="safe"
+    )
 
     if livestreams:
         now = datetime.now()

--- a/webapp/store/snap_details_views.py
+++ b/webapp/store/snap_details_views.py
@@ -78,13 +78,14 @@ def snap_details_views(store, api, handle_errors):
 
         icons = logic.get_icon(details["snap"]["media"])
 
-        publisher_info_and_snaps = helpers._get_file(
-            "/{}{}.yaml".format(
+        publisher_info_and_snaps = helpers.get_yaml(
+            "{}{}.yaml".format(
                 flask.current_app.config["CONTENT_DIRECTORY"][
                     "PUBLISHER_PAGES"
                 ],
                 details["snap"]["publisher"]["username"],
-            )
+            ),
+            typ="safe",
         )
 
         publisher_featured_snaps = None

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -290,8 +290,8 @@ def store_blueprint(store_query=None, testing=False):
             "PUBLISHER_PAGES"
         ]
 
-        context = helpers._get_file(
-            publisher_content_path + publisher + ".yaml"
+        context = helpers.get_yaml(
+            publisher_content_path + publisher + ".yaml", typ="safe"
         )
 
         if not context:


### PR DESCRIPTION
# Done
Moved all YAML helper functions to helpers and re-use them across the codebase.

# QA
- ./run
- Make sure all features that rely on YAML still work:
  - Livestream
  - Publisher pages
  - FSF
  - More snaps feature should work `http://0.0.0.0:8004/pycharm-professional`

Fixes #1948 
