### PR TITLE
Update bleach to latest version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # App dependencies
-bleach==2.0.0
+bleach==3.1.0
 Flask==1.0.2
 Flask-OpenID-Stateless==1.2.6
 Flask-WTF==0.14.2

--- a/webapp/publisher/snaps/views.py
+++ b/webapp/publisher/snaps/views.py
@@ -876,8 +876,8 @@ def get_register_name_dispute():
 @login_required
 def post_register_name_dispute():
     try:
-        snap_name = flask.request.form.get("snap-name")
-        claim_comment = flask.request.form.get("claim-comment")
+        snap_name = flask.request.form.get("snap-name", "")
+        claim_comment = flask.request.form.get("claim-comment", "")
         api.post_register_name_dispute(
             flask.session, bleach.clean(snap_name), bleach.clean(claim_comment)
         )


### PR DESCRIPTION
# summary

Fixes #1980 

Previous version of bleach was closing everything that was considered as a tag. The update of bleach fixes this issue.

# qa

- `./run`
- http://0.0.0.0:8004/featherpad/preview
- http://0.0.0.0:8004/featherpad
- The email shouldn't be a closed tag at the end of the description