### PR TITLE
Publisher settings sticky bar consistent with listings

### DIFF
--- a/static/sass/_snapcraft_market.scss
+++ b/static/sass/_snapcraft_market.scss
@@ -125,6 +125,14 @@
     .p-inline-list__item {
       line-height: 2.3rem;
     }
+
+    [class*="p-button"]:not([class*="p-button__"]) {
+      margin-right: $sph-inner;
+
+      &:last-child {
+        margin-right: 0;
+      }
+    }
   }
 
   .p-market-banner {

--- a/templates/publisher/_header.html
+++ b/templates/publisher/_header.html
@@ -13,7 +13,7 @@
     <a href="/snaps">&lsaquo; My snaps</a>
     <h1 class="p-heading--three">{% if snap_title %}{{ snap_title }}{% else %}{{ snap_name }}{% endif %}</h1>
     <nav class="p-tabs">
-      <ul class="p-tabs__list u-float-right" role="tablist">
+      <ul class="p-tabs__list u-float-right u-no-margin--bottom" role="tablist">
         <li class="p-tabs__item" role="presentation">
           <a
             href="/{{ snap_name }}/listing"

--- a/templates/publisher/listing.html
+++ b/templates/publisher/listing.html
@@ -14,7 +14,7 @@ Listing details for {% if display_title %}{{ display_title }}{% else %}{{ snap_t
     <input type="hidden" name="snap_id" value="{{ snap_id }}" />
 
     <div class="snapcraft-p-sticky" id="store-listing-notification">
-      <div class="row">
+      <div class="row u-no-margin--bottom">
         <div class="col-7">
           <p class="snapcraft-p-market-message u-no-margin--bottom">
             {% if private %}
@@ -30,7 +30,8 @@ Listing details for {% if display_title %}{{ display_title }}{% else %}{{ snap_t
               Preview
               <span class="p-tooltip__message" role="tooltip" id="preview-tooltip">Previews will only work in the same browser, locally</span>
             </button>
-            <button type="submit" class="p-button--positive p-button-spinner js-form-submit u-no-margin--bottom u-float-right" name="submit_apply" value="Save">
+            <a class="p-button--neutral js-form-revert u-no-margin--bottom" href="/account/snaps/{{ snap_name }}/listing">Revert</a>
+            <button type="submit" class="p-button--positive p-button-spinner js-form-submit u-no-margin--bottom" name="submit_apply" value="Save">
               {#
               to force dark icon variant we need a fake --dark class name:
               https://github.com/vanilla-framework/vanilla-framework/issues/1817
@@ -40,7 +41,6 @@ Listing details for {% if display_title %}{{ display_title }}{% else %}{{ snap_t
               </span>
               <span class="p-button__text">Save</span>
             </button>
-            <a class="p-button--neutral js-form-revert u-no-margin--bottom u-float-right" href="/account/snaps/{{ snap_name }}/listing">Revert</a>
           </div>
         </div>
       </div>

--- a/templates/publisher/settings.html
+++ b/templates/publisher/settings.html
@@ -17,7 +17,8 @@ Settings for {% if display_title %}{{ display_title }}{% else %}{{ snap_title }}
       <div class="row">
         <div class="col-5 col-start-large-8">
           <div class="u-align--right u-clearfix">
-            <button type="submit" class="p-button--positive p-button-spinner js-form-submit u-no-margin--bottom u-float-right" name="submit_apply" value="Save">
+            <a class="p-button--neutral js-form-revert u-no-margin--bottom" href="/{{ snap_name }}/settings">Revert</a>
+            <button type="submit" class="p-button--positive p-button-spinner js-form-submit u-no-margin--bottom" name="submit_apply" value="Save">
               {#
               to force dark icon variant we need a fake --dark class name:
               https://github.com/vanilla-framework/vanilla-framework/issues/1817
@@ -27,7 +28,6 @@ Settings for {% if display_title %}{{ display_title }}{% else %}{{ snap_title }}
               </span>
               <span class="p-button__text">Save</span>
             </button>
-            <a class="p-button--neutral js-form-revert u-no-margin--bottom u-float-right" href="/{{ snap_name }}/settings">Revert</a>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Fixes https://github.com/canonical-web-and-design/snapcraft.io/issues/2139

## QA
- Pull the branch
- `./run`
- Visit http://0.0.0.0:8004/snap_name/settings
- Ensure the page works as before
- The sticky bar should look the same as the listing page
- The sticky bar should be tighter
- Both the listing page and settings page sticky bar buttons should go full-width without margins at mobile size