### PR TITLE
Update distro page install title and remove duplicate snap

### DIFF
--- a/templates/store/snap-distro-install.html
+++ b/templates/store/snap-distro-install.html
@@ -120,7 +120,7 @@
       <div id="install" class="p-card--highlighted">
         <div class="row">
           <div class="col-10">
-          <h2>Install instructions for snaps on {{ distro_name }}</h2>
+          <h2>Enable snaps on {{ distro_name }} and install {{snap_title}}</h2>
           <p>Snaps are applications packaged with all their dependencies to run on all popular Linux distributions from a single build. They update automatically and roll back gracefully.</p>
           <p>Snaps are discoverable and installable from the <a href="/store">Snap Store</a>, an app store with an audience of millions.</p>
           </div>

--- a/webapp/store/snap_details_views.py
+++ b/webapp/store/snap_details_views.py
@@ -363,12 +363,16 @@ def snap_details_views(store, api, handle_errors):
 
         try:
             featured_snaps_results = api.get_searched_snaps(
-                snap_searched="", category="featured", size=12, page=1
+                snap_searched="", category="featured", size=13, page=1
             )
         except ApiError:
             featured_snaps_results = []
 
-        featured_snaps = logic.get_searched_snaps(featured_snaps_results)
+        featured_snaps = [
+            snap
+            for snap in logic.get_searched_snaps(featured_snaps_results)
+            if snap["package_name"] != snap_name
+        ][:12]
 
         context.update({"featured_snaps": featured_snaps})
         return flask.render_template(


### PR DESCRIPTION
Fixes https://github.com/canonical-web-and-design/snapcraft.io/issues/1993
Fixes https://github.com/canonical-web-and-design/snapcraft.io/issues/1992

## QA
- Pull the branch
- `./run`
- Visit http://0.0.0.0:8004/install/spotify/debian
- The install area title should be update: ["Enable snaps on Debian and install Spotify"](https://github.com/canonical-web-and-design/snapcraft.io/issues/1992)
- Spotify should not appear in the "Other popular snaps..." section
- Try with a few other snaps, both in the "other popular snaps" and not