### PR TITLE
Switch docs index topic back to the original one

### DIFF
--- a/webapp/docs/views.py
+++ b/webapp/docs/views.py
@@ -9,7 +9,7 @@ from canonicalwebteam.search import build_search_view
 def init_docs(app, url_prefix):
     discourse_parser = DocParser(
         api=DiscourseAPI(base_url="https://forum.snapcraft.io/"),
-        index_topic_id=12443,
+        index_topic_id=11127,
         url_prefix=url_prefix,
     )
     discourse_docs = DiscourseDocs(


### PR DESCRIPTION
I've updated the content in https://forum.snapcraft.io/t/snap-documentation/11127 to match the changes that were in https://forum.snapcraft.io/t/snap-docs/12443.

So here I'm switching back to using the original topic, so we can delete the temporary new one.

QA
--

`./run`, go to http://0.0.0.0:8004/docs and see that it looks the same as https://snapcraft.io/docs apart from that the title is "Snap documentation" rather than "Snap docs".

Check navigation links still work.