### PR TITLE
Highlight active revision in history panel

### DIFF
--- a/static/js/publisher/release/components/revisionsListRow.js
+++ b/static/js/publisher/release/components/revisionsListRow.js
@@ -12,7 +12,7 @@ import { getSelectedRevisions } from "../selectors";
 import DevmodeIcon from "./devmodeIcon";
 
 const RevisionsListRow = props => {
-  const { revision, isSelectable, showAllColumns, isPending } = props;
+  const { revision, isSelectable, showAllColumns, isPending, isActive } = props;
 
   const revisionDate = revision.release
     ? new Date(revision.release.when)
@@ -36,11 +36,11 @@ const RevisionsListRow = props => {
   });
 
   const id = `revision-check-${revision.revision}`;
-  const className = `p-revisions-list__revision is-draggable ${
-    isSelectable ? "is-clickable" : ""
-  } ${isPending || isSelected ? "is-pending" : ""} ${
-    isGrabbing ? "is-grabbing" : ""
-  } ${isDragging ? "is-dragging" : ""}`;
+  const className = `p-revisions-list__row is-draggable ${
+    isActive ? "is-active" : ""
+  } ${isSelectable ? "is-clickable" : ""} ${
+    isPending || isSelected ? "is-pending" : ""
+  } ${isGrabbing ? "is-grabbing" : ""} ${isDragging ? "is-dragging" : ""}`;
 
   return (
     <tr
@@ -61,12 +61,17 @@ const RevisionsListRow = props => {
               id={id}
               onChange={revisionSelectChange}
             />
-            <label className="u-no-margin--bottom" htmlFor={id}>
+            <label
+              className="p-revisions-list__revision u-no-margin--bottom"
+              htmlFor={id}
+            >
               {revision.revision}
             </label>
           </Fragment>
         ) : (
-          <span>{revision.revision}</span>
+          <span className="p-revisions-list__revision">
+            {revision.revision}
+          </span>
         )}
       </td>
       <td>
@@ -103,6 +108,7 @@ RevisionsListRow.propTypes = {
   isSelectable: PropTypes.bool,
   showAllColumns: PropTypes.bool,
   isPending: PropTypes.bool,
+  isActive: PropTypes.bool,
 
   // computed state (selectors)
   selectedRevisions: PropTypes.array.isRequired,

--- a/static/sass/_snapcraft_release.scss
+++ b/static/sass/_snapcraft_release.scss
@@ -215,21 +215,30 @@
       padding-left: 2rem;
     }
 
-    .p-revisions-list__revision {
-      background: $color-light;
+    .p-revisions-list__row {
+      background-color: $color-light;
       border: 0;
       border-bottom: 2px solid $color-x-light;
-    }
 
-    .is-pending {
-      background: $color-highlighted;
-    }
-
-    .is-clickable {
-      cursor: pointer;
-
-      &:hover {
+      &.is-active {
         background-color: $color-x-light;
+
+        .p-revisions-list__revision {
+          font-weight: bold;
+        }
+      }
+
+      &.is-pending {
+        background: $color-highlighted;
+      }
+
+      &.is-clickable {
+        @include vf-animation (#{background-color}, fast, in);
+        cursor: pointer;
+
+        &:hover {
+          background-color: $color-x-light;
+        }
       }
     }
 


### PR DESCRIPTION
Fixes #2053 

Highlight active (currently released) revision in history panel.

### QA
- ./run or https://snapcraft-io-canonical-web-and-design-pr-2054.run.demo.haus/
- go to releases page of any snap
- click on any revision cell, currently released revision (first on the list) should be highlighted in white with bold revision number

<img width="1053" alt="Screenshot 2019-07-02 at 12 59 30" src="https://user-images.githubusercontent.com/83575/60507840-5b8f7a80-9cc9-11e9-9252-f9ac3a46e538.png">
