### PR TITLE
Sitemap and change search to snapcraft.io/docs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # App dependencies
 bleach==3.1.0
-canonicalwebteam.discourse-docs==0.6.0
+canonicalwebteam.discourse-docs==0.6.4
 canonicalwebteam.yaml-responses==1.1.1
 canonicalwebteam.search==0.1.0
 Flask==1.0.2

--- a/webapp/docs/views.py
+++ b/webapp/docs/views.py
@@ -25,6 +25,6 @@ def init_docs(app, url_prefix):
         "/docs/search",
         "docs-search",
         build_search_view(
-            site="docs.snapcraft.io", template_path="docs/search.html"
+            site="snapcraft.io/docs", template_path="docs/search.html"
         ),
     )


### PR DESCRIPTION
Upgrade to canonicalwebteam.discourse-docs v0.6.2 so we get a
/docs/sitemap.txt endpoint.

Change search to return results from snapcraft.io/docs rather than
docs.snapcraft.io.

QA
--

`./run --env SEARCH_API_KEY={thekey}`, go to `/docs/sitemap.txt` and see it in all its glory.

Go to `/docs/search`, search for things, see the results returned are at `snapcraft.io/docs`.