### PR TITLE
White logos in distros

### DIFF
--- a/static/sass/_patterns_distro_banner.scss
+++ b/static/sass/_patterns_distro_banner.scss
@@ -56,8 +56,8 @@
   .distro-banner__logo {
     filter: brightness(40);
     float: right;
-    margin-top: 3rem;
-    width: 9rem;
+    margin-top: 1.5rem;
+    width: 5rem;
   }
 
   @media only screen and (min-width: $breakpoint-medium) {
@@ -67,10 +67,15 @@
     }
   }
 
+  @media only screen and (min-width: $breakpoint-large) {
+    .distro-banner__logo {
+      width: 9rem;
+    }
+  }
+
   @media only screen and (max-width: $breakpoint-medium) {
     .distro-banner__logo {
-      margin-top: 1.5rem;
-      width: 6rem;
+      display: none;
     }
   }
 }

--- a/static/sass/_patterns_distro_banner.scss
+++ b/static/sass/_patterns_distro_banner.scss
@@ -60,8 +60,4 @@
     }
   }
 
-  .distro-banner__logo {
-    filter: grayscale(100%) opacity(20%);
-    mix-blend-mode: multiply;
-  }
 }

--- a/static/sass/_patterns_distro_banner.scss
+++ b/static/sass/_patterns_distro_banner.scss
@@ -53,6 +53,13 @@
     right: 2rem;
   }
 
+  .distro-banner__logo {
+    filter: brightness(40);
+    float: right;
+    margin-top: 3rem;
+    width: 9rem;
+  }
+
   @media only screen and (min-width: $breakpoint-medium) {
     .distro-code-snippet {
       // to align code snippet with paragraph of text in column next to it
@@ -60,4 +67,10 @@
     }
   }
 
+  @media only screen and (max-width: $breakpoint-medium) {
+    .distro-banner__logo {
+      margin-top: 1.5rem;
+      width: 6rem;
+    }
+  }
 }

--- a/static/sass/_patterns_distro_banner.scss
+++ b/static/sass/_patterns_distro_banner.scss
@@ -55,7 +55,6 @@
 
   .distro-banner__logo {
     float: right;
-    margin-top: 1.5rem;
     width: 7rem;
   }
 
@@ -63,13 +62,6 @@
     .distro-code-snippet {
       // to align code snippet with paragraph of text in column next to it
       padding-top: .5rem;
-    }
-  }
-
-  @media only screen and (min-width: $breakpoint-large) {
-    .distro-banner__logo {
-      width: 8rem;
-      margin-top: 3rem;
     }
   }
 

--- a/static/sass/_patterns_distro_banner.scss
+++ b/static/sass/_patterns_distro_banner.scss
@@ -54,10 +54,9 @@
   }
 
   .distro-banner__logo {
-    filter: brightness(40);
     float: right;
     margin-top: 1.5rem;
-    width: 5rem;
+    width: 7rem;
   }
 
   @media only screen and (min-width: $breakpoint-medium) {
@@ -69,7 +68,8 @@
 
   @media only screen and (min-width: $breakpoint-large) {
     .distro-banner__logo {
-      width: 9rem;
+      width: 8rem;
+      margin-top: 3rem;
     }
   }
 

--- a/static/sass/_patterns_distro_banner.scss
+++ b/static/sass/_patterns_distro_banner.scss
@@ -65,9 +65,4 @@
     }
   }
 
-  @media only screen and (max-width: $breakpoint-medium) {
-    .distro-banner__logo {
-      display: none;
-    }
-  }
 }

--- a/templates/store/snap-distro-install.html
+++ b/templates/store/snap-distro-install.html
@@ -72,7 +72,7 @@
            <h1 class="p-heading--two u-no-margin is-light">How to install {{ snap_title }}<br/> on <b>{{ distro_name }}</b></h1>
         </div>
         {% if distro_logo_mono %}
-        <div class="col-4 mobile-col-2">
+        <div class="col-4 u-hide--small">
           <img class="distro-banner__logo u-vertically-center" src="{{ distro_logo_mono }}" />
        </div>
        {% endif %}

--- a/templates/store/snap-distro-install.html
+++ b/templates/store/snap-distro-install.html
@@ -67,9 +67,6 @@
       </svg>
       <div class="row">
         <div class="mobile-col-2 col-8"></div>
-        <div class="mobile-col-2 col-4">
-          <img class="distro-banner__logo" src="{{ distro_logo }}" />
-        </div>
       </div>
     </div>
     <div class="p-strip">

--- a/templates/store/snap-distro-install.html
+++ b/templates/store/snap-distro-install.html
@@ -67,6 +67,9 @@
       </svg>
       <div class="row">
         <div class="mobile-col-2 col-8"></div>
+        <div class="mobile-col-2 col-4">
+          <img class="distro-banner__logo" src="{{ distro_logo_mono }}" />
+        </div>
       </div>
     </div>
     <div class="p-strip">

--- a/templates/store/snap-distro-install.html
+++ b/templates/store/snap-distro-install.html
@@ -65,16 +65,17 @@
           </g>
         </g>
       </svg>
-      <div class="row">
-        <div class="mobile-col-2 col-8"></div>
-        <div class="mobile-col-2 col-4">
-          <img class="distro-banner__logo" src="{{ distro_logo_mono }}" />
-        </div>
-      </div>
     </div>
     <div class="p-strip">
       <div class="row">
-        <h1 class="p-heading--two u-no-margin is-light">How to install {{ snap_title }}<br/> on <b>{{ distro_name }}</b></h1>
+        <div class="col-8">
+           <h1 class="p-heading--two u-no-margin is-light">How to install {{ snap_title }}<br/> on <b>{{ distro_name }}</b></h1>
+        </div>
+        {% if distro_logo_mono %}
+        <div class="col-4 mobile-col-2">
+          <img class="distro-banner__logo u-vertically-center" src="{{ distro_logo_mono }}" />
+       </div>
+       {% endif %}
       </div>
     </div>
 

--- a/webapp/store/content/distros/arch.yaml
+++ b/webapp/store/content/distros/arch.yaml
@@ -2,7 +2,7 @@ name: Arch Linux
 color-1: "#1793D1"
 color-2: "#116F9E"
 logo: https://assets.ubuntu.com/v1/feca0fc0-Distro_Logo_ArchLinux.svg
-logo-mono: https://assets.ubuntu.com/v1/065aa7a2-Distro_Logo_ArchLinux_White.svg
+logo-mono: https://assets.ubuntu.com/v1/d1dabe71-Distro_Logo_ArchLinux_White.svg
 install:
   -
     action: |

--- a/webapp/store/content/distros/arch.yaml
+++ b/webapp/store/content/distros/arch.yaml
@@ -2,6 +2,7 @@ name: Arch Linux
 color-1: "#1793D1"
 color-2: "#116F9E"
 logo: https://assets.ubuntu.com/v1/feca0fc0-Distro_Logo_ArchLinux.svg
+logo-mono: https://assets.ubuntu.com/v1/065aa7a2-Distro_Logo_ArchLinux_White.svg
 install:
   -
     action: |

--- a/webapp/store/content/distros/centos.yaml
+++ b/webapp/store/content/distros/centos.yaml
@@ -2,7 +2,7 @@ name: CentOS
 color-1: "#265AA3"
 color-2: "#0E223D"
 logo: https://assets.ubuntu.com/v1/acf876d9-Distro_Logo_CentOS.svg
-logo-mono: https://assets.ubuntu.com/v1/dbb5d1a6-Distro_Logo_CentOS_White.svg
+logo-mono: https://assets.ubuntu.com/v1/7d49bfed-Distro_Logo_CentOS_White.svg
 install:
   -
     action: |

--- a/webapp/store/content/distros/centos.yaml
+++ b/webapp/store/content/distros/centos.yaml
@@ -2,6 +2,7 @@ name: CentOS
 color-1: "#265AA3"
 color-2: "#0E223D"
 logo: https://assets.ubuntu.com/v1/acf876d9-Distro_Logo_CentOS.svg
+logo-mono: https://assets.ubuntu.com/v1/dbb5d1a6-Distro_Logo_CentOS_White.svg
 install:
   -
     action: |

--- a/webapp/store/content/distros/debian.yaml
+++ b/webapp/store/content/distros/debian.yaml
@@ -2,6 +2,7 @@ name: Debian
 color-1: "#A80030"
 color-2: "#750022"
 logo: https://assets.ubuntu.com/v1/cfdc1144-Distro_Logo_Debian.svg
+logo-mono: https://assets.ubuntu.com/v1/496e3de6-Distro_Logo_Debian_White.svg
 install:
   -
     action: |

--- a/webapp/store/content/distros/debian.yaml
+++ b/webapp/store/content/distros/debian.yaml
@@ -2,7 +2,7 @@ name: Debian
 color-1: "#A80030"
 color-2: "#750022"
 logo: https://assets.ubuntu.com/v1/cfdc1144-Distro_Logo_Debian.svg
-logo-mono: https://assets.ubuntu.com/v1/496e3de6-Distro_Logo_Debian_White.svg
+logo-mono: https://assets.ubuntu.com/v1/dc7be4e8-Distro_Logo_Debian_White.svg
 install:
   -
     action: |

--- a/webapp/store/content/distros/elementary.yaml
+++ b/webapp/store/content/distros/elementary.yaml
@@ -2,7 +2,7 @@ name: elementary OS
 color-1: "#95A3AB"
 color-2: "#485A6C"
 logo: https://assets.ubuntu.com/v1/c0c09661-Distro_Logo_Elementary.svg
-logo-mono: https://assets.ubuntu.com/v1/23f8f64b-Distro_Logo_Elementary_White.svg
+logo-mono: https://assets.ubuntu.com/v1/4f36b56d-Distro_Logo_Elementary_White.svg
 install:
   -
     action: |

--- a/webapp/store/content/distros/elementary.yaml
+++ b/webapp/store/content/distros/elementary.yaml
@@ -2,6 +2,7 @@ name: elementary OS
 color-1: "#95A3AB"
 color-2: "#485A6C"
 logo: https://assets.ubuntu.com/v1/c0c09661-Distro_Logo_Elementary.svg
+logo-mono: https://assets.ubuntu.com/v1/23f8f64b-Distro_Logo_Elementary_White.svg
 install:
   -
     action: |

--- a/webapp/store/content/distros/fedora.yaml
+++ b/webapp/store/content/distros/fedora.yaml
@@ -1,8 +1,8 @@
 name: Fedora
 color-1: "#3C6EB4"
 color-2: "#294172"
-logo: https://assets.ubuntu.com/v1/6c5dc09e-Distro_Logo_Fedora.svg
-logo-mono: https://assets.ubuntu.com/v1/d8742cd7-Distro_Logo_Fedora_White.svg
+logo: https://assets.ubuntu.com/v1/c93d842f-fedora.png
+logo-mono: https://assets.ubuntu.com/v1/c93d842f-fedora.png
 install:
   -
     action: |

--- a/webapp/store/content/distros/fedora.yaml
+++ b/webapp/store/content/distros/fedora.yaml
@@ -2,6 +2,7 @@ name: Fedora
 color-1: "#3C6EB4"
 color-2: "#294172"
 logo: https://assets.ubuntu.com/v1/6c5dc09e-Distro_Logo_Fedora.svg
+logo-mono: https://assets.ubuntu.com/v1/e9af8126-Distro_Logo_Fedora_White.svg
 install:
   -
     action: |

--- a/webapp/store/content/distros/fedora.yaml
+++ b/webapp/store/content/distros/fedora.yaml
@@ -2,7 +2,7 @@ name: Fedora
 color-1: "#3C6EB4"
 color-2: "#294172"
 logo: https://assets.ubuntu.com/v1/6c5dc09e-Distro_Logo_Fedora.svg
-logo-mono: https://assets.ubuntu.com/v1/e9af8126-Distro_Logo_Fedora_White.svg
+logo-mono: https://assets.ubuntu.com/v1/d8742cd7-Distro_Logo_Fedora_White.svg
 install:
   -
     action: |

--- a/webapp/store/content/distros/kde-neon.yaml
+++ b/webapp/store/content/distros/kde-neon.yaml
@@ -2,7 +2,7 @@ name: KDE Neon
 color-1: "#20A3A8"
 color-2: "#167275"
 logo: https://assets.ubuntu.com/v1/d0593902-Distro_Logo_KDE+Neon.svg
-logo-mono: https://assets.ubuntu.com/v1/2d2eb959-Distro_Logo_KDE+Neon_White.svg
+logo-mono: https://assets.ubuntu.com/v1/31ced116-Distro_Logo_KDE+Neon_White.svg
 install:
   -
     action: |

--- a/webapp/store/content/distros/kde-neon.yaml
+++ b/webapp/store/content/distros/kde-neon.yaml
@@ -2,6 +2,7 @@ name: KDE Neon
 color-1: "#20A3A8"
 color-2: "#167275"
 logo: https://assets.ubuntu.com/v1/d0593902-Distro_Logo_KDE+Neon.svg
+logo-mono: https://assets.ubuntu.com/v1/2d2eb959-Distro_Logo_KDE+Neon_White.svg
 install:
   -
     action: |

--- a/webapp/store/content/distros/kubuntu.yaml
+++ b/webapp/store/content/distros/kubuntu.yaml
@@ -2,7 +2,7 @@ name: Kubuntu
 color-1: "#0079C1"
 color-2: "#005A8F"
 logo: https://assets.ubuntu.com/v1/7ab50a06-Distro_Logo_Kubuntu.svg
-logo-mono: https://assets.ubuntu.com/v1/72680685-Distro_Logo_Kubuntu_White.svg
+logo-mono: https://assets.ubuntu.com/v1/e9f102e3-Distro_Logo_Kubuntu_White.svg
 install:
   -
     action: |

--- a/webapp/store/content/distros/kubuntu.yaml
+++ b/webapp/store/content/distros/kubuntu.yaml
@@ -2,6 +2,7 @@ name: Kubuntu
 color-1: "#0079C1"
 color-2: "#005A8F"
 logo: https://assets.ubuntu.com/v1/7ab50a06-Distro_Logo_Kubuntu.svg
+logo-mono: https://assets.ubuntu.com/v1/72680685-Distro_Logo_Kubuntu_White.svg
 install:
   -
     action: |

--- a/webapp/store/content/distros/manjaro.yaml
+++ b/webapp/store/content/distros/manjaro.yaml
@@ -2,6 +2,7 @@ name: Manjaro Linux
 color-1: "#35BF5C"
 color-2: "#278C44"
 logo: https://assets.ubuntu.com/v1/4635a0bd-Distro_Logo_Manjaro.svg
+logo-mono: https://assets.ubuntu.com/v1/31ff03e7-Distro_Logo_Manjaro_White.svg
 install:
   -
     action: |

--- a/webapp/store/content/distros/manjaro.yaml
+++ b/webapp/store/content/distros/manjaro.yaml
@@ -2,7 +2,7 @@ name: Manjaro Linux
 color-1: "#35BF5C"
 color-2: "#278C44"
 logo: https://assets.ubuntu.com/v1/4635a0bd-Distro_Logo_Manjaro.svg
-logo-mono: https://assets.ubuntu.com/v1/31ff03e7-Distro_Logo_Manjaro_White.svg
+logo-mono: https://assets.ubuntu.com/v1/e1b2fbdb-Distro_Logo_Manjaro_White.svg
 install:
   -
     action: |

--- a/webapp/store/content/distros/mint.yaml
+++ b/webapp/store/content/distros/mint.yaml
@@ -2,7 +2,7 @@ name: Linux Mint
 color-1: "#81C53B"
 color-2: "#5F912C"
 logo: https://assets.ubuntu.com/v1/938d67b4-Distro_Logo_LinuxMint.svg
-logo-mono: https://assets.ubuntu.com/v1/cf7c8e91-Distro_Logo_LinuxMint_White.svg
+logo-mono: https://assets.ubuntu.com/v1/9a7dc8e2-Distro_Logo_LinuxMint_White.svg
 install:
   -
     action: |

--- a/webapp/store/content/distros/mint.yaml
+++ b/webapp/store/content/distros/mint.yaml
@@ -2,6 +2,7 @@ name: Linux Mint
 color-1: "#81C53B"
 color-2: "#5F912C"
 logo: https://assets.ubuntu.com/v1/938d67b4-Distro_Logo_LinuxMint.svg
+logo-mono: https://assets.ubuntu.com/v1/cf7c8e91-Distro_Logo_LinuxMint_White.svg
 install:
   -
     action: |

--- a/webapp/store/content/distros/opensuse.yaml
+++ b/webapp/store/content/distros/opensuse.yaml
@@ -2,6 +2,7 @@ name: openSUSE
 color-1: "#73BA25"
 color-2: "#54871B"
 logo: https://assets.ubuntu.com/v1/610301c6-Distro_Logo_OpenSUSE.svg
+logo-mono: https://assets.ubuntu.com/v1/55cfa9b9-Distro_Logo_OpenSUSE_White.svg
 install:
   -
     action: |

--- a/webapp/store/content/distros/opensuse.yaml
+++ b/webapp/store/content/distros/opensuse.yaml
@@ -2,7 +2,7 @@ name: openSUSE
 color-1: "#73BA25"
 color-2: "#54871B"
 logo: https://assets.ubuntu.com/v1/610301c6-Distro_Logo_OpenSUSE.svg
-logo-mono: https://assets.ubuntu.com/v1/55cfa9b9-Distro_Logo_OpenSUSE_White.svg
+logo-mono: https://assets.ubuntu.com/v1/e4e63887-Distro_Logo_OpenSUSE_White.svg
 install:
   -
     action: |

--- a/webapp/store/content/distros/ubuntu.yaml
+++ b/webapp/store/content/distros/ubuntu.yaml
@@ -2,6 +2,7 @@ name: Ubuntu
 color-1: "#E95420"
 color-2: "#B54119"
 logo: https://assets.ubuntu.com/v1/100386fb-Distro_Logo_Ubuntu.svg
+logo-mono: https://assets.ubuntu.com/v1/112dbadc-Distro_Logo_Ubuntu_White.svg
 install:
   -
     action: |

--- a/webapp/store/content/distros/ubuntu.yaml
+++ b/webapp/store/content/distros/ubuntu.yaml
@@ -2,7 +2,7 @@ name: Ubuntu
 color-1: "#E95420"
 color-2: "#B54119"
 logo: https://assets.ubuntu.com/v1/100386fb-Distro_Logo_Ubuntu.svg
-logo-mono: https://assets.ubuntu.com/v1/112dbadc-Distro_Logo_Ubuntu_White.svg
+logo-mono: https://assets.ubuntu.com/v1/20ba8b71-Distro_Logo_Ubuntu_White.svg
 install:
   -
     action: |

--- a/webapp/store/snap_details_views.py
+++ b/webapp/store/snap_details_views.py
@@ -348,6 +348,7 @@ def snap_details_views(store, api, handle_errors):
                 "distro": distro,
                 "distro_name": distro_data["name"],
                 "distro_logo": distro_data["logo"],
+                "distro_logo_mono": distro_data["logo-mono"],
                 "distro_color_1": distro_data["color-1"],
                 "distro_color_2": distro_data["color-2"],
                 "distro_install_steps": distro_data["install"],


### PR DESCRIPTION
Attempt to fix the problem with #2014 by making use of white version of logos

### QA Steps

1. Pull the branch or run the demo service
2. Visit any distro page (i.e. `/install/skype/mint` or `/install/skype/arch`)
3. Check the logo on the top right is white
4. Notice the white logo adapts between mobile and desktop
5. #winning