### PR TITLE
Charmed Kubernetes name change

### DIFF
--- a/templates/_footer.html
+++ b/templates/_footer.html
@@ -12,7 +12,7 @@
         &copy; 2019 Canonical Ltd. <br/>
         Ubuntu and Canonical are registered trademarks of Canonical Ltd.
         <br/>
-        Powered by <a href="https://www.ubuntu.com/kubernetes">the Charmed Distribution of Kubernetes</a>
+        Powered by <a href="https://www.ubuntu.com/kubernetes">Charmed Kubernetes</a>
       <p>
         <small>
           <a


### PR DESCRIPTION
We're calling it "Charmed Kubernetes" now.