### PR TITLE
Fix Fedora logo on snap details page

### DIFF
--- a/templates/store/snap-details/_distro-instructions-for-snap-support.html
+++ b/templates/store/snap-details/_distro-instructions-for-snap-support.html
@@ -50,7 +50,7 @@
             </a>
             <a class="p-media-object p-media-object--snap u-vertically-center" href="/install/{{package_name}}/fedora">
                 <span class="p-media-object__image">
-                    <img src="https://assets.ubuntu.com/v1/6c5dc09e-Distro_Logo_Fedora.svg" alt="">
+                    <img src="https://assets.ubuntu.com/v1/c93d842f-fedora.png" alt="">
                 </span>
                 <span class="p-media-object__details">
                     <h4 class="p-media-object__title p-heading--five u-no-margin--bottom">Fedora</h4>


### PR DESCRIPTION
Fixes #2039

Updates Fedora logo on distros list on snap details page.

### QA

- ./run or https://snapcraft-io-canonical-web-and-design-pr-2041.run.demo.haus/
- go to snap details page of any snap
- scroll down to distros section
- Fedora logo should be correct (hi res png)


<img width="1075" alt="Screenshot 2019-06-26 at 06 54 57" src="https://user-images.githubusercontent.com/83575/60152076-718bcf80-97df-11e9-8368-476fe4c7e399.png">
