### PR TITLE
Releases common version

### DIFF
--- a/static/js/publisher/release/components/releasesTableCell.js
+++ b/static/js/publisher/release/components/releasesTableCell.js
@@ -25,7 +25,7 @@ class ReleasesTableCell extends Component {
     this.props.undoRelease(revision, `${track}/${risk}`);
   }
 
-  renderRevision(revision, isPending) {
+  renderRevision(revision, isPending, showVersion) {
     return (
       <Fragment>
         <span className="p-release-data__info">
@@ -35,7 +35,9 @@ class ReleasesTableCell extends Component {
               <DevmodeIcon revision={revision} showTooltip={false} />
             </span>
           )}
-          <span className="p-release-data__meta">{revision.version}</span>
+          {showVersion && (
+            <span className="p-release-data__meta">{revision.version}</span>
+          )}
         </span>
         <span className="p-tooltip__message">
           {isPending && "Pending release of:"}
@@ -160,7 +162,11 @@ class ReleasesTableCell extends Component {
           {isChannelPendingClose
             ? this.renderCloseChannel()
             : currentRevision
-              ? this.renderRevision(currentRevision, hasPendingRelease)
+              ? this.renderRevision(
+                  currentRevision,
+                  hasPendingRelease,
+                  this.props.showVersion
+                )
               : this.renderEmpty(isUnassigned, availableCount, trackingChannel)}
         </div>
         {hasPendingRelease && (
@@ -195,7 +201,8 @@ ReleasesTableCell.propTypes = {
   // props
   track: PropTypes.string,
   risk: PropTypes.string,
-  arch: PropTypes.string
+  arch: PropTypes.string,
+  showVersion: PropTypes.bool
 };
 
 const mapStateToProps = state => {

--- a/static/js/publisher/release/components/releasesTableRow.js
+++ b/static/js/publisher/release/components/releasesTableRow.js
@@ -32,14 +32,14 @@ const disabledBecauseReleased = "The same revisions are already promoted.";
 const disabledBecauseNotSelected = "Select some revisions to promote them.";
 
 class ReleasesTableRow extends Component {
-  renderRevisionCell(track, risk, arch) {
+  renderRevisionCell(track, risk, arch, showVersion) {
     return (
       <ReleasesTableCell
         key={`${track}/${risk}/${arch}`}
         track={track}
         risk={risk}
         arch={arch}
-        pendingCloses={this.props.pendingCloses}
+        showVersion={showVersion}
       />
     );
   }
@@ -74,7 +74,6 @@ class ReleasesTableRow extends Component {
   renderChannelRow(risk) {
     const track = this.props.currentTrack;
     const archs = this.props.archs;
-    const channelMap = this.props.channelMap;
     const pendingChannelMap = this.props.pendingChannelMap;
 
     const channel = getChannelName(track, risk);
@@ -170,6 +169,8 @@ class ReleasesTableRow extends Component {
       }
     }
 
+    const showVersion = risk === AVAILABLE || !hasSameVersion;
+
     return (
       <Fragment>
         {risk === AVAILABLE && <h4>Revisions available to promote</h4>}
@@ -181,7 +182,7 @@ class ReleasesTableRow extends Component {
               filteredChannel === channel ? "is-active" : ""
             }`}
           >
-            {channel === AVAILABLE ? (
+            {risk === AVAILABLE ? (
               <span className="p-releases-channel__name">{channelName}</span>
             ) : (
               <span className="p-releases-channel__name p-release-data__info">
@@ -210,13 +211,7 @@ class ReleasesTableRow extends Component {
             </span>
           </div>
           {archs.map(arch =>
-            this.renderRevisionCell(
-              track,
-              risk,
-              arch,
-              channelMap,
-              pendingChannelMap
-            )
+            this.renderRevisionCell(track, risk, arch, showVersion)
           )}
         </div>
       </Fragment>
@@ -235,7 +230,6 @@ ReleasesTableRow.propTypes = {
   // state
   currentTrack: PropTypes.string.isRequired,
   filters: PropTypes.object,
-  channelMap: PropTypes.object.isRequired,
   pendingCloses: PropTypes.array.isRequired,
 
   archs: PropTypes.array.isRequired,
@@ -250,7 +244,6 @@ const mapStateToProps = state => {
   return {
     currentTrack: state.currentTrack,
     filters: state.history.filters,
-    channelMap: state.channelMap,
     pendingCloses: state.pendingCloses,
     archs: getArchitectures(state),
     pendingChannelMap: getPendingChannelMap(state)

--- a/static/js/publisher/release/components/releasesTableRow.js
+++ b/static/js/publisher/release/components/releasesTableRow.js
@@ -152,16 +152,18 @@ class ReleasesTableRow extends Component {
 
     let hasSameVersion = false;
     let channelVersion = "";
-
+    let versionsMap = {};
     if (pendingChannelMap[channel]) {
-      hasSameVersion = Object.values(pendingChannelMap[channel])
-        .map(r => r.version)
-        .every((e, i, a) => {
-          if (i) {
-            return e === a[i - 1];
-          }
-          return true;
-        });
+      // calculate map of architectures for each version
+      for (const arch in pendingChannelMap[channel]) {
+        const version = pendingChannelMap[channel][arch].version;
+        if (!versionsMap[version]) {
+          versionsMap[version] = [];
+        }
+        versionsMap[version].push(arch);
+      }
+
+      hasSameVersion = Object.keys(versionsMap).length === 1;
       if (hasSameVersion) {
         channelVersion = Object.values(pendingChannelMap[channel])[0].version;
       } else {
@@ -170,6 +172,18 @@ class ReleasesTableRow extends Component {
     }
 
     const showVersion = risk === AVAILABLE || !hasSameVersion;
+    const channelVersionTooltip = (
+      <Fragment>
+        {Object.keys(versionsMap).map(version => {
+          return (
+            <span key={`tooltip-${channel}-${version}`}>
+              {version}: <b>{versionsMap[version].join(", ")}</b>
+              <br />
+            </span>
+          );
+        })}
+      </Fragment>
+    );
 
     return (
       <Fragment>
@@ -185,9 +199,14 @@ class ReleasesTableRow extends Component {
             {risk === AVAILABLE ? (
               <span className="p-releases-channel__name">{channelName}</span>
             ) : (
-              <span className="p-releases-channel__name p-release-data__info">
+              <span className="p-releases-channel__name p-release-data__info p-tooltip p-tooltip--btm-center">
                 <span className="p-release-data__title">{channelName}</span>
                 <span className="p-release-data__meta">{channelVersion}</span>
+                {channelVersion && (
+                  <span className="p-tooltip__message">
+                    {channelVersionTooltip}
+                  </span>
+                )}
               </span>
             )}
 

--- a/static/js/publisher/release/components/releasesTableRow.js
+++ b/static/js/publisher/release/components/releasesTableRow.js
@@ -151,6 +151,25 @@ class ReleasesTableRow extends Component {
       this.props.filters &&
       getChannelName(this.props.filters.track, this.props.filters.risk);
 
+    let hasSameVersion = false;
+    let channelVersion = "";
+
+    if (pendingChannelMap[channel]) {
+      hasSameVersion = Object.values(pendingChannelMap[channel])
+        .map(r => r.version)
+        .every((e, i, a) => {
+          if (i) {
+            return e === a[i - 1];
+          }
+          return true;
+        });
+      if (hasSameVersion) {
+        channelVersion = Object.values(pendingChannelMap[channel])[0].version;
+      } else {
+        channelVersion = "Multiple versions";
+      }
+    }
+
     return (
       <Fragment>
         {risk === AVAILABLE && <h4>Revisions available to promote</h4>}
@@ -162,7 +181,15 @@ class ReleasesTableRow extends Component {
               filteredChannel === channel ? "is-active" : ""
             }`}
           >
-            <span className="p-releases-channel__name">{channelName}</span>
+            {channel === AVAILABLE ? (
+              <span className="p-releases-channel__name">{channelName}</span>
+            ) : (
+              <span className="p-releases-channel__name p-release-data__info">
+                <span className="p-release-data__title">{channelName}</span>
+                <span className="p-release-data__meta">{channelVersion}</span>
+              </span>
+            )}
+
             <span className="p-releases-table__menus">
               {canBePromoted && (
                 <PromoteMenu

--- a/static/sass/_snapcraft_release.scss
+++ b/static/sass/_snapcraft_release.scss
@@ -87,6 +87,10 @@
     flex-grow: 1;
     padding-right: $sph-intra--condensed;
     padding-top: ($spv-intra - .1rem);
+
+    .p-release-data__meta {
+      max-width: 115px;
+    }
   }
 
   // release cell


### PR DESCRIPTION
Fixes #1959 

Shows version under channel name in releases table.

### QA

- ./run or https://snapcraft-io-canonical-web-and-design-pr-2018.run.demo.haus/
- go to publisher releases page of any snap
- under channel name in each row version should be displayed:
  - version number if all revisions in this channel have same version
  - "Multiple versions" if revisions have different versions
  - nothing if channel has no revisions
- if all revisions have same version in channel versions are not shown in individual cells
- hovering over channel name/version shows tooltip with version breakdown per arch
- this all applies only to 4 channel rows, not to 'available revisions' row at the bottom

<img width="1052" alt="Screenshot 2019-06-18 at 13 01 11" src="https://user-images.githubusercontent.com/83575/59677003-2fec9a80-91c9-11e9-82bd-d946c12016a7.png">
