### PR TITLE
Vanilla layout fixes for docs

### DIFF
--- a/static/sass/_snapcraft_p-docs.scss
+++ b/static/sass/_snapcraft_p-docs.scss
@@ -4,8 +4,6 @@
   .docs-container {
     display: flex;
     margin: 0 auto;
-    max-width: 64.875rem;
-    width: 100%;
 
     // Discourse adds "emoji" <img>s, which are huge
     // They need to be constrained
@@ -64,6 +62,7 @@
 
     .p-content {
       flex: 5;
+      overflow: hidden;
 
       &__row {
         margin-left: inherit;

--- a/templates/docs/base.html
+++ b/templates/docs/base.html
@@ -2,7 +2,7 @@
 
 {% block content %}
 {% include "docs/_search-bar.html" %}
-<div class="docs-container">
+<div class="docs-container u-fixed-width">
   <aside class="p-sidebar" id="navigation">
     <div class="p-sidebar__banner u-hide--medium u-hide--large">
       <i class="p-sidebar__toggle p-icon--menu"></i>


### PR DESCRIPTION
Fixes #2133 

Fixes width of docs pages with Vanilla 2.0.

### QA

- go to /docs
- make sure they have full width of new page width
- browse some docs, make sure they render ok