### PR TITLE
Fixes errors when mobile button was not found in DOM

### DIFF
--- a/static/js/libs/mobile.js
+++ b/static/js/libs/mobile.js
@@ -5,8 +5,9 @@ function isMobile() {
   );
 
   // Use offsetWidth and offsetHeight to figure out if an element is visibile
-  return !(
-    mobileMenuButton.offsetWidth === 0 && mobileMenuButton.offsetHeight === 0
+  return (
+    mobileMenuButton &&
+    !(mobileMenuButton.offsetWidth === 0 && mobileMenuButton.offsetHeight === 0)
   );
 }
 


### PR DESCRIPTION
From Sentry: https://sentry.is.canonical.com/canonical/snapcraftio/issues/2195
### QA

I couldn't reproduce this one, but this makes sure functionality that uses affected function works:

- ./run or https://snapcraft-io-canonical-web-and-design-pr-2064.run.demo.haus/
- go to snap details page on small mobile screen
- click on a screenshot - should open in new tab, no errors in console
