### PR TITLE
Disable setting and clearing default tracks

### DIFF
--- a/static/js/publisher/release/components/releasesHeading.js
+++ b/static/js/publisher/release/components/releasesHeading.js
@@ -4,7 +4,6 @@ import { connect } from "react-redux";
 
 import { setCurrentTrack } from "../actions/currentTrack";
 import { getTracks } from "../selectors";
-import DefaultTrackModifier from "./defaultTrackModifier";
 
 class ReleasesHeading extends Component {
   onTrackChange(event) {
@@ -51,9 +50,11 @@ class ReleasesHeading extends Component {
             </Wrap>
           </h4>
         </div>
-        <div className="col-6">
-          {tracks.length > 1 && <DefaultTrackModifier />}
-        </div>
+        {/* disabled until default tracks are +1'd
+            <div className="col-6">
+              {tracks.length > 1 && <DefaultTrackModifier />}
+            </div>
+         */}
       </div>
     );
   }


### PR DESCRIPTION
As the default track conversation continues, we don't want people to get stuck in a hole because of the messaging we're providing.