### PR TITLE
Add GA events to starting, skipping and finishing the tour

### DIFF
--- a/static/js/publisher/tour/metricsEvents.js
+++ b/static/js/publisher/tour/metricsEvents.js
@@ -1,0 +1,33 @@
+import { triggerEvent } from "../../base/ga";
+
+export const tourStartedByUser = () =>
+  triggerEvent(
+    "tour-started-by-user",
+    window.location.href,
+    "",
+    `Tour started manually by user on "${document.title}" page`
+  );
+
+export const tourStartedAutomatically = () =>
+  triggerEvent(
+    "tour-started-automatically",
+    window.location.href,
+    "",
+    `Tour started automatically on "${document.title}" page`
+  );
+
+export const tourFinished = stepId =>
+  triggerEvent(
+    "tour-finished",
+    window.location.href,
+    "",
+    `Tour finished on "${document.title}" page on step ${stepId}`
+  );
+
+export const tourSkipped = stepId =>
+  triggerEvent(
+    "tour-skipped",
+    window.location.href,
+    "",
+    `Tour skipped on "${document.title}" page on step ${stepId}`
+  );

--- a/static/js/publisher/tour/tour.js
+++ b/static/js/publisher/tour/tour.js
@@ -5,20 +5,20 @@ import TourOverlay from "./tourOverlay";
 import TourBar from "./tourBar";
 
 export default function Tour({ steps }) {
-  const [showTour, setShowTour] = useState(false);
+  const [isTourOpen, setIsTourOpen] = useState(false);
 
-  const onShowTour = () => setShowTour(true);
-  const onHideTour = () => setShowTour(false);
+  const showTour = () => setIsTourOpen(true);
+  const hideTour = () => setIsTourOpen(false);
 
   return (
     <Fragment>
-      <TourBar onButtonClick={onShowTour} />
+      <TourBar showTour={showTour} />
 
-      {showTour && <TourOverlay steps={steps} onHideClick={onHideTour} />}
+      {isTourOpen && <TourOverlay steps={steps} hideTour={hideTour} />}
     </Fragment>
   );
 }
 
 Tour.propTypes = {
-  steps: PropTypes.array
+  steps: PropTypes.array.isRequired
 };

--- a/static/js/publisher/tour/tourBar.js
+++ b/static/js/publisher/tour/tourBar.js
@@ -1,7 +1,14 @@
 import React from "react";
 import PropTypes from "prop-types";
 
-export default function TourBar({ onButtonClick }) {
+import { tourStartedByUser } from "./metricsEvents";
+
+export default function TourBar({ showTour }) {
+  const onButtonClick = () => {
+    tourStartedByUser();
+    showTour();
+  };
+
   return (
     <div className="p-tour-bar">
       <div className="u-fixed-width u-clearfix">
@@ -18,5 +25,5 @@ export default function TourBar({ onButtonClick }) {
 }
 
 TourBar.propTypes = {
-  onButtonClick: PropTypes.func
+  showTour: PropTypes.func
 };

--- a/static/js/publisher/tour/tourOverlay.js
+++ b/static/js/publisher/tour/tourOverlay.js
@@ -5,6 +5,7 @@ import debounce from "../../libs/debounce";
 
 import TourStepCard from "./tourStepCard";
 import TourOverlayMask from "./tourOverlayMask";
+import { tourFinished, tourSkipped } from "./metricsEvents";
 
 import { animateScrollTo } from "../../public/scroll-to";
 
@@ -102,7 +103,7 @@ function prepareSteps(steps) {
     .filter(step => step.elements.length > 0);
 }
 
-export default function TourOverlay({ steps, onHideClick }) {
+export default function TourOverlay({ steps, hideTour }) {
   steps = prepareSteps(steps);
   const [currentStepIndex, setCurrentStepIndex] = useState(0);
 
@@ -188,6 +189,16 @@ export default function TourOverlay({ steps, onHideClick }) {
   const onPrevClick = () =>
     setCurrentStepIndex((currentStepIndex - 1) % steps.length);
 
+  const onFinishClick = () => {
+    tourFinished(step.id);
+    hideTour();
+  };
+
+  const onSkipClick = () => {
+    tourSkipped(step.id);
+    hideTour();
+  };
+
   return (
     <div className="p-tour-overlay" ref={overlayEl}>
       <TourOverlayMask mask={isResizing ? null : mask} />
@@ -195,7 +206,8 @@ export default function TourOverlay({ steps, onHideClick }) {
         steps={steps}
         currentStepIndex={currentStepIndex}
         mask={mask}
-        onHideClick={onHideClick}
+        onFinishClick={onFinishClick}
+        onSkipClick={onSkipClick}
         onNextClick={onNextClick}
         onPrevClick={onPrevClick}
       />
@@ -206,5 +218,5 @@ export default function TourOverlay({ steps, onHideClick }) {
 TourOverlay.propTypes = {
   steps: PropTypes.array,
   currentStepIndex: PropTypes.number,
-  onHideClick: PropTypes.func
+  hideTour: PropTypes.func
 };

--- a/static/js/publisher/tour/tourStepCard.js
+++ b/static/js/publisher/tour/tourStepCard.js
@@ -5,7 +5,8 @@ export default function TourStepCard({
   steps,
   currentStepIndex,
   mask,
-  onHideClick,
+  onFinishClick,
+  onSkipClick,
   onNextClick,
   onPrevClick
 }) {
@@ -65,7 +66,7 @@ export default function TourStepCard({
       <p className="p-tour-controls">
         {!isLastStep && (
           <span>
-            Done? <a onClick={onHideClick}>Skip tour</a>.
+            Done? <a onClick={onSkipClick}>Skip tour</a>.
           </span>
         )}
 
@@ -81,7 +82,7 @@ export default function TourStepCard({
             <i className="p-icon--contextual-menu is-prev">Previous step</i>
           </button>
           <button
-            onClick={isLastStep ? onHideClick : onNextClick}
+            onClick={isLastStep ? onFinishClick : onNextClick}
             className="p-button--positive is-inline has-icon u-no-margin--bottom u-no-margin--right"
           >
             {isLastStep ? (
@@ -107,7 +108,8 @@ TourStepCard.propTypes = {
   }).isRequired,
   steps: PropTypes.array.isRequired,
   currentStepIndex: PropTypes.number.isRequired,
-  onHideClick: PropTypes.func.isRequired,
+  onFinishClick: PropTypes.func.isRequired,
+  onSkipClick: PropTypes.func.isRequired,
   onNextClick: PropTypes.func.isRequired,
   onPrevClick: PropTypes.func.isRequired
 };


### PR DESCRIPTION
Fixes https://github.com/canonical-web-and-design/snap-squad/issues/1104
Adds GA event when tour is started, skipped or finished.

### QA
No data is sent to GA in test environments. To QA you can use `dataLayer` global variable to check list of events collected by GA.

- ./run or demo
- sign in
- go to snap listing page of any snap you own
- start the tour by clicking on (?) icon in bottom right
- check `dataLayer` for event about starting the tour
- go to some step, finish or skip the tour
- check `dataLayer` for event about finishing/skipping the tour

<img width="1134" alt="Screenshot 2019-08-28 at 12 35 55" src="https://user-images.githubusercontent.com/83575/63849126-a825c800-c991-11e9-8315-3330dd1c9e8d.png">
