### PR TITLE
If logged in, append fsf snap name with username

### DIFF
--- a/templates/first-snap/package.html
+++ b/templates/first-snap/package.html
@@ -26,7 +26,7 @@
                         Name should only have lowercase letters, numbers, and hyphens, must have at least one letter, and cannot start or end with a hyphen.
                       </p>
                     </div>
-                    <button class="p-button--positive" disabled>Choose snap name</button>
+                    <button class="p-button--positive" {% if "{name}" in snap_name %} disabled{% endif %}>Choose snap name</button>
                   </form>
                 </div>
               </div>

--- a/tests/first_snap/tests_views.py
+++ b/tests/first_snap/tests_views.py
@@ -179,7 +179,7 @@ class FirstSnap(TestCase):
         self.assert_context("language", "python")
         self.assert_context("os", "linux")
         self.assert_context("user", user_expected)
-        self.assert_context("snap_name", "test-offlineimap-{name}")
+        self.assert_context("snap_name", "test-offlineimap-Toto")
 
     def test_get_push_404(self):
         response = self.client.get("/first-snap/toto-lang/linux/push")

--- a/webapp/first_snap/views.py
+++ b/webapp/first_snap/views.py
@@ -105,6 +105,10 @@ def get_package(language, operating_system):
     snap_name = steps["name"]
     has_user_chosen_name = False
 
+    if flask.session.get("openid"):
+        user_name = flask.session["openid"]["nickname"]
+        snap_name = snap_name.replace("{name}", user_name)
+
     if snap_name_cookie in flask.request.cookies:
         snap_name = flask.request.cookies.get(snap_name_cookie)
         has_user_chosen_name = True
@@ -153,6 +157,10 @@ def get_build(language, operating_system):
 
     snap_name = steps["name"]
 
+    if flask.session.get("openid"):
+        user_name = flask.session["openid"]["nickname"]
+        snap_name = snap_name.replace("{name}", user_name)
+
     if snap_name_cookie in flask.request.cookies:
         snap_name = flask.request.cookies.get(snap_name_cookie)
 
@@ -178,6 +186,10 @@ def get_test(language, operating_system):
         return flask.abort(404)
 
     snap_name = steps["name"]
+
+    if flask.session.get("openid"):
+        user_name = flask.session["openid"]["nickname"]
+        snap_name = snap_name.replace("{name}", user_name)
 
     if snap_name_cookie in flask.request.cookies:
         snap_name = flask.request.cookies.get(snap_name_cookie)
@@ -216,6 +228,10 @@ def get_push(language, operating_system):
 
     snap_name = data["name"]
     has_user_chosen_name = False
+
+    if flask.session.get("openid"):
+        user_name = flask.session["openid"]["nickname"]
+        snap_name = snap_name.replace("{name}", user_name)
 
     if snap_name_cookie in flask.request.cookies:
         snap_name = flask.request.cookies.get(snap_name_cookie)


### PR DESCRIPTION
Fixes https://github.com/canonical-web-and-design/snapcraft.io/issues/1937

## QA

- Pull the branch
- `./run`
- Visit http://0.0.0.0:8004/first-snap
- Not logged in, the flow should work as before
- Log in
- Go through the steps as before - the snap name should at the "Package snap" step, should be suffixed with "-USERNAME" instead of "-{name}", but unlike if the name has been previously picked - you still need to "Choose snap name"