### PR TITLE
Fix checking if revision is active

### DIFF
--- a/static/js/publisher/release/components/revisionsList.js
+++ b/static/js/publisher/release/components/revisionsList.js
@@ -53,7 +53,8 @@ class RevisionsList extends Component {
 
   renderRows(revisions, isSelectable, showAllColumns, activeRevision) {
     return revisions.map(revision => {
-      const isActive = revision.revision === activeRevision.revision;
+      const isActive =
+        activeRevision && revision.revision === activeRevision.revision;
 
       return this.renderRow(
         revision,


### PR DESCRIPTION
Sentry: https://sentry.is.canonical.com/canonical/snapcraftio/issues/2531/

Fixes issue with checking if revision is active when there is no active revision (for example channel was closed).

### QA
- ./run or demo
- go to releases page of snap you own
- close some channel
- Save (so that changes are propagated to store)
- click on any empty cell in closed channel
- history panel should open, there should be no errors in console