### PR TITLE
Drag'n'drop to promote channel

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,6 +78,8 @@
     "prop-types": "^15.6.2",
     "raven-js": "^3.24.1",
     "react": "^16.4.1",
+    "react-dnd": "^8.0.0",
+    "react-dnd-html5-backend": "^8.0.0",
     "react-dom": "^16.4.1",
     "react-redux": "^5.1.1",
     "react-sortable-hoc": "^1.8.3",

--- a/static/js/publisher/release.js
+++ b/static/js/publisher/release.js
@@ -3,8 +3,10 @@ import ReactDOM from "react-dom";
 import { createStore, applyMiddleware, compose } from "redux";
 import thunk from "redux-thunk";
 import { Provider } from "react-redux";
-import ReleasesController from "./release/releasesController";
+import { DndProvider } from "react-dnd";
+import HTML5Backend from "react-dnd-html5-backend";
 
+import ReleasesController from "./release/releasesController";
 import releases from "./release/reducers";
 
 // setup redux store with thunk middleware and devtools extension:
@@ -22,12 +24,14 @@ const initReleases = (id, snapName, releasesData, channelMapsList, options) => {
 
   ReactDOM.render(
     <Provider store={store}>
-      <ReleasesController
-        snapName={snapName}
-        channelMapsList={channelMapsList}
-        releasesData={releasesData}
-        options={options}
-      />
+      <DndProvider backend={HTML5Backend}>
+        <ReleasesController
+          snapName={snapName}
+          channelMapsList={channelMapsList}
+          releasesData={releasesData}
+          options={options}
+        />
+      </DndProvider>
     </Provider>,
     document.querySelector(id)
   );

--- a/static/js/publisher/release/components/releasesTableCell.js
+++ b/static/js/publisher/release/components/releasesTableCell.js
@@ -12,7 +12,8 @@ import { undoRelease } from "../actions/pendingReleases";
 
 import {
   getPendingChannelMap,
-  getFilteredAvailableRevisionsForArch
+  getFilteredAvailableRevisionsForArch,
+  hasPendingRelease
 } from "../selectors";
 
 class ReleasesTableCell extends Component {
@@ -126,16 +127,11 @@ class ReleasesTableCell extends Component {
     const channel = getChannelName(track, risk);
 
     // current revision to show (released or pending)
-    let currentRevision =
+    const currentRevision =
       pendingChannelMap[channel] && pendingChannelMap[channel][arch];
-    // already released revision
-    let releasedRevision = channelMap[channel] && channelMap[channel][arch];
 
     // check if there is a pending release in this cell
-    const hasPendingRelease =
-      currentRevision &&
-      (!releasedRevision ||
-        releasedRevision.revision !== currentRevision.revision);
+    const hasPendingRelease = this.props.hasPendingRelease(channel, arch);
 
     const isChannelPendingClose = pendingCloses.includes(channel);
     const isPending = hasPendingRelease || isChannelPendingClose;
@@ -195,6 +191,7 @@ ReleasesTableCell.propTypes = {
   pendingChannelMap: PropTypes.object,
   // compute state
   getAvailableCount: PropTypes.func,
+  hasPendingRelease: PropTypes.func,
   // actions
   toggleHistoryPanel: PropTypes.func.isRequired,
   undoRelease: PropTypes.func.isRequired,
@@ -212,7 +209,9 @@ const mapStateToProps = state => {
     pendingCloses: state.pendingCloses,
     pendingChannelMap: getPendingChannelMap(state),
     getAvailableCount: arch =>
-      getFilteredAvailableRevisionsForArch(state, arch).length
+      getFilteredAvailableRevisionsForArch(state, arch).length,
+    hasPendingRelease: (channel, arch) =>
+      hasPendingRelease(state, channel, arch)
   };
 };
 

--- a/static/js/publisher/release/components/releasesTableRow.js
+++ b/static/js/publisher/release/components/releasesTableRow.js
@@ -275,7 +275,7 @@ const ReleasesTableRow = props => {
             }`}
           >
             <span className="p-releases-channel__handle">
-              <i className="p-icon--contextual-menu" />
+              <i className="p-icon--drag" />
             </span>
             <span className="p-releases-channel__name p-release-data__info p-tooltip p-tooltip--btm-center">
               <span className="p-release-data__title">{rowTitle}</span>

--- a/static/js/publisher/release/components/releasesTableRow.js
+++ b/static/js/publisher/release/components/releasesTableRow.js
@@ -3,7 +3,11 @@ import PropTypes from "prop-types";
 import { connect } from "react-redux";
 import { DragSource, DropTarget } from "react-dnd";
 
-import { getArchitectures, getPendingChannelMap } from "../selectors";
+import {
+  getArchitectures,
+  getPendingChannelMap,
+  hasPendingRelease
+} from "../selectors";
 import ReleasesTableCell from "./releasesTableCell";
 
 import { promoteChannel } from "../actions/pendingReleases";
@@ -209,6 +213,10 @@ class ReleasesTableRow extends Component {
 
     const rowTitle = risk === AVAILABLE ? channelVersion : channel;
 
+    const isHighlighted = archs.every(arch => {
+      return this.props.hasPendingRelease(channel, arch);
+    });
+
     return (
       <Fragment>
         {risk === AVAILABLE && (
@@ -232,7 +240,7 @@ class ReleasesTableRow extends Component {
                 <div
                   className={`p-releases-channel ${
                     filteredChannel === channel ? "is-active" : ""
-                  }`}
+                  } ${isHighlighted ? "is-highlighted" : ""}`}
                 >
                   {this.props.connectDragSource(
                     <span className="p-releases-channel__handle">
@@ -297,6 +305,8 @@ ReleasesTableRow.propTypes = {
   archs: PropTypes.array.isRequired,
   pendingChannelMap: PropTypes.object,
 
+  hasPendingRelease: PropTypes.func,
+
   // actions
   closeChannel: PropTypes.func.isRequired,
   promoteChannel: PropTypes.func.isRequired,
@@ -316,7 +326,9 @@ const mapStateToProps = state => {
     filters: state.history.filters,
     pendingCloses: state.pendingCloses,
     archs: getArchitectures(state),
-    pendingChannelMap: getPendingChannelMap(state)
+    pendingChannelMap: getPendingChannelMap(state),
+    hasPendingRelease: (channel, arch) =>
+      hasPendingRelease(state, channel, arch)
   };
 };
 

--- a/static/js/publisher/release/releasesController.js
+++ b/static/js/publisher/release/releasesController.js
@@ -1,9 +1,7 @@
-import React, { Component } from "react";
+import React, { Component, Fragment } from "react";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
 import "whatwg-fetch";
-import { DndProvider } from "react-dnd";
-import HTML5Backend from "react-dnd-html5-backend";
 
 import ReleasesTable from "./components/releasesTable";
 import Notification from "./components/notification";
@@ -265,7 +263,7 @@ class ReleasesController extends Component {
 
   render() {
     return (
-      <DndProvider backend={HTML5Backend}>
+      <Fragment>
         <div className="row">
           {this.state.error && (
             <Notification status="error" appearance="negative">
@@ -281,7 +279,7 @@ class ReleasesController extends Component {
         </div>
 
         <ReleasesTable />
-      </DndProvider>
+      </Fragment>
     );
   }
 }

--- a/static/js/publisher/release/releasesController.js
+++ b/static/js/publisher/release/releasesController.js
@@ -1,7 +1,9 @@
-import React, { Component, Fragment } from "react";
+import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
 import "whatwg-fetch";
+import { DndProvider } from "react-dnd";
+import HTML5Backend from "react-dnd-html5-backend";
 
 import ReleasesTable from "./components/releasesTable";
 import Notification from "./components/notification";
@@ -263,7 +265,7 @@ class ReleasesController extends Component {
 
   render() {
     return (
-      <Fragment>
+      <DndProvider backend={HTML5Backend}>
         <div className="row">
           {this.state.error && (
             <Notification status="error" appearance="negative">
@@ -279,7 +281,7 @@ class ReleasesController extends Component {
         </div>
 
         <ReleasesTable />
-      </Fragment>
+      </DndProvider>
     );
   }
 }

--- a/static/js/publisher/release/selectors/index.js
+++ b/static/js/publisher/release/selectors/index.js
@@ -177,3 +177,22 @@ export function getTracks(state) {
 
   return sortAlphaNum(tracks, "latest");
 }
+
+// return true if there is a pending release in given channel for given arch
+export function hasPendingRelease(state, channel, arch) {
+  const { channelMap } = state;
+  const pendingChannelMap = getPendingChannelMap(state);
+
+  // current revision to show (released or pending)
+  let currentRevision =
+    pendingChannelMap[channel] && pendingChannelMap[channel][arch];
+  // already released revision
+  let releasedRevision = channelMap[channel] && channelMap[channel][arch];
+
+  // check if there is a pending release in this cell
+  return (
+    currentRevision &&
+    (!releasedRevision ||
+      releasedRevision.revision !== currentRevision.revision)
+  );
+}

--- a/static/js/publisher/release/selectors/selectors.test.js
+++ b/static/js/publisher/release/selectors/selectors.test.js
@@ -11,6 +11,7 @@ import {
   getSelectedArchitectures,
   getPendingChannelMap,
   hasDevmodeRevisions,
+  hasPendingRelease,
   getFilteredAvailableRevisions,
   getFilteredAvailableRevisionsForArch,
   getArchitectures,
@@ -506,5 +507,74 @@ describe("getTracks", () => {
 
   it("should return list of all tracks", () => {
     expect(getTracks(stateWithReleases)).toEqual(["latest", "test", "12"]);
+  });
+});
+
+describe("hasPendingRelease", () => {
+  describe("when there are no pending releases", () => {
+    const stateWithNoPendingReleases = {
+      channelMap: {
+        "test/edge": {
+          test64: { revision: 1 }
+        }
+      },
+      pendingReleases: {}
+    };
+
+    it("should return false", () => {
+      expect(
+        hasPendingRelease(stateWithNoPendingReleases, "test/edge", "test64")
+      ).toBe(false);
+    });
+  });
+
+  describe("when there are pending releases to other channels", () => {
+    const stateWithPendingReleases = {
+      channelMap: {
+        "test/edge": {
+          test64: { revision: 1 }
+        }
+      },
+      pendingReleases: {
+        2: {
+          revision: { revision: 2, architectures: ["test64"] },
+          channels: ["latest/stable"]
+        }
+      }
+    };
+
+    it("should return false for channel/arch without pending release", () => {
+      expect(
+        hasPendingRelease(stateWithPendingReleases, "test/edge", "test64")
+      ).toBe(false);
+    });
+
+    it("should return true for channel/arch with pending release", () => {
+      expect(
+        hasPendingRelease(stateWithPendingReleases, "latest/stable", "test64")
+      ).toBe(true);
+    });
+  });
+
+  describe("when there are pending releases overriding existing releases", () => {
+    const stateWithPendingReleases = {
+      channelMap: {
+        "test/edge": {
+          test64: { revision: 1 }
+        }
+      },
+      pendingReleases: {
+        2: {
+          revision: { revision: 2, architectures: ["test64"] },
+          channels: ["test/edge"]
+        }
+      }
+    };
+
+    it("should return true for channel/arch with pending release", () => {
+      expect(
+        hasPendingRelease(stateWithPendingReleases, "test/edge", "test64")
+      ).toBe(true);
+    });
   });
 });

--- a/static/sass/_snapcraft_release.scss
+++ b/static/sass/_snapcraft_release.scss
@@ -368,4 +368,9 @@
     @extend %icon;
     background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='26' height='26'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cpath d='M0 0h26v26H0z'/%3E%3Cpath fill='gray' fill-rule='nonzero' d='M4.401 11.014L2 9.598l2.938-5.196 2.6 1.533a8.746 8.746 0 0 1 2.524-1.423V2h5.876v2.512c.92.332 1.772.817 2.523 1.423l2.601-1.533L24 9.598l-2.401 1.416a9.268 9.268 0 0 1 0 3.972L24 16.402l-2.938 5.196-2.6-1.533a8.746 8.746 0 0 1-2.524 1.423V24h-5.876v-2.512a8.746 8.746 0 0 1-2.523-1.423l-2.601 1.533L2 16.402l2.401-1.416A9.213 9.213 0 0 1 4.186 13c0-.683.074-1.347.215-1.986zM13 18c2.704 0 4.897-2.239 4.897-5S15.704 8 13 8s-4.897 2.239-4.897 5 2.193 5 4.897 5z'/%3E%3C/g%3E%3C/svg%3E");
   }
+
+  .p-icon--drag {
+    @extend %icon;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' height='12' width='12'%3E%3Cpath fill-rule='nonzero' fill='%23666' d='M4 3a1 1 0 1 1 0-2 1 1 0 0 1 0 2zm0 4a1 1 0 1 1 0-2 1 1 0 0 1 0 2zm0 4a1 1 0 1 1 0-2 1 1 0 0 1 0 2zm4-8a1 1 0 1 1 0-2 1 1 0 0 1 0 2zm0 4a1 1 0 1 1 0-2 1 1 0 0 1 0 2zm0 4a1 1 0 1 1 0-2 1 1 0 0 1 0 2z'/%3E%3C/svg%3E");
+  }
 }

--- a/static/sass/_snapcraft_release.scss
+++ b/static/sass/_snapcraft_release.scss
@@ -1,5 +1,5 @@
 @mixin snapcraft-release {
-  $color-highlighted: #ffecd4;
+  $color-highlighted: #fae6be;
 
   // RELEASES CONFIRM
 
@@ -90,6 +90,10 @@
     .is-over & {
       background-color: $color-highlighted;
     }
+
+    &.is-highlighted {
+      background-color: $color-highlighted;
+    }
   }
 
   .p-releases-channel__name {
@@ -106,7 +110,7 @@
   }
 
   .p-releases-channel__handle {
-    cursor: move;
+    cursor: grab;
     padding-right: $sph-intra--condensed;
     padding-top: ($spv-intra - .1rem);
   }

--- a/static/sass/_snapcraft_release.scss
+++ b/static/sass/_snapcraft_release.scss
@@ -83,6 +83,10 @@
       opacity: .5;
     }
 
+    .can-drop & {
+      opacity: 1;
+    }
+
     &:hover,
     &.is-active {
       opacity: 1;
@@ -145,6 +149,10 @@
 
     .has-active & {
       opacity: .5;
+    }
+
+    .can-drop & {
+      opacity: 1;
     }
 
     &.is-clickable:focus,

--- a/static/sass/_snapcraft_release.scss
+++ b/static/sass/_snapcraft_release.scss
@@ -27,6 +27,18 @@
   .p-releases-table__row {
     display: flex;
     margin-bottom: 2px;
+
+    &.is-dragging {
+      opacity: .5;
+    }
+
+    &.can-drop {
+      outline: 1px dashed $color-mid-light;
+    }
+
+    &.is-over {
+      background-color: $color-highlighted;
+    }
   }
 
   .p-releases-table__row--channel {
@@ -56,7 +68,7 @@
     flex-shrink: 0;
     font-size: 1rem;
     padding-left: $sph-intra--condensed;
-    width: 260px;
+    width: 280px;
 
     .p-promote-button {
       font-size: .9rem;
@@ -74,6 +86,10 @@
     &.is-placeholder {
       background: none;
     }
+
+    .is-over & {
+      background-color: $color-highlighted;
+    }
   }
 
   .p-releases-channel__name {
@@ -87,6 +103,12 @@
       overflow: hidden;
       text-overflow: ellipsis;
     }
+  }
+
+  .p-releases-channel__handle {
+    cursor: move;
+    padding-right: $sph-intra--condensed;
+    padding-top: ($spv-intra - .1rem);
   }
 
   // release cell
@@ -131,6 +153,10 @@
 
     &.is-highlighted {
       background: $color-highlighted;
+    }
+
+    .is-over & {
+      background-color: $color-highlighted;
     }
   }
 

--- a/static/sass/_snapcraft_release.scss
+++ b/static/sass/_snapcraft_release.scss
@@ -28,16 +28,21 @@
     display: flex;
     margin-bottom: 2px;
 
+    &.is-grabbing,
+    &.is-dragging {
+      opacity: .9; // little workaround for chrome
+
+      .p-tooltip__message {
+        display: none;
+      }
+    }
+
     &.is-dragging {
       opacity: .5;
     }
 
     &.can-drop {
       outline: 1px dashed $color-mid-light;
-    }
-
-    &.is-over {
-      background-color: $color-highlighted;
     }
   }
 
@@ -94,6 +99,10 @@
     &.is-highlighted {
       background-color: $color-highlighted;
     }
+
+    &.is-draggable {
+      cursor: grab;
+    }
   }
 
   .p-releases-channel__name {
@@ -110,9 +119,13 @@
   }
 
   .p-releases-channel__handle {
-    cursor: grab;
     padding-right: $sph-intra--condensed;
     padding-top: ($spv-intra - .1rem);
+    visibility: hidden;
+
+    .is-draggable & {
+      visibility: visible;
+    }
   }
 
   // release cell

--- a/yarn.lock
+++ b/yarn.lock
@@ -142,9 +142,27 @@
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/@sheerun/mutationobserver-shim/-/mutationobserver-shim-0.3.2.tgz#8013f2af54a2b7d735f71560ff360d3a8176a87b"
 
+"@types/hoist-non-react-statics@^3.3.1":
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz#1124aafe5118cb591977aeb1ceaaed1070eb039f"
+  dependencies:
+    "@types/react" "*"
+    hoist-non-react-statics "^3.3.0"
+
 "@types/istanbul-lib-coverage@^1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.0.tgz#2cc2ca41051498382b43157c8227fea60363f94a"
+
+"@types/prop-types@*":
+  version "15.7.1"
+  resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.1.tgz#f1a11e7babb0c3cad68100be381d1e064c68f1f6"
+
+"@types/react@*":
+  version "16.8.20"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.8.20.tgz#4f633ecbd0a4d56d0ccc50fff6f9321bbcd7d583"
+  dependencies:
+    "@types/prop-types" "*"
+    csstype "^2.2.0"
 
 "@types/yargs@^12.0.9":
   version "12.0.9"
@@ -517,6 +535,10 @@ array-unique@^0.3.2:
 arrify@^1.0.0, arrify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
+
+asap@^2.0.6:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
 
 asn1.js@^4.0.0:
   version "4.10.1"
@@ -1888,6 +1910,10 @@ cssstyle@^1.0.0:
   dependencies:
     cssom "0.3.x"
 
+csstype@^2.2.0:
+  version "2.6.5"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.5.tgz#1cd1dff742ebf4d7c991470ae71e12bb6751e034"
+
 currently-unhandled@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/currently-unhandled/-/currently-unhandled-0.4.1.tgz#988df33feab191ef799a61369dd76c17adf957ea"
@@ -2355,6 +2381,14 @@ diffie-hellman@^5.0.0:
     bn.js "^4.1.0"
     miller-rabin "^4.0.0"
     randombytes "^2.0.0"
+
+dnd-core@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/dnd-core/-/dnd-core-8.0.0.tgz#0e2c8b722809ae50ca47a5d4b80e7ed753decb25"
+  dependencies:
+    asap "^2.0.6"
+    invariant "^2.2.4"
+    redux "^4.0.1"
 
 doctrine@^1.2.2:
   version "1.5.0"
@@ -3547,6 +3581,12 @@ hoist-non-react-statics@^3.1.0:
   dependencies:
     react-is "^16.3.2"
 
+hoist-non-react-statics@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.0.tgz#b09178f0122184fb95acf525daaecb4d8f45958b"
+  dependencies:
+    react-is "^16.7.0"
+
 home-or-tmp@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/home-or-tmp/-/home-or-tmp-2.0.0.tgz#e36c3f2d2cae7d746a857e38d18d5f32a7882db8"
@@ -3730,15 +3770,15 @@ interpret@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.1.0.tgz#7ed1b1410c6a0e0f78cf95d3b8440c63f78b8614"
 
-invariant@^2.2.2:
-  version "2.2.3"
-  resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.3.tgz#1a827dfde7dcbd7c323f0ca826be8fa7c5e9d688"
+invariant@^2.1.0, invariant@^2.2.4:
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
   dependencies:
     loose-envify "^1.0.0"
 
-invariant@^2.2.4:
-  version "2.2.4"
-  resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
+invariant@^2.2.2:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.3.tgz#1a827dfde7dcbd7c323f0ca826be8fa7c5e9d688"
   dependencies:
     loose-envify "^1.0.0"
 
@@ -5975,6 +6015,22 @@ rc@^1.2.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
+react-dnd-html5-backend@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/react-dnd-html5-backend/-/react-dnd-html5-backend-8.0.0.tgz#918058134fc9222524c3ec9b6563821dee010db4"
+  dependencies:
+    dnd-core "^8.0.0"
+
+react-dnd@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/react-dnd/-/react-dnd-8.0.0.tgz#72fe2e0bd9da05db2c44b7d26e347ce7be2b4544"
+  dependencies:
+    "@types/hoist-non-react-statics" "^3.3.1"
+    dnd-core "^8.0.0"
+    hoist-non-react-statics "^3.3.0"
+    invariant "^2.1.0"
+    shallowequal "^1.1.0"
+
 react-dom@^16.4.1:
   version "16.8.6"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.8.6.tgz#71d6303f631e8b0097f56165ef608f051ff6e10f"
@@ -5988,7 +6044,7 @@ react-is@^16.3.2, react-is@^16.6.0:
   version "16.6.3"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.6.3.tgz#d2d7462fcfcbe6ec0da56ad69047e47e56e7eac0"
 
-react-is@^16.8.1:
+react-is@^16.7.0, react-is@^16.8.1:
   version "16.8.6"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.6.tgz#5bbc1e2d29141c9fbdfed456343fe2bc430a6a16"
 
@@ -6592,6 +6648,10 @@ sha.js@^2.4.0, sha.js@^2.4.8:
   dependencies:
     inherits "^2.0.1"
     safe-buffer "^5.0.1"
+
+shallowequal@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/shallowequal/-/shallowequal-1.1.0.tgz#188d521de95b9087404fd4dcb68b13df0ae4e7f8"
 
 shebang-command@^1.2.0:
   version "1.2.0"


### PR DESCRIPTION
Fixes #1961 
Fixes #1962 
Fixes #1963 

Adds drag'n'drop to releases page.
Channels can now be promoted using drag'n'drop.

### QA

This is new quite complex feature. Please make sure to QA on different snaps (different number of architectures, devmode revisions, closed channels, etc) and in different browsers (it uses native drag'n'drop, so browser implementations may differ).

- ./run or https://snapcraft-io-canonical-web-and-design-pr-2019.run.demo.haus/
- go to releases page or any snap (many snaps ideally)
- try to promote some stuff using drag'n'drop
- make sure that things that can be normally promoted can also be promoted with drag'n'drop
- make sure that things that can't be normally promoted (empty channel, devmode) can't be promoted with drag'n'drop
- click on things, try drag'n'drop in different UI states

<img width="1162" alt="Screenshot 2019-06-25 at 16 35 31" src="https://user-images.githubusercontent.com/83575/60108593-20d98f80-9769-11e9-95c7-04223adc26d8.png">
