### PR TITLE
 Disable sticky bar during the tour

### DIFF
--- a/static/js/publisher/market/stickyListingBar.js
+++ b/static/js/publisher/market/stickyListingBar.js
@@ -1,15 +1,16 @@
 import throttle from "../../libs/throttle";
 
+export const toggleClassWhenStickyOnTop = (el, className) => {
+  el.classList.toggle(className, el.getBoundingClientRect().top === 0);
+};
+
+export const toggleShadowWhenSticky = el => {
+  toggleClassWhenStickyOnTop(el, "sticky-shadow");
+};
+
 export default function() {
-  const checkListingBarIsStuck = () => {
-    const stickyBar = document.querySelector("#store-listing-notification");
-    if (stickyBar.getBoundingClientRect().top == 0) {
-      stickyBar.classList.add("sticky-shadow");
-    } else {
-      stickyBar.classList.remove("sticky-shadow");
-    }
-  };
-  checkListingBarIsStuck();
-  const onScroll = throttle(checkListingBarIsStuck, 30);
+  const stickyBar = document.querySelector(".snapcraft-p-sticky");
+  toggleShadowWhenSticky(stickyBar);
+  const onScroll = throttle(() => toggleShadowWhenSticky(stickyBar), 30);
   document.addEventListener("scroll", onScroll);
 }

--- a/static/js/publisher/market/stickyListingBar.js
+++ b/static/js/publisher/market/stickyListingBar.js
@@ -1,7 +1,9 @@
 import throttle from "../../libs/throttle";
 
 export const toggleClassWhenStickyOnTop = (el, className) => {
-  el.classList.toggle(className, el.getBoundingClientRect().top === 0);
+  if (el) {
+    el.classList.toggle(className, el.getBoundingClientRect().top === 0);
+  }
 };
 
 export const toggleShadowWhenSticky = el => {
@@ -9,7 +11,7 @@ export const toggleShadowWhenSticky = el => {
 };
 
 export default function() {
-  const stickyBar = document.querySelector(".snapcraft-p-sticky");
+  const stickyBar = document.querySelector(".js-sticky-bar");
   toggleShadowWhenSticky(stickyBar);
   const onScroll = throttle(() => toggleShadowWhenSticky(stickyBar), 30);
   document.addEventListener("scroll", onScroll);

--- a/static/js/publisher/tour.js
+++ b/static/js/publisher/tour.js
@@ -70,16 +70,22 @@ export function initListingTour({ snapName, container, steps, formFields }) {
   // (has less than 50% fields filled), and the tour wasn't closed before
   const startTour = !isFormCompleted && !isTourFinished;
 
-  const stickyHeader = document.querySelector(".snapcraft-p-sticky");
+  const stickyHeader = document.querySelector(".js-sticky-bar");
   const onTourClosed = () => {
     // save that tour was seen by user
     window.localStorage && window.localStorage.setItem(storageKey, true);
     // make header sticky again
-    stickyHeader.classList.remove("is-static");
+    if (stickyHeader) {
+      stickyHeader.classList.remove("is-static");
+    }
     toggleShadowWhenSticky(stickyHeader);
   };
 
-  const onTourStarted = () => stickyHeader.classList.add("is-static");
+  const onTourStarted = () => {
+    if (stickyHeader) {
+      stickyHeader.classList.add("is-static");
+    }
+  };
 
   initTour({ container, steps, onTourStarted, onTourClosed, startTour });
 }

--- a/static/js/publisher/tour.js
+++ b/static/js/publisher/tour.js
@@ -3,6 +3,8 @@ import ReactDOM from "react-dom";
 
 import Tour from "./tour/tour";
 
+import { toggleShadowWhenSticky } from "./market/stickyListingBar";
+
 // returns true if % of truthy values in the array is above the threshold
 function isCompleted(fields, threshold = 0.5) {
   const completed = fields.filter(isCompleted => isCompleted);
@@ -10,7 +12,13 @@ function isCompleted(fields, threshold = 0.5) {
   return completed.length / fields.length >= threshold;
 }
 
-export function initTour({ container, steps, onTourClosed, startTour }) {
+export function initTour({
+  container,
+  steps,
+  onTourStarted,
+  onTourClosed,
+  startTour
+}) {
   if (!document.contains(container)) {
     throw Error("initTour container element not found in document.");
   }
@@ -19,7 +27,12 @@ export function initTour({ container, steps, onTourClosed, startTour }) {
   }
 
   ReactDOM.render(
-    <Tour steps={steps} onTourClosed={onTourClosed} startTour={startTour} />,
+    <Tour
+      steps={steps}
+      onTourStarted={onTourStarted}
+      onTourClosed={onTourClosed}
+      startTour={startTour}
+    />,
     container
   );
 }
@@ -52,12 +65,21 @@ export function initListingTour({ snapName, container, steps, formFields }) {
   const isTourFinished = !!(
     window.localStorage && window.localStorage.getItem(storageKey)
   );
-  const onTourClosed = () =>
-    window.localStorage && window.localStorage.setItem(storageKey, true);
 
   // start the tour automatically if form is not completed
   // (has less than 50% fields filled), and the tour wasn't closed before
   const startTour = !isFormCompleted && !isTourFinished;
 
-  initTour({ container, steps, onTourClosed, startTour });
+  const stickyHeader = document.querySelector(".snapcraft-p-sticky");
+  const onTourClosed = () => {
+    // save that tour was seen by user
+    window.localStorage && window.localStorage.setItem(storageKey, true);
+    // make header sticky again
+    stickyHeader.classList.remove("is-static");
+    toggleShadowWhenSticky(stickyHeader);
+  };
+
+  const onTourStarted = () => stickyHeader.classList.add("is-static");
+
+  initTour({ container, steps, onTourStarted, onTourClosed, startTour });
 }

--- a/static/js/publisher/tour/tour.js
+++ b/static/js/publisher/tour/tour.js
@@ -6,7 +6,12 @@ import TourBar from "./tourBar";
 
 import { tourStartedAutomatically } from "./metricsEvents";
 
-export default function Tour({ steps, onTourClosed, startTour = false }) {
+export default function Tour({
+  steps,
+  onTourStarted,
+  onTourClosed,
+  startTour = false
+}) {
   // send metrics event if tour started automatically
   useEffect(
     () => {
@@ -20,14 +25,20 @@ export default function Tour({ steps, onTourClosed, startTour = false }) {
   const [isTourOpen, setIsTourOpen] = useState(startTour);
 
   const showTour = () => setIsTourOpen(true);
-  const hideTour = () => {
-    setIsTourOpen(false);
+  const hideTour = () => setIsTourOpen(false);
 
-    // if close callback was defined call it now
-    if (onTourClosed) {
-      onTourClosed();
-    }
-  };
+  // trigger callbacks when tour is started or finished
+  useEffect(
+    () => {
+      if (isTourOpen && onTourStarted) {
+        onTourStarted();
+      }
+      if (!isTourOpen && onTourClosed) {
+        onTourClosed();
+      }
+    },
+    [isTourOpen]
+  );
 
   return (
     <Fragment>
@@ -41,5 +52,6 @@ export default function Tour({ steps, onTourClosed, startTour = false }) {
 Tour.propTypes = {
   steps: PropTypes.array.isRequired,
   startTour: PropTypes.bool,
+  onTourStarted: PropTypes.func,
   onTourClosed: PropTypes.func
 };

--- a/static/sass/_snapcraft_market.scss
+++ b/static/sass/_snapcraft_market.scss
@@ -98,6 +98,11 @@
     top: 0;
     z-index: 1;
 
+    // force it back to static position (for example during the tour)
+    &.is-static {
+      position: static;
+    }
+
     & .row {
       padding-bottom: $sp-medium;
       padding-top: $sp-medium;

--- a/templates/publisher/listing.html
+++ b/templates/publisher/listing.html
@@ -13,7 +13,7 @@ Listing details for {% if display_title %}{{ display_title }}{% else %}{{ snap_t
     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
     <input type="hidden" name="snap_id" value="{{ snap_id }}" />
 
-    <div class="snapcraft-p-sticky">
+    <div class="snapcraft-p-sticky js-sticky-bar">
       <div class="row">
         <div class="col-7">
           <p class="snapcraft-p-market-message u-no-margin--bottom">

--- a/templates/publisher/listing.html
+++ b/templates/publisher/listing.html
@@ -13,7 +13,7 @@ Listing details for {% if display_title %}{{ display_title }}{% else %}{{ snap_t
     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
     <input type="hidden" name="snap_id" value="{{ snap_id }}" />
 
-    <div class="snapcraft-p-sticky" id="store-listing-notification">
+    <div class="snapcraft-p-sticky">
       <div class="row">
         <div class="col-7">
           <p class="snapcraft-p-market-message u-no-margin--bottom">

--- a/templates/publisher/settings.html
+++ b/templates/publisher/settings.html
@@ -13,7 +13,7 @@ Settings for {% if display_title %}{{ display_title }}{% else %}{{ snap_title }}
     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
     <input type="hidden" name="snap_id" value="{{ snap_id }}" />
 
-    <div class="snapcraft-p-sticky">
+    <div class="snapcraft-p-sticky js-sticky-bar">
       <div class="row">
         <div class="col-5 col-start-large-8">
           <div class="u-align--right u-clearfix">

--- a/templates/publisher/settings.html
+++ b/templates/publisher/settings.html
@@ -13,7 +13,7 @@ Settings for {% if display_title %}{{ display_title }}{% else %}{{ snap_title }}
     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
     <input type="hidden" name="snap_id" value="{{ snap_id }}" />
 
-    <div class="snapcraft-p-sticky" id="store-listing-notification">
+    <div class="snapcraft-p-sticky">
       <div class="row">
         <div class="col-5 col-start-large-8">
           <div class="u-align--right u-clearfix">


### PR DESCRIPTION
Fixes https://github.com/canonical-web-and-design/snap-squad/issues/1106

Requires #2221 - merge that one first
Only one commit relevant for code review: https://github.com/canonical-web-and-design/snapcraft.io/pull/2222/commits/4a7b2bdf061665e6e171a5ef60f08c7f00bda179

Disables sticky bar during the tour to avoid weird behaviour when scrolling.

### QA
- ./run or https://snapcraft-io-canonical-web-and-design-pr-2222.run.demo.haus/
- sign in, go to listing page of any snap, start the tour using the (?) icon in bottom right
- click through some steps
- scroll down with a tour step open (so the highlighted mask moves to top of the window)
- sticky header should not be there (as it's disabled during the tour)
- skip of finish the tour
- heading should be sticky again

<img width="1291" alt="Screenshot 2019-08-29 at 15 54 46" src="https://user-images.githubusercontent.com/83575/63946404-60786c80-ca75-11e9-9d20-07e8be20e2a0.png">
