### PR TITLE
Distro page navigation

### DIFF
--- a/templates/_header_empty.html
+++ b/templates/_header_empty.html
@@ -1,0 +1,11 @@
+<header id="navigation" class="p-navigation">
+  <div class="row">
+    <div class="p-navigation__banner">
+      <div class="p-navigation__logo">
+        <a class="p-navigation__link" href="/">
+          <img class="p-navigation__image" src="https://assets.ubuntu.com/v1/7f93bb62-snapcraft-logo--web-white-text.svg" alt="Snapcraft" />
+        </a>
+      </div>
+    </div>
+  </div>
+</header>

--- a/templates/_layout.html
+++ b/templates/_layout.html
@@ -51,11 +51,13 @@
       height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
     <!-- End Google Tag Manager (noscript) -->
 
+    {% block header %}
     <!-- JS that is needed right away -->
     <script src="{{ static_url('js/modules/global-nav.js') }}"></script>
     <script>canonicalGlobalNav.createNav({maxWidth: '64.875rem', showLogins: false});</script>
 
     {% include "_header.html" %}
+    {% endblock %}
 
     {% block content %}{% endblock %}
 

--- a/templates/store/snap-distro-install.html
+++ b/templates/store/snap-distro-install.html
@@ -43,6 +43,10 @@
   </script>
 {% endblock %}
 
+{% block header %}
+  {% include "_header_empty.html" %}
+{% endblock %}
+
 {% block content %}
   <section class="p-strip--light distro-banner u-no-padding--top">
     <div class="distro-banner__background">


### PR DESCRIPTION
Fixes #1952 

Removes navigation items on distro page.

### QA
- ./run or https://snapcraft-io-canonical-web-and-design-pr-1971.run.demo.haus/
- go to distro page of any snap (https://snapcraft-io-canonical-web-and-design-pr-1971.run.demo.haus/install/skype/arch)
- navigation should only contain snapcraft logo
- go to other pages (home, store, snap details, publisher pages)
- navigation should work as before

<img width="1085" alt="Screenshot 2019-06-05 at 13 24 17" src="https://user-images.githubusercontent.com/83575/58952900-3cb6ca80-8795-11e9-8988-0a4cc6c25c01.png">
