### PR TITLE
Move tracks dropdown to left side of heading

### DIFF
--- a/static/js/publisher/release/components/releasesHeading.js
+++ b/static/js/publisher/release/components/releasesHeading.js
@@ -1,4 +1,4 @@
-import React, { Component } from "react";
+import React, { Component, Fragment } from "react";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
 
@@ -12,36 +12,34 @@ class ReleasesHeading extends Component {
 
   renderTrackDropdown(tracks) {
     return (
-      <form className="p-form p-form--inline u-float--right">
-        <div className="p-form__group">
-          <label htmlFor="track-dropdown" className="p-form__label">
-            Show revisions released in
-          </label>
-          <div className="p-form__control u-clearfix">
-            <select
-              id="track-dropdown"
-              onChange={this.onTrackChange.bind(this)}
-            >
-              {tracks.map(track => (
-                <option key={`${track}`} value={track}>
-                  {track}
-                </option>
-              ))}
-            </select>
-          </div>
-        </div>
+      <form className="p-form p-form--inline">
+        <select id="track-dropdown" onChange={this.onTrackChange.bind(this)}>
+          {tracks.map(track => (
+            <option key={`${track}`} value={track}>
+              {track}
+            </option>
+          ))}
+        </select>
       </form>
     );
   }
 
   render() {
     const tracks = this.props.tracks;
-
+    const Wrap = tracks.length > 1 ? "label" : "span";
     return (
-      <div className="u-clearfix">
-        <h4 className="u-float--left">Releases available to install</h4>
-        {tracks.length > 1 && this.renderTrackDropdown(tracks)}
-      </div>
+      <h4>
+        <Wrap htmlFor="track-dropdown">
+          Releases available to install
+          {tracks.length > 1 && (
+            <Fragment>
+              {" "}
+              in &nbsp;
+              {this.renderTrackDropdown(tracks)}
+            </Fragment>
+          )}
+        </Wrap>
+      </h4>
     );
   }
 }


### PR DESCRIPTION
Fixes #2021

### QA
- ./run or https://snapcraft-io-canonical-web-and-design-pr-2023.run.demo.haus
- go to releases page of any snap with multiple tracks (https://snapcraft-io-canonical-web-and-design-pr-2023.run.demo.haus/skype/releases)
- track dropdown should be part of the heading on left side
- track dropdown should work as before
- check snap without tracks to see if they are not affected

<img width="748" alt="Screenshot 2019-06-18 at 13 43 21" src="https://user-images.githubusercontent.com/83575/59679426-0f274380-91cf-11e9-99a1-9c08a9f471b5.png">
