### PR TITLE
Disable ```fences``` code blocks in preview

### DIFF
--- a/static/js/publisher/preview.js
+++ b/static/js/publisher/preview.js
@@ -23,7 +23,8 @@ const md = new MarkdownIt({
   "escape",
   "strikethrough",
   "image",
-  "html_inline"
+  "html_inline",
+  "fence"
 ]);
 
 // For the different elements we might need to change different properties


### PR DESCRIPTION
Fixes #2033

### QA
- run or https://snapcraft-io-canonical-web-and-design-pr-2043.run.demo.haus/
- go to listing page of any snap
- edit description to contain code block using fences ```
- preview and make sure code block is not rendered as code block
- use code block using 4 spaces indent
- preview to make sure spaces indented code block is rendered as code block
- make sure inline code in ticks ` works 