### PR TITLE
Update docs index topic

### DIFF
--- a/static/sass/_snapcraft_p-docs.scss
+++ b/static/sass/_snapcraft_p-docs.scss
@@ -7,6 +7,12 @@
     max-width: 64.875rem;
     width: 100%;
 
+    // Discourse adds "emoji" <img>s, which are huge
+    // They need to be constrained
+    .emoji {
+      height: 1rem;
+    }
+
     .p-sidebar {
       border-right: .0625rem solid $color-mid-light;
       flex: 0 0 18rem;

--- a/webapp/docs/views.py
+++ b/webapp/docs/views.py
@@ -9,7 +9,7 @@ from canonicalwebteam.search import build_search_view
 def init_docs(app, url_prefix):
     discourse_parser = DocParser(
         api=DiscourseAPI(base_url="https://forum.snapcraft.io/"),
-        index_topic_id=11127,
+        index_topic_id=12443,
         url_prefix=url_prefix,
     )
     discourse_docs = DiscourseDocs(


### PR DESCRIPTION
# Done
Update the docs index topic to make the redirects work with the new `/docs` prefix.

# QA

- Navigate to `/docs`.
- Make sure the navigation links work.

Fixes #2103