### PR TITLE
Revision history dnd

### DIFF
--- a/static/js/publisher/release/components/dnd.js
+++ b/static/js/publisher/release/components/dnd.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from "react";
-import { useDrag } from "react-dnd";
+import { useDrag, useDrop } from "react-dnd";
 
 export const DND_ITEM_REVISION = "DND_ITEM_REVISION";
 export const DND_ITEM_CHANNEL = "DND_ITEM_CHANNEL";
@@ -10,6 +10,8 @@ export const Handle = () => (
   </span>
 );
 
+// it's a wrapper around react-dnd useDrag hook
+// with some added functionality and workaround for a bug
 export const useDragging = options => {
   const [isGrabbing, setIsGrabbing] = useState(false);
 
@@ -48,3 +50,7 @@ export const useDragging = options => {
 
   return [isDragging, isGrabbing, drag, preview];
 };
+
+// we don't need to add much common functionality to useDrag hook
+// so we just export it as it is
+export { useDrop };

--- a/static/js/publisher/release/components/dnd.js
+++ b/static/js/publisher/release/components/dnd.js
@@ -1,8 +1,14 @@
-import { useState, useEffect } from "react";
+import React, { useState, useEffect } from "react";
 import { useDrag } from "react-dnd";
 
 export const DND_ITEM_REVISION = "DND_ITEM_REVISION";
 export const DND_ITEM_CHANNEL = "DND_ITEM_CHANNEL";
+
+export const Handle = () => (
+  <span className="p-drag-handle">
+    <i className="p-icon--drag" />
+  </span>
+);
 
 export const useDragging = options => {
   const [isGrabbing, setIsGrabbing] = useState(false);

--- a/static/js/publisher/release/components/dnd.js
+++ b/static/js/publisher/release/components/dnd.js
@@ -1,0 +1,44 @@
+import { useState, useEffect } from "react";
+import { useDrag } from "react-dnd";
+
+export const DND_ITEM_REVISION = "DND_ITEM_REVISION";
+export const DND_ITEM_CHANNEL = "DND_ITEM_CHANNEL";
+
+export const useDragging = options => {
+  const [isGrabbing, setIsGrabbing] = useState(false);
+
+  // Calling useDrag end callback after history is closed (because promoting revisions closes history panel)
+  // history panel is automatically closed after promoting revision
+  // this causes an issue with dragging revision history item, because it's
+  // unmounted at the time the `end` callback is being called.
+  // This is likely an issue with react-dnd, hopefully to be fixed at some point:
+  // https://github.com/react-dnd/react-dnd/issues/1435
+  //
+  // This isRendered effect is an attempt to workaround that:
+  let isRendered = true;
+  useEffect(() => {
+    isRendered = true;
+    return () => {
+      isRendered = false;
+    };
+  });
+
+  const [{ isDragging }, drag, preview] = useDrag({
+    item: options.item,
+    canDrag: () => options.canDrag || true,
+    collect: monitor => ({
+      isDragging: !!monitor.isDragging()
+    }),
+
+    begin: () => {
+      setIsGrabbing(true);
+    },
+    end: () => {
+      if (isRendered) {
+        setIsGrabbing(false);
+      }
+    }
+  });
+
+  return [isDragging, isGrabbing, drag, preview];
+};

--- a/static/js/publisher/release/components/releasesTableCell.js
+++ b/static/js/publisher/release/components/releasesTableCell.js
@@ -7,7 +7,7 @@ import { STABLE, CANDIDATE, AVAILABLE } from "../constants";
 import { getTrackingChannel } from "../releasesState";
 import DevmodeIcon from "./devmodeIcon";
 import { getChannelName, isInDevmode } from "../helpers";
-import { useDragging, DND_ITEM_REVISION } from "./dnd";
+import { useDragging, DND_ITEM_REVISION, Handle } from "./dnd";
 
 import { toggleHistory } from "../actions/history";
 import { promoteRevision, undoRelease } from "../actions/pendingReleases";
@@ -221,9 +221,7 @@ const ReleasesTableCell = props => {
         ref={drag}
         className="p-release-data p-tooltip p-tooltip--btm-center"
       >
-        <span className="p-releases__handle">
-          <i className="p-icon--drag" />
-        </span>
+        <Handle />
         {isChannelPendingClose ? (
           <CloseChannelInfo />
         ) : currentRevision ? (

--- a/static/js/publisher/release/components/releasesTableCell.js
+++ b/static/js/publisher/release/components/releasesTableCell.js
@@ -1,13 +1,12 @@
 import React, { Fragment } from "react";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
-import { useDrop } from "react-dnd";
 
 import { STABLE, CANDIDATE, AVAILABLE } from "../constants";
 import { getTrackingChannel } from "../releasesState";
 import DevmodeIcon from "./devmodeIcon";
 import { getChannelName, isInDevmode } from "../helpers";
-import { useDragging, DND_ITEM_REVISION, Handle } from "./dnd";
+import { useDragging, useDrop, DND_ITEM_REVISION, Handle } from "./dnd";
 
 import { toggleHistory } from "../actions/history";
 import { promoteRevision, undoRelease } from "../actions/pendingReleases";

--- a/static/js/publisher/release/components/releasesTableCell.js
+++ b/static/js/publisher/release/components/releasesTableCell.js
@@ -1,12 +1,13 @@
-import React, { Fragment, useState } from "react";
+import React, { Fragment } from "react";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
-import { useDrop, useDrag } from "react-dnd";
+import { useDrop } from "react-dnd";
 
 import { STABLE, CANDIDATE, AVAILABLE } from "../constants";
 import { getTrackingChannel } from "../releasesState";
 import DevmodeIcon from "./devmodeIcon";
 import { getChannelName, isInDevmode } from "../helpers";
+import { useDragging, DND_ITEM_REVISION } from "./dnd";
 
 import { toggleHistory } from "../actions/history";
 import { promoteRevision, undoRelease } from "../actions/pendingReleases";
@@ -16,8 +17,6 @@ import {
   getFilteredAvailableRevisionsForArch,
   hasPendingRelease
 } from "../selectors";
-
-const DND_ITEM_REVISION = "DND_ITEM_REVISION";
 
 const CloseChannelInfo = () => (
   <Fragment>
@@ -145,22 +144,10 @@ const ReleasesTableCell = props => {
   const trackingChannel = getTrackingChannel(channelMap, track, risk, arch);
   const availableCount = props.getAvailableCount(arch);
 
-  const [isGrabbing, setIsGrabbing] = useState(false);
   const canDrag = currentRevision && !isChannelPendingClose;
-
-  const [{ isDragging }, drag] = useDrag({
+  const [isDragging, isGrabbing, drag] = useDragging({
     item: { revision: currentRevision, arch: arch, type: DND_ITEM_REVISION },
-    canDrag: () => canDrag,
-    collect: monitor => ({
-      isDragging: !!monitor.isDragging()
-    }),
-
-    begin: () => {
-      setIsGrabbing(true);
-    },
-    end: () => {
-      setIsGrabbing(false);
-    }
+    canDrag
   });
 
   const [{ isOver, canDrop }, drop] = useDrop({

--- a/static/js/publisher/release/components/releasesTableRow.js
+++ b/static/js/publisher/release/components/releasesTableRow.js
@@ -9,7 +9,7 @@ import {
   hasPendingRelease
 } from "../selectors";
 import ReleasesTableCell from "./releasesTableCell";
-import { useDragging, DND_ITEM_CHANNEL } from "./dnd";
+import { useDragging, DND_ITEM_CHANNEL, Handle } from "./dnd";
 
 import { promoteChannel } from "../actions/pendingReleases";
 import { closeChannel } from "../actions/pendingCloses";
@@ -259,9 +259,7 @@ const ReleasesTableRow = props => {
               canDrag ? "is-draggable" : ""
             }`}
           >
-            <span className="p-releases__handle">
-              <i className="p-icon--drag" />
-            </span>
+            <Handle />
             <div className="p-releases-channel__name p-tooltip p-tooltip--btm-center">
               <span className="p-release-data__info">
                 <span className="p-release-data__title">{rowTitle}</span>

--- a/static/js/publisher/release/components/releasesTableRow.js
+++ b/static/js/publisher/release/components/releasesTableRow.js
@@ -1,7 +1,7 @@
-import React, { Fragment, useState } from "react";
+import React, { Fragment } from "react";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
-import { useDrag, useDrop } from "react-dnd";
+import { useDrop } from "react-dnd";
 
 import {
   getArchitectures,
@@ -9,6 +9,7 @@ import {
   hasPendingRelease
 } from "../selectors";
 import ReleasesTableCell from "./releasesTableCell";
+import { useDragging, DND_ITEM_CHANNEL } from "./dnd";
 
 import { promoteChannel } from "../actions/pendingReleases";
 import { closeChannel } from "../actions/pendingCloses";
@@ -25,8 +26,6 @@ import {
 import { getChannelName, isInDevmode } from "../helpers";
 import ChannelMenu from "./channelMenu";
 import AvailableRevisionsMenu from "./availableRevisionsMenu";
-
-const DND_ITEM_CHANNEL = "DND_ITEM_CHANNEL";
 
 const disabledBecauseDevmode = (
   <Fragment>
@@ -60,23 +59,11 @@ const compareChannels = (channelMap, channel, targetChannel) => {
 const ReleasesTableRow = props => {
   const { currentTrack, risk, archs, pendingChannelMap } = props;
 
-  const [isGrabbing, setIsGrabbing] = useState(false);
-
   const draggedChannel = getChannelName(currentTrack, risk);
   const canDrag = !!pendingChannelMap[draggedChannel];
-  const [{ isDragging }, drag, preview] = useDrag({
+  const [isDragging, isGrabbing, drag, preview] = useDragging({
     item: { risk: props.risk, type: DND_ITEM_CHANNEL },
-    canDrag: () => canDrag,
-    collect: monitor => ({
-      isDragging: !!monitor.isDragging()
-    }),
-
-    begin: () => {
-      setIsGrabbing(true);
-    },
-    end: () => {
-      setIsGrabbing(false);
-    }
+    canDrag
   });
 
   const [{ isOver, canDrop }, drop] = useDrop({

--- a/static/js/publisher/release/components/releasesTableRow.js
+++ b/static/js/publisher/release/components/releasesTableRow.js
@@ -1,7 +1,6 @@
 import React, { Fragment } from "react";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
-import { useDrop } from "react-dnd";
 
 import {
   getArchitectures,
@@ -9,7 +8,7 @@ import {
   hasPendingRelease
 } from "../selectors";
 import ReleasesTableCell from "./releasesTableCell";
-import { useDragging, DND_ITEM_CHANNEL, Handle } from "./dnd";
+import { useDragging, useDrop, DND_ITEM_CHANNEL, Handle } from "./dnd";
 
 import { promoteChannel } from "../actions/pendingReleases";
 import { closeChannel } from "../actions/pendingCloses";

--- a/static/js/publisher/release/components/revisionsList.js
+++ b/static/js/publisher/release/components/revisionsList.js
@@ -252,6 +252,7 @@ class RevisionsList extends Component {
         <table className="p-revisions-list">
           <thead>
             <tr>
+              <th width="30px" />
               <th
                 className={!isReleaseHistory ? "col-checkbox-spacer" : ""}
                 width="150px"
@@ -285,7 +286,7 @@ class RevisionsList extends Component {
               )
             ) : (
               <tr>
-                <td colSpan="4">
+                <td colSpan="5">
                   <em>No releases</em>
                 </td>
               </tr>
@@ -293,7 +294,7 @@ class RevisionsList extends Component {
             {!showAllRevisions &&
               filteredRevisions.length > 10 && (
                 <tr>
-                  <td colSpan="4">
+                  <td colSpan={5}>
                     <a onClick={this.showAllRevisions.bind(this, key)}>
                       Show all {filteredRevisions.length} revisions
                     </a>

--- a/static/js/publisher/release/components/revisionsListRow.js
+++ b/static/js/publisher/release/components/revisionsListRow.js
@@ -36,9 +36,11 @@ const RevisionsListRow = props => {
   });
 
   const id = `revision-check-${revision.revision}`;
-  const className = `is-draggable ${isSelectable ? "is-clickable" : ""} ${
-    isPending || isSelected ? "is-pending" : ""
-  } ${isGrabbing ? "is-grabbing" : ""} ${isDragging ? "is-dragging" : ""}`;
+  const className = `p-revisions-list__revision is-draggable ${
+    isSelectable ? "is-clickable" : ""
+  } ${isPending || isSelected ? "is-pending" : ""} ${
+    isGrabbing ? "is-grabbing" : ""
+  } ${isDragging ? "is-dragging" : ""}`;
 
   return (
     <tr

--- a/static/js/publisher/release/components/revisionsListRow.js
+++ b/static/js/publisher/release/components/revisionsListRow.js
@@ -69,7 +69,7 @@ const RevisionsListRow = props => {
   });
 
   const id = `revision-check-${revision.revision}`;
-  const className = `${isSelectable ? "is-clickable" : ""} ${
+  const className = `is-draggable ${isSelectable ? "is-clickable" : ""} ${
     isPending || isSelected ? "is-pending" : ""
   } ${isGrabbing ? "is-grabbing" : ""} ${isDragging ? "is-dragging" : ""}`;
 
@@ -80,6 +80,11 @@ const RevisionsListRow = props => {
       className={className}
       onClick={isSelectable ? revisionSelectChange : null}
     >
+      <td>
+        <span className="p-releases__handle">
+          <i className="p-icon--drag" />
+        </span>
+      </td>
       <td>
         {isSelectable ? (
           <Fragment>

--- a/static/js/publisher/release/components/revisionsListRow.js
+++ b/static/js/publisher/release/components/revisionsListRow.js
@@ -1,17 +1,15 @@
-import React, { Fragment, useState, useEffect } from "react";
+import React, { Fragment } from "react";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
-import { useDrag } from "react-dnd";
 
 import distanceInWords from "date-fns/distance_in_words_strict";
 import format from "date-fns/format";
 
+import { useDragging, DND_ITEM_REVISION } from "./dnd";
 import { toggleRevision } from "../actions/channelMap";
 import { getSelectedRevisions } from "../selectors";
 
 import DevmodeIcon from "./devmodeIcon";
-
-const DND_ITEM_REVISION = "DND_ITEM_REVISION";
 
 const RevisionsListRow = props => {
   const { revision, isSelectable, showAllColumns, isPending } = props;
@@ -26,25 +24,7 @@ const RevisionsListRow = props => {
     props.toggleRevision(revision);
   }
 
-  const [isGrabbing, setIsGrabbing] = useState(false);
-
-  // Calling useDrag end callback after history is closed (because promoting revisions closes history panel)
-  // history panel is automatically closed after promoting revision
-  // this causes an issue with dragging revision history item, because it's
-  // unmounted at the time the `end` callback is being called.
-  // This is likely an issue with react-dnd, hopefully to be fixed at some point:
-  // https://github.com/react-dnd/react-dnd/issues/1435
-  //
-  // This isRendered effect is an attempt to workaround that:
-  let isRendered = true;
-  useEffect(() => {
-    isRendered = true;
-    return () => {
-      isRendered = false;
-    };
-  });
-
-  const [{ isDragging }, drag] = useDrag({
+  const [isDragging, isGrabbing, drag] = useDragging({
     item: {
       revision: revision,
       // TODO:
@@ -52,19 +32,6 @@ const RevisionsListRow = props => {
       // this may be trickier for revisions in multiple architectures
       arch: revision.architectures[0],
       type: DND_ITEM_REVISION
-    },
-    collect: monitor => ({
-      isDragging: !!monitor.isDragging()
-    }),
-
-    begin: () => {
-      setIsGrabbing(true);
-    },
-    end: () => {
-      // hacky way to prevent React warnings
-      if (isRendered) {
-        setIsGrabbing(false);
-      }
     }
   });
 

--- a/static/js/publisher/release/components/revisionsListRow.js
+++ b/static/js/publisher/release/components/revisionsListRow.js
@@ -5,7 +5,7 @@ import { connect } from "react-redux";
 import distanceInWords from "date-fns/distance_in_words_strict";
 import format from "date-fns/format";
 
-import { useDragging, DND_ITEM_REVISION } from "./dnd";
+import { useDragging, DND_ITEM_REVISION, Handle } from "./dnd";
 import { toggleRevision } from "../actions/channelMap";
 import { getSelectedRevisions } from "../selectors";
 
@@ -50,9 +50,7 @@ const RevisionsListRow = props => {
       onClick={isSelectable ? revisionSelectChange : null}
     >
       <td>
-        <span className="p-releases__handle">
-          <i className="p-icon--drag" />
-        </span>
+        <Handle />
       </td>
       <td>
         {isSelectable ? (

--- a/static/js/publisher/release/components/revisionsListRow.js
+++ b/static/js/publisher/release/components/revisionsListRow.js
@@ -1,4 +1,4 @@
-import React, { Component, Fragment } from "react";
+import React, { Fragment } from "react";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
 
@@ -10,80 +10,74 @@ import { getSelectedRevisions } from "../selectors";
 
 import DevmodeIcon from "./devmodeIcon";
 
-class RevisionsListRow extends Component {
-  revisionSelectChange(revision) {
-    this.props.toggleRevision(revision);
+const RevisionsListRow = props => {
+  const { revision, isSelectable, showAllColumns, isPending } = props;
+
+  const revisionDate = revision.release
+    ? new Date(revision.release.when)
+    : new Date(revision.created_at);
+
+  const isSelected = props.selectedRevisions.includes(revision.revision);
+
+  const id = `revision-check-${revision.revision}`;
+  const className = `${isSelectable ? "is-clickable" : ""} ${
+    isPending || isSelected ? "is-pending" : ""
+  }`;
+
+  function revisionSelectChange() {
+    props.toggleRevision(revision);
   }
 
-  renderRow(revision, isSelectable, showAllColumns, isPending) {
-    const revisionDate = revision.release
-      ? new Date(revision.release.when)
-      : new Date(revision.created_at);
-    const isSelected = this.props.selectedRevisions.includes(revision.revision);
-
-    const id = `revision-check-${revision.revision}`;
-    const className = `${isSelectable ? "is-clickable" : ""} ${
-      isPending || isSelected ? "is-pending" : ""
-    }`;
-
-    return (
-      <tr
-        key={id}
-        className={className}
-        onClick={
-          isSelectable ? this.revisionSelectChange.bind(this, revision) : null
-        }
-      >
-        <td>
-          {isSelectable ? (
-            <Fragment>
-              <input
-                type="checkbox"
-                checked={isSelected}
-                id={id}
-                onChange={this.revisionSelectChange.bind(this, revision)}
-              />
-              <label className="u-no-margin--bottom" htmlFor={id}>
-                {revision.revision}
-              </label>
-            </Fragment>
-          ) : (
-            <span>{revision.revision}</span>
-          )}
-        </td>
-        <td>
-          <DevmodeIcon revision={revision} showTooltip={true} />
-        </td>
-        <td>{revision.version}</td>
-        {showAllColumns && <td>{revision.channels.join(", ")}</td>}
-        <td className="u-align--right">
-          {isPending ? (
-            <em>pending release</em>
-          ) : (
+  return (
+    <tr
+      key={id}
+      className={className}
+      onClick={isSelectable ? revisionSelectChange : null}
+    >
+      <td>
+        {isSelectable ? (
+          <Fragment>
+            <input
+              type="checkbox"
+              checked={isSelected}
+              id={id}
+              onChange={revisionSelectChange}
+            />
+            <label className="u-no-margin--bottom" htmlFor={id}>
+              {revision.revision}
+            </label>
+          </Fragment>
+        ) : (
+          <span>{revision.revision}</span>
+        )}
+      </td>
+      <td>
+        <DevmodeIcon revision={revision} showTooltip={true} />
+      </td>
+      <td>{revision.version}</td>
+      {showAllColumns && <td>{revision.channels.join(", ")}</td>}
+      <td className="u-align--right">
+        {isPending ? (
+          <em>pending release</em>
+        ) : (
+          <span
+            className="p-tooltip p-tooltip--btm-center"
+            aria-describedby={`revision-uploaded-${revision.revision}`}
+          >
+            {distanceInWords(new Date(), revisionDate, { addSuffix: true })}
             <span
-              className="p-tooltip p-tooltip--btm-center"
-              aria-describedby={`revision-uploaded-${revision.revision}`}
+              className="p-tooltip__message u-align--center"
+              role="tooltip"
+              id={`revision-uploaded-${revision.revision}`}
             >
-              {distanceInWords(new Date(), revisionDate, { addSuffix: true })}
-              <span
-                className="p-tooltip__message u-align--center"
-                role="tooltip"
-                id={`revision-uploaded-${revision.revision}`}
-              >
-                {format(revisionDate, "YYYY-MM-DD HH:mm")}
-              </span>
+              {format(revisionDate, "YYYY-MM-DD HH:mm")}
             </span>
-          )}
-        </td>
-      </tr>
-    );
-  }
-
-  render() {
-    const { revision, isSelectable, showAllColumns, isPending } = this.props;
-    return this.renderRow(revision, isSelectable, showAllColumns, isPending);
-  }
-}
+          </span>
+        )}
+      </td>
+    </tr>
+  );
+};
 
 RevisionsListRow.propTypes = {
   // props

--- a/static/sass/_snapcraft_release.scss
+++ b/static/sass/_snapcraft_release.scss
@@ -287,8 +287,17 @@
       padding-left: 2rem;
     }
 
+    .p-revisions-list__revision {
+      background: $color-light;
+      border: 0;
+      border-bottom: 2px solid $color-x-light;
+    }
+
+    .is-pending {
+      background: $color-highlighted;
+    }
+
     .is-draggable {
-      background-color: $color-x-light;
       cursor: grab;
     }
 
@@ -296,13 +305,8 @@
       cursor: pointer;
 
       &:hover {
-        background-color: $color-light;
+        background-color: $color-x-light;
       }
-    }
-
-    .is-pending,
-    .is-pending:hover {
-      background: $color-highlighted;
     }
 
     .is-grabbing,

--- a/static/sass/_snapcraft_release.scss
+++ b/static/sass/_snapcraft_release.scss
@@ -28,20 +28,6 @@
     display: flex;
     margin-bottom: 2px;
 
-    &.is-grabbing,
-    &.is-dragging {
-      opacity: .9; // little workaround for chrome
-
-      .p-tooltip__message,
-      .p-contextual-menu__dropdown {
-        display: none;
-      }
-    }
-
-    &.is-dragging {
-      opacity: .5;
-    }
-
     &.can-drop {
       outline: 1px dashed $color-mid-light;
     }
@@ -108,25 +94,12 @@
     &.is-highlighted {
       background-color: $color-highlighted;
     }
-
-    &.is-draggable {
-      cursor: grab;
-    }
   }
 
   .p-releases-channel__name {
     flex-grow: 1;
     max-width: calc(100% - 55px); // leave space handle and settings menu
     padding-right: $sph-intra--condensed;
-  }
-
-  .p-drag-handle {
-    margin-right: $sph-intra--condensed;
-    visibility: hidden;
-
-    .is-draggable & {
-      visibility: visible;
-    }
   }
 
   // release cell
@@ -145,19 +118,6 @@
     transition-duration: 0s; // vf-animation doesn't allow to do that
 
     .has-active & {
-      opacity: .5;
-    }
-
-    &.is-grabbing,
-    &.is-dragging {
-      opacity: .9; // little workaround for chrome
-
-      .p-tooltip__message {
-        display: none;
-      }
-    }
-
-    &.is-dragging {
       opacity: .5;
     }
 
@@ -184,10 +144,6 @@
       @include vf-animation (#{background-color, border-color}, fast, in);
       background-color: $color-x-light;
       opacity: 1;
-    }
-
-    &.is-draggable {
-      cursor: grab;
     }
 
     &.is-active {
@@ -297,24 +253,11 @@
       background: $color-highlighted;
     }
 
-    .is-draggable {
-      cursor: grab;
-    }
-
     .is-clickable {
       cursor: pointer;
 
       &:hover {
         background-color: $color-x-light;
-      }
-    }
-
-    .is-grabbing,
-    .is-dragging {
-      opacity: .9; // little workaround for chrome
-
-      .p-tooltip__message {
-        display: none;
       }
     }
 
@@ -326,6 +269,34 @@
     td:last-of-type,
     th:last-of-type {
       padding-right: .5rem;
+    }
+  }
+
+  // DND
+  .is-draggable {
+    cursor: grab !important;
+  }
+
+  .is-grabbing,
+  .is-dragging {
+    opacity: .9; // little workaround for chrome
+
+    .p-tooltip__message,
+    .p-contextual-menu__dropdown {
+      display: none !important; // fighting specificity
+    }
+  }
+
+  .is-dragging {
+    opacity: .5 !important; // fighting specificity
+  }
+
+  .p-drag-handle {
+    margin-right: $sph-intra--condensed;
+    visibility: hidden;
+
+    .is-draggable & {
+      visibility: visible;
     }
   }
 

--- a/static/sass/_snapcraft_release.scss
+++ b/static/sass/_snapcraft_release.scss
@@ -27,10 +27,6 @@
   .p-releases-table__row {
     display: flex;
     margin-bottom: 2px;
-
-    &.can-drop {
-      outline: 1px dashed $color-mid-light;
-    }
   }
 
   .p-releases-table__row--channel {
@@ -70,14 +66,7 @@
       opacity: .5;
     }
 
-    .can-drop & {
-      opacity: 1;
-
-      .p-tooltip__message {
-        display: none;
-      }
-    }
-
+    .can-drop &,
     &:hover,
     &.is-active {
       opacity: 1;
@@ -87,10 +76,7 @@
       background: none;
     }
 
-    .is-over & {
-      background-color: $color-highlighted;
-    }
-
+    .is-over &,
     &.is-highlighted {
       background-color: $color-highlighted;
     }
@@ -121,17 +107,9 @@
       opacity: .5;
     }
 
-    .can-drop & {
-      opacity: 1;
-    }
-
+    .can-drop &,
     &.can-drop {
       opacity: 1;
-      outline: 1px dashed $color-mid-light;
-
-      .p-tooltip__message {
-        display: none;
-      }
     }
 
     &.is-clickable {
@@ -158,16 +136,10 @@
       }
     }
 
+    &.is-over,
+    .is-over &,
     &.is-highlighted {
       background: $color-highlighted;
-    }
-
-    .is-over & {
-      background-color: $color-highlighted;
-    }
-
-    &.is-over {
-      background-color: $color-highlighted;
     }
   }
 
@@ -297,6 +269,14 @@
 
     .is-draggable & {
       visibility: visible;
+    }
+  }
+
+  .can-drop {
+    outline: 1px dashed $color-mid-light;
+
+    .p-tooltip__message {
+      display: none !important;
     }
   }
 

--- a/static/sass/_snapcraft_release.scss
+++ b/static/sass/_snapcraft_release.scss
@@ -299,6 +299,15 @@
     .is-pending:hover {
       background: $color-highlighted;
     }
+
+    .is-grabbing,
+    .is-dragging {
+      opacity: .9; // little workaround for chrome
+
+      .p-tooltip__message {
+        display: none;
+      }
+    }
   }
 
   // HELPERS

--- a/static/sass/_snapcraft_release.scss
+++ b/static/sass/_snapcraft_release.scss
@@ -120,7 +120,7 @@
     padding-right: $sph-intra--condensed;
   }
 
-  .p-releases__handle {
+  .p-drag-handle {
     margin-right: $sph-intra--condensed;
     visibility: hidden;
 

--- a/static/sass/_snapcraft_release.scss
+++ b/static/sass/_snapcraft_release.scss
@@ -287,6 +287,11 @@
       padding-left: 2rem;
     }
 
+    .is-draggable {
+      background-color: $color-x-light;
+      cursor: grab;
+    }
+
     .is-clickable {
       cursor: pointer;
 
@@ -307,6 +312,16 @@
       .p-tooltip__message {
         display: none;
       }
+    }
+
+    td:first-of-type,
+    th:first-of-type {
+      padding-left: .2rem;
+    }
+
+    td:last-of-type,
+    th:last-of-type {
+      padding-right: .5rem;
     }
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -142,12 +142,20 @@
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/@sheerun/mutationobserver-shim/-/mutationobserver-shim-0.3.2.tgz#8013f2af54a2b7d735f71560ff360d3a8176a87b"
 
+"@types/asap@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@types/asap/-/asap-2.0.0.tgz#d529e9608c83499a62ae08c871c5e62271aa2963"
+
 "@types/hoist-non-react-statics@^3.3.1":
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz#1124aafe5118cb591977aeb1ceaaed1070eb039f"
   dependencies:
     "@types/react" "*"
     hoist-non-react-statics "^3.3.0"
+
+"@types/invariant@^2.2.29":
+  version "2.2.29"
+  resolved "https://registry.yarnpkg.com/@types/invariant/-/invariant-2.2.29.tgz#aa845204cd0a289f65d47e0de63a6a815e30cc66"
 
 "@types/istanbul-lib-coverage@^1.1.0":
   version "1.1.0"
@@ -158,11 +166,15 @@
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.1.tgz#f1a11e7babb0c3cad68100be381d1e064c68f1f6"
 
 "@types/react@*":
-  version "16.8.20"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.8.20.tgz#4f633ecbd0a4d56d0ccc50fff6f9321bbcd7d583"
+  version "16.8.22"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.8.22.tgz#7f18bf5ea0c1cad73c46b6b1c804a3ce0eec6d54"
   dependencies:
     "@types/prop-types" "*"
     csstype "^2.2.0"
+
+"@types/shallowequal@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@types/shallowequal/-/shallowequal-1.1.1.tgz#aad262bb3f2b1257d94c71d545268d592575c9b1"
 
 "@types/yargs@^12.0.9":
   version "12.0.9"
@@ -2382,10 +2394,12 @@ diffie-hellman@^5.0.0:
     miller-rabin "^4.0.0"
     randombytes "^2.0.0"
 
-dnd-core@^8.0.0:
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/dnd-core/-/dnd-core-8.0.0.tgz#0e2c8b722809ae50ca47a5d4b80e7ed753decb25"
+dnd-core@^8.0.3:
+  version "8.0.3"
+  resolved "https://registry.yarnpkg.com/dnd-core/-/dnd-core-8.0.3.tgz#96fdaae0f53ca86996ed50075000ebd758169682"
   dependencies:
+    "@types/asap" "^2.0.0"
+    "@types/invariant" "^2.2.29"
     asap "^2.0.6"
     invariant "^2.2.4"
     redux "^4.0.1"
@@ -3770,15 +3784,15 @@ interpret@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.1.0.tgz#7ed1b1410c6a0e0f78cf95d3b8440c63f78b8614"
 
-invariant@^2.1.0, invariant@^2.2.4:
-  version "2.2.4"
-  resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
-  dependencies:
-    loose-envify "^1.0.0"
-
 invariant@^2.2.2:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.3.tgz#1a827dfde7dcbd7c323f0ca826be8fa7c5e9d688"
+  dependencies:
+    loose-envify "^1.0.0"
+
+invariant@^2.2.4:
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
   dependencies:
     loose-envify "^1.0.0"
 
@@ -6016,19 +6030,19 @@ rc@^1.2.7:
     strip-json-comments "~2.0.1"
 
 react-dnd-html5-backend@^8.0.0:
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/react-dnd-html5-backend/-/react-dnd-html5-backend-8.0.0.tgz#918058134fc9222524c3ec9b6563821dee010db4"
+  version "8.0.3"
+  resolved "https://registry.yarnpkg.com/react-dnd-html5-backend/-/react-dnd-html5-backend-8.0.3.tgz#8f030444c7b79fd022f4ebd23ab5d20ed6ad248e"
   dependencies:
-    dnd-core "^8.0.0"
+    dnd-core "^8.0.3"
 
 react-dnd@^8.0.0:
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/react-dnd/-/react-dnd-8.0.0.tgz#72fe2e0bd9da05db2c44b7d26e347ce7be2b4544"
+  version "8.0.3"
+  resolved "https://registry.yarnpkg.com/react-dnd/-/react-dnd-8.0.3.tgz#6226e1a6476bc7f9593b98def86fdab7d45100f8"
   dependencies:
     "@types/hoist-non-react-statics" "^3.3.1"
-    dnd-core "^8.0.0"
+    "@types/shallowequal" "^1.1.1"
+    dnd-core "^8.0.3"
     hoist-non-react-statics "^3.3.0"
-    invariant "^2.1.0"
     shallowequal "^1.1.0"
 
 react-dom@^16.4.1:


### PR DESCRIPTION
Fixes #1965
- Adds possibility for dragging revision from history panel to promote it
- Refactors d'n'd by extracting shared functionality and styles

### QA
- ./run or  https://snapcraft-io-canonical-web-and-design-pr-2052.run.demo.haus/
- go to Releases page of any snap
- click on revision cell to open history panel
- drag any revisions in history to promote it to some channel
- make sure dragging revision cells and channel rows still work

<img width="1119" alt="Screenshot 2019-07-01 at 15 33 29" src="https://user-images.githubusercontent.com/83575/60440781-dac37680-9c15-11e9-8d91-421901a66881.png">

