### PR TITLE
Added title to docs so they appear on search results

### DIFF
--- a/templates/docs/document.html
+++ b/templates/docs/document.html
@@ -1,7 +1,7 @@
 
 {% extends "docs/base.html" %}
 
-{% block meta_title %}Snapcraft documentation | {{ document.title }} {% endblock %}
+{% block meta_title %} {{ document.title }} | Snapcraft documentation{% endblock %}
 
 {% block content_docs %}
 <div class="p-strip is-shallow">

--- a/templates/docs/document.html
+++ b/templates/docs/document.html
@@ -1,6 +1,8 @@
 
 {% extends "docs/base.html" %}
 
+{% block meta_title %}Snapcraft documentation | {{ document.title }} {% endblock %}
+
 {% block content_docs %}
 <div class="p-strip is-shallow">
     <div class="p-content__row">


### PR DESCRIPTION
Fixes #2161 

### QA Steps
1. Pull the branch or run locally
2. Visit `/docs`
3. Search for something in the docs
4. Results should have different title on results as opposed os current behaviour:

![image](https://user-images.githubusercontent.com/8167677/62688221-54dade00-b9c0-11e9-879f-343443556ce8.png)
