### PR TITLE
Add animated scroll to distro install instructions

### DIFF
--- a/static/js/public/public.js
+++ b/static/js/public/public.js
@@ -14,7 +14,7 @@ import nps from "./nps";
 import { newsletter } from "./newsletter";
 import initExpandableSnapDetails from "./expandable-details";
 import triggerEventWhenVisible from "./ga-scroll-event";
-import scrollTo from "./scroll-to";
+import { initLinkScroll } from "./scroll-to";
 
 export {
   map,
@@ -32,7 +32,7 @@ export {
   initReportSnap,
   firstSnapFlow,
   triggerEventWhenVisible,
-  scrollTo,
+  initLinkScroll,
   videos,
   nps,
   newsletter

--- a/static/js/public/public.js
+++ b/static/js/public/public.js
@@ -14,6 +14,7 @@ import nps from "./nps";
 import { newsletter } from "./newsletter";
 import initExpandableSnapDetails from "./expandable-details";
 import triggerEventWhenVisible from "./ga-scroll-event";
+import scrollTo from "./scroll-to";
 
 export {
   map,
@@ -31,6 +32,7 @@ export {
   initReportSnap,
   firstSnapFlow,
   triggerEventWhenVisible,
+  scrollTo,
   videos,
   nps,
   newsletter

--- a/static/js/public/scroll-to.js
+++ b/static/js/public/scroll-to.js
@@ -1,0 +1,73 @@
+// From: https://gist.github.com/felipenmoura/650e7e1292c1e7638bcf6c9f9aeb9dd5
+
+/**
+ * Will gracefuly scroll the page
+ * This function will scroll the page using
+ * an `ease-in-ou` effect.
+ *
+ * You can use it to scroll to a given element, as well.
+ * To do so, pass the element instead of a number as the position.
+ * Optionally, you can pass a `queryString` for an element selector.
+ *
+ * The default duration is half a second (500ms)
+ *
+ * This function returns a Promise that resolves as soon
+ * as it has finished scrolling. If a selector is passed and
+ * the element is not present in the page, it will reject.
+ *
+ * EXAMPLES:
+ *
+ * ```js
+ * window.scrollPageTo('#some-section', 2000);
+ * window.scrollPageTo(document.getElementById('some-section'), 1000);
+ * window.scrollPageTo(500); // will scroll to 500px in 500ms
+ * ```
+ *
+ * @returns {Promise}
+ * @param {HTMLElement|Number|Selector} Target
+ * @param {Number} Duration [default=500]
+ *
+ * Inspired by @andjosh's work
+ *
+ */
+export default function scrollPageTo(to, duration = 500, offset = 0) {
+  //t = current time
+  //b = start value
+  //c = change in value
+  //d = duration
+  const easeInOutQuad = function(t, b, c, d) {
+    t /= d / 2;
+    if (t < 1) return (c / 2) * t * t + b;
+    t--;
+    return (-c / 2) * (t * (t - 2) - 1) + b;
+  };
+
+  return new Promise((resolve, reject) => {
+    const element = document.scrollingElement;
+
+    if (typeof to === "string") {
+      to = document.querySelector(to) || reject();
+    }
+    if (typeof to !== "number") {
+      to = to.getBoundingClientRect().top + element.scrollTop;
+    }
+    to = to + offset;
+
+    let start = element.scrollTop,
+      change = to - start,
+      currentTime = 0,
+      increment = 20;
+
+    const animateScroll = function() {
+      currentTime += increment;
+      let val = easeInOutQuad(currentTime, start, change, duration);
+      element.scrollTop = val;
+      if (currentTime < duration) {
+        setTimeout(animateScroll, increment);
+      } else {
+        resolve();
+      }
+    };
+    animateScroll();
+  });
+}

--- a/static/js/public/scroll-to.js
+++ b/static/js/public/scroll-to.js
@@ -30,7 +30,7 @@
  * Inspired by @andjosh's work
  *
  */
-export default function scrollPageTo(to, duration = 500, offset = 0) {
+export function animateScrollTo(to, duration = 500, offset = 0) {
   //t = current time
   //b = start value
   //c = change in value
@@ -70,4 +70,19 @@ export default function scrollPageTo(to, duration = 500, offset = 0) {
     };
     animateScroll();
   });
+}
+
+export function initLinkScroll(link, { duration = 500, offset = 0 }) {
+  if (link && link.href) {
+    const href = link.getAttribute("href");
+    const target = document.querySelector(href);
+    if (target) {
+      link.addEventListener("click", event => {
+        event.preventDefault();
+        animateScrollTo(target, duration, offset).then(() => {
+          window.history.pushState({}, null, href);
+        });
+      });
+    }
+  }
 }

--- a/templates/store/snap-distro-install.html
+++ b/templates/store/snap-distro-install.html
@@ -86,7 +86,7 @@
               {% include 'store/snap-details/_snap_heading_data.html' %}
 
               <div class="p-snap-install-buttons">
-                <a class="p-button--neutral p-snap-install-buttons__install" href="#install">
+                <a class="p-button--neutral p-snap-install-buttons__install js-install" href="#install">
                     Install snap
                 </a>
               </div>
@@ -221,6 +221,16 @@
   <script src="{{ static_url('js/dist/public.js') }}"></script>
   <script>
     Raven.context(function () {
+      try {
+        document.querySelector(".js-install")
+          .addEventListener('click', function (event) {
+            event.preventDefault();
+            snapcraft.public.scrollTo("#install", 300, -20);
+          });
+      } catch(e) {
+        Raven.captureException(e);
+      }
+
       try {
         snapcraft.public.triggerEventWhenVisible("#snippet-snap-install-stable")
       } catch(e) {

--- a/templates/store/snap-distro-install.html
+++ b/templates/store/snap-distro-install.html
@@ -222,11 +222,7 @@
   <script>
     Raven.context(function () {
       try {
-        document.querySelector(".js-install")
-          .addEventListener('click', function (event) {
-            event.preventDefault();
-            snapcraft.public.scrollTo("#install", 300, -20);
-          });
+        snapcraft.public.initLinkScroll(document.querySelector(".js-install"), { offset: -20 });
       } catch(e) {
         Raven.captureException(e);
       }


### PR DESCRIPTION
Adds animated scroll to distro install instructions.

### QA
- ./run or https://snapcraft-io-canonical-web-and-design-pr-1982.run.demo.haus/
- go to distro page of any snap https://snapcraft-io-canonical-web-and-design-pr-1982.run.demo.haus/install/slack/arch
- click on "Install snap" button
- page should scroll smoothly to the install instructions
- there should be a small offset margin above card with instructions