### PR TITLE
Removed logo in fedora according to guidelines

### DIFF
--- a/templates/store/snap-distro-install.html
+++ b/templates/store/snap-distro-install.html
@@ -65,12 +65,14 @@
           </g>
         </g>
       </svg>
+      {% if distro_display_logo %}
       <div class="row">
         <div class="mobile-col-2 col-8"></div>
         <div class="mobile-col-2 col-4">
           <img class="distro-banner__logo" src="{{ distro_logo }}" />
         </div>
       </div>
+      {% endif %}
     </div>
     <div class="p-strip">
       <div class="row">

--- a/webapp/store/content/distros/arch.yaml
+++ b/webapp/store/content/distros/arch.yaml
@@ -2,6 +2,7 @@ name: Arch Linux
 color-1: "#1793D1"
 color-2: "#116F9E"
 logo: https://assets.ubuntu.com/v1/feca0fc0-Distro_Logo_ArchLinux.svg
+display-logo: true
 install:
   -
     action: |

--- a/webapp/store/content/distros/centos.yaml
+++ b/webapp/store/content/distros/centos.yaml
@@ -2,6 +2,7 @@ name: CentOS
 color-1: "#265AA3"
 color-2: "#0E223D"
 logo: https://assets.ubuntu.com/v1/acf876d9-Distro_Logo_CentOS.svg
+display-logo: true
 install:
   -
     action: |

--- a/webapp/store/content/distros/debian.yaml
+++ b/webapp/store/content/distros/debian.yaml
@@ -2,6 +2,7 @@ name: Debian
 color-1: "#A80030"
 color-2: "#750022"
 logo: https://assets.ubuntu.com/v1/cfdc1144-Distro_Logo_Debian.svg
+display-logo: true
 install:
   -
     action: |

--- a/webapp/store/content/distros/elementary.yaml
+++ b/webapp/store/content/distros/elementary.yaml
@@ -2,6 +2,7 @@ name: elementary OS
 color-1: "#95A3AB"
 color-2: "#485A6C"
 logo: https://assets.ubuntu.com/v1/c0c09661-Distro_Logo_Elementary.svg
+display-logo: true
 install:
   -
     action: |

--- a/webapp/store/content/distros/fedora.yaml
+++ b/webapp/store/content/distros/fedora.yaml
@@ -2,6 +2,7 @@ name: Fedora
 color-1: "#3C6EB4"
 color-2: "#294172"
 logo: https://assets.ubuntu.com/v1/6c5dc09e-Distro_Logo_Fedora.svg
+display-logo: false
 install:
   -
     action: |

--- a/webapp/store/content/distros/kde-neon.yaml
+++ b/webapp/store/content/distros/kde-neon.yaml
@@ -2,6 +2,7 @@ name: KDE Neon
 color-1: "#20A3A8"
 color-2: "#167275"
 logo: https://assets.ubuntu.com/v1/d0593902-Distro_Logo_KDE+Neon.svg
+display-logo: true
 install:
   -
     action: |

--- a/webapp/store/content/distros/kubuntu.yaml
+++ b/webapp/store/content/distros/kubuntu.yaml
@@ -2,6 +2,7 @@ name: Kubuntu
 color-1: "#0079C1"
 color-2: "#005A8F"
 logo: https://assets.ubuntu.com/v1/7ab50a06-Distro_Logo_Kubuntu.svg
+display-logo: true
 install:
   -
     action: |

--- a/webapp/store/content/distros/manjaro.yaml
+++ b/webapp/store/content/distros/manjaro.yaml
@@ -2,6 +2,7 @@ name: Manjaro Linux
 color-1: "#35BF5C"
 color-2: "#278C44"
 logo: https://assets.ubuntu.com/v1/4635a0bd-Distro_Logo_Manjaro.svg
+display-logo: true
 install:
   -
     action: |

--- a/webapp/store/content/distros/mint.yaml
+++ b/webapp/store/content/distros/mint.yaml
@@ -2,6 +2,7 @@ name: Linux Mint
 color-1: "#81C53B"
 color-2: "#5F912C"
 logo: https://assets.ubuntu.com/v1/938d67b4-Distro_Logo_LinuxMint.svg
+display-logo: true
 install:
   -
     action: |

--- a/webapp/store/content/distros/opensuse.yaml
+++ b/webapp/store/content/distros/opensuse.yaml
@@ -2,6 +2,7 @@ name: openSUSE
 color-1: "#73BA25"
 color-2: "#54871B"
 logo: https://assets.ubuntu.com/v1/610301c6-Distro_Logo_OpenSUSE.svg
+display-logo: true
 install:
   -
     action: |

--- a/webapp/store/content/distros/ubuntu.yaml
+++ b/webapp/store/content/distros/ubuntu.yaml
@@ -2,6 +2,7 @@ name: Ubuntu
 color-1: "#E95420"
 color-2: "#B54119"
 logo: https://assets.ubuntu.com/v1/100386fb-Distro_Logo_Ubuntu.svg
+display-logo: true
 install:
   -
     action: |

--- a/webapp/store/snap_details_views.py
+++ b/webapp/store/snap_details_views.py
@@ -349,6 +349,7 @@ def snap_details_views(store, api, handle_errors):
                 "distro": distro,
                 "distro_name": distro_data["name"],
                 "distro_logo": distro_data["logo"],
+                "distro_display_logo": distro_data["display-logo"],
                 "distro_color_1": distro_data["color-1"],
                 "distro_color_2": distro_data["color-2"],
                 "distro_install_steps": distro_data["install"],


### PR DESCRIPTION
Fixes #2007 

### QA Steps

1. Pull the branch or open the demo service
2. Open any distro pages with Fedora instructions like `/install/spotify/fedora`
3. Check the logo is not visible in the background according to [Fedora logo guidelines](https://fedoraproject.org/wiki/Logo/UsageGuidelines)
4. Visit another distro pages like openSuse `/install/spotify/opensuse`
5. Notice the logo should be there
6. #winning