### PR TITLE
Wider table for fewer archs

### DIFF
--- a/static/js/publisher/release/components/revisionsList.js
+++ b/static/js/publisher/release/components/revisionsList.js
@@ -282,7 +282,9 @@ class RevisionsList extends Component {
               >
                 Revision
               </th>
-              <th scope="col">Version</th>
+              <th scope="col" width="100%">
+                Version
+              </th>
               {showAllColumns && <th scope="col">Channels</th>}
               <th scope="col" width="130px" className="u-align--right">
                 {isReleaseHistory ? "Release date" : "Submission date"}

--- a/static/sass/_snapcraft_release.scss
+++ b/static/sass/_snapcraft_release.scss
@@ -100,6 +100,42 @@
     right: $sph-intra--condensed;
   }
 
+  // This is to have different width items depending on
+  // the number of architectures
+  // See https://www.growingwiththeweb.com/2014/06/detecting-number-of-siblings-with-css.html
+  // For more information
+  .p-releases-table__row {
+    &.p-releases-table__row--heading > div,
+    & > div:not(.is-placeholder) {
+      // 1 arch
+      &:first-child:nth-last-child(2),
+      &:first-child:nth-last-child(2) ~ div {
+        max-width: 50%;
+        width: 50%;
+      }
+
+      // 2 arch
+      &:first-child:nth-last-child(3),
+      &:first-child:nth-last-child(3) ~ div {
+        max-width: 33.3333333%;
+        width: 33.3333333%;
+      }
+    }
+  }
+
+  // Same again for branches
+  .p-releases-table__row--branch > div {
+    // 1 arch
+    &:first-child:nth-last-child(2).p-releases-channel {
+      width: calc(50% - 1rem);
+    }
+
+    // 2 arch
+    &:first-child:nth-last-child(3).p-releases-channel {
+      width: calc(33.333333% - 1rem);
+    }
+  }
+
   // channel cell
 
   .p-releases-channel {


### PR DESCRIPTION
Fixes https://github.com/canonical-web-and-design/snapcraft.io/issues/2078

## QA
- Pull the branch
- `./run`
- Visit http://0.0.0.0:8004/lukewh-test-2/releases
- See how it looks with 1 architecture
- Open things up - look at the branches etc.
- Visit http://0.0.0.0:8004/obs-studio/releases
- See how it looks with 2 architectures
- Visit http://0.0.0.0:8004/lxd/releases
- See how it looks with all the architectures (should be the same as before)