### PR TITLE
Convert double quotes to single to fix XSS issue

### DIFF
--- a/templates/store/search.html
+++ b/templates/store/search.html
@@ -2,7 +2,7 @@
 
 {% block meta_title %}
   {% if query %}
-    Snap search results for "{{ query }}"
+    Snap search results for '{{ query }}'
     {% if category_display %}
       in {{ category_display }}
       {% endif %}


### PR DESCRIPTION
# Summary

To fix the XSS issue:
```
https://snapcraft.io/search?q=accesskey=x%20onclick=alert(/XSS/)%20x
 

      <meta property="og:title" content="
  
    Snap search results for "accesskey=x onclick=alert(/XSS/) x"

— Linux software in the Snap Store
"/>

 
Triggered by Alt+Shift+X in Firefox
```

# QA

- On that branch try to reproduce the issue.
- It shouldn't work anymore.