### PR TITLE
Add new tour tooltip card pattern styles.

### DIFF
--- a/static/sass/_snapcraft_tour.scss
+++ b/static/sass/_snapcraft_tour.scss
@@ -1,0 +1,247 @@
+@mixin snapcraft-tour {
+  $color-overlay: transparentize($color-dark, .15);
+  $triangle-height: $sp-unit;
+
+  // some temporary testing overlay
+  body {
+    position: relative;
+  }
+
+  .p-tour-overlay {
+    background: $color-overlay;
+    bottom: 0;
+    left: 0;
+    position: absolute;
+    right: 0;
+    top: 0;
+    z-index: 9999;
+  }
+
+  // triange arrow for tooltips
+  %triangle {
+    &::before,
+    &::after {
+      border: {
+        bottom: $triangle-height solid transparent;
+        left: $triangle-height solid transparent;
+        right: $triangle-height solid transparent;
+        top: $triangle-height solid transparent;
+      }
+      content: '';
+      height: 0;
+      pointer-events: none;
+      position: absolute;
+      width: 0;
+    }
+  }
+
+  // for tooltips below element
+  %triangle--pointing-up {
+    @extend %triangle;
+
+    &::before,
+    &::after {
+      border-bottom-color: $color-mid-light;
+      bottom: 100%;
+    }
+
+    &::after {
+      border-bottom-color: $color-x-light;
+      bottom: calc(100% - 1px);
+    }
+  }
+
+  // for tooltips above element
+  %triangle--pointing-down {
+    @extend %triangle;
+
+    &::before,
+    &::after {
+      border-top-color: $color-mid-light;
+      top: 100%;
+    }
+
+    &::after {
+      border-top-color: $color-x-light;
+      top: calc(100% - 1px);
+    }
+  }
+
+  // horizontal placement of up/down arrow
+  %triangle--on-left {
+    &::before,
+    &::after {
+      left: $sph-inner;
+    }
+  }
+
+  %triangle--on-right {
+    &::before,
+    &::after {
+      right: $sph-inner;
+    }
+  }
+
+  %triangle--on-center-x { // horizontally centered
+    &::before,
+    &::after {
+      left: 50%;
+      transform: translateX(-50%);
+    }
+  }
+
+  // for tooltips on the left of element
+  %triangle--pointing-right {
+    @extend %triangle;
+
+    &::before,
+    &::after {
+      border-left-color: $color-mid-light;
+      left: 100%;
+    }
+
+    &::after {
+      border-left-color: $color-x-light;
+      left: calc(100% - 1px);
+    }
+  }
+
+  // for tooltips on the right of element
+  %triangle--pointing-left {
+    @extend %triangle;
+
+    &::before,
+    &::after {
+      border-right-color: $color-mid-light;
+      right: 100%;
+    }
+
+    &::after {
+      border-right-color: $color-x-light;
+      right: calc(100% - 1px);
+    }
+  }
+
+  // vertical placement of left/right arrow
+  %triangle--on-top {
+    &::before,
+    &::after {
+      top: $spv-inner--large;
+    }
+  }
+
+  %triangle--on-bottom {
+    &::before,
+    &::after {
+      bottom: $spv-inner--large;
+    }
+  }
+
+  %triangle--on-center-y { // vertically center
+    &::before,
+    &::after {
+      top: 50%;
+      transform: translateY(-50%);
+    }
+  }
+
+  // NOTE: name needs to start with `p-card` because of some styles
+  // applied in Vanilla by attribute selector to p-card children
+  .p-card--tour {
+    @extend .p-card; // sass-lint:disable-line placeholder-in-extend
+
+    max-width: 27rem;
+    overflow: visible; // to make tooltip arrow visible
+    position: absolute;
+
+    &.is-tooltip--bottom-left {
+      @extend %triangle--pointing-up;
+      @extend %triangle--on-left;
+    }
+
+    &.is-tooltip--bottom-right {
+      @extend %triangle--pointing-up;
+      @extend %triangle--on-right;
+    }
+
+    &.is-tooltip--bottom,
+    &.is-tooltip--bottom-center {
+      @extend %triangle--pointing-up;
+      @extend %triangle--on-center-x;
+    }
+
+    &.is-tooltip--top-left {
+      @extend %triangle--pointing-down;
+      @extend %triangle--on-left;
+    }
+
+    &.is-tooltip--top-right {
+      @extend %triangle--pointing-down;
+      @extend %triangle--on-right;
+    }
+
+    &.is-tooltip--top,
+    &.is-tooltip--top-center {
+      @extend %triangle--pointing-down;
+      @extend %triangle--on-center-x;
+    }
+
+    &.is-tooltip--right,
+    &.is-tooltip--right-center {
+      @extend %triangle--pointing-left;
+      @extend %triangle--on-center-y;
+    }
+
+    &.is-tooltip--left,
+    &.is-tooltip--left-center {
+      @extend %triangle--pointing-right;
+      @extend %triangle--on-center-y;
+    }
+
+    &.is-tooltip--left-top {
+      @extend %triangle--pointing-right;
+      @extend %triangle--on-top;
+    }
+
+    &.is-tooltip--left-bottom {
+      @extend %triangle--pointing-right;
+      @extend %triangle--on-bottom;
+    }
+
+    &.is-tooltip--right-top {
+      @extend %triangle--pointing-left;
+      @extend %triangle--on-top;
+    }
+
+    &.is-tooltip--right-bottom {
+      @extend %triangle--pointing-left;
+      @extend %triangle--on-bottom;
+    }
+  }
+
+  .p-tour-controls {
+    display: flex;
+    justify-content: space-between;
+
+    margin-top: $spv-inner--large;
+
+    // based on pagination pattern from Vanilla this turns contextual menu
+    // chevron icon into < > arrows
+    // let's hope Vanilla doesn't change this icon to something else ;)
+    .p-icon--contextual-menu.is-next {
+      transform: rotate(-90deg);
+    }
+
+    .p-icon--contextual-menu.is-prev {
+      transform: rotate(90deg);
+    }
+  }
+
+  .p-tour-controls__buttons {
+    display: flex;
+  }
+
+  .p-tour-controls__step {
+    margin-right: $sph-inner;
+  }
+}

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -219,3 +219,6 @@ $color-social-icon-foreground: $color-light;
 
 @import 'utilities_flex';
 @include u-flex;
+
+@import 'snapcraft_tour';
+@include snapcraft-tour;

--- a/templates/index.html
+++ b/templates/index.html
@@ -211,6 +211,68 @@
   </div>
 </section>
 
+
+
+<div class="p-tour-overlay">
+  <div class="p-card--tour is-tooltip--bottom" style="left: 400px; top: 150px">
+    <h4>Welcome to your snap listing page!</h4>
+    <p>Here you can manage the display of your snap listing with the store.</p>
+    <p>We'll give you a quick tour to get you up to speed!</p>
+
+    <p class="p-tour-controls">
+      <span>Done? <a>Skip tour</a>.</span>
+
+      <span class="p-tour-controls__buttons">
+        <small class="p-tour-controls__step">1/11</small>
+        <button class="p-button--neutral is-inline has-icon u-no-margin--bottom">
+          <i class="p-icon--contextual-menu is-prev">Previous step</i>
+        </button>
+        <button class="p-button--positive is-inline has-icon u-no-margin--bottom u-no-margin--right">
+          <i class="p-icon--contextual-menu is-light is-next">Next step</i>
+        </button>
+      </span>
+    </p>
+  </div>
+
+  <div class="p-card--tour is-tooltip--right" style="left: 100px; top: 450px">
+    <h4>Icons attract eyes...</h4>
+    <p>Including and icon will help your snap to stand out making it far more attractive to users browsing graphical interfaces such as snapcraft.io/store and the Snap Store.</p>
+
+    <p class="p-tour-controls">
+      <span>Done? <a>Skip tour</a>.</span>
+
+      <span class="p-tour-controls__buttons">
+        <small class="p-tour-controls__step">2/11</small>
+        <button class="p-button--neutral is-inline has-icon u-no-margin--bottom">
+          <i class="p-icon--contextual-menu is-prev">Previous step</i>
+        </button>
+        <button class="p-button--positive is-inline has-icon u-no-margin--bottom u-no-margin--right">
+          <i class="p-icon--contextual-menu is-light is-next">Next step</i>
+        </button>
+      </span>
+    </p>
+  </div>
+
+  <div class="p-card--tour is-tooltip--top-right" style="top: 700px; right: 200px;">
+    <h4>That's it for now!</h4>
+    <p>If you ever need more help just look for the tour icon.</p>
+    <p>For further information on how to improve your listing check out this blog post.</p>
+    <p>Still need help with something? Contact us.</p>
+    <p class="p-tour-controls">
+      <span>Done? <a>Skip tour</a>.</span>
+
+      <span class="p-tour-controls__buttons">
+        <small class="p-tour-controls__step">11/11</small>
+        <button class="p-button--neutral is-inline has-icon u-no-margin--bottom">
+          <i class="p-icon--contextual-menu is-prev">Previous step</i>
+        </button>
+        <button class="p-button--positive is-inline has-icon u-no-margin--bottom u-no-margin--right">
+          Finish tour
+        </button>
+      </span>
+    </p>
+  </div>
+</div>
 {% endblock %}
 
 {% block scripts %}


### PR DESCRIPTION
Fixes #2196 

This PR provides styles for guided tour tooltip cards.
Spec: https://docs.google.com/document/d/1kfpRShJe0tAA-ZCpUrxeaH8z452y_MqChwJGNk08xQY/edit#heading=h.cylvjjuf8ht2


This is only a style test, it's going to be merged to feature branch where work on rest on the functionality will continue.

### QA

- ./run or https://snapcraft-io-canonical-web-and-design-pr-2203.run.demo.haus/
- check the styling of the tooltips
- in devtools you can change `is-tooltip--` classes to try different positions of arrows.

<img width="1167" alt="Screenshot 2019-08-20 at 17 18 19" src="https://user-images.githubusercontent.com/83575/63360346-882d4d80-c36e-11e9-96d5-368dc4352a51.png">
