### PR TITLE
Limit branches shown to 10

### DIFF
--- a/static/js/publisher/release/components/releasesTableRow.js
+++ b/static/js/publisher/release/components/releasesTableRow.js
@@ -70,8 +70,13 @@ const ReleasesTableRow = props => {
     archs,
     pendingChannelMap,
     openBranches,
-    availableBranches
+    availableBranches,
+    isVisible
   } = props;
+
+  if (!isVisible) {
+    return null;
+  }
 
   const branchName = branch ? branch.branch : null;
 
@@ -80,7 +85,7 @@ const ReleasesTableRow = props => {
     const parentChannel = getChannelName(currentTrack, risk);
 
     if (!openBranches || !openBranches.includes(parentChannel)) {
-      return false;
+      return null;
     }
   }
 
@@ -418,12 +423,17 @@ const ReleasesTableRow = props => {
   );
 };
 
+ReleasesTableRow.defaultProps = {
+  isVisible: true
+};
+
 ReleasesTableRow.propTypes = {
   // props
   risk: PropTypes.string.isRequired,
   branch: PropTypes.object,
   numberOfBranches: PropTypes.number,
   availableBranches: PropTypes.array,
+  isVisible: PropTypes.bool,
 
   // state
   currentTrack: PropTypes.string.isRequired,

--- a/static/sass/_snapcraft_release.scss
+++ b/static/sass/_snapcraft_release.scss
@@ -44,6 +44,12 @@
     }
   }
 
+  .p-releases-table__row--show-all {
+    height: 3rem;
+    line-height: 2rem;
+    margin-left: 4rem;
+  }
+
   .p-releases-table__row--heading {
     height: 2rem;
   }


### PR DESCRIPTION
Fixes https://github.com/canonical-web-and-design/snapcraft.io/issues/2082
Fixes https://github.com/canonical-web-and-design/snapcraft.io/issues/2083

## QA
- Pull the branch
- `./run`
- Visit http://0.0.0.0:8004/lukewh-test/releases
- latest/stable should claim to have ~13 branches
- click the branches icon/label
- See 10 branches
- Scroll to the bottom and click the "Show all branches (13)" link
- See all 13 branches
- Scroll to the bottom and click the "Show only 10 branches" link
- The list should compact again
- Dragging and dropping should work as expected with 10 or all branches shown
- latest/edge should have 1 branch, but no link to "see all"
- Joy and happiness in snap-world