### PR TITLE
Start the tour automatically if the form is less than 50% complete

### DIFF
--- a/static/js/publisher/publisher.js
+++ b/static/js/publisher/publisher.js
@@ -9,7 +9,7 @@ import markdownToggle from "./market/markdown";
 import stickyListingBar from "./market/stickyListingBar";
 import { preview } from "./preview";
 import submitEnabler from "./submitEnabler";
-import initTour from "./tour";
+import * as tour from "./tour";
 
 const settings = { enableInput, changeHandler };
 
@@ -25,5 +25,5 @@ export {
   settings,
   preview,
   submitEnabler,
-  initTour
+  tour
 };

--- a/static/js/publisher/tour.js
+++ b/static/js/publisher/tour.js
@@ -3,7 +3,14 @@ import ReactDOM from "react-dom";
 
 import Tour from "./tour/tour";
 
-export default function initTour({ container, steps }) {
+// returns true if % of truthy values in the array is above the threshold
+function isCompleted(fields, threshold = 0.5) {
+  const completed = fields.filter(isCompleted => isCompleted);
+
+  return completed.length / fields.length >= threshold;
+}
+
+export function initTour({ container, steps, onTourClosed, startTour }) {
   if (!document.contains(container)) {
     throw Error("initTour container element not found in document.");
   }
@@ -11,5 +18,30 @@ export default function initTour({ container, steps }) {
     throw Error("initTour expects steps array as an argument.");
   }
 
-  ReactDOM.render(<Tour steps={steps} />, container);
+  ReactDOM.render(
+    <Tour steps={steps} onTourClosed={onTourClosed} startTour={startTour} />,
+    container
+  );
+}
+
+export function initListingTour({
+  snapName,
+  container,
+  steps,
+  completedFields
+}) {
+  const storageKey = `listing-tour-finished-${snapName}`;
+
+  const isFormCompleted = isCompleted(completedFields);
+  const isTourFinished = !!(
+    window.localStorage && window.localStorage.getItem(storageKey)
+  );
+  const onTourClosed = () =>
+    window.localStorage && window.localStorage.setItem(storageKey, true);
+
+  // start the tour automatically if form is not completed
+  // (has less than 50% fields filled), and the tour wasn't closed before
+  const startTour = !isFormCompleted && !isTourFinished;
+
+  initTour({ container, steps, onTourClosed, startTour });
 }

--- a/static/js/publisher/tour.js
+++ b/static/js/publisher/tour.js
@@ -24,13 +24,29 @@ export function initTour({ container, steps, onTourClosed, startTour }) {
   );
 }
 
-export function initListingTour({
-  snapName,
-  container,
-  steps,
-  completedFields
-}) {
+export function initListingTour({ snapName, container, steps, formFields }) {
   const storageKey = `listing-tour-finished-${snapName}`;
+
+  // check form fields completed status
+  // truthy value means field is considered completed
+  const completedFields = [
+    // title is completed if it is different from package name
+    formFields.title !== formFields.snap_name,
+    // category
+    formFields.categories.length,
+    // video
+    formFields.video_urls.length,
+    // icon
+    formFields.images.filter(i => i.type === "icon").length,
+    // images
+    formFields.images.filter(i => i.type === "screenshot").length,
+    // banner
+    formFields.images.filter(i => i.type === "banner").length,
+    // summary is completed if it is different from the title
+    formFields.summary !== formFields.title,
+    // if one of website or contact is filled we consider it completed
+    formFields.website || formFields.contact
+  ];
 
   const isFormCompleted = isCompleted(completedFields);
   const isTourFinished = !!(

--- a/static/js/publisher/tour/tour.js
+++ b/static/js/publisher/tour/tour.js
@@ -1,14 +1,33 @@
-import React, { Fragment, useState } from "react";
+import React, { Fragment, useState, useEffect } from "react";
 import PropTypes from "prop-types";
 
 import TourOverlay from "./tourOverlay";
 import TourBar from "./tourBar";
 
-export default function Tour({ steps }) {
-  const [isTourOpen, setIsTourOpen] = useState(false);
+import { tourStartedAutomatically } from "./metricsEvents";
+
+export default function Tour({ steps, onTourClosed, startTour = false }) {
+  // send metrics event if tour started automatically
+  useEffect(
+    () => {
+      if (startTour) {
+        tourStartedAutomatically();
+      }
+    },
+    [startTour]
+  );
+
+  const [isTourOpen, setIsTourOpen] = useState(startTour);
 
   const showTour = () => setIsTourOpen(true);
-  const hideTour = () => setIsTourOpen(false);
+  const hideTour = () => {
+    setIsTourOpen(false);
+
+    // if close callback was defined call it now
+    if (onTourClosed) {
+      onTourClosed();
+    }
+  };
 
   return (
     <Fragment>
@@ -20,5 +39,7 @@ export default function Tour({ steps }) {
 }
 
 Tour.propTypes = {
-  steps: PropTypes.array.isRequired
+  steps: PropTypes.array.isRequired,
+  startTour: PropTypes.bool,
+  onTourClosed: PropTypes.func
 };

--- a/templates/publisher/listing.html
+++ b/templates/publisher/listing.html
@@ -483,17 +483,8 @@ Listing details for {% if display_title %}{{ display_title }}{% else %}{{ snap_t
 <script>
   Raven.context(function () {
     snapcraft.publisher.initMultiselect('.js-license', {{ licenses|tojson }}, ' OR ');
-    snapcraft.publisher.market.initForm({
-      snapIconHolder: ".js-icon-holder",
-      bannerHolder: ".js-banner",
-      form: "market-form",
-      formNotification: "market-form-status",
-      licenseRadioContent: [
-        document.getElementById('license-simple-input'),
-        document.getElementById('license-custom-input')
-      ],
-      mediaHolder: ".js-media-holder",
-    }, {
+
+    const formFields = {
       snap_name: {{ snap_name|tojson }},
       title: {{ snap_title|tojson }},
       summary: {{ summary|tojson }},
@@ -516,12 +507,24 @@ Listing details for {% if display_title %}{{ display_title }}{% else %}{{ snap_t
       'public_metrics_blacklist': {{ join(public_metrics_blacklist, ',')|tojson }},
       'license': {{ license|tojson }},
       'video_urls': {% if video_urls %}{{ video_urls[0]|tojson }}{% else %}""{% endif %}
-    },
-    {% if error_list %}
-      {{ error_list|tojson}}
-    {% else %}
-      null
-    {% endif %}
+    };
+
+    const formErrors = {% if error_list %}{{ error_list|tojson}}{% else %}null{% endif %};
+
+    snapcraft.publisher.market.initForm(
+      {
+        snapIconHolder: ".js-icon-holder",
+        bannerHolder: ".js-banner",
+        form: "market-form",
+        formNotification: "market-form-status",
+        licenseRadioContent: [
+          document.getElementById('license-simple-input'),
+          document.getElementById('license-custom-input')
+        ],
+        mediaHolder: ".js-media-holder",
+      },
+      formFields,
+      formErrors
     );
 
     snapcraft.publisher.stickyListingBar();
@@ -532,25 +535,7 @@ Listing details for {% if display_title %}{{ display_title }}{% else %}{{ snap_t
       snapName: {{ snap_name|tojson }},
       container: document.getElementById("tour-container"),
       steps: {{ tour_steps|tojson }},
-      completedFields: [
-        // truthy value means field is considered completed
-        // icon
-        {{ icon_url|tojson }},
-        // title is completed if it is different from package name
-        {{ snap_title|tojson }} !== {{ snap_name|tojson }},
-        // category
-        {{ snap_categories.categories|tojson }}.length,
-        // video
-        {{ video_urls|tojson }}.length,
-        // images
-        {{ screenshot_urls|tojson }}.length,
-        // banner
-        {{ banner_urls|tojson }}.length,
-        // summary is completed if it is different from the title
-        {{ summary|tojson }} !== {{ snap_title|tojson }},
-        // if one of website or contact is filled we consider it completed
-        {{ website|tojson }} || {{ contact|tojson }},
-      ]
+      formFields: formFields
     });
   });
 </script>

--- a/templates/publisher/listing.html
+++ b/templates/publisher/listing.html
@@ -528,9 +528,29 @@ Listing details for {% if display_title %}{{ display_title }}{% else %}{{ snap_t
     snapcraft.publisher.markdownToggle();
     snapcraft.publisher.initCategories();
 
-    snapcraft.publisher.initTour({
+    snapcraft.publisher.tour.initListingTour({
+      snapName: {{ snap_name|tojson }},
       container: document.getElementById("tour-container"),
-      steps: {{ tour_steps|tojson }}
+      steps: {{ tour_steps|tojson }},
+      completedFields: [
+        // truthy value means field is considered completed
+        // icon
+        {{ icon_url|tojson }},
+        // title is completed if it is different from package name
+        {{ snap_title|tojson }} !== {{ snap_name|tojson }},
+        // category
+        {{ snap_categories.categories|tojson }}.length,
+        // video
+        {{ video_urls|tojson }}.length,
+        // images
+        {{ screenshot_urls|tojson }}.length,
+        // banner
+        {{ banner_urls|tojson }}.length,
+        // summary is completed if it is different from the title
+        {{ summary|tojson }} !== {{ snap_title|tojson }},
+        // if one of website or contact is filled we consider it completed
+        {{ website|tojson }} || {{ contact|tojson }},
+      ]
     });
   });
 </script>


### PR DESCRIPTION
Fixes #2201 

Tour on listing page will start automatically if less than 50% of fields are completed.

### QA
- ./run or https://snapcraft-io-canonical-web-and-design-pr-2221.run.demo.haus/
- sign in
- go to listing page of a snap that has little information filled in (or remove icon, images, contact details, categories and any other not mandatory data)
- tour should start automatically when listing page loads (for snap with little data)
- once the tour is skipped or finished it should not start automatically again for the same snap

<img width="989" alt="Screenshot 2019-08-29 at 14 12 22" src="https://user-images.githubusercontent.com/83575/63939478-af1f0a00-ca67-11e9-9d1b-64ce61f0a772.png">

After tour starts automatically verify if proper GA event is sent (in `dataLayer`):

<img width="918" alt="Screenshot 2019-08-29 at 14 12 05" src="https://user-images.githubusercontent.com/83575/63939479-af1f0a00-ca67-11e9-9a86-5d1ddaf79718.png">

To remove information that tour was finished from the browser clear local storage (or remove specific `listing-tour-finished-...` key):

<img width="919" alt="Screenshot 2019-08-29 at 14 11 27" src="https://user-images.githubusercontent.com/83575/63939481-af1f0a00-ca67-11e9-8098-bd9d608004f0.png">
