### PR TITLE
Fixes for publicise page

### DIFF
--- a/static/sass/_snapcraft-publicise.scss
+++ b/static/sass/_snapcraft-publicise.scss
@@ -8,4 +8,18 @@
   .snapcraft-publicise__download {
     margin-top: 1.6rem;
   }
+
+  .p-list__item {
+    padding-left: $sph-inner;
+
+    &.is-selected {
+      @include vf-highlight-bar($color-mid-light, left);
+      font-weight: 400;
+
+      // make sure to override link visited color
+      a {
+        color: $color-dark;
+      }
+    }
+  }
 }

--- a/templates/publisher/publicise/_publisher_publicise_layout.html
+++ b/templates/publisher/publicise/_publisher_publicise_layout.html
@@ -14,16 +14,16 @@ Publicise {% if display_title %}{{ display_title }}{% else %}{{ snap_title }}{% 
       <div class="col-3">
         <div class="p-navigation--sidebar">
 
-          <div class="sidebar__content js-sidebar-toggle u-hide" aria-hidden="true">
-            <ul class="p-list sidebar__first-level" data-js="sidebar-first-level">
-              <li>
-                <a class="sidebar__link {% if publicise_page == 'buttons' %}is-selected{% endif %}" href="/{{ snap_name }}/publicise/">Snap Store buttons</a>
+          <div class="sidebar__content">
+            <ul class="p-list">
+              <li class="p-list__item {% if publicise_page == 'buttons' %}is-selected{% endif %}">
+                <a href="/{{ snap_name }}/publicise/">Snap Store buttons</a>
               </li>
-              <li>
-                <a class="sidebar__link {% if publicise_page == 'badges' %}is-selected{% endif %}" href="/{{ snap_name }}/publicise/badges">GitHub badges</a>
+              <li class="p-list__item {% if publicise_page == 'badges' %}is-selected{% endif %}">
+                <a href="/{{ snap_name }}/publicise/badges">GitHub badges</a>
               </li>
-              <li>
-                <a class="sidebar__link {% if publicise_page == 'cards' %}is-selected{% endif %}" href="/{{ snap_name }}/publicise/cards">Embeddable cards</a>
+              <li class="p-list__item {% if publicise_page == 'cards' %}is-selected{% endif %}">
+                <a href="/{{ snap_name }}/publicise/cards">Embeddable cards</a>
               </li>
             </ul>
           </div>

--- a/templates/publisher/publicise/embedded_cards.html
+++ b/templates/publisher/publicise/embedded_cards.html
@@ -57,7 +57,7 @@
       <label>HTML:</label>
     </div>
     <div class="col-7">
-      <div class="p-code-copyable">
+      <div class="p-code-copyable not-cli">
         <code class="p-code-copyable__input" id="snippet-card-html">&lt;iframe src="https://snapcraft.io/{{ snap_name }}/embedded?button=black&channels=true&summary=true&screenshot=true" frameborder="0" width="100%" height="320px" style="border: 1px solid #CCC; border-radius: 2px;" &gt;&lt;/iframe&gt;</code>
         <button class="p-code-copyable__action js-clipboard-copy" data-clipboard-target="#snippet-card-html">Copy to clipboard</button>
       </div>

--- a/templates/publisher/publicise/github_badges.html
+++ b/templates/publisher/publicise/github_badges.html
@@ -24,7 +24,7 @@
       <label>HTML:</label>
     </div>
     <div class="col-7">
-      <div class="p-code-copyable">
+      <div class="p-code-copyable not-cli">
         <code class="p-code-copyable__input" id="snippet-badge-html">&lt;a href="https://snapcraft.io/{{ snap_name }}"&gt;
   &lt;img alt="{{ snap_title }}" src="https://snapcraft.io/{{ snap_name }}/badge.svg" /&gt;
 &lt;/a&gt;</code>
@@ -38,7 +38,7 @@
       <label>Markdown:</label>
     </div>
     <div class="col-7">
-      <div class="p-code-copyable">
+      <div class="p-code-copyable not-cli">
         <code class="p-code-copyable__input" id="snippet-badge-markdown">[![{{ snap_title }}](https://snapcraft.io/{{ snap_name }}/badge.svg)](https://snapcraft.io/{{ snap_name }})</code>
         <button class="p-code-copyable__action js-clipboard-copy" data-clipboard-target="#snippet-badge-markdown">Copy to clipboard</button>
       </div>

--- a/templates/publisher/publicise/store_buttons.html
+++ b/templates/publisher/publicise/store_buttons.html
@@ -51,7 +51,7 @@
           <label>HTML:</label>
         </div>
         <div class="col-7">
-          <div class="p-code-copyable">
+          <div class="p-code-copyable not-cli">
             <code class="p-code-copyable__input" id="snippet-{{ lang }}-black-html">&lt;a href="https://snapcraft.io/{{ snap_name }}"&gt;
   &lt;img alt="{{ data.text }}" src="https://snapcraft.io/static/images/badges/{{ lang }}/snap-store-black.svg" /&gt;
 &lt;/a&gt;</code>
@@ -65,7 +65,7 @@
           <label>Markdown:</label>
         </div>
         <div class="col-7">
-          <div class="p-code-copyable">
+          <div class="p-code-copyable not-cli">
             <code class="p-code-copyable__input" id="snippet-{{ lang }}-black-md">[![{{ data.text }}](https://snapcraft.io/static/images/badges/{{ lang }}/snap-store-black.svg)](https://snapcraft.io/{{ snap_name }})</code>
             <button class="p-code-copyable__action js-clipboard-copy" data-clipboard-target="#snippet-{{ lang }}-black-md">Copy to clipboard</button>
           </div>
@@ -98,7 +98,7 @@
           <label>HTML:</label>
         </div>
         <div class="col-7">
-          <div class="p-code-copyable">
+          <div class="p-code-copyable not-cli">
             <code class="p-code-copyable__input" id="snippet-{{ lang }}-white-html">&lt;a href="https://snapcraft.io/{{ snap_name }}"&gt;
   &lt;img alt="{{ data.text }}" src="https://snapcraft.io/static/images/badges/{{ lang }}/snap-store-white.svg" /&gt;
 &lt;/a&gt;</code>
@@ -112,7 +112,7 @@
           <label>Markdown:</label>
         </div>
         <div class="col-7">
-          <div class="p-code-copyable">
+          <div class="p-code-copyable not-cli">
             <code class="p-code-copyable__input" id="snippet-{{ lang }}-white-md">[![{{ data.text }}](https://snapcraft.io/static/images/badges/{{ lang }}/snap-store-white.svg)](https://snapcraft.io/{{ snap_name }})</code>
             <button class="p-code-copyable__action js-clipboard-copy" data-clipboard-target="#snippet-{{ lang }}-white-md">Copy to clipboard</button>
           </div>


### PR DESCRIPTION
Fixes #2138

- Updates sidebar navigation styles
- Fixes copyable code blocks

### QA

- go to publicise page of any snap
- make sure sidebar navigation is visible and works well
- make sure copyable code blocks look good (have no CLI icon) and work
- make sure functionality of the page works good on all sub pages (changing language of badges, changing settings of embeddable card, etc)

<img width="1150" alt="Screenshot 2019-08-07 at 16 59 00" src="https://user-images.githubusercontent.com/83575/62634719-a3439a80-b936-11e9-8c0e-841a6bf9e573.png">
