### PR TITLE
Use ESC to skip the tour

### DIFF
--- a/static/js/libs/debounce.js
+++ b/static/js/libs/debounce.js
@@ -6,7 +6,8 @@
  */
 export default function debounce(func, wait, immediate) {
   let timeout;
-  return function() {
+
+  const debounced = function() {
     const context = this,
       args = arguments;
     let later = function() {
@@ -18,4 +19,10 @@ export default function debounce(func, wait, immediate) {
     timeout = setTimeout(later, wait);
     if (callNow) func.apply(context, args);
   };
+
+  debounced.clear = function() {
+    clearTimeout(timeout);
+  };
+
+  return debounced;
 }

--- a/static/js/publisher/tour/tourOverlay.js
+++ b/static/js/publisher/tour/tourOverlay.js
@@ -118,8 +118,12 @@ export default function TourOverlay({ steps, hideTour }) {
       // when tooltip is on top of the mask, scroll into view aligning to bottom
       if (step.position.indexOf("top") === 0) {
         // scroll element into view aligning it to bottom
-        // only if it's in the top half of the screen
-        if (mask.top < SCROLL_MARGIN + scrollTop) {
+        // only if it's below the bottom border of the screen
+        // or it's in the top half of the screen
+        if (
+          mask.bottom > scrollTop + window.innerHeight ||
+          mask.top < SCROLL_MARGIN + scrollTop
+        ) {
           animateScrollTo(
             // we scroll relative to top of the screen, but we want to stick to bottom
             // so we need to substract the window height

--- a/static/js/publisher/tour/tourOverlay.js
+++ b/static/js/publisher/tour/tourOverlay.js
@@ -213,12 +213,17 @@ export default function TourOverlay({ steps, hideTour }) {
     hideTour();
   };
 
-  // skip on ESC
+  // close tour on ESC
+  // treat as 'finished' on last step and as 'skipped' on any other step
   useEffect(
     () => {
       const escClick = event => {
         if (event.keyCode === 27) {
-          onSkipClick();
+          if (currentStepIndex === steps.length - 1) {
+            onFinishClick();
+          } else {
+            onSkipClick();
+          }
         }
       };
       window.addEventListener("keyup", escClick);


### PR DESCRIPTION
Fixes https://github.com/canonical-web-and-design/snap-squad/issues/1105

Adds possibility to use ESC key to skip the tour.
Fixes some issues around scrolling to current step.

### QA
- ./run or https://snapcraft-io-canonical-web-and-design-pr-2219.run.demo.haus/
- sign in, go to listing page of any snap you own, click on tour icon (?) in bottom right
- when the tour is open hit ESC, tour should be skipped
- there should be Google Analytics skip event in the `dataLayer`
- press ESC on last step of the tour - GA event should be about finished tour instead of skipped

To QA the scrolling issue:
- open the tour, go to the final step (with the Finish button)
- scroll page up (to make sure contact details form inputs are below the border of the screen)
- click on "<" to go to previous step
- page should scroll to show the contact details tour step