### PR TITLE
Update visual style of release UI (in preparation for drag and drop)

### DIFF
--- a/static/js/publisher/release/components/releasesTable.js
+++ b/static/js/publisher/release/components/releasesTable.js
@@ -33,7 +33,7 @@ class ReleasesTable extends Component {
     ) {
       const historyPanelRow = (
         <div className="p-releases-table__row" key="history-panel-row">
-          <div className="p-releases-channel u-hide--small" />
+          <div className="p-releases-channel is-placeholder u-hide--small" />
           {this.renderHistoryPanel()}
         </div>
       );
@@ -60,7 +60,7 @@ class ReleasesTable extends Component {
       <div className="row">
         <div className={className}>
           <div className="p-releases-table__row p-releases-table__row--heading">
-            <div className="p-releases-channel" />
+            <div className="p-releases-channel is-placeholder" />
             {archs.map(arch => (
               <div
                 className={`p-releases-table__cell p-releases-table__arch ${

--- a/static/js/publisher/release/components/releasesTableCell.js
+++ b/static/js/publisher/release/components/releasesTableCell.js
@@ -147,7 +147,8 @@ class ReleasesTableCell extends Component {
       "p-releases-table__cell is-clickable",
       isUnassigned ? "is-unassigned" : "",
       isActive ? "is-active" : "",
-      isHighlighted ? "is-highlighted" : ""
+      isHighlighted ? "is-highlighted" : "",
+      isPending ? "is-pending" : ""
     ].join(" ");
 
     return (

--- a/static/sass/_snapcraft_release.scss
+++ b/static/sass/_snapcraft_release.scss
@@ -25,8 +25,8 @@
   // row
 
   .p-releases-table__row {
-    border-bottom: 1px solid $color-mid-light;
     display: flex;
+    margin-bottom: 2px;
   }
 
   .p-releases-table__row--channel {
@@ -34,7 +34,7 @@
   }
 
   .p-releases-table__row--heading {
-    height: 2.5rem;
+    height: 2rem;
   }
 
   .p-releases-table__row--edge {
@@ -58,10 +58,16 @@
 
   .p-releases-channel {
     align-items: flex-start;
+    background: $color-light;
     display: flex;
     flex-shrink: 0;
-    margin-right: 5px;
+    font-size: .9rem;
+    padding-left: $sph-intra--condensed;
     width: 260px;
+
+    .p-promote-button {
+      font-size: .9rem;
+    }
 
     .has-active & {
       opacity: .5;
@@ -70,6 +76,10 @@
     &:hover,
     &.is-active {
       opacity: 1;
+    }
+
+    &.is-placeholder {
+      background: none;
     }
   }
 
@@ -87,7 +97,8 @@
     border-bottom: 3px solid transparent;
     flex-basis: 100px;
     flex-grow: 1;
-    margin-left: 1px;
+    font-size: .9rem;
+    margin-left: 2px;
     max-width: 25.2%; // fill the whole space for 3 archs
     min-width: 100px;
     position: relative;
@@ -133,8 +144,8 @@
 
   .p-release-buttons {
     position: absolute;
-    right: .5rem;
-    top: .5rem;
+    right: .4rem;
+    top: .4rem;
   }
 
   .p-release-data {
@@ -146,12 +157,18 @@
   }
 
   .p-release-data__info {
-    width: 100%;
     white-space: nowrap;
+    width: 100%;
 
     &.is-pending {
       font-weight: 400;
       padding-right: $sph-inter;
+    }
+  }
+
+  .is-pending {
+    .p-release-data__icon {
+      margin-right: 20px;
     }
   }
 
@@ -167,7 +184,7 @@
   .p-release-data__meta {
     color: $color-mid-dark;
     display: block;
-    font-size: .8em;
+    font-size: .8rem;
     overflow: hidden;
     text-overflow: ellipsis;
   }


### PR DESCRIPTION
Fixes #1958
Fixes #1943

Updates visual style of release UI (as per #1958) in preparation for drag and drop.
Also fixes alignment of devmode icon (see #1943)

### QA

- ./run or https://snapcraft-io-canonical-web-and-design-pr-1990.run.demo.haus/
- go to Releases page of any snap
- see that design is updated as described in #1958
- check different states of the UI (promote some cannel, open history panel of any release, hover on things)
- try to promote any devmode revision: devmode icon and cancel icon should appear next to each other not overlapping

<img width="1097" alt="Screenshot 2019-06-12 at 15 02 00" src="https://user-images.githubusercontent.com/83575/59353758-fbd62d00-8d23-11e9-8d21-1eaada35019f.png">
