### PR TITLE
Include react-dnd ES6 modules in babel-loader

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -33,8 +33,11 @@ module.exports = {
     rules: [
       {
         test: /\.js$/,
-        // http://idangero.us/swiper/get-started/
-        exclude: /node_modules\/(?!(dom7|ssr-window|swiper)\/).*/,
+        // Exclude node_modules from using babel-loader
+        // except some that use ES6 modules and need to be transpiled:
+        // such as swiper http://idangero.us/swiper/get-started/
+        // and also react-dnd related
+        exclude: /node_modules\/(?!(dom7|ssr-window|swiper|dnd-core|react-dnd|react-dnd-html5-backend)\/).*/,
         use: {
           loader: "babel-loader"
         }


### PR DESCRIPTION
react-dnd since v8 uses ES6 modules. This means we need to include it in babel loader transpilation in webpack.

### QA
- ./run --env ENVIRONMENT=production build
- everything should build without errors