### PR TITLE
Fix navigation breakpoint

### DIFF
--- a/static/sass/_search-form.scss
+++ b/static/sass/_search-form.scss
@@ -7,7 +7,7 @@
   .p-form--search {
     width: 60%;
 
-    @media screen and (max-width: $breakpoint-navigation-threshold) {
+    @media screen and (max-width: $breakpoint-medium) {
       width: 100%;
 
       .p-button--positive {
@@ -22,7 +22,7 @@
         flex-grow: 0;
       }
 
-      @media screen and (max-width: $breakpoint-navigation-threshold) {
+      @media screen and (max-width: $breakpoint-medium) {
         margin-bottom: $spv-outer--medium;
       }
     }

--- a/static/sass/_snapcraft_distro-chart.scss
+++ b/static/sass/_snapcraft_distro-chart.scss
@@ -4,7 +4,7 @@
 
   .snapcraft-distro-chart {
 
-    @media screen and (min-width: $breakpoint-navigation-threshold) {
+    @media screen and (min-width: $breakpoint-medium) {
       max-height: 80vh;
       overflow: auto;
     }

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -5,6 +5,8 @@ $color-navigation-background: #333;
 $color-navigation-border: $color-navigation-background;
 $color-navigation-selected: #9c9c9c;
 
+$breakpoint-navigation-threshold: 800px;
+
 // vanilla patterns
 @import 'vanilla-framework/scss/vanilla';
 


### PR DESCRIPTION
Fixes #2194

Changes navigation breakpoint value to make sure all nav items fit in one line. When they don't mobile nav dropdown should be used instead.
Also updated other components not to rely on navigation breakpoint variable to change layout, but on standard medium breakpoint.

### QA

- ./run or https://snapcraft-io-canonical-web-and-design-pr-2202.run.demo.haus/
- make screen smaller until mobile navigation pops in
- make sure "Forum" link doesn't drop to second line at any width

![nav-wrap](https://user-images.githubusercontent.com/83575/63328409-657c4400-c330-11e9-8cfa-e18429d2d0cf.gif)
