### PR TITLE
Release UI: Use history icon to open history panel

### DIFF
--- a/static/js/publisher/release/components/historyIcon.js
+++ b/static/js/publisher/release/components/historyIcon.js
@@ -1,0 +1,16 @@
+import React from "react";
+import PropTypes from "prop-types";
+
+export default function HistoryIcon({ onClick }) {
+  return (
+    <span className="p-release-data__icon">
+      <span className="p-icon p-icon--history" onClick={onClick}>
+        History
+      </span>
+    </span>
+  );
+}
+
+HistoryIcon.propTypes = {
+  onClick: PropTypes.func.isRequired
+};

--- a/static/js/publisher/release/components/historyIcon.js
+++ b/static/js/publisher/release/components/historyIcon.js
@@ -3,10 +3,8 @@ import PropTypes from "prop-types";
 
 export default function HistoryIcon({ onClick }) {
   return (
-    <span className="p-release-data__icon">
-      <span className="p-icon p-icon--history" onClick={onClick}>
-        History
-      </span>
+    <span className="p-release-data__icon" onClick={onClick}>
+      <span className="p-icon p-icon--history">History</span>
     </span>
   );
 }

--- a/static/js/publisher/release/components/releasesTableCell.js
+++ b/static/js/publisher/release/components/releasesTableCell.js
@@ -5,6 +5,7 @@ import { connect } from "react-redux";
 import { STABLE, CANDIDATE, AVAILABLE } from "../constants";
 import { getTrackingChannel } from "../releasesState";
 import DevmodeRevision from "./devmodeRevision";
+import HistoryIcon from "./historyIcon";
 import { getChannelName, isInDevmode } from "../helpers";
 import { useDragging, useDrop, DND_ITEM_REVISION, Handle } from "./dnd";
 
@@ -192,7 +193,7 @@ const ReleasesTableCell = props => {
     })
   });
 
-  function handleReleaseCellClick(arch, risk, track, branchName) {
+  function handleHistoryIconClick(arch, risk, track, branchName) {
     props.toggleHistoryPanel({ arch, risk, track, branch: branchName });
   }
 
@@ -202,7 +203,7 @@ const ReleasesTableCell = props => {
   }
 
   const className = [
-    "p-releases-table__cell is-clickable",
+    "p-releases-table__cell",
     isUnassigned ? "is-unassigned" : "",
     isActive ? "is-active" : "",
     isHighlighted ? "is-highlighted" : "",
@@ -215,11 +216,7 @@ const ReleasesTableCell = props => {
   ].join(" ");
 
   return (
-    <div
-      ref={drop}
-      className={className}
-      onClick={handleReleaseCellClick.bind(this, arch, risk, track, branchName)}
-    >
+    <div ref={drop} className={className}>
       <div
         ref={drag}
         className="p-release-data p-tooltip p-tooltip--btm-center"
@@ -240,6 +237,15 @@ const ReleasesTableCell = props => {
             trackingChannel={trackingChannel}
           />
         )}
+        <HistoryIcon
+          onClick={handleHistoryIconClick.bind(
+            this,
+            arch,
+            risk,
+            track,
+            branchName
+          )}
+        />
       </div>
       {hasPendingRelease && (
         <div className="p-release-buttons">

--- a/static/js/publisher/release/components/releasesTableRow.js
+++ b/static/js/publisher/release/components/releasesTableRow.js
@@ -84,6 +84,8 @@ const ReleasesTableRow = props => {
     }
   }
 
+  const hasOpenBranches = openBranches.includes(channel);
+
   const canDrag = !!pendingChannelMap[channel];
   const [isDragging, isGrabbing, drag, preview] = useDragging({
     item: {
@@ -381,7 +383,9 @@ const ReleasesTableRow = props => {
 
             {numberOfBranches > 0 && (
               <span
-                className="p-releases-table__branches"
+                className={`p-releases-table__branches ${
+                  hasOpenBranches ? "is-open" : ""
+                }`}
                 onClick={props.toggleBranches.bind(this, channel)}
               >
                 <i className="p-icon" />

--- a/static/sass/_snapcraft_patterns_icons.scss
+++ b/static/sass/_snapcraft_patterns_icons.scss
@@ -8,3 +8,7 @@
 @mixin snapcraft-icon-branch($color, $width, $height) {
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='$width' height='$height'%3E%3Cpath fill='#{vf-url-friendly-color($color)}' fill-rule='nonzero' d='M3 6h1.268a2 2 0 1 1 0 2H3v2a1 1 0 0 1-2 0V3.732a2 2 0 1 1 2 0V6zM2 3a1 1 0 1 0 0-2 1 1 0 0 0 0 2zm4 5a1 1 0 1 0 0-2 1 1 0 0 0 0 2z'/%3E%3C/svg%3E");
 }
+
+@mixin snapcraft-icon-history($color) {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='26' height='26'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cpath d='M0 0h26v26H0z'/%3E%3Cpath fill='#{vf-url-friendly-color($color)}' d='M17.881 22.624c3.143-1.703 5.273-4.999 5.273-8.786 0-5.532-4.546-10.017-10.154-10.017S2.846 8.306 2.846 13.838c0 2.27.766 4.365 2.056 6.045l-1.46 1.113A11.684 11.684 0 0 1 1 13.838C1 7.3 6.373 2 13 2s12 5.3 12 11.838c0 4.432-2.468 8.294-6.121 10.323l.594.917s-2.073.352-4.143.263v-.003l-.001-.002c.817-2.013 1.927-3.675 1.927-3.675l.625.963zm-4.36-8.079h5.218v2.091h-7.304V7.227h2.087v7.318z'/%3E%3C/g%3E%3C/svg%3E");
+}

--- a/static/sass/_snapcraft_release.scss
+++ b/static/sass/_snapcraft_release.scss
@@ -63,7 +63,7 @@
     align-items: center;
     background: transparent;
     border-radius: 3px;
-    color: $color-mid-dark;
+    color: $color-dark;
     display: flex;
     font-size: .8rem;
     line-height: .8rem;
@@ -73,15 +73,18 @@
   .p-releases-table__branches {
     bottom: .2rem;
     cursor: pointer;
+    opacity: .6;
     padding: .2rem $sph-intra--condensed;
     right: .2rem;
 
-    &:hover {
-      background: rgba($color-x-light, .7);
+    &:hover,
+    &.is-open {
+      background: $color-x-light;
+      opacity: 1;
     }
 
     .p-icon {
-      @include snapcraft-icon-branch($color-mid-dark, "8px", "11px");
+      @include snapcraft-icon-branch($color-dark, "8px", "11px");
       top: 2px;
     }
   }
@@ -221,25 +224,34 @@
   }
 
   .p-release-data__icon {
+    border-radius: 3px;
     cursor: pointer;
     opacity: 0;
+    padding: 0 $sph-intra--condensed;
     position: absolute;
-    right: 10px;
-    top: 8px;
+    right: .5rem;
+    top: .5rem;
+  }
+
+  .p-release-data:hover {
+    .p-release-data__icon {
+      opacity: .6;
+
+      &:hover {
+        background-color: $color-x-light;
+        opacity: 1;
+      }
+    }
+  }
+
+  .p-releases-table__cell.is-active .p-release-data__icon {
+    opacity: 1;
   }
 
   .is-pending {
     .p-release-data__icon {
       margin-right: 20px;
     }
-  }
-
-  .p-release-data:hover .p-release-data__icon {
-    opacity: .6;
-  }
-
-  .p-releases-table__cell.is-active .p-release-data__icon {
-    opacity: 1;
   }
 
   .p-release-data__info--empty {

--- a/static/sass/_snapcraft_release.scss
+++ b/static/sass/_snapcraft_release.scss
@@ -60,21 +60,21 @@
 
   .p-releases-table__branches,
   .p-releases-table__branch-timeleft {
-    position: absolute;
+    align-items: center;
+    background: transparent;
+    border-radius: 3px;
     color: $color-mid-dark;
+    display: flex;
     font-size: .8rem;
     line-height: .8rem;
-    display: flex;
-    align-items: center;
-    border-radius: 3px;
-    background: transparent;
+    position: absolute;
   }
 
   .p-releases-table__branches {
-    padding: .2rem $sph-intra--condensed;
-    cursor: pointer;
-    right: .2rem;
     bottom: .2rem;
+    cursor: pointer;
+    padding: .2rem $sph-intra--condensed;
+    right: .2rem;
 
     &:hover {
       background: rgba($color-x-light, .7);
@@ -221,6 +221,8 @@
   }
 
   .p-release-data__icon {
+    cursor: pointer;
+    opacity: 0;
     position: absolute;
     right: 10px;
     top: 8px;
@@ -230,6 +232,14 @@
     .p-release-data__icon {
       margin-right: 20px;
     }
+  }
+
+  .p-release-data:hover .p-release-data__icon {
+    opacity: .6;
+  }
+
+  .p-releases-table__cell.is-active .p-release-data__icon {
+    opacity: 1;
   }
 
   .p-release-data__info--empty {
@@ -457,5 +467,9 @@
   .p-icon--drag {
     @extend %icon;
     background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' height='12' width='12'%3E%3Cpath fill-rule='nonzero' fill='%23666' d='M4 3a1 1 0 1 1 0-2 1 1 0 0 1 0 2zm0 4a1 1 0 1 1 0-2 1 1 0 0 1 0 2zm0 4a1 1 0 1 1 0-2 1 1 0 0 1 0 2zm4-8a1 1 0 1 1 0-2 1 1 0 0 1 0 2zm0 4a1 1 0 1 1 0-2 1 1 0 0 1 0 2zm0 4a1 1 0 1 1 0-2 1 1 0 0 1 0 2z'/%3E%3C/svg%3E");
+  }
+
+  .p-icon--history {
+    @include snapcraft-icon-history($color-dark);
   }
 }


### PR DESCRIPTION
Fixes https://github.com/canonical-web-and-design/snapcraft.io/issues/2080

## QA
- Pull the branch
- `./run`
- Visit http://0.0.0.0:8004/lukewh-test/releases
- Hovering around the table should show the history icon in the top right of cells
- Clicking on the icon should expand the history for that channel/arch combo
- Clicking again should close the history
- Click the "x" in the top right of the history table should also close the history
- If you promote a channel/arch (drag to another cell) the history icon should move to the left to make space for the "x" cancel icon