### PR TITLE
FSF- Added brew cask install multipass

### DIFF
--- a/templates/first-snap/_install-macos.html
+++ b/templates/first-snap/_install-macos.html
@@ -12,24 +12,27 @@
       <ol class="p-list-step">
         <li class="p-list-step__item">
             <h4 class="p-list-step__title">
-              <span class="p-list-step__bullet">1</span>
-              <a href="https://multipass.run/install" target="_blank" class="p-link--external">Install Multipass</a>, a virtualisation product from <br/>Canonical that can set up a complete Linux environment <br/>in a couple of minutes
+              <span class="p-list-step__bullet">2</span>
+              <a href="https://brew.sh" target="_blank" class="p-link--external">Install Homebrew</a>, if you don't have it already.
             </h4>
-          </li>
-        <li class="p-list-step__item">
-          <h4 class="p-list-step__title">
-            <span class="p-list-step__bullet">2</span>
-            <a href="https://brew.sh" target="_blank" class="p-link--external">Install Homebrew</a>, if you don't have it already
-          </h4>
         </li>
         <li class="p-list-step__item">
-          <h4 class="p-list-step__title">
-            <span class="p-list-step__bullet">3</span>
-            <a href="https://docs.snapcraft.io/snapcraft-overview" target="_blank" class="p-link--external">Install Snapcraft</a>, the command-line tool for building snaps
-          </h4>
-          {% set snippet_value = "brew install snapcraft" %}
-          {% set snippet_id = "macos-install-snapcraft" %}
-          {% include "/partials/_code-snippet.html" %}
+            <h4 class="p-list-step__title">
+              <span class="p-list-step__bullet">3</span>
+              <a href="https://docs.snapcraft.io/snapcraft-overview" target="_blank" class="p-link--external">Install Snapcraft</a>, the command-line tool for building snaps:
+            </h4>
+            {% set snippet_value = "brew install snapcraft" %}
+            {% set snippet_id = "macos-install-snapcraft" %}
+            {% include "/partials/_code-snippet.html" %}
+        </li>
+        <li class="p-list-step__item">
+            <h4 class="p-list-step__title">
+              <span class="p-list-step__bullet">1</span>
+              <a href="https://multipass.run/install" target="_blank" class="p-link--external">Install Multipass</a>, a virtualisation product from <br/>Canonical that can set up a complete Linux environment <br/>in a couple of minutes:
+            </h4>
+            {% set snippet_value = "brew cask install multipass" %}
+            {% set snippet_id = "macos-install-multipass" %}
+            {% include "/partials/_code-snippet.html" %}
         </li>
       </ol>
     </div>

--- a/templates/first-snap/_install-macos.html
+++ b/templates/first-snap/_install-macos.html
@@ -25,7 +25,7 @@
             {% set snippet_id = "macos-install-snapcraft" %}
             {% include "/partials/_code-snippet.html" %}
         </li>
-        <li class="p-list-step__item">
+        <li class="p-list-step__item">git 
             <h4 class="p-list-step__title">
               <span class="p-list-step__bullet">1</span>
               <a href="https://multipass.run/install" target="_blank" class="p-link--external">Install Multipass</a>, a virtualisation product from <br/>Canonical that can set up a complete Linux environment <br/>in a couple of minutes:

--- a/templates/first-snap/_install-macos.html
+++ b/templates/first-snap/_install-macos.html
@@ -25,7 +25,7 @@
             {% set snippet_id = "macos-install-snapcraft" %}
             {% include "/partials/_code-snippet.html" %}
         </li>
-        <li class="p-list-step__item">git 
+        <li class="p-list-step__item"> 
             <h4 class="p-list-step__title">
               <span class="p-list-step__bullet">1</span>
               <a href="https://multipass.run/install" target="_blank" class="p-link--external">Install Multipass</a>, a virtualisation product from <br/>Canonical that can set up a complete Linux environment <br/>in a couple of minutes:

--- a/templates/first-snap/_install-macos.html
+++ b/templates/first-snap/_install-macos.html
@@ -25,7 +25,7 @@
         <li class="p-list-step__item">
           <h4 class="p-list-step__title">
             <span class="p-list-step__bullet">3</span>
-            Install Snapcraft, the command-line tool for building snaps
+            <a href="https://docs.snapcraft.io/snapcraft-overview" target="_blank" class="p-link--external">Install Snapcraft</a>, the command-line tool for building snaps
           </h4>
           {% set snippet_value = "brew install snapcraft" %}
           {% set snippet_id = "macos-install-snapcraft" %}

--- a/templates/first-snap/_install-macos.html
+++ b/templates/first-snap/_install-macos.html
@@ -12,13 +12,13 @@
       <ol class="p-list-step">
         <li class="p-list-step__item">
             <h4 class="p-list-step__title">
-              <span class="p-list-step__bullet">2</span>
+              <span class="p-list-step__bullet">1</span>
               <a href="https://brew.sh" target="_blank" class="p-link--external">Install Homebrew</a>, if you don't have it already.
             </h4>
         </li>
         <li class="p-list-step__item">
             <h4 class="p-list-step__title">
-              <span class="p-list-step__bullet">3</span>
+              <span class="p-list-step__bullet">2</span>
               <a href="https://docs.snapcraft.io/snapcraft-overview" target="_blank" class="p-link--external">Install Snapcraft</a>, the command-line tool for building snaps:
             </h4>
             {% set snippet_value = "brew install snapcraft" %}
@@ -27,7 +27,7 @@
         </li>
         <li class="p-list-step__item"> 
             <h4 class="p-list-step__title">
-              <span class="p-list-step__bullet">1</span>
+              <span class="p-list-step__bullet">3</span>
               <a href="https://multipass.run/install" target="_blank" class="p-link--external">Install Multipass</a>, a virtualisation product from <br/>Canonical that can set up a complete Linux environment <br/>in a couple of minutes:
             </h4>
             {% set snippet_value = "brew cask install multipass" %}


### PR DESCRIPTION
Tiny first PR..

Fixes #2049
 
### QA Steps: 
1. Pull the branch or run the demo service
2. Go to the FSF and go to the 'Install Snapcraft' stage of the tutorial
3. The install steps should be re-ordered Homebrew, Snapcraft, Multipass
4. You should be able to `brew cask install Multipass`