### PR TITLE
Distro page GA events

### DIFF
--- a/static/js/base/ga.js
+++ b/static/js/base/ga.js
@@ -45,6 +45,10 @@ if (typeof dataLayer !== "undefined") {
     }
 
     if (!target) {
+      target = e.target.closest(".p-code-snippet");
+    }
+
+    if (!target) {
       return;
     }
 
@@ -80,6 +84,27 @@ if (typeof dataLayer !== "undefined") {
 
       triggerEvent(
         "clipboard-copy",
+        origin,
+        clipboardTarget,
+        `Copied code: ${copiedValue}`
+      );
+    }
+
+    // clicking on code snippet
+    if (target.matches(".p-code-snippet")) {
+      e.stopImmediatePropagation();
+      const copyButton = target.querySelector(".js-clipboard-copy");
+      const clipboardTarget = copyButton.dataset.clipboardTarget;
+
+      const clipboardTargetEl = document.querySelector(clipboardTarget);
+      const copiedValue = clipboardTargetEl.value
+        ? clipboardTargetEl.value.trim()
+        : clipboardTargetEl.text
+          ? clipboardTargetEl.text.trim()
+          : clipboardTargetEl.innerText.trim();
+
+      triggerEvent(
+        "clipboard-copy-click",
         origin,
         clipboardTarget,
         `Copied code: ${copiedValue}`

--- a/static/js/public/ga-scroll-event.js
+++ b/static/js/public/ga-scroll-event.js
@@ -1,0 +1,43 @@
+import { triggerEvent } from "../base/ga";
+import debounce from "../libs/debounce";
+
+const isInViewport = el => {
+  var bounding = el.getBoundingClientRect();
+  return (
+    bounding.top >= 0 &&
+    bounding.left >= 0 &&
+    bounding.bottom <=
+      (window.innerHeight || document.documentElement.clientHeight) &&
+    bounding.right <=
+      (window.innerWidth || document.documentElement.clientWidth)
+  );
+};
+
+export default function triggerEventWhenVisible(selector) {
+  const el = document.querySelector(selector);
+
+  if (isInViewport(el)) {
+    triggerEvent(
+      "element-visible",
+      origin,
+      selector,
+      `Element visible on screen: ${selector}`
+    );
+  } else {
+    let triggered = false;
+    window.addEventListener(
+      "scroll",
+      debounce(() => {
+        if (!triggered && isInViewport(el)) {
+          triggerEvent(
+            "element-visible",
+            origin,
+            selector,
+            `Element visible on screen: ${selector}`
+          );
+          triggered = true;
+        }
+      }, 500)
+    );
+  }
+}

--- a/static/js/public/public.js
+++ b/static/js/public/public.js
@@ -13,6 +13,7 @@ import firstSnapFlow from "./first-snap-flow";
 import nps from "./nps";
 import { newsletter } from "./newsletter";
 import initExpandableSnapDetails from "./expandable-details";
+import triggerEventWhenVisible from "./ga-scroll-event";
 
 export {
   map,
@@ -29,6 +30,7 @@ export {
   initFSFLanguageSelect,
   initReportSnap,
   firstSnapFlow,
+  triggerEventWhenVisible,
   videos,
   nps,
   newsletter

--- a/templates/store/snap-distro-install.html
+++ b/templates/store/snap-distro-install.html
@@ -225,6 +225,12 @@
   <script>
     Raven.context(function () {
       try {
+        snapcraft.public.triggerEventWhenVisible("#snippet-snap-install-stable")
+      } catch(e) {
+        Raven.captureException(e);
+      }
+
+      try {
         snapcraft.public.initExpandableSnapDetails();
       } catch(e) {
         Raven.captureException(e);


### PR DESCRIPTION
Fixes #1954 

Adds GA when code snippets are clicked (assuming they are selected to be copied) and when install instructions are scrolled into view.

### QA

GA events are not triggered on test environments.
Testing can be done by checking contents of `dataLayer` array in browser console. It should contain all GA events prepared to be sent.


- ./run or https://snapcraft-io-canonical-web-and-design-pr-1976.run.demo.haus/
- go to distro page of any snap (https://snapcraft-io-canonical-web-and-design-pr-1976.run.demo.haus/skype/debian)
- check GA events in `dataLayer` (only page loads should be there)
- scroll down to see snap install instructions ("snap install skype")
- check GA events in `dataLayer` (last event should be about visible install instructions)
- click on install instructions input
- check GA events in `dataLayer` (click event for install instructions should be on the list)


<img width="416" alt="Screenshot 2019-06-06 at 15 46 58" src="https://user-images.githubusercontent.com/83575/59037847-5a0d9680-8872-11e9-9e58-acdca5d1d71f.png">
