### PR TITLE
Add page content .yamls for all the distros

### DIFF
--- a/static/sass/_patterns_distro_banner.scss
+++ b/static/sass/_patterns_distro_banner.scss
@@ -59,4 +59,9 @@
       padding-top: .5rem;
     }
   }
+
+  .distro-banner__logo {
+    filter: grayscale(100%) opacity(20%);
+    mix-blend-mode: multiply;
+  }
 }

--- a/static/sass/_patterns_distro_banner.scss
+++ b/static/sass/_patterns_distro_banner.scss
@@ -10,7 +10,7 @@
     position: relative;
   }
 
-  .distro-banner .p-card {
+  .distro-banner .p-card--highlighted {
     padding: 2rem;
   }
 

--- a/templates/store/snap-distro-install.html
+++ b/templates/store/snap-distro-install.html
@@ -79,7 +79,7 @@
     </div>
 
     <div class="row">
-      <div class="p-card" style="position: relative;">
+      <div class="p-card--highlighted" style="position: relative;">
         <div class="row">
           <div class="details-block">
             <div class="p-snap-heading">
@@ -112,18 +112,18 @@
         </div>
 
         <div class="snap-description-more u-hide">
-          <a href="/{{ package_name }}" class="js-show-more-description">Show more <i class="p-icon--chevron"></i></a>
+          <a href="/{{ package_name }}" class="js-show-more-description">Show more</a>
         </div>
       </div>
 
-      <div id="install" class="p-card">
+      <div id="install" class="p-card--highlighted">
         <div class="row">
           <div class="col-10">
           <h2>Snap install instructions for {{ distro_name }}</h2>
           <p>Snaps are applications packaged with all their dependencies to run on all popular Linux distributions from a single build. They update automatically and roll back gracefully.</p>
           <p>Snaps are discoverable and installable from the <a href="/store">Snap Store</a>, an app store with an audience of millions.</p>
           </div>
-          <div class="u-hide--mobile col-2">
+          <div class="u-hide--small col-2">
             <img src="{{ distro_logo }}" />
           </div>
         </div>
@@ -153,7 +153,7 @@
         </div>
         <div class="row">
           <div class="col-7">
-            <p>To install a snap, simply use the following command:</p>
+            <p>To install {{ snap_title }}, simply use the following command:</p>
           </div>
           <div class="col-5 distro-code-snippet">
             {% set snippet_value = "sudo snap install " + package_name %}
@@ -186,7 +186,7 @@
     </div>
     <div class="row">
       <div class="col-6">
-        <div class="p-card">
+        <div class="p-card--highlighted">
           <a href="/snap-store">
             <img src="https://assets.ubuntu.com/v1/e737ad29-Snap+Store.png" alt="" height="180" />
           </a>
@@ -197,7 +197,7 @@
         </div>
       </div>
       <div class="col-6">
-        <div class="p-card">
+        <div class="p-card--highlighted">
           <a href="https://docs.snapcraft.io">
             <img src="https://assets.ubuntu.com/v1/fe51ed53-Learn+about+snaps.png" alt="" height="180" />
           </a>

--- a/templates/store/snap-distro-install.html
+++ b/templates/store/snap-distro-install.html
@@ -50,22 +50,19 @@
 {% block content %}
   <section class="p-strip--light distro-banner u-no-padding--top">
     <div class="distro-banner__background">
-      <svg class="distro-banner__suru" viewBox="0 0 1440 776" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      <svg class="distro-banner__suru" viewBox="0 0 1440 700" xmlns="http://www.w3.org/2000/svg">
         <defs>
-          <linearGradient x1="100%" y1="50%" x2="0%" y2="50%" id="b">
+          <linearGradient x1="100%" y1="50%" x2="0%" y2="50%" id="a">
             <stop stop-color="{{ distro_color_1 }}" offset="0%"/>
             <stop stop-color="{{ distro_color_2 }}" offset="100%"/>
           </linearGradient>
-          <path id="a" d="M0 0h1440v776H0z"/>
-          <linearGradient x1="100%" y1="50%" x2="0%" y2="50%" id="c">
-            <stop stop-color="{{ distro_color_2 }}" offset="0%"/>
-            <stop stop-color="{{ distro_color_1 }}" offset="100%"/>
-          </linearGradient>
         </defs>
-        <g fill="none" fill-rule="evenodd">
-          <mask id="d" fill="#fff"><use xlink:href="#a"/></mask>
-          <use fill="url(#b)" xlink:href="#a"/>
-          <path fill="url(#c)" mask="url(#d)" opacity="0.5" d="M0 169l295 607H0V169L1440 0v776H703l737-432V0z"/>
+        <g fill-rule="nonzero" fill="none">
+          <path fill="url(#a)" d="M0 0h1440v700H0z"/>
+          <g fill="#FFF">
+            <path d="M1440 700V198L808 700z" fill-opacity=".04"/>
+            <path d="M0 341v359h1231z" fill-opacity=".06"/>
+          </g>
         </g>
       </svg>
       <div class="row">

--- a/templates/store/snap-distro-install.html
+++ b/templates/store/snap-distro-install.html
@@ -65,13 +65,13 @@
         <g fill="none" fill-rule="evenodd">
           <mask id="d" fill="#fff"><use xlink:href="#a"/></mask>
           <use fill="url(#b)" xlink:href="#a"/>
-          <path fill="url(#c)" mask="url(#d)" d="M0 169l295 607H0V169L1440 0v776H703l737-432V0z"/>
+          <path fill="url(#c)" mask="url(#d)" opacity="0.5" d="M0 169l295 607H0V169L1440 0v776H703l737-432V0z"/>
         </g>
       </svg>
       <div class="row">
         <div class="mobile-col-2 col-8"></div>
         <div class="mobile-col-2 col-4">
-          <img src="{{ distro_logo }}" />
+          <img class="distro-banner__logo" src="{{ distro_logo }}" />
         </div>
       </div>
     </div>

--- a/templates/store/snap-distro-install.html
+++ b/templates/store/snap-distro-install.html
@@ -139,7 +139,7 @@
             <div class="col-5 distro-code-snippet">
               {% set snippet_value = step.command %}
               {% set snippet_id = "distro-install-command-" + loop.index|string %}
-              {% if step.command.count('\n') == 0 %}
+              {% if (step.command|trim).count('\n') == 0 %}
                 {% include "/partials/_code-snippet.html" %}
               {% else %}
                 {% include "/partials/_code-snippet-multi.html" %}

--- a/webapp/store/content/distros/arch.yaml
+++ b/webapp/store/content/distros/arch.yaml
@@ -16,9 +16,12 @@ install:
   -
     action: |
       Once installed, the <em>systemd</em> unit that manages the main snap communication socket needs to be enabled:
-    command: sudo systemctl enable --now snapd.socket
+    command: |
+      sudo systemctl enable --now snapd.socket
   -
     action: |
       To enable <em>classic</em> snap support, enter the following to create a symbolic link between <code>/var/lib/snapd/snap</code> and <code>/snap</code>:
-    command: sudo ln -s /var/lib/snapd/snap /snap
-  - action: Either log out and back in again, or restart your system, to ensure snap’s paths are updated correctly.
+    command: |
+      sudo ln -s /var/lib/snapd/snap /snap
+  - action: |
+      Either log out and back in again, or restart your system, to ensure snap’s paths are updated correctly.

--- a/webapp/store/content/distros/arch.yaml
+++ b/webapp/store/content/distros/arch.yaml
@@ -1,6 +1,6 @@
 name: Arch Linux
-color-1: "#5ebeed"
-color-2: "#1271a1"
+color-1: "#1793D1"
+color-2: "#116F9E"
 logo: https://assets.ubuntu.com/v1/feca0fc0-Distro_Logo_ArchLinux.svg
 install:
   -

--- a/webapp/store/content/distros/centos.yaml
+++ b/webapp/store/content/distros/centos.yaml
@@ -1,0 +1,28 @@
+name: CentOS
+color-1: "#666666"
+color-2: "#111111"
+logo: https://assets.ubuntu.com/v1/acf876d9-Distro_Logo_CentOS.svg
+install:
+  -
+    action: |
+      Snap is available for <a href="">CentOS 7.6+</a>, and Red Hat Enterprise Linux 7.6+, from the <a href="https://fedoraproject.org/wiki/EPEL">Extra Packages for Enterprise Linux</a> (EPEL) repository. The EPEL repository can be added to your system with the following command:
+    command: |
+      sudo yum install epel-release
+  -
+    action: |
+      Snap can now be installed as follows:
+    command: |
+      sudo yum install snapd
+  -
+    action: |
+      Once installed, the <em>systemd</em> unit that manages the main snap communication socket needs to be enabled:
+    command: |
+      sudo systemctl enable --now snapd.socket
+  -
+    action: |
+      To enable <em>classic</em> snap support, enter the following to create a symbolic link between <code>/var/lib/snapd/snap</code> and <code>/snap</code>:
+    command: |
+      sudo ln -s /var/lib/snapd/snap /snap
+  -
+    action: |
+      Either log out and back in again, or restart your system, to ensure snap’s paths are updated correctly.

--- a/webapp/store/content/distros/centos.yaml
+++ b/webapp/store/content/distros/centos.yaml
@@ -1,6 +1,6 @@
 name: CentOS
-color-1: "#666666"
-color-2: "#111111"
+color-1: "#161545"
+color-2: "#262577"
 logo: https://assets.ubuntu.com/v1/acf876d9-Distro_Logo_CentOS.svg
 install:
   -

--- a/webapp/store/content/distros/debian.yaml
+++ b/webapp/store/content/distros/debian.yaml
@@ -1,6 +1,6 @@
 name: Debian
-color-1: "#db003e"
-color-2: "#750021"
+color-1: "#A80030"
+color-2: "#750022"
 logo: https://assets.ubuntu.com/v1/cfdc1144-Distro_Logo_Debian.svg
 install:
   -

--- a/webapp/store/content/distros/elementary-os.yaml
+++ b/webapp/store/content/distros/elementary-os.yaml
@@ -1,11 +1,11 @@
-name: ElementaryOS
+name: elementary OS
 color-1: "#666666"
 color-2: "#111111"
 logo: https://assets.ubuntu.com/v1/c0c09661-Distro_Logo_Elementary.svg
 install:
   -
     action: |
-      Snap can be installed on Elementary OS from the command line. Open <em>Terminal</em> from the Applications launcher and type the following:
+      Snap can be installed on elementary OS from the command line. Open <em>Terminal</em> from the Applications launcher and type the following:
     command: |
       sudo apt update
       sudo apt install snapd

--- a/webapp/store/content/distros/elementary-os.yaml
+++ b/webapp/store/content/distros/elementary-os.yaml
@@ -1,6 +1,6 @@
 name: elementary OS
-color-1: "#666666"
-color-2: "#111111"
+color-1: "#95A3AB"
+color-2: "#485A6C"
 logo: https://assets.ubuntu.com/v1/c0c09661-Distro_Logo_Elementary.svg
 install:
   -

--- a/webapp/store/content/distros/elementaryos.yaml
+++ b/webapp/store/content/distros/elementaryos.yaml
@@ -1,0 +1,13 @@
+name: ElementaryOS
+color-1: "#666666"
+color-2: "#111111"
+logo: https://assets.ubuntu.com/v1/c0c09661-Distro_Logo_Elementary.svg
+install:
+  -
+    action: |
+      Snap can be installed on Elementary OS from the command line. Open <em>Terminal</em> from the Applications launcher and type the following:
+    command: |
+      sudo apt update
+      sudo apt install snapd
+  - action: |
+      Either log out and back in again, or restart your system, to ensure snap’s paths are updated correctly.

--- a/webapp/store/content/distros/fedora.yaml
+++ b/webapp/store/content/distros/fedora.yaml
@@ -1,0 +1,18 @@
+name: Fedora
+color-1: "#666666"
+color-2: "#111111"
+logo: https://assets.ubuntu.com/v1/6c5dc09e-Distro_Logo_Fedora.svg
+install:
+  -
+    action: |
+      Snap can be installed on Fedora from the command line:
+    command: |
+      sudo dnf install snapd
+  -
+    action: |
+      Either log out and back in again, or restart your system, to ensure snap’s paths are updated correctly.
+  -
+    action: |
+      To enable <em>classic</em> snap support, enter the following to create a symbolic link between <code>/var/lib/snapd/snap</code> and <code>/snap</code>:
+    command: |
+      sudo ln -s /var/lib/snapd/snap /snap

--- a/webapp/store/content/distros/fedora.yaml
+++ b/webapp/store/content/distros/fedora.yaml
@@ -1,6 +1,6 @@
 name: Fedora
-color-1: "#666666"
-color-2: "#111111"
+color-1: "#3C6EB4"
+color-2: "#294172"
 logo: https://assets.ubuntu.com/v1/6c5dc09e-Distro_Logo_Fedora.svg
 install:
   -

--- a/webapp/store/content/distros/kde-neon.yaml
+++ b/webapp/store/content/distros/kde-neon.yaml
@@ -1,6 +1,6 @@
 name: KDE Neon
-color-1: "#666666"
-color-2: "#111111"
+color-1: "#20A3A8"
+color-2: "#167275"
 logo: https://assets.ubuntu.com/v1/d0593902-Distro_Logo_KDE+Neon.svg
 install:
   -

--- a/webapp/store/content/distros/kde-neon.yaml
+++ b/webapp/store/content/distros/kde-neon.yaml
@@ -1,0 +1,11 @@
+name: KDE Neon
+color-1: "#666666"
+color-2: "#111111"
+logo: https://assets.ubuntu.com/v1/d0593902-Distro_Logo_KDE+Neon.svg
+install:
+  -
+    action: |
+      Snap can be installed from the command line. Open the <em>Konsole</em> terminal and enter the following:
+    command: |
+      sudo apt update
+      sudo apt install snapd

--- a/webapp/store/content/distros/kubuntu.yaml
+++ b/webapp/store/content/distros/kubuntu.yaml
@@ -1,0 +1,14 @@
+name: Kubuntu
+color-1: "#666666"
+color-2: "#111111"
+logo: https://assets.ubuntu.com/v1/7ab50a06-Distro_Logo_Kubuntu.svg
+install:
+  -
+    action: |
+      If you’re running <a href="https://kubuntu.org/">Kubuntu 16.04 LTS (Xenial Xerus)</a> or later, including <a href="https://wiki.ubuntu.com/BionicBeaver/ReleaseNotes/Kubuntu">Kubuntu 18.04 LTS (Bionic Beaver)</a> and <a href="https://wiki.ubuntu.com/CosmicCuttlefish/ReleaseNotes/Kubuntu">Kubuntu 18.10 (Cosmic Cuttlefish)</a>, you don’t need to do anything. Snap is already installed and ready to go.
+  -
+    action: |
+      Versions of Kubuntu between <a href="https://kubuntu.org/news/kubuntu-14-04-lts">14.04 LTS (Trusty Tahr)</a> and <a href="https://kubuntu.org/news/kubuntu-15-10">15.10 (Wily Werewolf)</a> don’t include <em>snap</em> by default, but <em>snap</em> can be installed from the command line as follows:
+    command: |
+      sudo apt update
+      sudo apt install snapd

--- a/webapp/store/content/distros/kubuntu.yaml
+++ b/webapp/store/content/distros/kubuntu.yaml
@@ -1,6 +1,6 @@
 name: Kubuntu
-color-1: "#666666"
-color-2: "#111111"
+color-1: "#0079C1"
+color-2: "#005A8F"
 logo: https://assets.ubuntu.com/v1/7ab50a06-Distro_Logo_Kubuntu.svg
 install:
   -

--- a/webapp/store/content/distros/manjaro.yaml
+++ b/webapp/store/content/distros/manjaro.yaml
@@ -1,0 +1,26 @@
+name: Manjaro Linux
+color-1: "#666666"
+color-2: "#111111"
+logo: https://assets.ubuntu.com/v1/4635a0bd-Distro_Logo_Manjaro.svg
+install:
+  -
+    action: |
+      Snapd can be installed from Manjaro’s Add/Remove Software application (Pamac), found in the launch menu. From the application, search for <em>snapd</em>, select the result, and click Apply.
+  -
+    action: |
+      Alternatively, <em>snapd</em> can be installed from the command line:
+    command: |
+      sudo pacman -S snapd
+  -
+    action: |
+      Once installed, the <em>systemd</em> unit that manages the main snap communication socket needs to be enabled:
+    command: |
+      sudo systemctl enable --now snapd.socket
+  -
+    action: |
+      To enable <em>classic</em> snap support, enter the following to create a symbolic link between <code>/var/lib/snapd/snap</code> and <code>/snap</code>:
+    command: |
+      sudo ln -s /var/lib/snapd/snap /snap
+  -
+    action: |
+      Either log out and back in again, or restart your system, to ensure snap’s paths are updated correctly.

--- a/webapp/store/content/distros/manjaro.yaml
+++ b/webapp/store/content/distros/manjaro.yaml
@@ -1,6 +1,6 @@
 name: Manjaro Linux
-color-1: "#666666"
-color-2: "#111111"
+color-1: "#35BF5C"
+color-2: "#278C44"
 logo: https://assets.ubuntu.com/v1/4635a0bd-Distro_Logo_Manjaro.svg
 install:
   -

--- a/webapp/store/content/distros/mint.yaml
+++ b/webapp/store/content/distros/mint.yaml
@@ -1,6 +1,6 @@
 name: Linux Mint
-color-1: "#666666"
-color-2: "#111111"
+color-1: "#81C53B"
+color-2: "#5F912C"
 logo: https://assets.ubuntu.com/v1/938d67b4-Distro_Logo_LinuxMint.svg
 install:
   -

--- a/webapp/store/content/distros/mint.yaml
+++ b/webapp/store/content/distros/mint.yaml
@@ -1,0 +1,18 @@
+name: Linux Mint
+color-1: "#666666"
+color-2: "#111111"
+logo: https://assets.ubuntu.com/v1/938d67b4-Distro_Logo_LinuxMint.svg
+install:
+  -
+    action: |
+      Snap is available for Linux Mint 18.2 (Sonya), Linux Mint 18.3 (Sylvia), and the latest releases, Linux Mint 19 (Tara) and Linux Mint 19.1 (Tessa).
+      You can find out which version of Linux Mint you’re running by opening <em>System info</em> from the <em>Preferences</em> menu. To install snap from the Software Manager application, search for <em>snapd</em> and click Install.
+  -
+    action: |
+      Alternatively, snapd can be installed from the command line:
+    command: |
+      sudo apt update
+      sudo apt install snapd
+  -
+    action: |
+      Either restart your machine, or log out and in again, to complete the installation.

--- a/webapp/store/content/distros/opensuse.yaml
+++ b/webapp/store/content/distros/opensuse.yaml
@@ -1,0 +1,44 @@
+name: OpenSUSE
+color-1: "#666666"
+color-2: "#111111"
+logo: https://assets.ubuntu.com/v1/610301c6-Distro_Logo_OpenSUSE.svg
+install:
+  -
+    action: |
+      Snap can be installed from the command line on openSUSE Leap 42.3, Leap 15 and Tumbleweed.
+  -
+    action: |
+      You need first add the <em>snappy</em> repository from the terminal. Leap 15 users, for example, can do this with the following command:
+    command: |
+      sudo zypper addrepo --refresh https://download.opensuse.org/repositories/system:/snappy/openSUSE_Leap_15.0 snappy
+  -
+    action: |
+      Swap out <code>openSUSE_Leap_15.0</code> for either <code>openSUSE_Leap_42.3</code> or <code>openSUSE_Tumbleweed</code> if you’re using a different version of openSUSE.
+  -
+    action: |
+      With the repository added, import its GPG key:
+    command: |
+      sudo zypper --gpg-auto-import-keys refresh
+  -
+    action: |
+      Finally, upgrade the package cache to include the new <em>snappy</em> repository:
+    command: |
+      sudo zypper dup --from snappy
+  -
+    action: |
+      Snap can now be installed with the following:
+    command: |
+      sudo zypper install snapd
+  -
+    action: |
+      You then need to either reboot, logout/login or <code>source /etc/profile</code> to have /snap/bin added to PATH.
+      Additionally, enable and start both the <em>snapd</em> and the <em>snapd.apparmor</em> services with the following commands:
+    command: |
+      sudo systemctl enable snapd
+      sudo systemctl start snapd
+  -
+    action: |
+      Tumbleweed users also need to run the following:
+    command: |
+      sudo systemctl enable snapd.apparmor
+      sudo systemctl start snapd.apparmor

--- a/webapp/store/content/distros/opensuse.yaml
+++ b/webapp/store/content/distros/opensuse.yaml
@@ -1,6 +1,6 @@
 name: OpenSUSE
-color-1: "#666666"
-color-2: "#111111"
+color-1: "#73BA25"
+color-2: "#54871B"
 logo: https://assets.ubuntu.com/v1/610301c6-Distro_Logo_OpenSUSE.svg
 install:
   -

--- a/webapp/store/content/distros/ubuntu.yaml
+++ b/webapp/store/content/distros/ubuntu.yaml
@@ -1,6 +1,6 @@
 name: Ubuntu
-color-1: "#666666"
-color-2: "#111111"
+color-1: "#E95420"
+color-2: "#B54119"
 logo: https://assets.ubuntu.com/v1/100386fb-Distro_Logo_Ubuntu.svg
 install:
   -

--- a/webapp/store/content/distros/ubuntu.yaml
+++ b/webapp/store/content/distros/ubuntu.yaml
@@ -1,0 +1,20 @@
+name: Ubuntu
+color-1: "#666666"
+color-2: "#111111"
+logo: https://assets.ubuntu.com/v1/100386fb-Distro_Logo_Ubuntu.svg
+install:
+  -
+    action: |
+      If you’re running <a href="https://www.ubuntu.com/">Ubuntu 16.04 LTS (Xenial Xerus)</a> or later, including <a href="https://www.ubuntu.com/desktop/features">Ubuntu 18.04 LTS (Bionic Beaver)</a>, <a href="https://wiki.ubuntu.com/CosmicCuttlefish/ReleaseNotes">Ubuntu 18.10 (Cosmic Cuttlefish)</a> and <a href="https://wiki.ubuntu.com/DiscoDingo/ReleaseNotes">Ubuntu 19.04 (Disco Dingo)</a>, you don’t need to do anything. Snap is already installed and ready to go.
+  -
+    action: |
+      For versions of Ubuntu between <a href="https://wiki.ubuntu.com/TrustyTahr/ReleaseNotes">14.04 LTS (Trusty Tahr)</a> and <a href="https://wiki.ubuntu.com/WilyWerewolf/ReleaseNotes">15.10 (Wily Werewolf)</a>, as well as Ubuntu flavours that don’t include <em>snap</em> by default, <em>snap</em> can be installed from the Ubuntu Software Centre by searching for <em>snapd</em>.
+  -
+    action: |
+      Alternatively, snapd can be installed from the command line:
+    command: |
+      sudo apt update
+      sudo apt install snapd
+  -
+    action: |
+      Either log out and back in again, or restart your system, to ensure snap’s paths are updated correctly.


### PR DESCRIPTION
Fixes #1975 

Adds content for all other supported distros and fixes couple of design review issues:
- using highlighted card
- dropping chevron icon
- small copy adjustments
- making sure single line commands are not detected as multiline

### QA
- ./run or https://snapcraft-io-canonical-web-and-design-pr-1978.run.demo.haus/
- Visit distro page for all the distros and make sure they render fine (try with different snaps):
https://snapcraft-io-canonical-web-and-design-pr-1978.run.demo.haus/install/riot-web/arch
https://snapcraft-io-canonical-web-and-design-pr-1978.run.demo.haus/install/pick-colour-picker/centos
https://snapcraft-io-canonical-web-and-design-pr-1978.run.demo.haus/install/wing7/debian
https://snapcraft-io-canonical-web-and-design-pr-1978.run.demo.haus/install/eric-ide/elementary-os
https://snapcraft-io-canonical-web-and-design-pr-1978.run.demo.haus/install/rider/fedora
https://snapcraft-io-canonical-web-and-design-pr-1978.run.demo.haus/install/emacs/kde-neon
https://snapcraft-io-canonical-web-and-design-pr-1978.run.demo.haus/install/toontown/kubuntu
https://snapcraft-io-canonical-web-and-design-pr-1978.run.demo.haus/install/scrn/manjaro
https://snapcraft-io-canonical-web-and-design-pr-1978.run.demo.haus/install/eric-ide/mint
https://snapcraft-io-canonical-web-and-design-pr-1978.run.demo.haus/install/natron/opensuse
https://snapcraft-io-canonical-web-and-design-pr-1978.run.demo.haus/install/marsshooter/ubuntu

Known issues from design review:
- CentOS logo/background needs adjusting