### PR TITLE
Removed unsquash fs from all language guides

### DIFF
--- a/webapp/first_snap/content/c/build.yaml
+++ b/webapp/first_snap/content/c/build.yaml
@@ -3,8 +3,6 @@ linux:
   auto:
     - action: Return to the root directory of the project containing your snapcraft.yaml and run snapcraft
       command: snapcraft
-    - action: You will find a .snap file in the same directory that you ran the snapcraft command. You can inspect the contents to ensure it contains all of the application's assets
-      command: unsquashfs -l *.snap
     - action: Install the snap
       command: sudo snap install --devmode --dangerous *.snap
     - action: List your installed snaps to confirm
@@ -16,8 +14,6 @@ linux:
   manual:
     - action: Return to the root directory of the project containing your snapcraft.yaml and run the snapcraft Docker image
       command: docker run -v $PWD:$PWD -w $PWD snapcore/snapcraft snapcraft
-    - action: You will find a .snap file in the same directory that you ran the snapcraft command. You can inspect the contents to ensure it contains all of the application's assets
-      command: unsquashfs -l *.snap
     - action: Install the snap
       command: sudo snap install --devmode --dangerous *.snap
     - action: List your installed snaps to confirm
@@ -30,26 +26,14 @@ macos:
   auto:
     - action: Return to the root directory of the project containing your snapcraft.yaml and run snapcraft
       command: snapcraft
-    - action: You will find a .snap file in the same directory that you ran the snapcraft command. You can inspect the contents to ensure it contains all of the application's assets
-      command: |
-        brew install squashfs
-        unsquashfs -l *.snap
   manual:
     - action: Return to the root directory of the project containing your snapcraft.yaml and run the snapcraft Docker image
       command: docker run -v $PWD:$PWD -w $PWD snapcore/snapcraft snapcraft
-    - action: You will find a .snap file in the same directory that you ran the snapcraft command. You can inspect the contents to ensure it contains all of the application's assets
-      command: |
-        brew install squashfs
-        unsquashfs -l *.snap
 windows:
   auto:
     - action: Run Windows Subsystem for Linux from the Windows Start menu
     - action: Return to the root directory of the project containing your snapcraft.yaml and run snapcraft
       command: snapcraft
-    - action: You will find a .snap file in the same directory that you ran the snapcraft command. You can inspect the contents to ensure it contains all of the application's assets
-      command: unsquashfs -l *.snap
   manual:
     - action: Return to the root directory of the project containing your snapcraft.yaml and run the snapcraft Docker image
       command: docker run -v $PWD:$PWD -w $PWD snapcore/snapcraft snapcraft
-    - action: You will find a .snap file in the same directory that you ran the snapcraft command. You can inspect the contents to ensure it contains all of the application's assets
-      command: unsquashfs -l *.snap

--- a/webapp/first_snap/content/golang/build.yaml
+++ b/webapp/first_snap/content/golang/build.yaml
@@ -3,8 +3,6 @@ linux:
   auto:
     - action: Return to the root directory of the project containing your snapcraft.yaml and run snapcraft
       command: snapcraft
-    - action: You will find a .snap file in the same directory that you ran the snapcraft command. You can inspect the contents to ensure it contains all of the application's assets
-      command: unsquashfs -l *.snap
     - action: Install the snap
       command: sudo snap install --devmode --dangerous *.snap
     - action: List your installed snaps to confirm
@@ -16,8 +14,6 @@ linux:
   manual:
     - action: Return to the root directory of the project containing your snapcraft.yaml and run the snapcraft Docker image
       command: docker run -v $PWD:$PWD -w $PWD snapcore/snapcraft snapcraft
-    - action: You will find a .snap file in the same directory that you ran the snapcraft command. You can inspect the contents to ensure it contains all of the application's assets
-      command: unsquashfs -l *.snap
     - action: Install the snap
       command: sudo snap install --devmode --dangerous *.snap
     - action: List your installed snaps to confirm
@@ -30,26 +26,14 @@ macos:
   auto:
     - action: Return to the root directory of the project containing your snapcraft.yaml and run snapcraft
       command: snapcraft
-    - action: You will find a .snap file in the same directory that you ran the snapcraft command. You can inspect the contents to ensure it contains all of the application's assets
-      command: |
-        brew install squashfs
-        unsquashfs -l *.snap
   manual:
     - action: Return to the root directory of the project containing your snapcraft.yaml and run the snapcraft Docker image
       command: docker run -v $PWD:$PWD -w $PWD snapcore/snapcraft snapcraft
-    - action: You will find a .snap file in the same directory that you ran the snapcraft command. You can inspect the contents to ensure it contains all of the application's assets
-      command: |
-        brew install squashfs
-        unsquashfs -l *.snap
 windows:
   auto:
     - action: Run Windows Subsystem for Linux from the Windows Start menu
     - action: Return to the root directory of the project containing your snapcraft.yaml and run snapcraft
       command: snapcraft
-    - action: You will find a .snap file in the same directory that you ran the snapcraft command. You can inspect the contents to ensure it contains all of the application's assets
-      command: unsquashfs -l *.snap
   manual:
     - action: Return to the root directory of the project containing your snapcraft.yaml and run the snapcraft Docker image
       command: docker run -v $PWD:$PWD -w $PWD snapcore/snapcraft snapcraft
-    - action: You will find a .snap file in the same directory that you ran the snapcraft command. You can inspect the contents to ensure it contains all of the application's assets
-      command: unsquashfs -l *.snap

--- a/webapp/first_snap/content/java/build.yaml
+++ b/webapp/first_snap/content/java/build.yaml
@@ -3,8 +3,6 @@ linux:
   auto:
     - action: Return to the root directory of the project containing your snapcraft.yaml and run snapcraft
       command: snapcraft
-    - action: You will find a .snap file in the same directory that you ran the snapcraft command. You can inspect the contents to ensure it contains all of the application's assets
-      command: unsquashfs -l *.snap
     - action: Install the snap
       command: sudo snap install --devmode --dangerous *.snap
     - action: List your installed snaps to confirm
@@ -16,8 +14,6 @@ linux:
   manual:
     - action: Return to the root directory of the project containing your snapcraft.yaml and run the snapcraft Docker image
       command: docker run -v $PWD:$PWD -w $PWD snapcore/snapcraft snapcraft
-    - action: You will find a .snap file in the same directory that you ran the snapcraft command. You can inspect the contents to ensure it contains all of the application's assets
-      command: unsquashfs -l *.snap
     - action: Install the snap
       command: sudo snap install --devmode --dangerous *.snap
     - action: List your installed snaps to confirm
@@ -30,26 +26,14 @@ macos:
   auto:
     - action: Return to the root directory of the project containing your snapcraft.yaml and run snapcraft
       command: snapcraft
-    - action: You will find a .snap file in the same directory that you ran the snapcraft command. You can inspect the contents to ensure it contains all of the application's assets
-      command: |
-        brew install squashfs
-        unsquashfs -l *.snap
   manual:
     - action: Return to the root directory of the project containing your snapcraft.yaml and run the snapcraft Docker image
       command: docker run -v $PWD:$PWD -w $PWD snapcore/snapcraft snapcraft
-    - action: You will find a .snap file in the same directory that you ran the snapcraft command. You can inspect the contents to ensure it contains all of the application's assets
-      command: |
-        brew install squashfs
-        unsquashfs -l *.snap
 windows:
   auto:
     - action: Run Windows Subsystem for Linux from the Windows Start menu
     - action: Return to the root directory of the project containing your snapcraft.yaml and run snapcraft
       command: snapcraft
-    - action: You will find a .snap file in the same directory that you ran the snapcraft command. You can inspect the contents to ensure it contains all of the application's assets
-      command: unsquashfs -l *.snap
   manual:
     - action: Return to the root directory of the project containing your snapcraft.yaml and run the snapcraft Docker image
       command: docker run -v $PWD:$PWD -w $PWD snapcore/snapcraft snapcraft
-    - action: You will find a .snap file in the same directory that you ran the snapcraft command. You can inspect the contents to ensure it contains all of the application's assets
-      command: unsquashfs -l *.snap

--- a/webapp/first_snap/content/moos/build.yaml
+++ b/webapp/first_snap/content/moos/build.yaml
@@ -3,8 +3,6 @@ linux:
   auto:
     - action: Return to the root directory of the project containing your snapcraft.yaml and run snapcraft
       command: snapcraft
-    - action: You will find a .snap file in the same directory that you ran the snapcraft command. You can inspect the contents to ensure it contains all of the application's assets
-      command: unsquashfs -l *.snap
     - action: Install the snap
       command: sudo snap install --devmode --dangerous *.snap
     - action: List your installed snaps to confirm
@@ -16,8 +14,6 @@ linux:
   manual:
     - action: Return to the root directory of the project containing your snapcraft.yaml and run the snapcraft Docker image
       command: docker run -v $PWD:$PWD -w $PWD snapcore/snapcraft snapcraft
-    - action: You will find a .snap file in the same directory that you ran the snapcraft command. You can inspect the contents to ensure it contains all of the application's assets
-      command: unsquashfs -l *.snap
     - action: Install the snap
       command: sudo snap install --devmode --dangerous *.snap
     - action: List your installed snaps to confirm
@@ -30,26 +26,14 @@ macos:
   auto:
     - action: Return to the root directory of the project containing your snapcraft.yaml and run snapcraft
       command: snapcraft
-    - action: You will find a .snap file in the same directory that you ran the snapcraft command. You can inspect the contents to ensure it contains all of the application's assets
-      command: |
-        brew install squashfs
-        unsquashfs -l *.snap
   manual:
     - action: Return to the root directory of the project containing your snapcraft.yaml and run the snapcraft Docker image
       command: docker run -v $PWD:$PWD -w $PWD snapcore/snapcraft snapcraft
-    - action: You will find a .snap file in the same directory that you ran the snapcraft command. You can inspect the contents to ensure it contains all of the application's assets
-      command: |
-        brew install squashfs
-        unsquashfs -l *.snap
 windows:
   auto:
     - action: Run Windows Subsystem for Linux from the Windows Start menu
     - action: Return to the root directory of the project containing your snapcraft.yaml and run snapcraft
       command: snapcraft
-    - action: You will find a .snap file in the same directory that you ran the snapcraft command. You can inspect the contents to ensure it contains all of the application's assets
-      command: unsquashfs -l *.snap
   manual:
     - action: Return to the root directory of the project containing your snapcraft.yaml and run the snapcraft Docker image
       command: docker run -v $PWD:$PWD -w $PWD snapcore/snapcraft snapcraft
-    - action: You will find a .snap file in the same directory that you ran the snapcraft command. You can inspect the contents to ensure it contains all of the application's assets
-      command: unsquashfs -l *.snap

--- a/webapp/first_snap/content/node/build.yaml
+++ b/webapp/first_snap/content/node/build.yaml
@@ -3,8 +3,6 @@ linux:
   auto:
     - action: Return to the root directory of the project containing your snapcraft.yaml and run snapcraft
       command: snapcraft
-    - action: You will find a .snap file in the same directory that you ran the snapcraft command. You can inspect the contents to ensure it contains all of the application's assets
-      command: unsquashfs -l *.snap
     - action: Install the snap
       command: sudo snap install --devmode --dangerous *.snap
     - action: List your installed snaps to confirm
@@ -16,8 +14,6 @@ linux:
   manual:
     - action: Return to the root directory of the project containing your snapcraft.yaml and run the snapcraft Docker image
       command: docker run -v $PWD:$PWD -w $PWD snapcore/snapcraft snapcraft
-    - action: You will find a .snap file in the same directory that you ran the snapcraft command. You can inspect the contents to ensure it contains all of the application's assets
-      command: unsquashfs -l *.snap
     - action: Install the snap
       command: sudo snap install --devmode --dangerous *.snap
     - action: List your installed snaps to confirm
@@ -30,26 +26,14 @@ macos:
   auto:
     - action: Return to the root directory of the project containing your snapcraft.yaml and run snapcraft
       command: snapcraft
-    - action: You will find a .snap file in the same directory that you ran the snapcraft command. You can inspect the contents to ensure it contains all of the application's assets
-      command: |
-        brew install squashfs
-        unsquashfs -l *.snap
   manual:
     - action: Return to the root directory of the project containing your snapcraft.yaml and run the snapcraft Docker image
       command: docker run -v $PWD:$PWD -w $PWD snapcore/snapcraft snapcraft
-    - action: You will find a .snap file in the same directory that you ran the snapcraft command. You can inspect the contents to ensure it contains all of the application's assets
-      command: |
-        brew install squashfs
-        unsquashfs -l *.snap
 windows:
   auto:
     - action: Run Windows Subsystem for Linux from the Windows Start menu
     - action: Return to the root directory of the project containing your snapcraft.yaml and run snapcraft
       command: snapcraft
-    - action: You will find a .snap file in the same directory that you ran the snapcraft command. You can inspect the contents to ensure it contains all of the application's assets
-      command: unsquashfs -l *.snap
   manual:
     - action: Return to the root directory of the project containing your snapcraft.yaml and run the snapcraft Docker image
       command: docker run -v $PWD:$PWD -w $PWD snapcore/snapcraft snapcraft
-    - action: You will find a .snap file in the same directory that you ran the snapcraft command. You can inspect the contents to ensure it contains all of the application's assets
-      command: unsquashfs -l *.snap

--- a/webapp/first_snap/content/pre-built/build.yaml
+++ b/webapp/first_snap/content/pre-built/build.yaml
@@ -3,8 +3,6 @@ linux:
   auto:
     - action: Return to the root directory of the project containing your snapcraft.yaml and run snapcraft
       command: snapcraft
-    - action: You will find a .snap file in the same directory that you ran the snapcraft command. You can inspect the contents to ensure it contains all of the application's assets
-      command: unsquashfs -l *.snap
     - action: Install the snap
       command: sudo snap install --devmode --dangerous *.snap
     - action: List your installed snaps to confirm
@@ -16,8 +14,6 @@ linux:
   manual:
     - action: Return to the root directory of the project containing your snapcraft.yaml and run the snapcraft Docker image
       command: docker run -v $PWD:$PWD -w $PWD snapcore/snapcraft snapcraft
-    - action: You will find a .snap file in the same directory that you ran the snapcraft command. You can inspect the contents to ensure it contains all of the application's assets
-      command: unsquashfs -l *.snap
     - action: Install the snap
       command: sudo snap install --devmode --dangerous *.snap
     - action: List your installed snaps to confirm
@@ -30,26 +26,14 @@ macos:
   auto:
     - action: Return to the root directory of the project containing your snapcraft.yaml and run snapcraft
       command: snapcraft
-    - action: You will find a .snap file in the same directory that you ran the snapcraft command. You can inspect the contents to ensure it contains all of the application's assets
-      command:  |
-        brew install squashfs
-        unsquashfs -l *.snap
   manual:
     - action: Return to the root directory of the project containing your snapcraft.yaml and run the snapcraft Docker image
       command: docker run -v $PWD:$PWD -w $PWD snapcore/snapcraft snapcraft
-    - action: You will find a .snap file in the same directory that you ran the snapcraft command. You can inspect the contents to ensure it contains all of the application's assets
-      command: |
-        brew install squashfs
-        unsquashfs -l *.snap
 windows:
   auto:
     - action: Run Windows Subsystem for Linux from the Windows Start menu
     - action: Return to the root directory of the project containing your snapcraft.yaml and run snapcraft
       command: snapcraft
-    - action: You will find a .snap file in the same directory that you ran the snapcraft command. You can inspect the contents to ensure it contains all of the application's assets
-      command: unsquashfs -l *.snap
   manual:
     - action: Return to the root directory of the project containing your snapcraft.yaml and run the snapcraft Docker image
       command: docker run -v $PWD:$PWD -w $PWD snapcore/snapcraft snapcraft
-    - action: You will find a .snap file in the same directory that you ran the snapcraft command. You can inspect the contents to ensure it contains all of the application's assets
-      command: unsquashfs -l *.snap

--- a/webapp/first_snap/content/python/build.yaml
+++ b/webapp/first_snap/content/python/build.yaml
@@ -3,8 +3,6 @@ linux:
   auto:
     - action: Return to the root directory of the project containing your snapcraft.yaml and run snapcraft
       command: snapcraft
-    - action: You will find a .snap file in the same directory that you ran the snapcraft command. You can inspect the contents to ensure it contains all of the application's assets
-      command: unsquashfs -l *.snap
     - action: Install the snap
       command: sudo snap install --devmode --dangerous *.snap
     - action: List your installed snaps to confirm
@@ -16,8 +14,6 @@ linux:
   manual:
     - action: Return to the root directory of the project containing your snapcraft.yaml and run the snapcraft Docker image
       command: docker run -v $PWD:$PWD -w $PWD snapcore/snapcraft snapcraft
-    - action: You will find a .snap file in the same directory that you ran the snapcraft command. You can inspect the contents to ensure it contains all of the application's assets
-      command: unsquashfs -l *.snap
     - action: Install the snap
       command: sudo snap install --devmode --dangerous *.snap
     - action: List your installed snaps to confirm
@@ -30,26 +26,14 @@ macos:
   auto:
     - action: Return to the root directory of the project containing your snapcraft.yaml and run snapcraft
       command: snapcraft
-    - action: You will find a .snap file in the same directory that you ran the snapcraft command. You can inspect the contents to ensure it contains all of the application's assets
-      command: |
-        brew install squashfs
-        unsquashfs -l *.snap
   manual:
     - action: Return to the root directory of the project containing your snapcraft.yaml and run the snapcraft Docker image
       command: docker run -v $PWD:$PWD -w $PWD snapcore/snapcraft snapcraft
-    - action: You will find a .snap file in the same directory that you ran the snapcraft command. You can inspect the contents to ensure it contains all of the application's assets
-      command: |
-        brew install squashfs
-        unsquashfs -l *.snap
 windows:
   auto:
     - action: Run Windows Subsystem for Linux from the Windows Start menu
     - action: Return to the root directory of the project containing your snapcraft.yaml and run snapcraft
       command: snapcraft
-    - action: You will find a .snap file in the same directory that you ran the snapcraft command. You can inspect the contents to ensure it contains all of the application's assets
-      command: unsquashfs -l *.snap
   manual:
     - action: Return to the root directory of the project containing your snapcraft.yaml and run the snapcraft Docker image
       command: docker run -v $PWD:$PWD -w $PWD snapcore/snapcraft snapcraft
-    - action: You will find a .snap file in the same directory that you ran the snapcraft command. You can inspect the contents to ensure it contains all of the application's assets
-      command: unsquashfs -l *.snap

--- a/webapp/first_snap/content/ros/build.yaml
+++ b/webapp/first_snap/content/ros/build.yaml
@@ -3,8 +3,6 @@ linux:
   auto:
     - action: Return to the root directory of the project containing your snapcraft.yaml and run snapcraft
       command: snapcraft
-    - action: You will find a .snap file in the same directory that you ran the snapcraft command. You can inspect the contents to ensure it contains all of the application's assets
-      command: unsquashfs -l *.snap
     - action: Install the snap
       command: sudo snap install --devmode --dangerous *.snap
     - action: List your installed snaps to confirm
@@ -16,8 +14,6 @@ linux:
   manual:
     - action: Return to the root directory of the project containing your snapcraft.yaml and run the snapcraft Docker image
       command: docker run -v $PWD:$PWD -w $PWD snapcore/snapcraft snapcraft
-    - action: You will find a .snap file in the same directory that you ran the snapcraft command. You can inspect the contents to ensure it contains all of the application's assets
-      command: unsquashfs -l *.snap
     - action: Install the snap
       command: sudo snap install --devmode --dangerous *.snap
     - action: List your installed snaps to confirm
@@ -30,26 +26,14 @@ macos:
   auto:
     - action: Return to the root directory of the project containing your snapcraft.yaml and run snapcraft
       command: snapcraft
-    - action: You will find a .snap file in the same directory that you ran the snapcraft command. You can inspect the contents to ensure it contains all of the application's assets
-      command: |
-        brew install squashfs
-        unsquashfs -l *.snap
   manual:
     - action: Return to the root directory of the project containing your snapcraft.yaml and run the snapcraft Docker image
       command: docker run -v $PWD:$PWD -w $PWD snapcore/snapcraft snapcraft
-    - action: You will find a .snap file in the same directory that you ran the snapcraft command. You can inspect the contents to ensure it contains all of the application's assets
-      command: |
-        brew install squashfs
-        unsquashfs -l *.snap
 windows:
   auto:
     - action: Run Windows Subsystem for Linux from the Windows Start menu
     - action: Return to the root directory of the project containing your snapcraft.yaml and run snapcraft
       command: snapcraft
-    - action: You will find a .snap file in the same directory that you ran the snapcraft command. You can inspect the contents to ensure it contains all of the application's assets
-      command: unsquashfs -l *.snap
   manual:
     - action: Return to the root directory of the project containing your snapcraft.yaml and run the snapcraft Docker image
       command: docker run -v $PWD:$PWD -w $PWD snapcore/snapcraft snapcraft
-    - action: You will find a .snap file in the same directory that you ran the snapcraft command. You can inspect the contents to ensure it contains all of the application's assets
-      command: unsquashfs -l *.snap

--- a/webapp/first_snap/content/ros2/build.yaml
+++ b/webapp/first_snap/content/ros2/build.yaml
@@ -3,8 +3,6 @@ linux:
   auto:
     - action: Return to the root directory of the project containing your snapcraft.yaml and run snapcraft
       command: snapcraft
-    - action: You will find a .snap file in the same directory that you ran the snapcraft command. You can inspect the contents to ensure it contains all of the application's assets
-      command: unsquashfs -l *.snap
     - action: Install the snap
       command: sudo snap install --devmode --dangerous *.snap
     - action: List your installed snaps to confirm
@@ -16,8 +14,6 @@ linux:
   manual:
     - action: Return to the root directory of the project containing your snapcraft.yaml and run the snapcraft Docker image
       command: docker run -v $PWD:$PWD -w $PWD snapcore/snapcraft snapcraft
-    - action: You will find a .snap file in the same directory that you ran the snapcraft command. You can inspect the contents to ensure it contains all of the application's assets
-      command: unsquashfs -l *.snap
     - action: Install the snap
       command: sudo snap install --devmode --dangerous *.snap
     - action: List your installed snaps to confirm
@@ -30,26 +26,14 @@ macos:
   auto:
     - action: Return to the root directory of the project containing your snapcraft.yaml and run snapcraft
       command: snapcraft
-    - action: You will find a .snap file in the same directory that you ran the snapcraft command. You can inspect the contents to ensure it contains all of the application's assets
-      command: |
-        brew install squashfs
-        unsquashfs -l *.snap
   manual:
     - action: Return to the root directory of the project containing your snapcraft.yaml and run the snapcraft Docker image
       command: docker run -v $PWD:$PWD -w $PWD snapcore/snapcraft snapcraft
-    - action: You will find a .snap file in the same directory that you ran the snapcraft command. You can inspect the contents to ensure it contains all of the application's assets
-      command: |
-        brew install squashfs
-        unsquashfs -l *.snap
 windows:
   auto:
     - action: Run Windows Subsystem for Linux from the Windows Start menu
     - action: Return to the root directory of the project containing your snapcraft.yaml and run snapcraft
       command: snapcraft
-    - action: You will find a .snap file in the same directory that you ran the snapcraft command. You can inspect the contents to ensure it contains all of the application's assets
-      command: unsquashfs -l *.snap
   manual:
     - action: Return to the root directory of the project containing your snapcraft.yaml and run the snapcraft Docker image
       command: docker run -v $PWD:$PWD -w $PWD snapcore/snapcraft snapcraft
-    - action: You will find a .snap file in the same directory that you ran the snapcraft command. You can inspect the contents to ensure it contains all of the application's assets
-      command: unsquashfs -l *.snap

--- a/webapp/first_snap/content/ruby/build.yaml
+++ b/webapp/first_snap/content/ruby/build.yaml
@@ -3,8 +3,6 @@ linux:
   auto:
     - action: Return to the root directory of the project containing your snapcraft.yaml and run snapcraft
       command: snapcraft
-    - action: You will find a .snap file in the same directory that you ran the snapcraft command. You can inspect the contents to ensure it contains all of the application's assets
-      command: unsquashfs -l *.snap
     - action: Install the snap
       command: sudo snap install --devmode --dangerous *.snap
     - action: List your installed snaps to confirm
@@ -16,8 +14,6 @@ linux:
   manual:
     - action: Return to the root directory of the project containing your snapcraft.yaml and run the snapcraft Docker image
       command: docker run -v $PWD:$PWD -w $PWD snapcore/snapcraft snapcraft
-    - action: You will find a .snap file in the same directory that you ran the snapcraft command. You can inspect the contents to ensure it contains all of the application's assets
-      command: unsquashfs -l *.snap
     - action: Install the snap
       command: sudo snap install --devmode --dangerous *.snap
     - action: List your installed snaps to confirm
@@ -30,26 +26,14 @@ macos:
   auto:
     - action: Return to the root directory of the project containing your snapcraft.yaml and run snapcraft
       command: snapcraft
-    - action: You will find a .snap file in the same directory that you ran the snapcraft command. You can inspect the contents to ensure it contains all of the application's assets
-      command: |
-        brew install squashfs
-        unsquashfs -l *.snap
   manual:
     - action: Return to the root directory of the project containing your snapcraft.yaml and run the snapcraft Docker image
       command: docker run -v $PWD:$PWD -w $PWD snapcore/snapcraft snapcraft
-    - action: You will find a .snap file in the same directory that you ran the snapcraft command. You can inspect the contents to ensure it contains all of the application's assets
-      command: |
-        brew install squashfs
-        unsquashfs -l *.snap
 windows:
   auto:
     - action: Run Windows Subsystem for Linux from the Windows Start menu
     - action: Return to the root directory of the project containing your snapcraft.yaml and run snapcraft
       command: snapcraft
-    - action: You will find a .snap file in the same directory that you ran the snapcraft command. You can inspect the contents to ensure it contains all of the application's assets
-      command: unsquashfs -l *.snap
   manual:
     - action: Return to the root directory of the project containing your snapcraft.yaml and run the snapcraft Docker image
       command: docker run -v $PWD:$PWD -w $PWD snapcore/snapcraft snapcraft
-    - action: You will find a .snap file in the same directory that you ran the snapcraft command. You can inspect the contents to ensure it contains all of the application's assets
-      command: unsquashfs -l *.snap

--- a/webapp/first_snap/content/rust/build.yaml
+++ b/webapp/first_snap/content/rust/build.yaml
@@ -3,8 +3,6 @@ linux:
   auto:
     - action: Return to the root directory of the project containing your snapcraft.yaml and run snapcraft
       command: snapcraft
-    - action: You will find a .snap file in the same directory that you ran the snapcraft command. You can inspect the contents to ensure it contains all of the application's assets
-      command: unsquashfs -l *.snap
     - action: Install the snap
       command: sudo snap install --devmode --dangerous *.snap
     - action: List your installed snaps to confirm
@@ -16,8 +14,6 @@ linux:
   manual:
     - action: Return to the root directory of the project containing your snapcraft.yaml and run the snapcraft Docker image
       command: docker run -v $PWD:$PWD -w $PWD snapcore/snapcraft snapcraft
-    - action: You will find a .snap file in the same directory that you ran the snapcraft command. You can inspect the contents to ensure it contains all of the application's assets
-      command: unsquashfs -l *.snap
     - action: Install the snap
       command: sudo snap install --devmode --dangerous *.snap
     - action: List your installed snaps to confirm
@@ -30,26 +26,14 @@ macos:
   auto:
     - action: Return to the root directory of the project containing your snapcraft.yaml and run snapcraft
       command: snapcraft
-    - action: You will find a .snap file in the same directory that you ran the snapcraft command. You can inspect the contents to ensure it contains all of the application's assets
-      command: |
-        brew install squashfs
-        unsquashfs -l *.snap
   manual:
     - action: Return to the root directory of the project containing your snapcraft.yaml and run the snapcraft Docker image
       command: docker run -v $PWD:$PWD -w $PWD snapcore/snapcraft snapcraft
-    - action: You will find a .snap file in the same directory that you ran the snapcraft command. You can inspect the contents to ensure it contains all of the application's assets
-      command: |
-        brew install squashfs
-        unsquashfs -l *.snap
 windows:
   auto:
     - action: Run Windows Subsystem for Linux from the Windows Start menu
     - action: Return to the root directory of the project containing your snapcraft.yaml and run snapcraft
       command: snapcraft
-    - action: You will find a .snap file in the same directory that you ran the snapcraft command. You can inspect the contents to ensure it contains all of the application's assets
-      command: unsquashfs -l *.snap
   manual:
     - action: Return to the root directory of the project containing your snapcraft.yaml and run the snapcraft Docker image
       command: docker run -v $PWD:$PWD -w $PWD snapcore/snapcraft snapcraft
-    - action: You will find a .snap file in the same directory that you ran the snapcraft command. You can inspect the contents to ensure it contains all of the application's assets
-      command: unsquashfs -l *.snap


### PR DESCRIPTION
Fixes [ss#1046](https://github.com/canonical-web-and-design/snap-squad/issues/1046)

### QA Steps

1. Pull the branch or run the demo service
2. Go to the build step of FSF flow and notice there is no reference to unsquashfs on Linux or MacOS
3. Rinse and repeat on all languages
4. #winning 