### PR TITLE
Fix capitalisation of openSUSE

### DIFF
--- a/templates/store/snap-details/_distro-instructions-for-snap-support.html
+++ b/templates/store/snap-details/_distro-instructions-for-snap-support.html
@@ -93,7 +93,7 @@
                     <img src="https://assets.ubuntu.com/v1/610301c6-Distro_Logo_OpenSUSE.svg" alt="">
                 </span>
                 <span class="p-media-object__details">
-                    <h4 class="p-media-object__title p-heading--five u-no-margin--bottom">OpenSUSE</h4>
+                    <h4 class="p-media-object__title p-heading--five u-no-margin--bottom">openSUSE</h4>
                 </span>
             </a>
             <a class="p-media-object p-media-object--snap u-vertically-center" href="/install/{{package_name}}/ubuntu">


### PR DESCRIPTION
It's "openSUSE", not "OpenSUSE"