### PR TITLE
Fix calling forEach on NodeList in older browsers

### DIFF
--- a/static/js/public/accordion.js
+++ b/static/js/public/accordion.js
@@ -28,9 +28,9 @@ export default function initAccordion(accordionContainerSelector) {
       const target = e.target.closest(".p-accordion__tab");
       if (target && !target.disabled) {
         // Find any open panels within the container and close them.
-        e.currentTarget
-          .querySelectorAll("[aria-expanded=true]")
-          .forEach(element => toggleAccordion(element, false));
+        Array.from(
+          e.currentTarget.querySelectorAll("[aria-expanded=true]")
+        ).forEach(element => toggleAccordion(element, false));
         // Open the target.
         toggleAccordion(target, true);
       }

--- a/static/js/public/first-snap-flow.js
+++ b/static/js/public/first-snap-flow.js
@@ -3,12 +3,12 @@
 import "whatwg-fetch";
 
 function install(language) {
-  const osPickers = document.querySelectorAll(".js-os-select");
-  const osWrappers = document.querySelectorAll(".js-os-wrapper");
+  const osPickers = Array.from(document.querySelectorAll(".js-os-select"));
+  const osWrappers = Array.from(document.querySelectorAll(".js-os-wrapper"));
 
   function select(selectedOs) {
     if (osWrappers) {
-      Array.prototype.slice.call(osWrappers).forEach(function(wrapper) {
+      osWrappers.forEach(function(wrapper) {
         wrapper.classList.add("u-hide");
       });
     }
@@ -32,7 +32,7 @@ function install(language) {
     const isLinux = !!userAgent.match(/(Linux)|(X11)/);
     const userOS = isMac ? "macos" : isLinux ? "linux" : null;
 
-    Array.prototype.slice.call(osPickers).forEach(function(os) {
+    osPickers.forEach(function(os) {
       if (os.dataset.os === userOS) {
         os.classList.add("is-selected");
       }
@@ -70,7 +70,7 @@ function install(language) {
 
     if (osWrappers) {
       osWrappers.forEach(function(wrapper) {
-        const rows = wrapper.querySelectorAll(".js-os-type");
+        const rows = Array.from(wrapper.querySelectorAll(".js-os-type"));
         if (rows) {
           rows.forEach(function(row) {
             row.classList.add("u-hide");


### PR DESCRIPTION
From Sentry: 
https://sentry.is.canonical.com/canonical/snapcraftio/issues/1190/
https://sentry.is.canonical.com/canonical/snapcraftio/issues/1757/

Makes sure all occurrences of document.querySelectorAll are properly wrapped in Arrays.

### QA
- ./run or demo
- ideally use old browser that doesn't support .forEach on NodeList ;)
- go to first snap flow, click on OS picker, click through pages, open accordions
- there should be no errors in console, everything should work