### PR TITLE
Revision attributes basics

### DIFF
--- a/static/js/publisher/release/components/releasesTableCell.js
+++ b/static/js/publisher/release/components/releasesTableCell.js
@@ -79,6 +79,13 @@ const RevisionInfo = ({ revision, isPending, showVersion }) => {
           Revision: <b>{revision.revision}</b>
           <br />
           Version: <b>{revision.version}</b>
+          {revision.attributes &&
+            revision.attributes["build-request-id"] && (
+              <Fragment>
+                <br />
+                Build Request: <b>{revision.attributes["build-request-id"]}</b>
+              </Fragment>
+            )}
           {isInDevmode(revision) && (
             <Fragment>
               <br />

--- a/static/js/publisher/release/components/revisionsList.js
+++ b/static/js/publisher/release/components/revisionsList.js
@@ -21,7 +21,8 @@ import {
   getSelectedRevisions,
   getSelectedArchitectures,
   getFilteredAvailableRevisions,
-  getFilteredAvailableRevisionsForArch
+  getFilteredAvailableRevisionsForArch,
+  hasBuildRequestId
 } from "../selectors";
 
 import { getPendingRelease } from "../releasesState";
@@ -38,20 +39,20 @@ class RevisionsList extends Component {
     revisions.forEach(revision => this.props.toggleRevision(revision));
   }
 
-  renderRow(revision, isSelectable, showAllColumns, isPending, isActive) {
+  renderRow(revision, isSelectable, showChannels, isPending, isActive) {
     return (
       <RevisionsListRow
         key={`revision-row-${revision.revision}`}
         revision={revision}
         isSelectable={isSelectable}
-        showAllColumns={showAllColumns}
+        showChannels={showChannels}
         isPending={isPending}
         isActive={isActive}
       />
     );
   }
 
-  renderRows(revisions, isSelectable, showAllColumns, activeRevision) {
+  renderRows(revisions, isSelectable, showChannels, activeRevision) {
     return revisions.map(revision => {
       const isActive =
         activeRevision && revision.revision === activeRevision.revision;
@@ -59,7 +60,7 @@ class RevisionsList extends Component {
       return this.renderRow(
         revision,
         isSelectable,
-        showAllColumns,
+        showChannels,
         false,
         isActive
       );
@@ -80,9 +81,10 @@ class RevisionsList extends Component {
   render() {
     let {
       availableRevisionsSelect,
-      showAllColumns,
+      showChannels,
       filteredAvailableRevisions,
-      pendingChannelMap
+      pendingChannelMap,
+      showBuildRequest
     } = this.props;
     let filteredRevisions = filteredAvailableRevisions;
     let title = "Latest revisions";
@@ -283,7 +285,8 @@ class RevisionsList extends Component {
                 Revision
               </th>
               <th scope="col">Version</th>
-              {showAllColumns && <th scope="col">Channels</th>}
+              {showBuildRequest && <th scope="col">Build Request</th>}
+              {showChannels && <th scope="col">Channels</th>}
               <th scope="col" width="130px" className="u-align--right">
                 {isReleaseHistory ? "Release date" : "Submission date"}
               </th>
@@ -294,7 +297,7 @@ class RevisionsList extends Component {
               this.renderRow(
                 pendingRelease,
                 !isReleaseHistory,
-                showAllColumns,
+                showChannels,
                 true,
                 activeRevision.revision === pendingRelease.revision
               )}
@@ -304,7 +307,7 @@ class RevisionsList extends Component {
                   ? filteredRevisions
                   : filteredRevisions.slice(0, 10),
                 !isReleaseHistory,
-                showAllColumns,
+                showChannels,
                 activeRevision
               )
             ) : (
@@ -339,7 +342,8 @@ RevisionsList.propTypes = {
   availableRevisionsSelect: PropTypes.string.isRequired,
 
   // computed state (selectors)
-  showAllColumns: PropTypes.bool,
+  showChannels: PropTypes.bool,
+  showBuildRequest: PropTypes.bool,
   filteredReleaseHistory: PropTypes.array,
   selectedRevisions: PropTypes.array.isRequired,
   selectedArchitectures: PropTypes.array.isRequired,
@@ -357,11 +361,12 @@ RevisionsList.propTypes = {
 const mapStateToProps = state => {
   return {
     availableRevisionsSelect: state.availableRevisionsSelect,
-    showAllColumns:
+    showChannels:
       !state.history.filters ||
       (state.history.filters &&
         state.history.filters.risk === AVAILABLE &&
         state.availableRevisionsSelect === AVAILABLE_REVISIONS_SELECT_ALL),
+    showBuildRequest: hasBuildRequestId(state),
     filters: state.history.filters,
     revisions: state.revisions,
     pendingReleases: state.pendingReleases,

--- a/static/js/publisher/release/components/revisionsListRow.js
+++ b/static/js/publisher/release/components/revisionsListRow.js
@@ -7,12 +7,19 @@ import format from "date-fns/format";
 
 import { useDragging, DND_ITEM_REVISION, Handle } from "./dnd";
 import { toggleRevision } from "../actions/channelMap";
-import { getSelectedRevisions } from "../selectors";
+import { getSelectedRevisions, hasBuildRequestId } from "../selectors";
 
 import DevmodeRevision from "./devmodeRevision";
 
 const RevisionsListRow = props => {
-  const { revision, isSelectable, showAllColumns, isPending, isActive } = props;
+  const {
+    revision,
+    isSelectable,
+    showChannels,
+    showBuildRequest,
+    isPending,
+    isActive
+  } = props;
 
   const revisionDate = revision.release
     ? new Date(revision.release.when)
@@ -41,6 +48,9 @@ const RevisionsListRow = props => {
   } ${isSelectable ? "is-clickable" : ""} ${
     isPending || isSelected ? "is-pending" : ""
   } ${isGrabbing ? "is-grabbing" : ""} ${isDragging ? "is-dragging" : ""}`;
+
+  const buildRequestId =
+    revision.attributes && revision.attributes["build-request-id"];
 
   return (
     <tr
@@ -75,7 +85,8 @@ const RevisionsListRow = props => {
         )}
       </td>
       <td>{revision.version}</td>
-      {showAllColumns && <td>{revision.channels.join(", ")}</td>}
+      {showBuildRequest && <td>{buildRequestId}</td>}
+      {showChannels && <td>{revision.channels.join(", ")}</td>}
       <td className="u-align--right">
         {isPending ? (
           <em>pending release</em>
@@ -103,12 +114,13 @@ RevisionsListRow.propTypes = {
   // props
   revision: PropTypes.object.isRequired,
   isSelectable: PropTypes.bool,
-  showAllColumns: PropTypes.bool,
+  showChannels: PropTypes.bool,
   isPending: PropTypes.bool,
   isActive: PropTypes.bool,
 
   // computed state (selectors)
   selectedRevisions: PropTypes.array.isRequired,
+  showBuildRequest: PropTypes.bool.isRequired,
 
   // actions
   toggleRevision: PropTypes.func.isRequired
@@ -116,7 +128,8 @@ RevisionsListRow.propTypes = {
 
 const mapStateToProps = state => {
   return {
-    selectedRevisions: getSelectedRevisions(state)
+    selectedRevisions: getSelectedRevisions(state),
+    showBuildRequest: hasBuildRequestId(state)
   };
 };
 

--- a/static/js/publisher/release/selectors/index.js
+++ b/static/js/publisher/release/selectors/index.js
@@ -242,3 +242,10 @@ export function getTrackRevisions({ channelMap }, track) {
   );
   return trackKeys.map(trackName => channelMap[trackName]);
 }
+
+// return true if any revision has build-request-id attribute
+export function hasBuildRequestId(state) {
+  return getAllRevisions(state).some(
+    revision => revision.attributes && revision.attributes["build-request-id"]
+  );
+}

--- a/static/js/publisher/release/selectors/selectors.test.js
+++ b/static/js/publisher/release/selectors/selectors.test.js
@@ -17,7 +17,8 @@ import {
   getArchitectures,
   getTracks,
   getTrackRevisions,
-  getBranches
+  getBranches,
+  hasBuildRequestId
 } from "./index";
 
 import reducers from "../reducers";
@@ -675,5 +676,35 @@ describe("getBranches", () => {
         when: lessThan30DaysAgo
       }
     ]);
+  });
+});
+
+describe("hasBuildRequestId", () => {
+  const initialState = reducers(undefined, {});
+  const stateWithoutBuildRequestId = {
+    ...initialState,
+    revisions: {
+      1: { revision: 1, version: "1" },
+      2: { revision: 2, version: "2" },
+      3: { revision: 3, version: "3" }
+    }
+  };
+  const stateWithBuildRequestId = {
+    ...stateWithoutBuildRequestId,
+    revisions: {
+      ...stateWithoutBuildRequestId.revisions,
+      4: {
+        revision: 4,
+        version: "4",
+        attributes: { "build-request-id": "test-1234" }
+      }
+    }
+  };
+  it("should return false if none of the revisions have build-request-id attribute", () => {
+    expect(hasBuildRequestId(stateWithoutBuildRequestId)).toBe(false);
+  });
+
+  it("should return true if any of the revisions have build-request-id attribute", () => {
+    expect(hasBuildRequestId(stateWithBuildRequestId)).toBe(true);
   });
 });


### PR DESCRIPTION
Fixes #2224

Show build request id from revision attributes in release UI (in revisions history and in release table tooltip).

This is currently being merged to feature branch, until we figure out final shape of the feature.

### QA

- ./run or demo
- go to releases page of any snap built by Launchpad (e.g. https://snapcraft-io-canonical-web-and-design-pr-2227.run.demo.haus/surl/releases)
- look for revision attributes in revision history list or in tooltips

<img width="1147" alt="Screenshot 2019-09-03 at 16 51 50" src="https://user-images.githubusercontent.com/83575/64184408-b54c2680-ce6b-11e9-97bb-fe47fc1a09dd.png">
