### PR TITLE
Vanilla - Fixes for publisher snap listing

### DIFF
--- a/static/js/publisher/form/AccordionHelp.js
+++ b/static/js/publisher/form/AccordionHelp.js
@@ -33,7 +33,7 @@ class AccordionHelp extends React.Component {
 
     return (
       <Fragment>
-        <p className="p-form-help-text u-no-margin--bottom">
+        <p className="p-form-help-text u-no-margin">
           <a role="button" onClick={this.toggleHelp}>
             {label}
           </a>

--- a/static/js/publisher/form/icon.js
+++ b/static/js/publisher/form/icon.js
@@ -89,7 +89,7 @@ class Icon extends React.Component {
     return (
       <Fragment>
         {this.renderErrors()}
-        <div className="u-vertically-center">
+        <div className="u-flex u-vertically-center">
           <div className="p-editable-icon">
             <FileInput
               restrictions={restrictions}

--- a/static/sass/_snapcraft_market.scss
+++ b/static/sass/_snapcraft_market.scss
@@ -88,7 +88,6 @@
 
   .p-editable-icon__actions {
     display: block;
-    float: left;
   }
 
   .p-editable-icon__delete {

--- a/static/sass/_utilities_flex.scss
+++ b/static/sass/_utilities_flex.scss
@@ -1,0 +1,7 @@
+@mixin u-flex {
+  // There are several issues with using floats for layout in Vanilla 2.0
+  // This utility tries to give tools to overcome some of them
+  .u-flex {
+    display: flex;
+  }
+}

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -214,3 +214,6 @@ $color-navigation-selected: #9c9c9c;
 
 @import 'utilities_no-limit';
 @include u-no-limit;
+
+@import 'utilities_flex';
+@include u-flex;

--- a/templates/publisher/listing.html
+++ b/templates/publisher/listing.html
@@ -407,7 +407,7 @@ Listing details for {% if display_title %}{{ display_title }}{% else %}{{ snap_t
           <div class="js-license p-multiselect__wrapper" {% if license_type != 'simple' %}style="display: none;"{% endif %} id="license-simple-input">
             <input type="text" class="js-multiselect-input" name="license-simple" value="{% if license_type == 'simple' %}{{ license }}{% endif %}" />
             <div class="js-multiselect-holder"></div>
-            <p class="p-form-help-text u-no-margin--bottom">The license(s) under which you will release your snap.<br />Multiple licenses can be selected to indicate alternative choices.</p>
+            <p class="p-form-help-text u-no-margin">The license(s) under which you will release your snap.<br />Multiple licenses can be selected to indicate alternative choices.</p>
           </div>
           <input type="radio" name="license-type" value="custom" id="license-custom-option" {% if license_type == 'custom' %}checked="checked"{% endif %} />
           <label for="license-custom-option">Custom SPDX expression</label>


### PR DESCRIPTION
Fixes #2135

- fixes positioning of delete icon icon
- fixes spacing of helper text on some fields

### QA

- go to listing page of some snaps (with icon, without icon, with screenshots, without, etc)
- check if everything looks and works as expected
- check the preview
- check screeshot/banner drag n drop
- check licences fields
- edit something, save

