### PR TITLE
Featured banners

### DIFF
--- a/static/js/publisher/form/AccordionHelp.js
+++ b/static/js/publisher/form/AccordionHelp.js
@@ -24,21 +24,19 @@ class AccordionHelp extends React.Component {
     const { open } = this.state;
     const { name, children } = this.props;
 
-    const classNames = ["row"];
     let label = `Hide ${name.toLowerCase()}`;
     if (!open) {
-      classNames.push("u-hide");
       label = `Show ${name.toLowerCase()}`;
     }
 
     return (
       <Fragment>
-        <p className={`p-form-help-text${open ? " u-no-margin--bottom" : ""}`}>
+        <p className="p-form-help-text">
           <a role="button" onClick={this.toggleHelp}>
             {label}
           </a>
         </p>
-        <div className={classNames.join(" ")}>{children}</div>
+        <div className={`${open ? "" : "u-hide"}`}>{children}</div>
       </Fragment>
     );
   }

--- a/static/js/publisher/form/banner.js
+++ b/static/js/publisher/form/banner.js
@@ -161,46 +161,38 @@ class Banner extends React.Component {
           you eligible to be featured.
         </p>
         <AccordionHelp name="banner restrictions">
-          <div className="col-8">
-            <ul className="u-no-margin--bottom">
-              <li>
-                <small>
-                  Accepted image formats include: <b>JPEG & PNG files</b>
-                </small>
-              </li>
-              <li>
-                <small>
-                  Min resolution: <b>720 x 240 pixels</b>
-                  <br />
-                  <i>
-                    For best results on <a href="/store">the store</a> we
-                    {/*
-                       wtf prettier? having 'or' on a newline removes the space
-                       having it on the same line says "add a newline" using {' '}
-                       complains even more!
-                     */}
-                    recommend a resolution of <b>1920 x 640 pixels</b>
-                    &nbsp;or greater
-                  </i>
-                </small>
-              </li>
-              <li>
-                <small>
-                  Max resolution: <b>4320 x 1440 pixels</b>
-                </small>
-              </li>
-              <li>
-                <small>
-                  Aspect ratio: <b>3:1</b>
-                </small>
-              </li>
-              <li>
-                <small>
-                  File size limit: <b>2MB</b>
-                </small>
-              </li>
-            </ul>
-          </div>
+          <ul>
+            <li>
+              <small>
+                Accepted image formats include: <b>JPEG & PNG files</b>
+              </small>
+            </li>
+            <li>
+              <small>
+                Min resolution: <b>720 x 240 pixels</b>
+                <br />
+                <i>
+                  For best results on <a href="/store">the store</a> we
+                  recommend a resolution of <b>1920 x 640 pixels</b> or greater
+                </i>
+              </small>
+            </li>
+            <li>
+              <small>
+                Max resolution: <b>4320 x 1440 pixels</b>
+              </small>
+            </li>
+            <li>
+              <small>
+                Aspect ratio: <b>3:1</b>
+              </small>
+            </li>
+            <li>
+              <small>
+                File size limit: <b>2MB</b>
+              </small>
+            </li>
+          </ul>
         </AccordionHelp>
       </Fragment>
     );

--- a/static/js/publisher/form/banner.js
+++ b/static/js/publisher/form/banner.js
@@ -162,24 +162,44 @@ class Banner extends React.Component {
         </p>
         <AccordionHelp name="banner restrictions">
           <div className="col-8">
-            <p>
-              <small>
-                Accepted image formats include: <b>JPEG & PNG files</b>
-                <br />
-                Min resolution: <b>720 x 240 pixels</b>
-                <br />
-                Max resolution: <b>4320 x 1440 pixels</b>
-                <br />
-                <i>
-                  For best results on <a href="/store">the store</a> we
-                  recommend a resolution of <b>1920 x 640 pixels</b> or greater
-                </i>
-                <br />
-                Aspect ratio: <b>3:1</b>
-                <br />
-                File size limit: <b>2MB</b>
-              </small>
-            </p>
+            <ul className="u-no-margin--bottom">
+              <li>
+                <small>
+                  Accepted image formats include: <b>JPEG & PNG files</b>
+                </small>
+              </li>
+              <li>
+                <small>
+                  Min resolution: <b>720 x 240 pixels</b>
+                  <br />
+                  <i>
+                    For best results on <a href="/store">the store</a> we
+                    {/*
+                       wtf prettier? having 'or' on a newline removes the space
+                       having it on the same line says "add a newline" using {' '}
+                       complains even more!
+                     */}
+                    recommend a resolution of <b>1920 x 640 pixels</b>
+                    &nbsp;or greater
+                  </i>
+                </small>
+              </li>
+              <li>
+                <small>
+                  Max resolution: <b>4320 x 1440 pixels</b>
+                </small>
+              </li>
+              <li>
+                <small>
+                  Aspect ratio: <b>3:1</b>
+                </small>
+              </li>
+              <li>
+                <small>
+                  File size limit: <b>2MB</b>
+                </small>
+              </li>
+            </ul>
           </div>
         </AccordionHelp>
       </Fragment>

--- a/static/js/publisher/form/banner.js
+++ b/static/js/publisher/form/banner.js
@@ -170,6 +170,8 @@ class Banner extends React.Component {
                 <br />
                 Max resolution: <b>4320 x 1440 pixels</b>
                 <br />
+                Recommended resolution: <b>1920 x 640 pixels</b>
+                <br />
                 Aspect ratio: <b>3:1</b>
                 <br />
                 File size limit: <b>2MB</b>

--- a/static/js/publisher/form/banner.js
+++ b/static/js/publisher/form/banner.js
@@ -170,7 +170,10 @@ class Banner extends React.Component {
                 <br />
                 Max resolution: <b>4320 x 1440 pixels</b>
                 <br />
-                Recommended resolution: <b>1920 x 640 pixels</b>
+                <i>
+                  For best results on <a href="/store">the store</a> we
+                  recommend a resolution of <b>1920 x 640 pixels</b> or greater
+                </i>
                 <br />
                 Aspect ratio: <b>3:1</b>
                 <br />

--- a/static/js/publisher/form/media.js
+++ b/static/js/publisher/form/media.js
@@ -99,50 +99,48 @@ class Media extends React.Component {
   renderRescrictions() {
     return (
       <AccordionHelp name="image restrictions">
-        <div className="col-8">
-          <ul className="u-no-margin--bottom">
-            <li>
-              <small>
-                Accepted image formats include: <b>GIF, JPEG & PNG files</b>
-              </small>
-            </li>
-            <li>
-              <small>
-                Min resolution: <b>480 x 480 pixels</b>
-              </small>
-            </li>
-            <li>
-              <small>
-                Max resolution: <b>3840 x 2160 pixels</b>
-              </small>
-            </li>
-            <li>
-              <small>
-                Aspect ratio: <b>Between 1:2 and 2:1</b>
-              </small>
-            </li>
-            <li>
-              <small>
-                File size limit: <b>2MB</b>
-              </small>
-            </li>
-            <li>
-              <small>
-                Animation min fps: <b>1</b>
-              </small>
-            </li>
-            <li>
-              <small>
-                Animation max fps: <b>30</b>
-              </small>
-            </li>
-            <li>
-              <small>
-                Animation max length: <b>40 seconds</b>
-              </small>
-            </li>
-          </ul>
-        </div>
+        <ul>
+          <li>
+            <small>
+              Accepted image formats include: <b>GIF, JPEG & PNG files</b>
+            </small>
+          </li>
+          <li>
+            <small>
+              Min resolution: <b>480 x 480 pixels</b>
+            </small>
+          </li>
+          <li>
+            <small>
+              Max resolution: <b>3840 x 2160 pixels</b>
+            </small>
+          </li>
+          <li>
+            <small>
+              Aspect ratio: <b>Between 1:2 and 2:1</b>
+            </small>
+          </li>
+          <li>
+            <small>
+              File size limit: <b>2MB</b>
+            </small>
+          </li>
+          <li>
+            <small>
+              Animation min fps: <b>1</b>
+            </small>
+          </li>
+          <li>
+            <small>
+              Animation max fps: <b>30</b>
+            </small>
+          </li>
+          <li>
+            <small>
+              Animation max length: <b>40 seconds</b>
+            </small>
+          </li>
+        </ul>
       </AccordionHelp>
     );
   }

--- a/static/js/publisher/form/media.js
+++ b/static/js/publisher/form/media.js
@@ -100,25 +100,48 @@ class Media extends React.Component {
     return (
       <AccordionHelp name="image restrictions">
         <div className="col-8">
-          <p>
-            <small>
-              Accepted image formats include: <b>GIF, JPEG & PNG files</b>
-              <br />
-              Min resolution: <b>480 x 480 pixels</b>
-              <br />
-              Max resolution: <b>3840 x 2160 pixels</b>
-              <br />
-              Aspect ratio: <b>Between 1:2 and 2:1</b>
-              <br />
-              File size limit: <b>2MB</b>
-              <br />
-              Animation min fps: <b>1</b>
-              <br />
-              Animation max fps: <b>30</b>
-              <br />
-              Animation max length: <b>40 seconds</b>
-            </small>
-          </p>
+          <ul className="u-no-margin--bottom">
+            <li>
+              <small>
+                Accepted image formats include: <b>GIF, JPEG & PNG files</b>
+              </small>
+            </li>
+            <li>
+              <small>
+                Min resolution: <b>480 x 480 pixels</b>
+              </small>
+            </li>
+            <li>
+              <small>
+                Max resolution: <b>3840 x 2160 pixels</b>
+              </small>
+            </li>
+            <li>
+              <small>
+                Aspect ratio: <b>Between 1:2 and 2:1</b>
+              </small>
+            </li>
+            <li>
+              <small>
+                File size limit: <b>2MB</b>
+              </small>
+            </li>
+            <li>
+              <small>
+                Animation min fps: <b>1</b>
+              </small>
+            </li>
+            <li>
+              <small>
+                Animation max fps: <b>30</b>
+              </small>
+            </li>
+            <li>
+              <small>
+                Animation max length: <b>40 seconds</b>
+              </small>
+            </li>
+          </ul>
         </div>
       </AccordionHelp>
     );

--- a/static/sass/_snapcraft_p-featured-snap.scss
+++ b/static/sass/_snapcraft_p-featured-snap.scss
@@ -42,18 +42,11 @@
   .p-featured-snap--generated {
     background-color: $default-color;
     border-radius: $border-radius;
-    column-gap: $sp-xxx-large;
-    display: grid;
-    grid-template-columns: minmax(5rem, 50rem) minmax(1rem, 14rem);
     margin-bottom: $sp-xxx-large;
-    padding: $sph-outer;
+    padding: $spv-inner--large * 2;
     text-decoration: none;
     transition: background-color 1s ease-out, background 1s ease-out;
     width: 100%;
-
-    @media screen and (min-width: $breakpoint-navigation-threshold) {
-      padding: 4.5rem $sp-xxx-large;
-    }
 
     .p-featured-snap__details {
       align-items: center;
@@ -66,15 +59,6 @@
       .p-heading--three {
         padding-top: $sp-large;
       }
-    }
-
-    .p-featured-snap__icon {
-      height: 100%;
-      max-height: 12rem;
-      max-width: 12rem;
-      min-height: 4rem;
-      min-width: 4rem;
-      width: 100%;
     }
 
     &:hover {
@@ -114,8 +98,7 @@
     }
 
     @media screen and (max-width: $breakpoint-small) {
-      column-gap: $sp-x-large;
-      padding: $sp-medium $sp-x-large;
+      padding: $sp-medium;
     }
 
     @media screen and (min-width: $breakpoint-small) {

--- a/static/sass/_snapcraft_p-featured-snap.scss
+++ b/static/sass/_snapcraft_p-featured-snap.scss
@@ -94,6 +94,8 @@
     .p-featured-snap__icon {
       img {
         display: block;
+        min-height: 4rem;
+        min-width: 4rem;
       }
     }
 

--- a/static/sass/_snapcraft_p-featured-snap.scss
+++ b/static/sass/_snapcraft_p-featured-snap.scss
@@ -27,12 +27,24 @@
     }
   }
 
+  .p-featured-snap--banner {
+    background: transparent;
+    display: block;
+    margin-bottom: $sp-xxx-large;
+    padding: 0;
+
+    img {
+      display: block;
+      width: 100%;
+    }
+  }
+
   .p-featured-snap--generated {
     background-color: $default-color;
     border-radius: $border-radius;
     column-gap: $sp-xxx-large;
     display: grid;
-    grid-template-columns: minmax(5rem, 50rem) minmax(1rem, 160px);
+    grid-template-columns: minmax(5rem, 50rem) minmax(1rem, 14rem);
     margin-bottom: $sp-xxx-large;
     padding: $sph-outer;
     text-decoration: none;
@@ -40,7 +52,7 @@
     width: 100%;
 
     @media screen and (min-width: $breakpoint-navigation-threshold) {
-      padding: $sp-x-large $sp-xxx-large;
+      padding: 4.5rem $sp-xxx-large;
     }
 
     .p-featured-snap__details {
@@ -57,8 +69,12 @@
     }
 
     .p-featured-snap__icon {
-      height: 9rem;
-      width: 9rem;
+      height: 100%;
+      max-height: 14rem;
+      max-width: 14rem;
+      min-height: 4rem;
+      min-width: 4rem;
+      width: 100%;
     }
 
     &:hover {

--- a/static/sass/_snapcraft_p-featured-snap.scss
+++ b/static/sass/_snapcraft_p-featured-snap.scss
@@ -70,8 +70,8 @@
 
     .p-featured-snap__icon {
       height: 100%;
-      max-height: 14rem;
-      max-width: 14rem;
+      max-height: 12rem;
+      max-width: 12rem;
       min-height: 4rem;
       min-width: 4rem;
       width: 100%;

--- a/templates/store/_category-partial.html
+++ b/templates/store/_category-partial.html
@@ -2,7 +2,7 @@
   <div class="u-fixed-width">
     {% if has_featured %}
       {% if snaps[0].banner_url %}
-        <a class="p-featured-snap p-featured-snap--banner" href="/{{ snaps[0].package_name }}">
+        <a class="p-featured-snap--banner" href="/{{ snaps[0].package_name }}">
           <img src="{{ snaps[0].banner_url }}" />
         </a>
       {% else %}
@@ -19,7 +19,7 @@
           {% if loop.index != 1 or snap["icon_url"] == "" %}
               {% if has_featured %}
                   {% set icon_size = "large" %}
-                  <div class="col-4 col-medium-3">
+                  <div class="col-4 col-medium-3 col-small-2">
               {% else %}
                   <div class="col-3">
               {% endif %}

--- a/templates/store/_category-partial.html
+++ b/templates/store/_category-partial.html
@@ -19,7 +19,7 @@
           {% if loop.index != 1 or snap["icon_url"] == "" %}
               {% if has_featured %}
                   {% set icon_size = "large" %}
-                  <div class="col-4 col-medium-3 col-small-2">
+                  <div class="col-4 col-medium-3">
               {% else %}
                   <div class="col-3">
               {% endif %}

--- a/templates/store/_category-partial.html
+++ b/templates/store/_category-partial.html
@@ -1,10 +1,16 @@
 <div id="js-snap-{{ category }}">
   <div class="u-fixed-width">
     {% if has_featured %}
+      {% if snaps[0].banner_url %}
+        <a class="p-featured-snap p-featured-snap--banner" href="/{{ snaps[0].package_name }}">
+          <img src="{{ snaps[0].banner_url }}" />
+        </a>
+      {% else %}
         {% if snaps[0]["icon_url"] != "" %}
             {% set snap = snaps[0] %}
             {% include "store/_generated-featured-snap-partial.html" %}
         {% endif %}
+      {% endif %}
     {% endif %}
   </div>
   <div class="row">

--- a/templates/store/_generated-featured-snap-partial.html
+++ b/templates/store/_generated-featured-snap-partial.html
@@ -1,5 +1,5 @@
-<a class="p-featured-snap p-featured-snap--generated is-light" href="/{{ snap.package_name }}">
-    <div class="p-featured-snap__details">
+<a class="row p-featured-snap p-featured-snap--generated is-light" href="/{{ snap.package_name }}">
+    <div class="col-9 col-medium-4 col-small-3 p-featured-snap__details">
         <div class="p-featured-snap__summary">
             <p class="p-muted-heading u-no-margin--bottom">
                 {{ snap.title }}
@@ -12,7 +12,7 @@
             <p class="p-heading--three u-no-margin--bottom">{{ snap.title }}</p>
         </div>
     </div>
-    <div class="p-featured-snap__icon">
+    <div class="col-3 col-medium-2 col-small-1 p-featured-snap__icon">
         <img src="{{ snap.icon_url }}" crossOrigin="anonymous" />
     </div>
 </a>

--- a/templates/store/_generated-featured-snap-partial.html
+++ b/templates/store/_generated-featured-snap-partial.html
@@ -1,5 +1,5 @@
 <a class="row p-featured-snap p-featured-snap--generated is-light" href="/{{ snap.package_name }}">
-    <div class="col-9 col-medium-4 col-small-3 p-featured-snap__details">
+    <div class="col-10 col-medium-4 col-small-3 p-featured-snap__details">
         <div class="p-featured-snap__summary">
             <p class="p-muted-heading u-no-margin--bottom">
                 {{ snap.title }}
@@ -12,7 +12,7 @@
             <p class="p-heading--three u-no-margin--bottom">{{ snap.title }}</p>
         </div>
     </div>
-    <div class="col-3 col-medium-2 col-small-1 p-featured-snap__icon">
+    <div class="col-2 col-medium-2 col-small-1 p-featured-snap__icon">
         <img src="{{ snap.icon_url }}" crossOrigin="anonymous" />
     </div>
 </a>

--- a/templates/store/_generated-featured-snap-partial.html
+++ b/templates/store/_generated-featured-snap-partial.html
@@ -13,6 +13,6 @@
         </div>
     </div>
     <div class="p-featured-snap__icon">
-        <img src="{{ snap.icon_url }}" crossOrigin="anonymous" width="160" height="160" />
+        <img src="{{ snap.icon_url }}" crossOrigin="anonymous" />
     </div>
 </a>

--- a/templates/store/_generated-featured-snap-partial.html
+++ b/templates/store/_generated-featured-snap-partial.html
@@ -9,7 +9,7 @@
             </p>
         </div>
         <div class="p-featured-snap__title">
-            <p class="p-heading--three u-no-margin--bottom">{{ snap.title }}</p>
+            <p class="p-heading--three u-no-margin--bottom u-no-padding--top">{{ snap.title }}</p>
         </div>
     </div>
     <div class="col-2 col-medium-2 col-small-1 p-featured-snap__icon">

--- a/tests/store/tests_get_store_view.py
+++ b/tests/store/tests_get_store_view.py
@@ -58,6 +58,46 @@ class GetStoreViewTest(TestCase):
         self.assert_template_used("store/store.html")
 
     @responses.activate
+    def test_get_store_view_with_featured(self):
+        payload_categories = {}
+        payload_featured_snaps = {
+            "_embedded": {
+                "clickindex:package": [
+                    {
+                        "media": [{"type": "icon", "url": "test.png"}],
+                        "package_name": "featured_test",
+                    }
+                ]
+            },
+            "total": 1,
+        }
+
+        responses.add(
+            responses.Response(
+                method="GET",
+                url=self.categories_api_url,
+                json=payload_categories,
+                status=200,
+            )
+        )
+
+        responses.add(
+            responses.Response(
+                method="GET",
+                url=self.featured_snaps_api_url,
+                json=payload_featured_snaps,
+                status=200,
+            )
+        )
+
+        response = self.client.get(self.endpoint_url)
+
+        assert len(responses.calls) == 2
+        assert response.status_code == 200
+
+        self.assert_template_used("store/store.html")
+
+    @responses.activate
     def test_get_store_view_fail_categories(self):
         payload_categories = {}
         payload_featured_snaps = {}

--- a/tests/store/tests_public_logic.py
+++ b/tests/store/tests_public_logic.py
@@ -310,3 +310,28 @@ class StoreLogicTest(unittest.TestCase):
         result = logic.convert_date(date_test)
 
         self.assertEqual(result, "Today")
+
+    def test_get_snap_banner(self):
+        snap_with_banner = {
+            "media": [
+                {"type": "icon", "url": "icon.png"},
+                {"type": "banner", "url": "banner.png"},
+                {"type": "screenshot", "url": "screenshot.png"},
+            ]
+        }
+
+        result = logic.get_snap_banner_url(snap_with_banner)
+
+        self.assertEqual(result.get("banner_url"), "banner.png")
+
+    def test_get_snap_banner_no_banner(self):
+        snap_with_banner = {
+            "media": [
+                {"type": "icon", "url": "icon.png"},
+                {"type": "screenshot", "url": "screenshot.png"},
+            ]
+        }
+
+        result = logic.get_snap_banner_url(snap_with_banner)
+
+        self.assertEqual(result.get("banner_url"), None)

--- a/webapp/api/store.py
+++ b/webapp/api/store.py
@@ -32,7 +32,7 @@ SNAP_SEARCH_URL = "".join(
         "snaps/search",
         "?q={snap_name}&page={page}&size={size}&scope=wide&arch=wide",
         "&confinement=strict,classic",
-        "&fields=package_name,title,summary,icon_url,publisher,",
+        "&fields=package_name,title,summary,icon_url,media,publisher,",
         "developer_validation,origin",
     ]
 )

--- a/webapp/configs/snapcraft.py
+++ b/webapp/configs/snapcraft.py
@@ -2,4 +2,8 @@ import os
 
 WEBAPP_CONFIG = {"LAYOUT": "_layout.html", "STORE_NAME": "Snap store"}
 
+FEATURED_BANNERS_ENABLED = os.getenv(
+    "FEATURED_BANNERS_ENABLED", "false"
+).lower() in ["1", "t", "true"]
+
 BLOG_CATEGORIES_ENABLED = os.getenv("BLOG_CATEGORIES_ENABLED", "false")

--- a/webapp/store/logic.py
+++ b/webapp/store/logic.py
@@ -29,6 +29,25 @@ def get_searched_snaps(search_results):
     )
 
 
+def get_snap_banner_url(snap_result):
+    """Get snaps banner url from media object
+
+    :param snap_result: the snap dictionnary
+    :returns: the snap dict with banner key
+    """
+    snap_result_with_banner = dict(snap_result)
+
+    def f(x):
+        return x["url"] if x["type"] == "banner" else None
+
+    banner_url = list(filter(f, snap_result_with_banner["media"]))
+
+    if len(banner_url) > 0:
+        snap_result_with_banner["banner_url"] = banner_url[0]["url"]
+
+    return snap_result_with_banner
+
+
 def get_pages_details(url, links):
     """Transform returned navigation links from search API from limit/offset
     to size/page

--- a/webapp/store/logic.py
+++ b/webapp/store/logic.py
@@ -35,17 +35,12 @@ def get_snap_banner_url(snap_result):
     :param snap_result: the snap dictionnary
     :returns: the snap dict with banner key
     """
-    snap_result_with_banner = dict(snap_result)
+    for media in snap_result["media"]:
+        if media["type"] == "banner":
+            snap_result["banner_url"] = media["url"]
+            break
 
-    def f(x):
-        return x["url"] if x["type"] == "banner" else None
-
-    banner_url = list(filter(f, snap_result_with_banner["media"]))
-
-    if len(banner_url) > 0:
-        snap_result_with_banner["banner_url"] = banner_url[0]["url"]
-
-    return snap_result_with_banner
+    return snap_result
 
 
 def get_pages_details(url, links):

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -82,6 +82,11 @@ def store_blueprint(store_query=None, testing=False):
         if len(featured_snaps) == 10 and featured_snaps[0]["icon_url"] == "":
             featured_snaps = featured_snaps[:-1]
 
+        for index in range(len(featured_snaps)):
+            featured_snaps[index] = logic.get_snap_banner_url(
+                featured_snaps[index]
+            )
+
         livestream = snapcraft_logic.get_livestreams()
 
         return (
@@ -317,6 +322,11 @@ def store_blueprint(store_query=None, testing=False):
         # snap from the list to avoid a hanging snap (grid of 9)
         if len(snaps_results) == 10 and snaps_results[0]["icon_url"] == "":
             snaps_results = snaps_results[:-1]
+
+        for index in range(len(snaps_results)):
+            snaps_results[index] = logic.get_snap_banner_url(
+                snaps_results[index]
+            )
 
         context = {
             "category": category,

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -82,10 +82,15 @@ def store_blueprint(store_query=None, testing=False):
         if len(featured_snaps) == 10 and featured_snaps[0]["icon_url"] == "":
             featured_snaps = featured_snaps[:-1]
 
-        for index in range(len(featured_snaps)):
-            featured_snaps[index] = logic.get_snap_banner_url(
-                featured_snaps[index]
-            )
+        featured_banners_enabled = flask.current_app.config.get(
+            "FEATURED_BANNERS_ENABLED"
+        )
+
+        if featured_banners_enabled:
+            for index in range(len(featured_snaps)):
+                featured_snaps[index] = logic.get_snap_banner_url(
+                    featured_snaps[index]
+                )
 
         livestream = snapcraft_logic.get_livestreams()
 
@@ -323,10 +328,15 @@ def store_blueprint(store_query=None, testing=False):
         if len(snaps_results) == 10 and snaps_results[0]["icon_url"] == "":
             snaps_results = snaps_results[:-1]
 
-        for index in range(len(snaps_results)):
-            snaps_results[index] = logic.get_snap_banner_url(
-                snaps_results[index]
-            )
+        featured_banners_enabled = flask.current_app.config.get(
+            "FEATURED_BANNERS_ENABLED"
+        )
+
+        if featured_banners_enabled:
+            for index in range(len(snaps_results)):
+                snaps_results[index] = logic.get_snap_banner_url(
+                    snaps_results[index]
+                )
 
         context = {
             "category": category,


### PR DESCRIPTION
Supersedes https://github.com/canonical-web-and-design/snapcraft.io/pull/2116

## QA
- Pull the branch
- `./run --env FEATURED_BANNERS_ENABLED=True`
- Visit http://0.0.0.0:8004/store
- See featured banner images and updated generated banners
- Visit http://0.0.0.0:8004/snap_name/listing
- Ensure that clicking "Show banner restrictions" under the banner image lists the recommended size of 1920x640