### PR TITLE
Fix selectors throwing errors in Safari

### DIFF
--- a/static/js/public/fsf-language-select.js
+++ b/static/js/public/fsf-language-select.js
@@ -38,7 +38,7 @@ function initFSFLanguageSelect(rootEl) {
       if (!isOpen) {
         // find the end of the row of icons to place details panel properly
         var details = rootEl.querySelector(
-          `[data-flow-details='${link.dataset.flowLink}'`
+          `[data-flow-details='${link.dataset.flowLink}']`
         );
 
         if (nextRow) {
@@ -76,7 +76,7 @@ function initFSFLanguageSelect(rootEl) {
   // if there is a hash in URL that corresponds to one of the languages
   // open given language section (for example /first-snap#python)
   const hash = window.location.hash.slice(1);
-  const link = rootEl.querySelector(`[data-flow-link='${hash}'`);
+  const link = rootEl.querySelector(`[data-flow-link='${hash}']`);
   if (link) {
     openDetails(link);
   }


### PR DESCRIPTION
Fixes #2204 

Fixes typo in attribute selectors that causes Safari to fail with error.

### QA
Use Safari on a Mac

- ./run or https://snapcraft-io-canonical-web-and-design-pr-2206.run.demo.haus/
- go to snapcraft home page
- there should be no `SyntaxError` in console 
- go to "Learn how to snap in 30 minutes", click on any language, panel should open with details
- go to first snap flow https://snapcraft-io-canonical-web-and-design-pr-2206.run.demo.haus/first-snap
- language panel should also work correctly
- go to language selector with # in URL https://snapcraft-io-canonical-web-and-design-pr-2206.run.demo.haus//first-snap#ruby (reload page with # in URL)
- language selector should open on given language automatically

<img width="1789" alt="Screenshot 2019-08-22 at 13 40 03" src="https://user-images.githubusercontent.com/83575/63512012-fc88fd80-c4e2-11e9-9483-f093c82c3858.png">
