### PR TITLE
Fix td styles for headings in blog posts

### DIFF
--- a/static/sass/_patterns_blog-post.scss
+++ b/static/sass/_patterns_blog-post.scss
@@ -3,10 +3,6 @@
     * {
       max-width: 100%;
     }
-
-    img {
-      padding: 2rem 0;
-    }
   }
 
   .p-blog-aside {


### PR DESCRIPTION
### QA

- go to  https://snapcraft-io-canonical-web-and-design-pr-2182.run.demo.haus/blog/top-snaps-in-2018
- see if headings in blog are rendered correctly

<img width="770" alt="Screenshot 2019-08-12 at 13 58 25" src="https://user-images.githubusercontent.com/83575/62863520-49ade800-bd09-11e9-9a1a-eeeb555e7f74.png">
