### PR TITLE
Release single revision using drag'n'drop

### DIFF
--- a/static/js/publisher/release/components/releasesTableCell.js
+++ b/static/js/publisher/release/components/releasesTableCell.js
@@ -234,6 +234,9 @@ const ReleasesTableCell = props => {
         ref={drag}
         className="p-release-data p-tooltip p-tooltip--btm-center"
       >
+        <span className="p-release-data__handle">
+          <i className="p-icon--drag" />
+        </span>
         {isChannelPendingClose ? (
           <CloseChannelInfo />
         ) : currentRevision ? (

--- a/static/js/publisher/release/components/releasesTableCell.js
+++ b/static/js/publisher/release/components/releasesTableCell.js
@@ -1,4 +1,4 @@
-import React, { Component, Fragment } from "react";
+import React, { Fragment } from "react";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
 
@@ -16,172 +16,187 @@ import {
   hasPendingRelease
 } from "../selectors";
 
-class ReleasesTableCell extends Component {
-  handleReleaseCellClick(arch, risk, track) {
-    this.props.toggleHistoryPanel({ arch, risk, track });
-  }
+const CloseChannelInfo = () => (
+  <Fragment>
+    <em>close channel</em>
+    <span className="p-tooltip__message">Pending channel close</span>
+  </Fragment>
+);
 
-  undoClick(revision, track, risk, event) {
-    event.stopPropagation();
-    this.props.undoRelease(revision, `${track}/${risk}`);
-  }
-
-  renderRevision(revision, isPending, showVersion) {
-    return (
-      <Fragment>
-        <span className="p-release-data__info">
-          <span className="p-release-data__title">{revision.revision}</span>
-          {isInDevmode(revision) && (
-            <span className="p-release-data__icon u-float-right">
-              <DevmodeIcon revision={revision} showTooltip={false} />
+const EmptyInfo = ({ isUnassigned, availableCount, trackingChannel }) => {
+  return (
+    <Fragment>
+      {isUnassigned ? (
+        <Fragment>
+          <span className="p-release-data__info">
+            <span className="p-release-data__title">Add revision</span>
+            <span className="p-release-data__meta">
+              {availableCount} available
             </span>
-          )}
-          {showVersion && (
-            <span className="p-release-data__meta">{revision.version}</span>
-          )}
-        </span>
+          </span>
+        </Fragment>
+      ) : (
+        <Fragment>
+          <span className="p-release-data__info--empty">
+            {trackingChannel ? "↑" : "–"}
+          </span>
+        </Fragment>
+      )}
+      {!isUnassigned && (
         <span className="p-tooltip__message">
-          {isPending && "Pending release of:"}
-
-          <div className="p-tooltip__group">
-            Revision: <b>{revision.revision}</b>
-            <br />
-            Version: <b>{revision.version}</b>
-            {isInDevmode(revision) && (
-              <Fragment>
-                <br />
-                {revision.confinement === "devmode" ? (
-                  <Fragment>
-                    Confinement: <b>devmode</b>
-                  </Fragment>
-                ) : (
-                  <Fragment>
-                    Grade: <b>devel</b>
-                  </Fragment>
-                )}
-              </Fragment>
-            )}
-          </div>
-
-          {isInDevmode(revision) && (
-            <div className="p-tooltip__group">
-              Revisions in devmode can’t be promoted
-              <br />
-              to stable or candidate channels.
-            </div>
-          )}
+          {trackingChannel
+            ? `Tracking channel ${trackingChannel}`
+            : "Nothing currently released"}
         </span>
-      </Fragment>
-    );
-  }
+      )}
+    </Fragment>
+  );
+};
 
-  renderCloseChannel() {
-    return (
-      <Fragment>
-        <em>close channel</em>
-        <span className="p-tooltip__message">Pending channel close</span>
-      </Fragment>
-    );
-  }
+EmptyInfo.propTypes = {
+  isUnassigned: PropTypes.bool,
+  availableCount: PropTypes.number,
+  trackingChannel: PropTypes.string
+};
 
-  renderEmpty(isUnassigned, availableCount, trackingChannel) {
-    return (
-      <Fragment>
-        {isUnassigned ? (
-          <Fragment>
-            <span className="p-release-data__info">
-              <span className="p-release-data__title">Add revision</span>
-              <span className="p-release-data__meta">
-                {availableCount} available
-              </span>
-            </span>
-          </Fragment>
-        ) : (
-          <Fragment>
-            <span className="p-release-data__info--empty">
-              {trackingChannel ? "↑" : "–"}
-            </span>
-          </Fragment>
-        )}
-        {!isUnassigned && (
-          <span className="p-tooltip__message">
-            {trackingChannel
-              ? `Tracking channel ${trackingChannel}`
-              : "Nothing currently released"}
+const RevisionInfo = ({ revision, isPending, showVersion }) => {
+  return (
+    <Fragment>
+      <span className="p-release-data__info">
+        <span className="p-release-data__title">{revision.revision}</span>
+        {isInDevmode(revision) && (
+          <span className="p-release-data__icon u-float-right">
+            <DevmodeIcon revision={revision} showTooltip={false} />
           </span>
         )}
-      </Fragment>
-    );
-  }
+        {showVersion && (
+          <span className="p-release-data__meta">{revision.version}</span>
+        )}
+      </span>
+      <span className="p-tooltip__message">
+        {isPending && "Pending release of:"}
 
-  render() {
-    const {
-      track,
-      risk,
-      arch,
-      channelMap,
-      pendingChannelMap,
-      pendingCloses,
-      filters
-    } = this.props;
-    const channel = getChannelName(track, risk);
-
-    // current revision to show (released or pending)
-    const currentRevision =
-      pendingChannelMap[channel] && pendingChannelMap[channel][arch];
-
-    // check if there is a pending release in this cell
-    const hasPendingRelease = this.props.hasPendingRelease(channel, arch);
-
-    const isChannelPendingClose = pendingCloses.includes(channel);
-    const isPending = hasPendingRelease || isChannelPendingClose;
-    const isUnassigned = risk === AVAILABLE;
-    const isActive = filters && filters.arch === arch && filters.risk === risk;
-    const isHighlighted = isPending || (isUnassigned && currentRevision);
-    const trackingChannel = getTrackingChannel(channelMap, track, risk, arch);
-    const availableCount = this.props.getAvailableCount(arch);
-
-    const className = [
-      "p-releases-table__cell is-clickable",
-      isUnassigned ? "is-unassigned" : "",
-      isActive ? "is-active" : "",
-      isHighlighted ? "is-highlighted" : "",
-      isPending ? "is-pending" : ""
-    ].join(" ");
-
-    return (
-      <div
-        className={className}
-        onClick={this.handleReleaseCellClick.bind(this, arch, risk, track)}
-      >
-        <div className="p-release-data p-tooltip p-tooltip--btm-center">
-          {isChannelPendingClose
-            ? this.renderCloseChannel()
-            : currentRevision
-              ? this.renderRevision(
-                  currentRevision,
-                  hasPendingRelease,
-                  this.props.showVersion
-                )
-              : this.renderEmpty(isUnassigned, availableCount, trackingChannel)}
+        <div className="p-tooltip__group">
+          Revision: <b>{revision.revision}</b>
+          <br />
+          Version: <b>{revision.version}</b>
+          {isInDevmode(revision) && (
+            <Fragment>
+              <br />
+              {revision.confinement === "devmode" ? (
+                <Fragment>
+                  Confinement: <b>devmode</b>
+                </Fragment>
+              ) : (
+                <Fragment>
+                  Grade: <b>devel</b>
+                </Fragment>
+              )}
+            </Fragment>
+          )}
         </div>
-        {hasPendingRelease && (
-          <div className="p-release-buttons">
-            <button
-              className="p-action-button p-tooltip p-tooltip--btm-center"
-              onClick={this.undoClick.bind(this, currentRevision, track, risk)}
-            >
-              <i className="p-icon--close" />
-              <span className="p-tooltip__message">
-                Cancel promoting this revision
-              </span>
-            </button>
+
+        {isInDevmode(revision) && (
+          <div className="p-tooltip__group">
+            Revisions in devmode can’t be promoted
+            <br />
+            to stable or candidate channels.
           </div>
         )}
-      </div>
-    );
+      </span>
+    </Fragment>
+  );
+};
+
+RevisionInfo.propTypes = {
+  revision: PropTypes.object,
+  isPending: PropTypes.bool,
+  showVersion: PropTypes.bool
+};
+
+const ReleasesTableCell = props => {
+  const {
+    track,
+    risk,
+    arch,
+    channelMap,
+    pendingChannelMap,
+    pendingCloses,
+    filters
+  } = props;
+
+  const channel = getChannelName(track, risk);
+
+  // current revision to show (released or pending)
+  const currentRevision =
+    pendingChannelMap[channel] && pendingChannelMap[channel][arch];
+
+  // check if there is a pending release in this cell
+  const hasPendingRelease = props.hasPendingRelease(channel, arch);
+
+  const isChannelPendingClose = pendingCloses.includes(channel);
+  const isPending = hasPendingRelease || isChannelPendingClose;
+  const isUnassigned = risk === AVAILABLE;
+  const isActive = filters && filters.arch === arch && filters.risk === risk;
+  const isHighlighted = isPending || (isUnassigned && currentRevision);
+  const trackingChannel = getTrackingChannel(channelMap, track, risk, arch);
+  const availableCount = props.getAvailableCount(arch);
+
+  const className = [
+    "p-releases-table__cell is-clickable",
+    isUnassigned ? "is-unassigned" : "",
+    isActive ? "is-active" : "",
+    isHighlighted ? "is-highlighted" : "",
+    isPending ? "is-pending" : ""
+  ].join(" ");
+
+  function handleReleaseCellClick(arch, risk, track) {
+    props.toggleHistoryPanel({ arch, risk, track });
   }
-}
+
+  function undoClick(revision, track, risk, event) {
+    event.stopPropagation();
+    props.undoRelease(revision, `${track}/${risk}`);
+  }
+
+  return (
+    <div
+      className={className}
+      onClick={handleReleaseCellClick.bind(this, arch, risk, track)}
+    >
+      <div className="p-release-data p-tooltip p-tooltip--btm-center">
+        {isChannelPendingClose ? (
+          <CloseChannelInfo />
+        ) : currentRevision ? (
+          <RevisionInfo
+            revision={currentRevision}
+            isPending={hasPendingRelease}
+            showVersion={props.showVersion}
+          />
+        ) : (
+          <EmptyInfo
+            isUnassigned={isUnassigned}
+            availableCount={availableCount}
+            trackingChannel={trackingChannel}
+          />
+        )}
+      </div>
+      {hasPendingRelease && (
+        <div className="p-release-buttons">
+          <button
+            className="p-action-button p-tooltip p-tooltip--btm-center"
+            onClick={undoClick.bind(this, currentRevision, track, risk)}
+          >
+            <i className="p-icon--close" />
+            <span className="p-tooltip__message">
+              Cancel promoting this revision
+            </span>
+          </button>
+        </div>
+      )}
+    </div>
+  );
+};
 
 ReleasesTableCell.propTypes = {
   // state

--- a/static/js/publisher/release/components/releasesTableCell.js
+++ b/static/js/publisher/release/components/releasesTableCell.js
@@ -234,7 +234,7 @@ const ReleasesTableCell = props => {
         ref={drag}
         className="p-release-data p-tooltip p-tooltip--btm-center"
       >
-        <span className="p-release-data__handle">
+        <span className="p-releases__handle">
           <i className="p-icon--drag" />
         </span>
         {isChannelPendingClose ? (

--- a/static/js/publisher/release/components/releasesTableCell.js
+++ b/static/js/publisher/release/components/releasesTableCell.js
@@ -68,7 +68,7 @@ const RevisionInfo = ({ revision, isPending, showVersion }) => {
       <span className="p-release-data__info">
         <span className="p-release-data__title">{revision.revision}</span>
         {isInDevmode(revision) && (
-          <span className="p-release-data__icon u-float-right">
+          <span className="p-release-data__icon">
             <DevmodeIcon revision={revision} showTooltip={false} />
           </span>
         )}

--- a/static/js/publisher/release/components/releasesTableRow.js
+++ b/static/js/publisher/release/components/releasesTableRow.js
@@ -275,17 +275,19 @@ const ReleasesTableRow = props => {
             <span className="p-releases__handle">
               <i className="p-icon--drag" />
             </span>
-            <span className="p-releases-channel__name p-release-data__info p-tooltip p-tooltip--btm-center">
-              <span className="p-release-data__title">{rowTitle}</span>
-              {risk !== AVAILABLE && (
-                <span className="p-release-data__meta">{channelVersion}</span>
-              )}
-              {channelVersion && (
-                <span className="p-tooltip__message">
-                  {channelVersionTooltip}
-                </span>
-              )}
-            </span>
+            <div className="p-releases-channel__name p-tooltip p-tooltip--btm-center">
+              <span className="p-release-data__info">
+                <span className="p-release-data__title">{rowTitle}</span>
+                {risk !== AVAILABLE && (
+                  <span className="p-release-data__meta">{channelVersion}</span>
+                )}
+                {channelVersion && (
+                  <span className="p-tooltip__message">
+                    {channelVersionTooltip}
+                  </span>
+                )}
+              </span>
+            </div>
 
             <span className="p-releases-table__menus">
               {(canBePromoted || canBeClosed) && (

--- a/static/js/publisher/release/components/releasesTableRow.js
+++ b/static/js/publisher/release/components/releasesTableRow.js
@@ -26,9 +26,7 @@ import { getChannelName, isInDevmode } from "../helpers";
 import ChannelMenu from "./channelMenu";
 import AvailableRevisionsMenu from "./availableRevisionsMenu";
 
-export const ItemTypes = {
-  RELEASE: "release"
-};
+const DND_ITEM_CHANNEL = "DND_ITEM_CHANNEL";
 
 const disabledBecauseDevmode = (
   <Fragment>
@@ -67,7 +65,7 @@ const ReleasesTableRow = props => {
   const draggedChannel = getChannelName(currentTrack, risk);
   const canDrag = !!pendingChannelMap[draggedChannel];
   const [{ isDragging }, drag, preview] = useDrag({
-    item: { risk: props.risk, type: ItemTypes.RELEASE },
+    item: { risk: props.risk, type: DND_ITEM_CHANNEL },
     canDrag: () => canDrag,
     collect: monitor => ({
       isDragging: !!monitor.isDragging()
@@ -82,7 +80,7 @@ const ReleasesTableRow = props => {
   });
 
   const [{ isOver, canDrop }, drop] = useDrop({
-    accept: ItemTypes.RELEASE,
+    accept: DND_ITEM_CHANNEL,
     drop: item => {
       props.promoteChannel(
         getChannelName(props.currentTrack, item.risk),

--- a/static/js/publisher/release/components/releasesTableRow.js
+++ b/static/js/publisher/release/components/releasesTableRow.js
@@ -272,7 +272,7 @@ const ReleasesTableRow = props => {
               canDrag ? "is-draggable" : ""
             }`}
           >
-            <span className="p-releases-channel__handle">
+            <span className="p-releases__handle">
               <i className="p-icon--drag" />
             </span>
             <span className="p-releases-channel__name p-release-data__info p-tooltip p-tooltip--btm-center">

--- a/static/sass/_snapcraft_release.scss
+++ b/static/sass/_snapcraft_release.scss
@@ -225,8 +225,8 @@
 
   .p-release-buttons {
     position: absolute;
-    right: .4rem;
-    top: .4rem;
+    right: 6px;
+    top: 10px;
   }
 
   .p-release-data {
@@ -245,6 +245,12 @@
       font-weight: 400;
       padding-right: $sph-inter;
     }
+  }
+
+  .p-release-data__icon {
+    position: absolute;
+    right: 10px;
+    top: 8px;
   }
 
   .is-pending {

--- a/static/sass/_snapcraft_release.scss
+++ b/static/sass/_snapcraft_release.scss
@@ -124,7 +124,7 @@
 
   .p-releases-channel__handle {
     padding-right: $sph-intra--condensed;
-    padding-top: ($spv-intra - .1rem);
+    padding-top: $spv-intra;
     visibility: hidden;
 
     .is-draggable & {
@@ -217,7 +217,7 @@
   .p-releases-table__arch {
     background: none;
     border: 0;
-    padding: ($spv-intra - .1rem) $sph-intra; // same as p-release-data
+    padding: ($spv-intra - .1rem) $sph-intra--condensed; // same as p-release-data
   }
 
   // cell contents (release info)
@@ -232,8 +232,17 @@
     display: flex;
     height: 100%;
     max-width: 100%;
-    padding: $spv-intra $sph-intra; // p-releases-table__arch
-    padding-right: .6rem; // give it a bit more space for version ellipsis
+    padding: $spv-intra $sph-intra--condensed; // p-releases-table__arch
+    padding-left: ($sph-intra--condensed - .1rem);
+  }
+
+  .p-release-data__handle {
+    margin-right: $sph-intra--condensed;
+    visibility: hidden;
+
+    .is-draggable & {
+      visibility: visible;
+    }
   }
 
   .p-release-data__info {

--- a/static/sass/_snapcraft_release.scss
+++ b/static/sass/_snapcraft_release.scss
@@ -86,6 +86,10 @@
 
     .can-drop & {
       opacity: 1;
+
+      .p-tooltip__message {
+        display: none;
+      }
     }
 
     &:hover,
@@ -164,6 +168,10 @@
     &.can-drop {
       opacity: 1;
       outline: 1px dashed $color-mid-light;
+
+      .p-tooltip__message {
+        display: none;
+      }
     }
 
     &.is-clickable {

--- a/static/sass/_snapcraft_release.scss
+++ b/static/sass/_snapcraft_release.scss
@@ -151,8 +151,25 @@
       opacity: .5;
     }
 
+    &.is-grabbing,
+    &.is-dragging {
+      opacity: .9; // little workaround for chrome
+
+      .p-tooltip__message {
+        display: none;
+      }
+    }
+
+    &.is-dragging {
+      opacity: .5;
+    }
+
     .can-drop & {
       opacity: 1;
+    }
+
+    &.is-clickable {
+      cursor: pointer;
     }
 
     &.is-clickable:focus,
@@ -160,8 +177,11 @@
     &.is-active {
       @include vf-animation (#{background-color, border-color}, fast, in);
       background-color: $color-x-light;
-      cursor: pointer;
       opacity: 1;
+    }
+
+    &.is-draggable {
+      cursor: grab;
     }
 
     &.is-active {

--- a/static/sass/_snapcraft_release.scss
+++ b/static/sass/_snapcraft_release.scss
@@ -32,7 +32,8 @@
     &.is-dragging {
       opacity: .9; // little workaround for chrome
 
-      .p-tooltip__message {
+      .p-tooltip__message,
+      .p-contextual-menu__dropdown {
         display: none;
       }
     }
@@ -111,14 +112,8 @@
 
   .p-releases-channel__name {
     flex-grow: 1;
-    max-width: calc(100% - 40px); // leave space for channel menu
+    max-width: calc(100% - 55px); // leave space handle and settings menu
     padding-right: $sph-intra--condensed;
-
-    .p-release-data__title {
-      display: block;
-      overflow: hidden;
-      text-overflow: ellipsis;
-    }
   }
 
   .p-releases__handle {
@@ -235,8 +230,8 @@
   }
 
   .p-release-data__info {
+    overflow: hidden;
     white-space: nowrap;
-    width: 100%;
 
     &.is-pending {
       font-weight: 400;
@@ -259,12 +254,16 @@
     white-space: nowrap;
   }
 
+  .p-release-data__title,
   .p-release-data__meta {
-    color: $color-mid-dark;
     display: block;
-    font-size: .8rem;
     overflow: hidden;
     text-overflow: ellipsis;
+  }
+
+  .p-release-data__meta {
+    color: $color-mid-dark;
+    font-size: .8rem;
   }
 
   // REVISIONS LIST

--- a/static/sass/_snapcraft_release.scss
+++ b/static/sass/_snapcraft_release.scss
@@ -168,6 +168,11 @@
       opacity: 1;
     }
 
+    &.can-drop {
+      opacity: 1;
+      outline: 1px dashed $color-mid-light;
+    }
+
     &.is-clickable {
       cursor: pointer;
     }
@@ -201,6 +206,10 @@
     }
 
     .is-over & {
+      background-color: $color-highlighted;
+    }
+
+    &.is-over {
       background-color: $color-highlighted;
     }
   }

--- a/static/sass/_snapcraft_release.scss
+++ b/static/sass/_snapcraft_release.scss
@@ -60,8 +60,8 @@
 
   .p-releases-table__menus {
     margin-left: auto;
-    margin-right: ($sp-unit - .1rem);
-    margin-top: ($sp-unit - .1rem);
+    margin-right: -.1rem;
+    margin-top: -.1rem;
   }
 
   // channel cell
@@ -72,7 +72,7 @@
     display: flex;
     flex-shrink: 0;
     font-size: 1rem;
-    padding-left: $sph-intra--condensed;
+    padding: $spv-intra $sph-intra--condensed;
     width: 280px;
 
     .p-promote-button {
@@ -113,7 +113,6 @@
     flex-grow: 1;
     max-width: calc(100% - 40px); // leave space for channel menu
     padding-right: $sph-intra--condensed;
-    padding-top: $spv-intra;
 
     .p-release-data__title {
       display: block;
@@ -122,9 +121,8 @@
     }
   }
 
-  .p-releases-channel__handle {
-    padding-right: $sph-intra--condensed;
-    padding-top: $spv-intra;
+  .p-releases__handle {
+    margin-right: $sph-intra--condensed;
     visibility: hidden;
 
     .is-draggable & {
@@ -234,15 +232,6 @@
     max-width: 100%;
     padding: $spv-intra $sph-intra--condensed; // p-releases-table__arch
     padding-left: ($sph-intra--condensed - .1rem);
-  }
-
-  .p-release-data__handle {
-    margin-right: $sph-intra--condensed;
-    visibility: hidden;
-
-    .is-draggable & {
-      visibility: visible;
-    }
   }
 
   .p-release-data__info {


### PR DESCRIPTION
Fixes #1964

### QA

- ./run or https://snapcraft-io-canonical-web-and-design-pr-2045.run.demo.haus/
- go to releases page of any snap
- individual revision cells in releases table should have a drag handle
- you should be able to drag the revision to other channel in same architecture
- you should not be able to drag revision to different architecture
- you should not be able to drag empty cells (with no revisions)
- you should not be able to drag devmode revisions to stable/candidate
- make sure dragging whole channel still works as before
- try with different snaps in different browsers

<img width="1090" alt="Screenshot 2019-06-27 at 13 50 48" src="https://user-images.githubusercontent.com/83575/60264106-b4829b80-98e2-11e9-94ea-86f6d9054f6d.png">
