### PR TITLE
Tour steps functionality

### DIFF
--- a/static/js/publisher/tour.js
+++ b/static/js/publisher/tour.js
@@ -3,10 +3,10 @@ import ReactDOM from "react-dom";
 
 import Tour from "./tour/tour";
 
-export default function initTour() {
-  const tour = document.createElement("div");
-  document.body.appendChild(tour);
-
-  const target = document.querySelector("h2");
-  ReactDOM.render(<Tour target={target} />, tour);
+export default function initTour({ container, target }) {
+  if (document.contains(container) && document.contains(target)) {
+    ReactDOM.render(<Tour target={target} />, container);
+  } else {
+    throw Error("initTour container or target elements not found in document");
+  }
 }

--- a/static/js/publisher/tour.js
+++ b/static/js/publisher/tour.js
@@ -3,10 +3,13 @@ import ReactDOM from "react-dom";
 
 import Tour from "./tour/tour";
 
-export default function initTour({ container, target }) {
-  if (document.contains(container) && document.contains(target)) {
-    ReactDOM.render(<Tour target={target} />, container);
-  } else {
-    throw Error("initTour container or target elements not found in document");
+export default function initTour({ container, steps }) {
+  if (!document.contains(container)) {
+    throw Error("initTour container element not found in document.");
   }
+  if (!steps || !steps.length) {
+    throw Error("initTour expects steps array as an argument.");
+  }
+
+  ReactDOM.render(<Tour steps={steps} />, container);
 }

--- a/static/js/publisher/tour/tour.js
+++ b/static/js/publisher/tour/tour.js
@@ -1,51 +1,8 @@
-import React, { useState, useRef, useEffect } from "react";
+import React, { Fragment, useState } from "react";
 import PropTypes from "prop-types";
 
-import debounce from "../../libs/debounce";
-
-import TourStepCard from "./tourStepCard";
-import TourOverlayMask from "./tourOverlayMask";
-
-export const MASK_OFFSET = 5;
-
-// get rectangle of given DOM element
-// relative to the page, taking scroll into account
-const getRectFromEl = el => {
-  let clientRect = el.getBoundingClientRect();
-  return {
-    top:
-      clientRect.top +
-      (window.pageYOffset || document.documentElement.scrollTop),
-    left:
-      clientRect.left +
-      (window.pageXOffset || document.documentElement.scrollLeft),
-    width: clientRect.width,
-    height: clientRect.height
-  };
-};
-
-// get mask based on rectangle
-const getMaskFromRect = rect => {
-  let top = rect.top - MASK_OFFSET;
-  if (top < 0) {
-    top = 0;
-  }
-
-  let left = rect.left - MASK_OFFSET;
-  if (left < 0) {
-    left = 0;
-  }
-
-  let bottom = rect.top + rect.height + MASK_OFFSET;
-  let right = rect.left + rect.width + MASK_OFFSET;
-
-  return {
-    top,
-    bottom,
-    left,
-    right
-  };
-};
+import TourOverlay from "./tourOverlay";
+import TourBar from "./tourBar";
 
 export default function Tour({ target }) {
   // ignore elements that are not in DOM
@@ -53,41 +10,17 @@ export default function Tour({ target }) {
     target = null;
   }
 
-  const [targetEl, setTargetEl] = useState(target);
-  const overlayEl = useRef(null);
+  const [showTour, setShowTour] = useState(false);
 
-  const mask = targetEl ? getMaskFromRect(getRectFromEl(targetEl)) : null;
-
-  // rerender on resize
-  // it is an unusual use of useState to force rerender, but on resize
-  // the state of component doesn't change, it's the position of elements
-  // in DOM that changes and component needs to rerender to adapt
-  const [, forceUpdate] = useState();
-  const rerender = () => forceUpdate({});
-
-  useEffect(() => {
-    const onResize = debounce(() => rerender(), 500);
-    window.addEventListener("resize", onResize);
-
-    return () => {
-      window.removeEventListener("resize", onResize);
-    };
-  });
-
-  const onClick = event => {
-    // we need to "click through" the overlay to check what is underneath it
-    overlayEl.current.style.pointerEvents = "none";
-    const targetEl = document.elementFromPoint(event.clientX, event.clientY);
-    overlayEl.current.style.pointerEvents = "";
-
-    setTargetEl(targetEl);
-  };
+  const onShowTour = () => setShowTour(true);
+  const onHideTour = () => setShowTour(false);
 
   return (
-    <div className="p-tour-overlay" ref={overlayEl} onClick={onClick}>
-      <TourOverlayMask mask={mask} />
-      <TourStepCard mask={mask} />
-    </div>
+    <Fragment>
+      <TourBar onButtonClick={onShowTour} />
+
+      {showTour && <TourOverlay target={target} onHideClick={onHideTour} />}
+    </Fragment>
   );
 }
 

--- a/static/js/publisher/tour/tour.js
+++ b/static/js/publisher/tour/tour.js
@@ -4,12 +4,7 @@ import PropTypes from "prop-types";
 import TourOverlay from "./tourOverlay";
 import TourBar from "./tourBar";
 
-export default function Tour({ target }) {
-  // ignore elements that are not in DOM
-  if (!document.contains(target)) {
-    target = null;
-  }
-
+export default function Tour({ steps }) {
   const [showTour, setShowTour] = useState(false);
 
   const onShowTour = () => setShowTour(true);
@@ -19,11 +14,11 @@ export default function Tour({ target }) {
     <Fragment>
       <TourBar onButtonClick={onShowTour} />
 
-      {showTour && <TourOverlay target={target} onHideClick={onHideTour} />}
+      {showTour && <TourOverlay steps={steps} onHideClick={onHideTour} />}
     </Fragment>
   );
 }
 
 Tour.propTypes = {
-  target: PropTypes.instanceOf(Element)
+  steps: PropTypes.array
 };

--- a/static/js/publisher/tour/tourBar.js
+++ b/static/js/publisher/tour/tourBar.js
@@ -1,0 +1,18 @@
+import React from "react";
+import PropTypes from "prop-types";
+
+export default function TourBar({ onButtonClick }) {
+  return (
+    <div className="p-tour-bar">
+      <div className="u-fixed-width u-clearfix">
+        <button className="p-tour-bar__button" onClick={onButtonClick}>
+          <i className="p-icon--question">Tour</i>
+        </button>
+      </div>
+    </div>
+  );
+}
+
+TourBar.propTypes = {
+  onButtonClick: PropTypes.func
+};

--- a/static/js/publisher/tour/tourBar.js
+++ b/static/js/publisher/tour/tourBar.js
@@ -5,7 +5,11 @@ export default function TourBar({ onButtonClick }) {
   return (
     <div className="p-tour-bar">
       <div className="u-fixed-width u-clearfix">
-        <button className="p-tour-bar__button" onClick={onButtonClick}>
+        <button
+          className="p-tour-bar__button"
+          data-tour="tour-end"
+          onClick={onButtonClick}
+        >
           <i className="p-icon--question">Tour</i>
         </button>
       </div>

--- a/static/js/publisher/tour/tourOverlay.js
+++ b/static/js/publisher/tour/tourOverlay.js
@@ -6,7 +6,8 @@ import debounce from "../../libs/debounce";
 import TourStepCard from "./tourStepCard";
 import TourOverlayMask from "./tourOverlayMask";
 
-export const MASK_OFFSET = 5;
+const REM = parseFloat(getComputedStyle(document.documentElement).fontSize);
+const MASK_OFFSET = REM / 2; // .5rem  is a default spacing unit in Vanilla
 
 // get rectangle of given DOM element
 // relative to the page, taking scroll into account

--- a/static/js/publisher/tour/tourOverlay.js
+++ b/static/js/publisher/tour/tourOverlay.js
@@ -47,13 +47,13 @@ const getMaskFromRect = rect => {
   };
 };
 
-export default function TourOverlay({ target, onHideClick }) {
-  // ignore elements that are not in DOM
-  if (!document.contains(target)) {
-    target = null;
-  }
+export default function TourOverlay({ steps, onHideClick }) {
+  const [currentStepIndex] = useState(0);
+  const step = steps[currentStepIndex];
 
-  const [targetEl, setTargetEl] = useState(target);
+  const [targetEl, setTargetEl] = useState(
+    document.querySelector(`[data-tour="${step.id}"]`)
+  );
   const overlayEl = useRef(null);
 
   const mask = targetEl ? getMaskFromRect(getRectFromEl(targetEl)) : null;
@@ -86,12 +86,18 @@ export default function TourOverlay({ target, onHideClick }) {
   return (
     <div className="p-tour-overlay" ref={overlayEl} onClick={onClick}>
       <TourOverlayMask mask={mask} />
-      <TourStepCard mask={mask} onHideClick={onHideClick} />
+      <TourStepCard
+        steps={steps}
+        currentStepIndex={currentStepIndex}
+        mask={mask}
+        onHideClick={onHideClick}
+      />
     </div>
   );
 }
 
 TourOverlay.propTypes = {
-  target: PropTypes.instanceOf(Element),
+  steps: PropTypes.array,
+  currentStepIndex: PropTypes.number,
   onHideClick: PropTypes.func
 };

--- a/static/js/publisher/tour/tourOverlay.js
+++ b/static/js/publisher/tour/tourOverlay.js
@@ -1,0 +1,97 @@
+import React, { useState, useRef, useEffect } from "react";
+import PropTypes from "prop-types";
+
+import debounce from "../../libs/debounce";
+
+import TourStepCard from "./tourStepCard";
+import TourOverlayMask from "./tourOverlayMask";
+
+export const MASK_OFFSET = 5;
+
+// get rectangle of given DOM element
+// relative to the page, taking scroll into account
+const getRectFromEl = el => {
+  let clientRect = el.getBoundingClientRect();
+  return {
+    top:
+      clientRect.top +
+      (window.pageYOffset || document.documentElement.scrollTop),
+    left:
+      clientRect.left +
+      (window.pageXOffset || document.documentElement.scrollLeft),
+    width: clientRect.width,
+    height: clientRect.height
+  };
+};
+
+// get mask based on rectangle
+const getMaskFromRect = rect => {
+  let top = rect.top - MASK_OFFSET;
+  if (top < 0) {
+    top = 0;
+  }
+
+  let left = rect.left - MASK_OFFSET;
+  if (left < 0) {
+    left = 0;
+  }
+
+  let bottom = rect.top + rect.height + MASK_OFFSET;
+  let right = rect.left + rect.width + MASK_OFFSET;
+
+  return {
+    top,
+    bottom,
+    left,
+    right
+  };
+};
+
+export default function TourOverlay({ target, onHideClick }) {
+  // ignore elements that are not in DOM
+  if (!document.contains(target)) {
+    target = null;
+  }
+
+  const [targetEl, setTargetEl] = useState(target);
+  const overlayEl = useRef(null);
+
+  const mask = targetEl ? getMaskFromRect(getRectFromEl(targetEl)) : null;
+
+  // rerender on resize
+  // it is an unusual use of useState to force rerender, but on resize
+  // the state of component doesn't change, it's the position of elements
+  // in DOM that changes and component needs to rerender to adapt
+  const [, forceUpdate] = useState();
+  const rerender = () => forceUpdate({});
+
+  useEffect(() => {
+    const onResize = debounce(() => rerender(), 500);
+    window.addEventListener("resize", onResize);
+
+    return () => {
+      window.removeEventListener("resize", onResize);
+    };
+  });
+
+  const onClick = event => {
+    // we need to "click through" the overlay to check what is underneath it
+    overlayEl.current.style.pointerEvents = "none";
+    const targetEl = document.elementFromPoint(event.clientX, event.clientY);
+    overlayEl.current.style.pointerEvents = "";
+
+    setTargetEl(targetEl);
+  };
+
+  return (
+    <div className="p-tour-overlay" ref={overlayEl} onClick={onClick}>
+      <TourOverlayMask mask={mask} />
+      <TourStepCard mask={mask} onHideClick={onHideClick} />
+    </div>
+  );
+}
+
+TourOverlay.propTypes = {
+  target: PropTypes.instanceOf(Element),
+  onHideClick: PropTypes.func
+};

--- a/static/js/publisher/tour/tourStepCard.js
+++ b/static/js/publisher/tour/tourStepCard.js
@@ -37,6 +37,8 @@ export default function TourStepCard({
   // so it should be safe to set it via dangerouslySetInnerHTML
   const content = { __html: step.content };
 
+  const isLastStep = currentStepIndex === steps.length - 1;
+
   return (
     <div
       className={`p-card--tour is-tooltip--${step.position}`}
@@ -65,13 +67,16 @@ export default function TourStepCard({
             <i className="p-icon--contextual-menu is-prev">Previous step</i>
           </button>
           <button
-            disabled={currentStepIndex === steps.length - 1}
-            onClick={onNextClick}
+            onClick={isLastStep ? onHideClick : onNextClick}
             className="p-button--positive is-inline has-icon u-no-margin--bottom u-no-margin--right"
           >
-            <i className="p-icon--contextual-menu is-light is-next">
-              Next step
-            </i>
+            {isLastStep ? (
+              "Finish tour"
+            ) : (
+              <i className="p-icon--contextual-menu is-light is-next">
+                Next step
+              </i>
+            )}
           </button>
         </span>
       </p>

--- a/static/js/publisher/tour/tourStepCard.js
+++ b/static/js/publisher/tour/tourStepCard.js
@@ -1,9 +1,9 @@
 import React from "react";
 import PropTypes from "prop-types";
 
-import { MASK_OFFSET } from "./tour";
+import { MASK_OFFSET } from "./tourOverlay";
 
-export default function TourStepCard({ mask }) {
+export default function TourStepCard({ mask, onHideClick }) {
   let tooltipStyle = {};
 
   if (mask) {
@@ -25,8 +25,7 @@ export default function TourStepCard({ mask }) {
 
       <p className="p-tour-controls">
         <span>
-          Done?{" "}
-          <a href="https://www.youtube.com/watch?v=dQw4w9WgXcQ">Skip tour</a>.
+          Done? <a onClick={onHideClick}>Skip tour</a>.
         </span>
 
         <span className="p-tour-controls__buttons">
@@ -57,5 +56,6 @@ TourStepCard.propTypes = {
     bottom: PropTypes.number,
     left: PropTypes.number,
     right: PropTypes.number
-  })
+  }),
+  onHideClick: PropTypes.func
 };

--- a/static/js/publisher/tour/tourStepCard.js
+++ b/static/js/publisher/tour/tourStepCard.js
@@ -1,23 +1,36 @@
 import React from "react";
 import PropTypes from "prop-types";
 
-import { MASK_OFFSET } from "./tourOverlay";
-
 export default function TourStepCard({
   steps,
   currentStepIndex,
   mask,
-  onHideClick
+  onHideClick,
+  onNextClick,
+  onPrevClick
 }) {
   const step = steps[currentStepIndex];
 
   let tooltipStyle = {};
 
-  if (mask) {
-    tooltipStyle = {
-      top: mask.bottom,
-      left: mask.left > MASK_OFFSET ? mask.left : MASK_OFFSET
-    };
+  // for positioning relative to right/bottom of the screen
+  const overlayHeight = document.body.clientHeight;
+  const overlayWidth = document.body.clientWidth;
+
+  switch (step.position) {
+    // TODO: support for all available tooltip positions
+    case "bottom-left":
+      tooltipStyle = {
+        top: mask.bottom,
+        left: mask.left
+      };
+      break;
+    case "top-right":
+      tooltipStyle = {
+        bottom: overlayHeight - mask.top,
+        right: overlayWidth - mask.right
+      };
+      break;
   }
 
   // step content is controlled by us and passed as data to component directly
@@ -25,7 +38,10 @@ export default function TourStepCard({
   const content = { __html: step.content };
 
   return (
-    <div className="p-card--tour is-tooltip--bottom-left" style={tooltipStyle}>
+    <div
+      className={`p-card--tour is-tooltip--${step.position}`}
+      style={tooltipStyle}
+    >
       <h4>{step.title}</h4>
       <div
         className="p-card--tour__content"
@@ -42,13 +58,15 @@ export default function TourStepCard({
             {currentStepIndex + 1}/{steps.length}
           </small>
           <button
-            disabled
+            disabled={currentStepIndex === 0}
+            onClick={onPrevClick}
             className="p-button--neutral is-inline has-icon u-no-margin--bottom"
           >
             <i className="p-icon--contextual-menu is-prev">Previous step</i>
           </button>
           <button
-            disabled
+            disabled={currentStepIndex === steps.length - 1}
+            onClick={onNextClick}
             className="p-button--positive is-inline has-icon u-no-margin--bottom u-no-margin--right"
           >
             <i className="p-icon--contextual-menu is-light is-next">
@@ -67,9 +85,10 @@ TourStepCard.propTypes = {
     bottom: PropTypes.number,
     left: PropTypes.number,
     right: PropTypes.number
-  }),
-  steps: PropTypes.array,
-  currentStepIndex: PropTypes.number,
-  allStepsCount: PropTypes.number,
-  onHideClick: PropTypes.func
+  }).isRequired,
+  steps: PropTypes.array.isRequired,
+  currentStepIndex: PropTypes.number.isRequired,
+  onHideClick: PropTypes.func.isRequired,
+  onNextClick: PropTypes.func.isRequired,
+  onPrevClick: PropTypes.func.isRequired
 };

--- a/static/js/publisher/tour/tourStepCard.js
+++ b/static/js/publisher/tour/tourStepCard.js
@@ -3,7 +3,14 @@ import PropTypes from "prop-types";
 
 import { MASK_OFFSET } from "./tourOverlay";
 
-export default function TourStepCard({ mask, onHideClick }) {
+export default function TourStepCard({
+  steps,
+  currentStepIndex,
+  mask,
+  onHideClick
+}) {
+  const step = steps[currentStepIndex];
+
   let tooltipStyle = {};
 
   if (mask) {
@@ -13,15 +20,17 @@ export default function TourStepCard({ mask, onHideClick }) {
     };
   }
 
+  // step content is controlled by us and passed as data to component directly
+  // so it should be safe to set it via dangerouslySetInnerHTML
+  const content = { __html: step.content };
+
   return (
     <div className="p-card--tour is-tooltip--bottom-left" style={tooltipStyle}>
-      <h4>Welcome to the demo tour!</h4>
-      <p>
-        This is just a test to see how to position such information and how to
-        mask overlay background to highlight target element.
-      </p>
-      <p>Click around and see how overlay highlights the element.</p>
-      <p>Thank you for testing!</p>
+      <h4>{step.title}</h4>
+      <div
+        className="p-card--tour__content"
+        dangerouslySetInnerHTML={content}
+      />
 
       <p className="p-tour-controls">
         <span>
@@ -29,7 +38,9 @@ export default function TourStepCard({ mask, onHideClick }) {
         </span>
 
         <span className="p-tour-controls__buttons">
-          <small className="p-tour-controls__step">1/1</small>
+          <small className="p-tour-controls__step">
+            {currentStepIndex + 1}/{steps.length}
+          </small>
           <button
             disabled
             className="p-button--neutral is-inline has-icon u-no-margin--bottom"
@@ -57,5 +68,8 @@ TourStepCard.propTypes = {
     left: PropTypes.number,
     right: PropTypes.number
   }),
+  steps: PropTypes.array,
+  currentStepIndex: PropTypes.number,
+  allStepsCount: PropTypes.number,
   onHideClick: PropTypes.func
 };

--- a/static/sass/_snapcraft_tour.scss
+++ b/static/sass/_snapcraft_tour.scss
@@ -7,6 +7,21 @@
     position: relative;
   }
 
+  .p-tour-bar {
+    position: fixed;
+    padding: $spv-inner--medium;
+    bottom: 0;
+    left: 0;
+    right: 0;
+  }
+
+  .p-tour-bar__button {
+    @extend %p-button--neutral;
+
+    float: right;
+    margin: 0;
+  }
+
   .p-tour-overlay {
     bottom: 0;
     left: 0;

--- a/static/sass/_snapcraft_tour.scss
+++ b/static/sass/_snapcraft_tour.scss
@@ -1,6 +1,7 @@
 @mixin snapcraft-tour {
   $color-overlay: transparentize($color-dark, .15);
   $triangle-height: $sp-unit;
+  $triangle-spacing: 2 * $triangle-height;
 
   // some temporary testing overlay
   body {
@@ -14,6 +15,7 @@
     pointer-events: none;
     position: fixed;
     right: 0;
+    z-index: 1;
   }
 
   .p-tour-bar__button {
@@ -63,7 +65,7 @@
   // for tooltips below element
   %triangle--pointing-up {
     @extend %triangle;
-    margin-top: 2 * $triangle-height;
+    margin-top: $triangle-spacing;
 
     &::before,
     &::after {
@@ -80,7 +82,7 @@
   // for tooltips above element
   %triangle--pointing-down {
     @extend %triangle;
-    margin-bottom: 2 * $triangle-height;
+    margin-bottom: $triangle-spacing;
 
     &::before,
     &::after {
@@ -120,7 +122,7 @@
   // for tooltips on the left of element
   %triangle--pointing-right {
     @extend %triangle;
-    margin-left: 2 * $triangle-height;
+    margin-left: $triangle-spacing;
 
     &::before,
     &::after {
@@ -137,7 +139,7 @@
   // for tooltips on the right of element
   %triangle--pointing-left {
     @extend %triangle;
-    margin-right: 2 * $triangle-height;
+    margin-right: $triangle-spacing;
 
     &::before,
     &::after {

--- a/static/sass/_snapcraft_tour.scss
+++ b/static/sass/_snapcraft_tour.scss
@@ -8,10 +8,11 @@
   }
 
   .p-tour-bar {
-    position: fixed;
-    padding: $spv-inner--medium;
     bottom: 0;
     left: 0;
+    padding: $spv-inner--medium;
+    pointer-events: none;
+    position: fixed;
     right: 0;
   }
 
@@ -20,6 +21,7 @@
 
     float: right;
     margin: 0;
+    pointer-events: all;
   }
 
   .p-tour-overlay {
@@ -245,6 +247,11 @@
       @extend %triangle--pointing-left;
       @extend %triangle--on-bottom;
     }
+  }
+
+  .p-card--tour__content {
+    // compensate spacing for content being wrapped in div instead of being directly after heading
+    @extend %sp--hp;
   }
 
   .p-tour-controls {

--- a/static/sass/_utilities_flex.scss
+++ b/static/sass/_utilities_flex.scss
@@ -4,9 +4,4 @@
   .u-flex {
     display: flex;
   }
-
-  .u-flex--space-between {
-    display: flex;
-    justify-content: space-between;
-  }
 }

--- a/static/sass/_utilities_flex.scss
+++ b/static/sass/_utilities_flex.scss
@@ -4,4 +4,9 @@
   .u-flex {
     display: flex;
   }
+
+  .u-flex--space-between {
+    display: flex;
+    justify-content: space-between;
+  }
 }

--- a/templates/index.html
+++ b/templates/index.html
@@ -226,7 +226,5 @@
       snapcraft.public.nps();
     {% endif %}
   });
-
-  snapcraft.publisher.initTour();
 </script>
 {% endblock %}

--- a/templates/publisher/_header.html
+++ b/templates/publisher/_header.html
@@ -16,6 +16,7 @@
       <ul class="p-tabs__list u-float-right u-no-margin--bottom" role="tablist">
         <li class="p-tabs__item" role="presentation">
           <a
+            data-tour="listing-intro"
             href="/{{ snap_name }}/listing"
             class="p-tabs__link"
             tabindex="0"

--- a/templates/publisher/listing.html
+++ b/templates/publisher/listing.html
@@ -92,7 +92,7 @@ Listing details for {% if display_title %}{{ display_title }}{% else %}{{ snap_t
       </div>
       {% endif %}
 
-      <div class="row p-form__group p-form__group--top" data-validation-name="icon">
+      <div class="row p-form__group p-form__group--top" data-validation-name="icon" data-tour="listing-icon">
         <div class="col-2">
           <label class="p-form__label" for="snap-icon">Snap icon:</label>
         </div>
@@ -533,12 +533,27 @@ Listing details for {% if display_title %}{{ display_title }}{% else %}{{ snap_t
       steps: [
         {
           id: "listing-intro",
-          title: "Welcome to the demo tour!",
+          title: "Welcome to your snap listing page!",
           content: `
-            <p>This is just a test to see how to position such information and how to mask overlay background to highlight target element.</p>
-            <p>Click around and see how overlay highlights the element.</p>
-            <p>Thank you for testing!</p>
+            <p>Here you can manage the display of your snap listing within the store.</p>
+            <p>We’ll give you a quick tour to get you up to speed!</p>
           `
+        },
+        {
+          id: "listing-icon",
+          title: "Icons attract eyes…",
+          content: `
+            <p>Including an icon will help your snap to stand out making it far more attractive to users browsing graphical interfaces such as snapcraft.io/store and the Snap Store.</p>
+          `
+        },
+        {
+          id: "tour-end",
+          title: "That’s it for now!",
+          content: `
+            <p>If you ever need more help just look for the tour icon.</p>
+            <p>Still need help with something? <a href="https://www.youtube.com/watch?v=NiRj5m63oig&feature=youtu.be&t=68" target="_blank">Contact us</a>.</p>
+          `,
+          position: "top-right"
         }
       ]
     });

--- a/templates/publisher/listing.html
+++ b/templates/publisher/listing.html
@@ -199,7 +199,7 @@ Listing details for {% if display_title %}{{ display_title }}{% else %}{{ snap_t
           </div>
         </div>
       </div>
-      
+
       <div class="row p-form__group p-form-validation {% if field_errors and field_errors['video_urls'] %}is-error{% endif %}">
         <div class="col-2">
           <label for="video" class="p-form__label">Video:</label>
@@ -236,7 +236,7 @@ Listing details for {% if display_title %}{{ display_title }}{% else %}{{ snap_t
         </div>
         {% endif %}
       </div>
-        
+
       <div class="row p-form__group p-form__group--top" data-validation-name="screenshots">
         <div class="col-2">
           <label class="p-form__label">Images:</label>
@@ -474,6 +474,8 @@ Listing details for {% if display_title %}{{ display_title }}{% else %}{{ snap_t
     <input type="text" name="state" value="" />
   </form>
 </div>
+
+<div id="tour-container"></div>
 {% endblock %}
 
 {% block scripts %}
@@ -525,6 +527,11 @@ Listing details for {% if display_title %}{{ display_title }}{% else %}{{ snap_t
     snapcraft.publisher.stickyListingBar();
     snapcraft.publisher.markdownToggle();
     snapcraft.publisher.initCategories();
+
+    snapcraft.publisher.initTour({
+      container: document.getElementById("tour-container"),
+      target: document.querySelector("[data-tour='listing-intro']")
+    });
   });
 </script>
 {% endblock %}

--- a/templates/publisher/listing.html
+++ b/templates/publisher/listing.html
@@ -530,7 +530,17 @@ Listing details for {% if display_title %}{{ display_title }}{% else %}{{ snap_t
 
     snapcraft.publisher.initTour({
       container: document.getElementById("tour-container"),
-      target: document.querySelector("[data-tour='listing-intro']")
+      steps: [
+        {
+          id: "listing-intro",
+          title: "Welcome to the demo tour!",
+          content: `
+            <p>This is just a test to see how to position such information and how to mask overlay background to highlight target element.</p>
+            <p>Click around and see how overlay highlights the element.</p>
+            <p>Thank you for testing!</p>
+          `
+        }
+      ]
     });
   });
 </script>


### PR DESCRIPTION
Fixes #2198 

- Moves demo tour to publisher listing page
- Adds support for multiple steps with content provided via JSON
- Adds support for different positioning of tooltips to adjust to different elements on page (2 possible positions for the sake of demo)

### QA
This is not a complete feature. It's a minimal functional demo of the tour, merged to a feature branch where the work on it will continue.

- ./run or demo
-  sign in and go to listing page of any snap you own
- find a tour question mark (?) button in right bottom corner
- click it to trigger the tour
- navigate between the steps
- skip or finish tour to close
- tour should handle scrolling and resizing of the screen

<img width="1154" alt="Screenshot 2019-08-23 at 13 26 05" src="https://user-images.githubusercontent.com/83575/63589544-ba76bf00-c5a9-11e9-89d1-a4fa4ea2cfa5.png">
