### PR TITLE
Don't rely only on href when animating scroll

### DIFF
--- a/static/js/public/scroll-to.js
+++ b/static/js/public/scroll-to.js
@@ -73,8 +73,8 @@ export function animateScrollTo(to, duration = 500, offset = 0) {
 }
 
 export function initLinkScroll(link, { duration = 500, offset = 0 }) {
-  if (link && link.href) {
-    const href = link.getAttribute("href");
+  if (link && (link.dataset.scrollTo || link.href)) {
+    const href = link.dataset.scrollTo || link.getAttribute("href");
     const target = document.querySelector(href);
     if (target) {
       link.addEventListener("click", event => {

--- a/templates/store/snap-distro-install.html
+++ b/templates/store/snap-distro-install.html
@@ -87,7 +87,7 @@
               {% include 'store/snap-details/_snap_heading_data.html' %}
 
               <div class="p-snap-install-buttons">
-                <a class="p-button--neutral p-snap-install-buttons__install js-install" href="#install">
+                <a class="p-button--neutral p-snap-install-buttons__install js-install" href="#install" data-scroll-to="#install">
                     Install snap
                 </a>
               </div>


### PR DESCRIPTION
From Sentry: https://sentry.is.canonical.com/canonical/snapcraftio/issues/2239/

When accessing distro page via google translate link `href`s are modified. This causes animated scroll script to throw error when href is expected to be id of element on the page but is actually a full `http://` URL.

This PR introduces separate data attribute, so that even with modified href animate scroll script will work without errors.

###
- ./run or demo
- go to distro page of some snap
- open devtools, find "Install" button, modify the href attribute from "#install" to some random string or URL
- click on the button, animated scroll should work, no errors should be sent to sentry