### PR TITLE
Tour with interactive page

### DIFF
--- a/static/js/publisher/tour/tourOverlay.js
+++ b/static/js/publisher/tour/tourOverlay.js
@@ -51,10 +51,17 @@ const getMaskFromRect = rect => {
 // calculate mask for given element
 const getMaskFromEl = el => getMaskFromRect(getRectFromEl(el));
 
+// check if element is part of the DOM and is visible
+const isVisibleInDocument = el =>
+  document.contains(el) && !(el.offsetWidth === 0 && el.offsetHeight === 0);
+
 // get mask that is an union of all elements' masks
 // calculates the rectangle that contains each individual element rectangles
 const getMaskFromElements = elements => {
-  const masks = elements.map(el => getMaskFromEl(el));
+  const masks = elements
+    .filter(isVisibleInDocument)
+    .map(el => getMaskFromEl(el));
+
   return masks.reduce(
     (unionMask, elMask) => {
       return {

--- a/static/sass/_snapcraft_tour.scss
+++ b/static/sass/_snapcraft_tour.scss
@@ -29,6 +29,7 @@
   .p-tour-overlay {
     bottom: 0;
     left: 0;
+    pointer-events: none;
     position: absolute;
     right: 0;
     top: 0;
@@ -39,6 +40,7 @@
     background: $color-overlay;
     bottom: 0;
     left: 0;
+    pointer-events: all;
     position: absolute;
     right: 0;
     top: 0;
@@ -183,6 +185,7 @@
 
     max-width: 27rem;
     overflow: visible; // to make tooltip arrow visible
+    pointer-events: all;
     position: absolute;
     transition: 200ms;
 

--- a/templates/publisher/listing.html
+++ b/templates/publisher/listing.html
@@ -123,9 +123,8 @@ Listing details for {% if display_title %}{{ display_title }}{% else %}{{ snap_t
           <label class="p-form__label">Category:</label>
         </div>
         <div class="col-4">
-          <div class="p-form__control">
+          <div class="p-form__control" data-tour="listing-category">
             <select
-              data-tour="listing-category"
               name="primary_category"
               {% if snap_categories.categories[0] %}
               value="{{ snap_categories.categories[0].name }}"
@@ -145,7 +144,7 @@ Listing details for {% if display_title %}{{ display_title }}{% else %}{{ snap_t
             </select>
           </div>
         </div>
-        <div class="col-12">
+        <div class="col-12" data-tour="listing-category">
           <div class="js-categories-category1-help-text row {% if snap_categories.categories[0] %}u-hide{% endif %}">
             <div class="col-8 col-start-large-3">
               <p class="p-form-help-text">

--- a/templates/publisher/listing.html
+++ b/templates/publisher/listing.html
@@ -205,9 +205,8 @@ Listing details for {% if display_title %}{{ display_title }}{% else %}{{ snap_t
           <label for="video" class="p-form__label">Video:</label>
         </div>
         <div class="col-8">
-          <div class="p-form__control">
+          <div class="p-form__control" data-tour="listing-video">
             <input
-              data-tour="listing-video"
               class="p-form-validation__input"
               type="text"
               name="video_urls"
@@ -331,9 +330,8 @@ Listing details for {% if display_title %}{{ display_title }}{% else %}{{ snap_t
           <label for="developer-website" class="p-form__label">Developer website:</label>
         </div>
         <div class="col-8" >
-          <div class="p-form__control">
+          <div class="p-form__control" data-tour="listing-contact">
             <input
-              data-tour="listing-contact"
               class="p-form-validation__input"
               id="developer-website"
               type="url"
@@ -358,9 +356,8 @@ Listing details for {% if display_title %}{{ display_title }}{% else %}{{ snap_t
           <label for="contact p-form__input">Contact {{ publisher_name }}:</label>
         </div>
         <div class="col-8">
-          <div class="p-form__control">
+          <div class="p-form__control" data-tour="listing-contact">
             <input
-              data-tour="listing-contact"
               id="contact"
               class="p-form-validation__input"
               type="url"


### PR DESCRIPTION
Makes the highlighted elements interactive during the tour.

### QA
- ./run or https://snapcraft-io-canonical-web-and-design-pr-2215.run.demo.haus/
- sign in
- go to snap listing page of any snap you own
- click on the tour icon (?) in bottom right
- click through the tour
- while clicking through the tour steps interact with elements that are featured, try to edit them during the tour
