### PR TITLE
Fix search when category not existing

### DIFF
--- a/templates/store/search.html
+++ b/templates/store/search.html
@@ -72,8 +72,12 @@
         {% endif %}
     {% else %}
       <div class="row">
-        <h2>We couldn't find anything for your search <div class="no-search-query">{{query}}.</div></h2>
-        <h4>Try using some different, or more general keywords.</h4>
+        {% if query %}
+          <h2>We couldn't find anything for your search <div class="no-search-query">{{query}}.</div></h2>
+          <h4>Try using some different, or more general keywords.</h4>
+        {% else %}
+          <h2>We couldn't find the category <div class="no-search-query">{{category_display}}.</div></h2>
+        {% endif %}
       </div>
     {% endif %}
   </section>

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -200,7 +200,7 @@ def store_blueprint(store_query=None, testing=False):
         number_of_featured_snaps = 19
 
         if snap_category_display and page == 1:
-            if snaps_results[0]:
+            if snaps_results and snaps_results[0]:
                 if snaps_results[0]["icon_url"] == "":
                     snaps_results = logic.promote_snap_with_icon(snaps_results)
 


### PR DESCRIPTION
Fixes https://sentry.is.canonical.com/canonical/ubuntu-com/issues/2325/?query=is%3Aunresolved

When category not existing and no query paramenter.

# qa 

- `./run`
- http://127.0.0.1:5000/search?category=toto
- Should get a page telling you couldn't find snaps on this category.
