### PR TITLE
Replace devmode icon with asterisk

### DIFF
--- a/static/js/publisher/release/components/devmodeRevision.js
+++ b/static/js/publisher/release/components/devmodeRevision.js
@@ -3,15 +3,14 @@ import PropTypes from "prop-types";
 
 import { isInDevmode } from "../helpers";
 
-export default function DevmodeIcon({ revision, showTooltip }) {
-  return (
-    isInDevmode(revision) && (
+export default function DevmodeRevision({ revision, showTooltip }) {
+  if (isInDevmode(revision)) {
+    return (
       <span
         className="p-tooltip p-tooltip--btm-center"
         aria-describedby={`revision-devmode-${revision.revision}`}
       >
-        <i className="p-icon--information" />
-
+        {revision.revision}*
         {showTooltip && (
           <span
             className="p-tooltip__message u-align--center"
@@ -28,11 +27,13 @@ export default function DevmodeIcon({ revision, showTooltip }) {
           </span>
         )}
       </span>
-    )
-  );
+    );
+  }
+
+  return revision.revision;
 }
 
-DevmodeIcon.propTypes = {
+DevmodeRevision.propTypes = {
   revision: PropTypes.object.isRequired,
   showTooltip: PropTypes.bool
 };

--- a/static/js/publisher/release/components/releasesTableCell.js
+++ b/static/js/publisher/release/components/releasesTableCell.js
@@ -4,7 +4,7 @@ import { connect } from "react-redux";
 
 import { STABLE, CANDIDATE, AVAILABLE } from "../constants";
 import { getTrackingChannel } from "../releasesState";
-import DevmodeIcon from "./devmodeIcon";
+import DevmodeRevision from "./devmodeRevision";
 import { getChannelName, isInDevmode } from "../helpers";
 import { useDragging, useDrop, DND_ITEM_REVISION, Handle } from "./dnd";
 
@@ -64,12 +64,9 @@ const RevisionInfo = ({ revision, isPending, showVersion }) => {
   return (
     <Fragment>
       <span className="p-release-data__info">
-        <span className="p-release-data__title">{revision.revision}</span>
-        {isInDevmode(revision) && (
-          <span className="p-release-data__icon">
-            <DevmodeIcon revision={revision} showTooltip={false} />
-          </span>
-        )}
+        <span className="p-release-data__title">
+          <DevmodeRevision revision={revision} showTooltip={false} />
+        </span>
         {showVersion && (
           <span className="p-release-data__meta">{revision.version}</span>
         )}

--- a/static/js/publisher/release/components/revisionsList.js
+++ b/static/js/publisher/release/components/revisionsList.js
@@ -282,7 +282,6 @@ class RevisionsList extends Component {
               >
                 Revision
               </th>
-              <th width="20px" />
               <th scope="col">Version</th>
               {showAllColumns && <th scope="col">Channels</th>}
               <th scope="col" width="130px" className="u-align--right">

--- a/static/js/publisher/release/components/revisionsListRow.js
+++ b/static/js/publisher/release/components/revisionsListRow.js
@@ -9,7 +9,7 @@ import { useDragging, DND_ITEM_REVISION, Handle } from "./dnd";
 import { toggleRevision } from "../actions/channelMap";
 import { getSelectedRevisions } from "../selectors";
 
-import DevmodeIcon from "./devmodeIcon";
+import DevmodeRevision from "./devmodeRevision";
 
 const RevisionsListRow = props => {
   const { revision, isSelectable, showAllColumns, isPending, isActive } = props;
@@ -65,17 +65,14 @@ const RevisionsListRow = props => {
               className="p-revisions-list__revision u-no-margin--bottom"
               htmlFor={id}
             >
-              {revision.revision}
+              <DevmodeRevision revision={revision} showTooltip={true} />
             </label>
           </Fragment>
         ) : (
           <span className="p-revisions-list__revision">
-            {revision.revision}
+            <DevmodeRevision revision={revision} showTooltip={true} />
           </span>
         )}
-      </td>
-      <td>
-        <DevmodeIcon revision={revision} showTooltip={true} />
       </td>
       <td>{revision.version}</td>
       {showAllColumns && <td>{revision.channels.join(", ")}</td>}

--- a/static/sass/_snapcraft_release.scss
+++ b/static/sass/_snapcraft_release.scss
@@ -271,6 +271,10 @@
         .p-revisions-list__revision {
           font-weight: bold;
         }
+
+        .p-revisions-list__revision .p-tooltip__message {
+          font-weight: normal;
+        }
       }
 
       &.is-pending {


### PR DESCRIPTION
Fixes https://github.com/canonical-web-and-design/snapcraft.io/issues/2077

## QA

- Pull the branch
- `./run`
- Visit http://0.0.0.0:8004/lukewh-test/releases
- There should no longer be an [i] icon, for any revision that's devmode or devel grade
- Instead there should be an * next to the revision
- Hovering over these cells/ revisions should show a tooltip.
- This should also all work within the history tables when you click on a cell.
- Compare with https://staging.snapcraft.io/lukewh-test/releases