### PR TITLE
Fix annotated code styles in first snap flow

### DIFF
--- a/static/sass/_patterns_annotated_code.scss
+++ b/static/sass/_patterns_annotated_code.scss
@@ -10,6 +10,12 @@
     text-align: left;
     text-shadow: none;
 
+    code {
+      background: none;
+      box-shadow: none;
+      white-space: pre;
+    }
+
     code b {
       color: $color-positive;
       font-weight: bold;


### PR DESCRIPTION
Fixes styling of annotated code in first snap flow.

### QA

- go to first snap flow "package snap" step
- click on generate snapcraft.yaml
- annotated code should look fine, hovering should show tooltips
- compare with production