### PR TITLE
Tour scroll improvements

### DIFF
--- a/static/js/public/scroll-to.js
+++ b/static/js/public/scroll-to.js
@@ -1,87 +1,29 @@
-// From: https://gist.github.com/felipenmoura/650e7e1292c1e7638bcf6c9f9aeb9dd5
+export function animateScrollTo(to, offset = 0) {
+  const element = document.scrollingElement;
 
-/**
- * Will gracefuly scroll the page
- * This function will scroll the page using
- * an `ease-in-ou` effect.
- *
- * You can use it to scroll to a given element, as well.
- * To do so, pass the element instead of a number as the position.
- * Optionally, you can pass a `queryString` for an element selector.
- *
- * The default duration is half a second (500ms)
- *
- * This function returns a Promise that resolves as soon
- * as it has finished scrolling. If a selector is passed and
- * the element is not present in the page, it will reject.
- *
- * EXAMPLES:
- *
- * ```js
- * window.scrollPageTo('#some-section', 2000);
- * window.scrollPageTo(document.getElementById('some-section'), 1000);
- * window.scrollPageTo(500); // will scroll to 500px in 500ms
- * ```
- *
- * @returns {Promise}
- * @param {HTMLElement|Number|Selector} Target
- * @param {Number} Duration [default=500]
- *
- * Inspired by @andjosh's work
- *
- */
-export function animateScrollTo(to, duration = 500, offset = 0) {
-  //t = current time
-  //b = start value
-  //c = change in value
-  //d = duration
-  const easeInOutQuad = function(t, b, c, d) {
-    t /= d / 2;
-    if (t < 1) return (c / 2) * t * t + b;
-    t--;
-    return (-c / 2) * (t * (t - 2) - 1) + b;
-  };
-
-  return new Promise((resolve, reject) => {
-    const element = document.scrollingElement;
-
-    if (typeof to === "string") {
-      to = document.querySelector(to) || reject();
+  if (typeof to === "string") {
+    to = document.querySelector(to);
+    if (!to) {
+      throw Error(`Can't find any element for "${to}" in animateScrollTo.`);
     }
-    if (typeof to !== "number") {
-      to = to.getBoundingClientRect().top + element.scrollTop;
-    }
-    to = to + offset;
+  }
+  if (typeof to !== "number") {
+    to = to.getBoundingClientRect().top + element.scrollTop;
+  }
+  to = to - offset;
 
-    let start = element.scrollTop,
-      change = to - start,
-      currentTime = 0,
-      increment = 20;
-
-    const animateScroll = function() {
-      currentTime += increment;
-      let val = easeInOutQuad(currentTime, start, change, duration);
-      element.scrollTop = val;
-      if (currentTime < duration) {
-        setTimeout(animateScroll, increment);
-      } else {
-        resolve();
-      }
-    };
-    animateScroll();
-  });
+  element.scrollTo({ top: to, behavior: "smooth" });
 }
 
-export function initLinkScroll(link, { duration = 500, offset = 0 }) {
+export function initLinkScroll(link, { offset = 0 }) {
   if (link && (link.dataset.scrollTo || link.href)) {
     const href = link.dataset.scrollTo || link.getAttribute("href");
     const target = document.querySelector(href);
     if (target) {
       link.addEventListener("click", event => {
         event.preventDefault();
-        animateScrollTo(target, duration, offset).then(() => {
-          window.history.pushState({}, null, href);
-        });
+        animateScrollTo(target, offset);
+        setTimeout(() => window.history.pushState({}, null, href), 100);
       });
     }
   }

--- a/static/js/publisher/tour/tourOverlay.js
+++ b/static/js/publisher/tour/tourOverlay.js
@@ -6,8 +6,14 @@ import debounce from "../../libs/debounce";
 import TourStepCard from "./tourStepCard";
 import TourOverlayMask from "./tourOverlayMask";
 
+import { animateScrollTo } from "../../public/scroll-to";
+
 const REM = parseFloat(getComputedStyle(document.documentElement).fontSize);
 const MASK_OFFSET = REM / 2; // .5rem  is a default spacing unit in Vanilla
+
+const SCROLL_MARGIN = 400; // if element highlighted element doesn't fit into this top/bottom area of the screen, we scroll it into view
+const SCROLL_OFFSET_TOP = 100; // to make sure we position elements below sticky header on listing page
+const SCROLL_OFFSET_BOTTOM = 10;
 
 // get rectangle of given DOM element
 // relative to the page, taking scroll into account
@@ -105,8 +111,33 @@ export default function TourOverlay({ steps, onHideClick }) {
   // when current step changes, scroll step element into view
   useEffect(
     () => {
-      // TODO: consider scrolling based on mask position instead of element
-      step.elements[0].scrollIntoView({ block: "center", behavior: "smooth" });
+      const scrollTop =
+        window.pageYOffset || document.documentElement.scrollTop;
+
+      // when tooltip is on top of the mask, scroll into view aligning to bottom
+      if (step.position.indexOf("top") === 0) {
+        // scroll element into view aligning it to bottom
+        // only if it's in the top half of the screen
+        if (mask.top < SCROLL_MARGIN + scrollTop) {
+          animateScrollTo(
+            // we scroll relative to top of the screen, but we want to stick to bottom
+            // so we need to substract the window height
+            mask.bottom - window.innerHeight,
+            -SCROLL_OFFSET_BOTTOM
+          );
+        }
+      }
+      // when tooltip is on the bottom of the mask, scroll aligning to top
+      if (step.position.indexOf("bottom") === 0) {
+        // scroll element into view, but only if it's higher on page than top offset
+        // or it is in the bottom half of screen
+        if (
+          mask.top < SCROLL_OFFSET_TOP + scrollTop ||
+          mask.bottom > SCROLL_MARGIN + scrollTop
+        ) {
+          animateScrollTo(mask.top, SCROLL_OFFSET_TOP);
+        }
+      }
     },
     [currentStepIndex]
   );

--- a/static/js/publisher/tour/tourStepCard.js
+++ b/static/js/publisher/tour/tourStepCard.js
@@ -25,6 +25,12 @@ export default function TourStepCard({
         left: mask.left
       };
       break;
+    case "top-left":
+      tooltipStyle = {
+        bottom: overlayHeight - mask.top,
+        left: mask.left
+      };
+      break;
     case "top-right":
       tooltipStyle = {
         bottom: overlayHeight - mask.top,

--- a/static/js/publisher/tour/tourStepCard.js
+++ b/static/js/publisher/tour/tourStepCard.js
@@ -25,6 +25,12 @@ export default function TourStepCard({
         left: mask.left
       };
       break;
+    case "bottom-right":
+      tooltipStyle = {
+        top: mask.bottom,
+        right: overlayWidth - mask.right
+      };
+      break;
     case "top-left":
       tooltipStyle = {
         bottom: overlayHeight - mask.top,

--- a/static/sass/_snapcraft_tour.scss
+++ b/static/sass/_snapcraft_tour.scss
@@ -124,7 +124,7 @@
   // for tooltips on the left of element
   %triangle--pointing-right {
     @extend %triangle;
-    margin-left: $triangle-spacing;
+    margin-right: $triangle-spacing;
 
     &::before,
     &::after {
@@ -141,7 +141,7 @@
   // for tooltips on the right of element
   %triangle--pointing-left {
     @extend %triangle;
-    margin-right: $triangle-spacing;
+    margin-left: $triangle-spacing;
 
     &::before,
     &::after {
@@ -183,6 +183,7 @@
   .p-card--tour {
     @extend .p-card; // sass-lint:disable-line placeholder-in-extend
 
+    margin: 0; // reset any margins from p-card
     max-width: 27rem;
     overflow: visible; // to make tooltip arrow visible
     pointer-events: all;

--- a/templates/store/snap-distro-install.html
+++ b/templates/store/snap-distro-install.html
@@ -232,7 +232,7 @@
   <script>
     Raven.context(function () {
       try {
-        snapcraft.public.initLinkScroll(document.querySelector(".js-install"), { offset: -20 });
+        snapcraft.public.initLinkScroll(document.querySelector(".js-install"), { offset: 20 });
       } catch(e) {
         Raven.captureException(e);
       }

--- a/webapp/publisher/content/listing_tour.yaml
+++ b/webapp/publisher/content/listing_tour.yaml
@@ -50,6 +50,7 @@
   content: |
     <p>Give users the opportunity to learn more about your application and find support when needed.</p>
     <p>Alternatively, you can add an email address if you prefer direct contact.</p>
+  position: top-left
 
 - id: tour-end
   title: That’s it for now!


### PR DESCRIPTION
Fixes some issues around scrolling elements into view during the tour.

### QA
- ./run or  https://snapcraft-io-canonical-web-and-design-pr-2216.run.demo.haus/
- sign in
- go to snap listing page of any snap you own
- click on tour icon (?) in bottom right
- go through the tour
- make sure highlighted elements scroll into place leaving enough space for a tooltip below or above it