### PR TITLE
Update pagination on blog to new pattern

### DIFF
--- a/templates/blog/index.html
+++ b/templates/blog/index.html
@@ -38,7 +38,7 @@
       </form>
     </div>
   {% endif %}
-  </div>
+
   <div class="row u-clearfix">
     {% for article in articles %}
       {% if current_page == 1 and loop.index == 3 %}
@@ -52,51 +52,86 @@
   </div>
 
   <div class="u-fixed-width">
-    <ul class="p-inline-list--middot u-align--center" style="margin-bottom: 1rem;">
+    <ol class="p-pagination u-align--center">
+
       {% if current_page > 1 %}
-        <li class="p-inline-list__item"><a href="/blog?page={{ current_page - 1 }}">Previous</a></li>
+        <li class="p-pagination__item">
+          <a class="p-pagination__link--previous" href="/blog?page={{ current_page - 1 }}" title="Previous page">
+            <i class="p-icon--contextual-menu">Previous page</i>
+          </a>
+        </li>
+      {% else %}
+        <li class="p-pagination__item">
+          <span class="p-pagination__link--previous is-disabled"><i class="p-icon--contextual-menu">Previous page</i></span>
+        </li>
       {% endif %}
 
       {# always show 5 pages in pagination #}
       {% if current_page > 4 and current_page == total_pages %}
-        <li class="p-inline-list__item"><a class="p-link--soft" href="/blog?page={{ current_page - 4 }}">{{ current_page - 4 }}</a></li>
+        <li class="p-pagination__item">
+          <a class="p-pagination__link" href="/blog?page={{ current_page - 4 }}">{{ current_page - 4 }}</a>
+        </li>
       {% endif %}
 
       {% if current_page > 3 and current_page >= total_pages - 1 %}
-        <li class="p-inline-list__item"><a class="p-link--soft" href="/blog?page={{ current_page - 3 }}">{{ current_page - 3 }}</a></li>
+        <li class="p-pagination__item">
+          <a class="p-pagination__link" href="/blog?page={{ current_page - 3 }}">{{ current_page - 3 }}</a>
+        </li>
       {% endif %}
 
       {% if current_page > 2 %}
-        <li class="p-inline-list__item"><a class="p-link--soft" href="/blog?page={{ current_page - 2 }}">{{ current_page - 2 }}</a></li>
+        <li class="p-pagination__item">
+          <a class="p-pagination__link" href="/blog?page={{ current_page - 2 }}">{{ current_page - 2 }}</a>
+        </li>
       {% endif %}
 
       {% if current_page > 1 %}
-        <li class="p-inline-list__item"><a class="p-link--soft" href="/blog?page={{ current_page - 1 }}">{{ current_page - 1 }}</a></li>
+        <li class="p-pagination__item">
+          <a class="p-pagination__link" href="/blog?page={{ current_page - 1 }}">{{ current_page - 1 }}</a>
+        </li>
       {% endif %}
 
       <!-- current page -->
-      <li class="p-inline-list__item"><a class="p-link--strong p-heading--five" href="/blog?page={{ current_page }}"><b>{{ current_page}}</b></a></li>
+      <li class="p-pagination__item">
+        <a class="p-pagination__link is-active" href="/blog?page={{ current_page }}">{{ current_page }}</a>
+      </li>
 
       {% if current_page < total_pages %}
-        <li class="p-inline-list__item"><a class="p-link--soft" href="/blog?page={{ current_page + 1 }}">{{ current_page + 1 }}</a></li>
+        <li class="p-pagination__item">
+          <a class="p-pagination__link" href="/blog?page={{ current_page + 1 }}">{{ current_page + 1 }}</a>
+        </li>
       {% endif %}
 
       {% if current_page < total_pages - 1 %}
-        <li class="p-inline-list__item"><a class="p-link--soft" href="/blog?page={{ current_page + 2 }}">{{ current_page + 2 }}</a></li>
+        <li class="p-pagination__item">
+          <a class="p-pagination__link" href="/blog?page={{ current_page + 2 }}">{{ current_page + 2 }}</a>
+        </li>
       {% endif %}
 
       {% if current_page < total_pages - 2 and current_page <= 2 %}
-        <li class="p-inline-list__item"><a class="p-link--soft" href="/blog?page={{ current_page + 3 }}">{{ current_page + 3 }}</a></li>
+        <li class="p-pagination__item">
+          <a class="p-pagination__link" href="/blog?page={{ current_page + 3 }}">{{ current_page + 3 }}</a>
+        </li>
       {% endif %}
 
       {% if current_page < total_pages - 3 and current_page == 1 %}
-        <li class="p-inline-list__item"><a class="p-link--soft" href="/blog?page={{ current_page + 4 }}">{{ current_page + 4 }}</a></li>
+        <li class="p-pagination__item">
+          <a class="p-pagination__link" href="/blog?page={{ current_page + 4 }}">{{ current_page + 4 }}</a>
+        </li>
       {% endif %}
 
       {% if current_page != total_pages %}
-        <li class="p-inline-list__item"><a href="/blog?page={{ current_page + 1 }}">Next</a></li>
+        <li class="p-pagination__item">
+          <a class="p-pagination__link--next" href="/blog?page={{ current_page + 1 }}" title="Next page">
+            <i class="p-icon--contextual-menu">Next page</i>
+          </a>
+        </li>
+      {% else %}
+        <li class="p-pagination__item">
+          <span class="p-pagination__link--next is-disabled"><i class="p-icon--contextual-menu">Next page</i></span>
+        </li>
       {% endif %}
-    </ul>
+    </ol>
   </div>
 </section>
 


### PR DESCRIPTION
Fixes #2132

Uses new Vanilla pagination pattern on blog

### QA

- go to /blog
- check nice new pagination
- use new pagination
- make sure it works in all the edge cases (first page, last page, etc)

<img width="1137" alt="Screenshot 2019-08-07 at 15 01 26" src="https://user-images.githubusercontent.com/83575/62625052-bd747d00-b924-11e9-91df-69d463906815.png">


Known issues:
- visited pagination buttons get blue (https://github.com/canonical-web-and-design/vanilla-framework/issues/2458)
- pagination is not exactly centred (https://github.com/canonical-web-and-design/vanilla-framework/issues/2459) 