### PR TITLE
Use default track for channel map if set

### DIFF
--- a/static/js/public/snap-details/channelMap.js
+++ b/static/js/public/snap-details/channelMap.js
@@ -7,11 +7,7 @@ class ChannelMap {
     this.packageName = packageName;
     this.currentTab = "overview";
 
-    if (!defaultTrack) {
-      this.defaultTrack = "latest";
-    } else {
-      this.defaultTrack = defaultTrack;
-    }
+    this.defaultTrack = defaultTrack;
 
     this.selectorString = selectorString;
     this.channelMapEl = document.querySelector(this.selectorString);
@@ -312,10 +308,10 @@ class ChannelMap {
     let paramString = "";
 
     // By default no params are required
-    // If you switch risk on latest you can use the shorthand --{risk} syntax
+    // If you switch risk on the default track you can use the shorthand --{risk} syntax
     // For all other tracks and risks, use the full --channel={channel} syntax
-    if (channel.indexOf("latest/") === 0) {
-      if (channel !== "latest/stable") {
+    if (channel.indexOf(`${this.defaultTrack}`) === 0) {
+      if (channel !== `${this.defaultTrack}/stable`) {
         paramString = ` --${channel.split("/")[1]}`;
       }
     } else {

--- a/templates/store/snap-details/_channel_map.html
+++ b/templates/store/snap-details/_channel_map.html
@@ -25,7 +25,7 @@
             class="p-code-snippet__input"
             id="snap-install"
             value="{{ install_snippet(
-                  package_name, default_track, default_track, lowest_risk_available, confinement
+                  package_name, default_track, lowest_risk_available, confinement
                   ) }}"
             readonly="readonly"
           />

--- a/templates/store/snap-details/_channel_map.html
+++ b/templates/store/snap-details/_channel_map.html
@@ -6,7 +6,7 @@
         <label>Ubuntu 16.04 or later?</label>
         <button
           data-snap="{{ package_name }}
-            {% if default_track != 'latest' or lowest_risk_available != 'stable' %}
+            {% if lowest_risk_available != 'stable' %}
               ?channel={{ default_track }}/{{ lowest_risk_available }}
             {% endif %}"
           class="p-view-store-button"
@@ -25,7 +25,7 @@
             class="p-code-snippet__input"
             id="snap-install"
             value="{{ install_snippet(
-                  package_name, default_track, lowest_risk_available, confinement
+                  package_name, default_track, default_track, lowest_risk_available, confinement
                   ) }}"
             readonly="readonly"
           />

--- a/tests/store/tests_details.py
+++ b/tests/store/tests_details.py
@@ -80,6 +80,7 @@ class GetDetailsPageTest(TestCase):
         payload = {
             "snap-id": "id",
             "name": "snapName",
+            "default-track": None,
             "snap": {
                 "title": "Snap Title",
                 "summary": "This is a summary",
@@ -111,6 +112,7 @@ class GetDetailsPageTest(TestCase):
         payload = {
             "snap-id": "id",
             "name": "toto",
+            "default-track": None,
             "snap": {
                 "title": "Snap Title",
                 "summary": "This is a summary",
@@ -172,6 +174,7 @@ class GetDetailsPageTest(TestCase):
         payload = {
             "snap-id": "id",
             "name": "snapName",
+            "default-track": None,
             "snap": {
                 "title": "Snap Title",
                 "summary": "This is a summary",
@@ -225,6 +228,7 @@ class GetDetailsPageTest(TestCase):
         payload = {
             "snap-id": "id",
             "name": "snapName",
+            "default-track": None,
             "snap": {
                 "title": "Snap Title",
                 "summary": "This is a summary",

--- a/tests/store/tests_distro_page.py
+++ b/tests/store/tests_distro_page.py
@@ -9,6 +9,7 @@ class GetDistroPageTest(TestCase):
     snap_payload = {
         "snap-id": "id",
         "name": "snapName",
+        "default-track": None,
         "snap": {
             "title": "Snap Title",
             "summary": "This is a summary",

--- a/tests/store/tests_embedded_card.py
+++ b/tests/store/tests_embedded_card.py
@@ -9,6 +9,7 @@ class GetEmbeddedCardTest(TestCase):
     snap_payload = {
         "snap-id": "id",
         "name": "snapName",
+        "default-track": None,
         "snap": {
             "title": "Snap Title",
             "summary": "This is a summary",

--- a/tests/store/tests_github_badge.py
+++ b/tests/store/tests_github_badge.py
@@ -9,6 +9,7 @@ class GetGitHubBadgeTest(TestCase):
     snap_payload = {
         "snap-id": "id",
         "name": "snapName",
+        "default-track": None,
         "snap": {
             "title": "Snap Title",
             "summary": "This is a summary",

--- a/tests/store/tests_github_badge.py
+++ b/tests/store/tests_github_badge.py
@@ -9,7 +9,7 @@ class GetGitHubBadgeTest(TestCase):
     snap_payload = {
         "snap-id": "id",
         "name": "snapName",
-        "default-track": None,
+        "default-track": "test",
         "snap": {
             "title": "Snap Title",
             "summary": "This is a summary",
@@ -36,7 +36,19 @@ class GetGitHubBadgeTest(TestCase):
                 "version": "1.0",
                 "confinement": "conf",
                 "download": {"size": 100000},
-            }
+            },
+            {
+                "channel": {
+                    "architecture": "amd64",
+                    "name": "stable",
+                    "risk": "stable",
+                    "track": "test",
+                },
+                "created-at": "2018-09-18T14:45:28.064633+00:00",
+                "version": "1.0",
+                "confinement": "conf",
+                "download": {"size": 100000},
+            },
         ],
     }
 

--- a/webapp/helpers.py
+++ b/webapp/helpers.py
@@ -48,7 +48,7 @@ def get_licenses():
 def get_default_track(snap_name):
     # until default tracks are supported by the API we special case node
     # to use 10, rather then latest
-    default_track = "10" if snap_name == "node" else "latest"
+    default_track = "10" if snap_name == "node" else None
 
     return default_track
 

--- a/webapp/store/snap_details_views.py
+++ b/webapp/store/snap_details_views.py
@@ -104,11 +104,7 @@ def snap_details_views(store, api, handle_errors):
         # to use 10, rather then latest
         default_track = helpers.get_default_track(details["name"])
         if not default_track:
-            default_track = (
-                details["default-track"]
-                if details["default-track"]
-                else "latest"
-            )
+            default_track = details.get("default-track", "latest")
 
         lowest_risk_available = logic.get_lowest_available_risk(
             channel_maps_list, default_track

--- a/webapp/store/snap_details_views.py
+++ b/webapp/store/snap_details_views.py
@@ -103,6 +103,12 @@ def snap_details_views(store, api, handle_errors):
         # until default tracks are supported by the API we special case node
         # to use 10, rather then latest
         default_track = helpers.get_default_track(details["name"])
+        if not default_track:
+            default_track = (
+                details["default-track"]
+                if details["default-track"]
+                else "latest"
+            )
 
         lowest_risk_available = logic.get_lowest_available_risk(
             channel_maps_list, default_track

--- a/webapp/template_utils.py
+++ b/webapp/template_utils.py
@@ -80,7 +80,7 @@ def static_url(filename):
 
 
 def install_snippet(
-    package_name, track, default_track, lowest_risk_available, confinement
+    package_name, default_track, lowest_risk_available, confinement
 ):
     """
     Template function that returns the snippet value to
@@ -90,9 +90,7 @@ def install_snippet(
 
     snippet_value = "sudo snap install " + package_name
 
-    if track != default_track:
-        snippet_value += f" --channel={default_track}/{lowest_risk_available}"
-    elif lowest_risk_available != "stable":
+    if lowest_risk_available != "stable":
         snippet_value += f" --{lowest_risk_available}"
 
     if confinement == "classic":

--- a/webapp/template_utils.py
+++ b/webapp/template_utils.py
@@ -80,7 +80,7 @@ def static_url(filename):
 
 
 def install_snippet(
-    package_name, default_track, lowest_risk_available, confinement
+    package_name, track, default_track, lowest_risk_available, confinement
 ):
     """
     Template function that returns the snippet value to
@@ -90,7 +90,7 @@ def install_snippet(
 
     snippet_value = "sudo snap install " + package_name
 
-    if default_track != "latest":
+    if track != default_track:
         snippet_value += f" --channel={default_track}/{lowest_risk_available}"
     elif lowest_risk_available != "stable":
         snippet_value += f" --{lowest_risk_available}"


### PR DESCRIPTION
Fixes https://github.com/canonical-web-and-design/snapcraft.io/issues/1968

## QA
- Set your env to point to staging (as described in the README)
- Pull this branch
- `./run`
- Visit http://0.0.0.0:8004/lukewh-test
- The channel map dropdown at the top should have the updated text
- Clicking the dropdown and clicking "install >" on a row should display the appropriate install instructions:
  - As track 2.0 is the default track the install instructions should simple be `snap install lukewh-test`
  - The beta version should be `snap install lukewh-test --edge`
  - The 1.0/beta should be `snap install lukewh-test --channel=1.0/beta`
- Also inspect the "View in Desktop store" buttons to ensure they have the correct format of `snapname?channel` if required.

- You should also check that any other snaps that doesn't have a default track set still show "latest" properly. You can do this pointing the codebase to production/ use the demo
- Also check against production that `/node` is still hardcoded to 10 (temporary)