### PR TITLE
Fix embedded card sizing issue in Safari

### DIFF
--- a/static/js/publisher/publicise.js
+++ b/static/js/publisher/publicise.js
@@ -152,7 +152,7 @@ function initEmbeddedCardPicker(options) {
     if (previewFrame.offsetParent) {
       const height =
         Math.floor(
-          (previewFrame.contentWindow.document.body.scrollHeight + 20) / 10
+          (previewFrame.contentWindow.document.body.clientHeight + 10) / 10
         ) * 10;
 
       if (height !== state.frameHeight) {


### PR DESCRIPTION
Fixes #2004 

Fix embedded card sizing issue in Safari

### QA

- ./run or https://snapcraft-io-canonical-web-and-design-pr-2042.run.demo.haus/
- go to publicise page of any of your snaps in Safari
- go to Embedded cards page
- embedded card preview should resize to fit content, but should stop resizing 