### PR TITLE
Allow youtu.be video urls

### DIFF
--- a/static/js/publisher/preview.js
+++ b/static/js/publisher/preview.js
@@ -99,6 +99,13 @@ function getVideoDetails(url) {
       id: url.split("v=")[1].split("&")[0]
     };
   }
+  if (url.indexOf("youtu.be") > -1) {
+    return {
+      type: "youtube",
+      url: url.replace("youtu.be/", "youtube.com/embed/"),
+      id: url.split("/")[1].split("?")[0]
+    };
+  }
   if (url.indexOf("vimeo") > -1) {
     const splitUrl = url.split("/");
     return {

--- a/tests/store/tests_public_logic.py
+++ b/tests/store/tests_public_logic.py
@@ -266,6 +266,17 @@ class StoreLogicTest(unittest.TestCase):
             },
         )
 
+        youtu_be_url = "https://youtu.be/123"
+        embed = logic.get_video_embed_code(youtu_be_url)
+        self.assertEqual(
+            embed,
+            {
+                "type": "youtube",
+                "url": "https://youtube.com/embed/123",
+                "id": "123",
+            },
+        )
+
         vimeo_url = "https://vimeo.com/123123"
         embed = logic.get_video_embed_code(vimeo_url)
         self.assertEqual(

--- a/webapp/store/logic.py
+++ b/webapp/store/logic.py
@@ -378,6 +378,12 @@ def get_video_embed_code(url):
             "url": url.replace("watch?v=", "embed/"),
             "id": url.rsplit("?v=", 1)[-1],
         }
+    if "youtu.be" in url:
+        return {
+            "type": "youtube",
+            "url": url.replace("youtu.be/", "youtube.com/embed/"),
+            "id": url.rsplit("/", 1)[-1],
+        }
     if "vimeo" in url:
         return {
             "type": "vimeo",


### PR DESCRIPTION
Fixes https://github.com/canonical-web-and-design/snapcraft.io/issues/1994

## QA
- Pull the branch
- `./run`
- Visit a snap listings page http://0.0.0.0:8004/<snap_name>/listing
- Add a youtu.be url (https://youtu.be/3OFhVtqfDBQ)
- Preview the page
- Save the page
- Visit http://0.0.0.0:8004/<snap_name>
- The video should work