### PR TITLE
Fix accordion steps in first snap flow

### DIFF
--- a/static/sass/_patterns_first-snap-flow.scss
+++ b/static/sass/_patterns_first-snap-flow.scss
@@ -23,15 +23,11 @@
     margin-bottom: map-get($sp-after, p) - map-get($nudges, nudge--p);
   }
 
-  .p-accordion__step {
-    display: block;
-    float: left;
-    width: 3rem;
-  }
-
   .p-accordion__panel {
+    $icon-size: map-get($icon-sizes, accordion);
+
     overflow: visible;
-    padding-left: 4rem;
+    padding-left: $sph-inner + $icon-size + $sph-inner; // same as accordion button
   }
 
   .p-form-validation__message {

--- a/templates/first-snap/package.html
+++ b/templates/first-snap/package.html
@@ -8,8 +8,7 @@
         <li class="p-accordion__group">
           <button {% if has_user_chosen_name %}aria-expanded="false"{% else %}aria-expanded="true"{% endif %} type="button" class="p-accordion__tab" id="tab1" role="tab" aria-controls="#tab1-section" >
             <h4 class="u-no-margin--bottom">
-              <span class="p-accordion__step">1.</span>
-              Choose snap name
+              Step 1: Choose snap name
               {% if has_user_chosen_name %}<i class="p-icon--success"></i>{% endif %}
             </h4>
           </button>
@@ -36,8 +35,7 @@
         <li class="p-accordion__group">
           <button {% if has_user_chosen_name %}aria-expanded="true"{% else %}aria-expanded="false"{% endif %} type="button" class="p-accordion__tab" id="tab2" role="tab" aria-controls="#tab2-section" >
             <h4 class="u-no-margin--bottom">
-              <span class="p-accordion__step">2.</span>
-              Download an example app
+              Step 2: Download an example app
               <i class="p-icon--success u-hide"></i>
             </h4>
           </button>
@@ -58,8 +56,7 @@
         <li class="p-accordion__group">
           <button aria-expanded="false" type="button" class="p-accordion__tab" id="tab3" role="tab" aria-controls="#tab3-section" >
             <h4 class="u-no-margin--bottom">
-              <span class="p-accordion__step">3.</span>
-              Download your snapcraft.yaml
+              Step 3: Download your snapcraft.yaml
             </h4>
           </button>
           <section class="p-accordion__panel" id="tab3-section" role="tabpanel" aria-hidden="true" aria-labelledby="tab3-section">

--- a/templates/first-snap/push.html
+++ b/templates/first-snap/push.html
@@ -27,8 +27,7 @@
         <li class="p-accordion__group">
           <button {% if user %}disabled aria-expanded="false"{% else %}aria-expanded="true"{% endif %} type="button" class="p-accordion__tab" id="tab1" role="tab" aria-controls="#tab1-section" >
             <h4 class="u-no-margin--bottom">
-              <span class="p-accordion__step">1.</span>
-              Create an Ubuntu One account
+              Step 1: Create an Ubuntu One account
               {% if user %}<i class="p-icon--success"></i>{% endif %}
             </h4>
           </button>
@@ -51,8 +50,7 @@
         <li class="p-accordion__group">
           <button {% if not user %}disabled aria-expanded="false"{% else %}aria-expanded="true"{% endif %} type="button" class="p-accordion__tab" id="tab2" role="tab" aria-controls="#tab2-section" aria-expanded="false">
             <h4 class="u-no-margin--bottom">
-              <span class="p-accordion__step">2.</span>
-              Register your snap name
+              Step 2: Register your snap name
               <i id="register-name-success" class="p-icon--success u-hide"></i>
             </h4>
           </button>
@@ -85,8 +83,7 @@
         <li class="p-accordion__group">
           <button {% if not user %}disabled{% endif %} type="button" class="p-accordion__tab" id="tab3" role="tab" aria-controls="#tab3-section" aria-expanded="false">
             <h4 class="u-no-margin--bottom">
-              <span class="p-accordion__step">3.</span>
-              Push to the Snap store
+              Step 3: Push to the Snap store
             </h4>
           </button>
           <section class="p-accordion__panel" id="tab3-section" role="tabpanel" aria-hidden="true" aria-labelledby="tab3-section">


### PR DESCRIPTION
Fixes #2134

Updates styles for accordion in first snap flow

### QA

- go to first snap flow
- click through steps to get to accordion (Package step and Push step)
- accordion should have 'Step X:' in headings and layout should look good

<img width="1160" alt="Screenshot 2019-08-07 at 14 19 52" src="https://user-images.githubusercontent.com/83575/62622398-8d29e000-b91e-11e9-9173-eb4d5c7508bb.png">
