### PR TITLE
Updates to distro page template

### DIFF
--- a/templates/store/snap-distro-install.html
+++ b/templates/store/snap-distro-install.html
@@ -119,7 +119,7 @@
       <div id="install" class="p-card--highlighted">
         <div class="row">
           <div class="col-10">
-          <h2>Snap install instructions for {{ distro_name }}</h2>
+          <h2>Install instructions for snaps on {{ distro_name }}</h2>
           <p>Snaps are applications packaged with all their dependencies to run on all popular Linux distributions from a single build. They update automatically and roll back gracefully.</p>
           <p>Snaps are discoverable and installable from the <a href="/store">Snap Store</a>, an app store with an audience of millions.</p>
           </div>
@@ -171,10 +171,15 @@
       <a href="/search?category=featured" class="p-button--neutral u-float--right u-hide--small p-featured-snap__see-more">See more...</a>
     </div>
     <div class="row">
-      {% set snaps = featured_snaps %}
-      {% set category = "featured" %}
-      {% set show_summary = True %}
-      {% include "store/_category-partial.html" %}
+      <div class="col-12">
+        <div class="snapcraft-p-grid">
+            {% set show_summary = True %}
+            {% for snap in featured_snaps %}
+                {% set media_object_classname = "u-no-margin--bottom" %}
+                {% include "store/_media-object-snap-partial.html" %}
+            {% endfor %}
+        </div>
+      </div>
     </div>
     <div class="row u-hide--medium u-hide--large">
       <a href="/search?category=featured" class="p-button--neutral u-float--right">See more in Featured</a>

--- a/webapp/store/snap_details_views.py
+++ b/webapp/store/snap_details_views.py
@@ -357,7 +357,7 @@ def snap_details_views(store, api, handle_errors):
 
         try:
             featured_snaps_results = api.get_searched_snaps(
-                snap_searched="", category="featured", size=10, page=1
+                snap_searched="", category="featured", size=12, page=1
             )
         except ApiError:
             featured_snaps_results = []


### PR DESCRIPTION
 https://snapcraft-io-canonical-web-and-design-pr-1983.run.demo.haus/install/android-studio/debian

- updated heading of install instructions
- showing 12 featured snaps