### PR TITLE
Update all links to docs.snapcraft.io to /docs

### DIFF
--- a/static/js/publisher/release/components/revisionsList.js
+++ b/static/js/publisher/release/components/revisionsList.js
@@ -235,11 +235,11 @@ class RevisionsList extends Component {
             candidate channels.
             <br />
             You can read more about{" "}
-            <a href="https://docs.snapcraft.io/t/snap-confinement/6233">
+            <a href="/docs/snap-confinement">
               <code>devmode</code> confinement
             </a>{" "}
             and{" "}
-            <a href="https://docs.snapcraft.io/t/snapcraft-yaml-reference/4276">
+            <a href="/docs/snapcraft-yaml-reference">
               <code>devel</code> grade
             </a>
             .

--- a/templates/404.html
+++ b/templates/404.html
@@ -17,7 +17,7 @@
       </div>
        <button type="submit" alt="search" class="p-button--positive">Search</button>
     </form>
-        <p>Or try the Snapcraft <a class="p-link--external" href="https://forum.snapcraft.io/categories">Forum</a> or <a href="https://docs.snapcraft.io">Documentation</a></p>
+        <p>Or try the Snapcraft <a class="p-link--external" href="https://forum.snapcraft.io/categories">Forum</a> or <a href="/docs">Documentation</a></p>
     </div>
   </div>
 </div>

--- a/templates/410.html
+++ b/templates/410.html
@@ -17,7 +17,7 @@
       </div>
        <button type="submit" alt="search" class="p-button--positive">Search</button>
     </form>
-        <p>Or try the Snapcraft <a class="p-link--external" href="https://forum.snapcraft.io/categories">Forum</a> or <a href="https://docs.snapcraft.io">Documentation</a></p>
+        <p>Or try the Snapcraft <a class="p-link--external" href="https://forum.snapcraft.io/categories">Forum</a> or <a href="/docs">Documentation</a></p>
     </div>
   </div>
 </div>

--- a/templates/docs/search.html
+++ b/templates/docs/search.html
@@ -66,7 +66,7 @@
       <div class="col-6">
         <h3>Still no luck?</h3>
         <ul class="p-list">
-          <li class="p-list__item is-ticked"><a href="/docs">Visit docs.snapcraft.io</a></li>
+          <li class="p-list__item is-ticked"><a href="/docs">Visit snapcraft.io/docs</a></li>
           <li class="p-list__item is-ticked"><a href="https://forum.snapcraft.io">Ask on the forum</a></li>
         </ul>
       </div>

--- a/templates/first-snap/_install-linux.html
+++ b/templates/first-snap/_install-linux.html
@@ -13,7 +13,7 @@
         <li class="p-stepped-list__item">
           <h4 class="p-stepped-list__title u-no-limit">
             <span>
-              <a href="https://docs.snapcraft.io/core/install" target="_blank" class="p-link--external">Install snap support</a>, if you don't have it already
+              <a href="/docs/installing-snapd" target="_blank" class="p-link--external">Install snap support</a>, if you don't have it already
             </span>
           </h4>
         </li>

--- a/templates/first-snap/_install-macos.html
+++ b/templates/first-snap/_install-macos.html
@@ -20,7 +20,7 @@
         <li class="p-stepped-list__item">
             <h4 class="p-stepped-list__title u-no-limit">
               <span>
-                <a href="https://docs.snapcraft.io/snapcraft-overview" target="_blank" class="p-link--external">Install Snapcraft</a>, the command-line tool for building snaps:
+                <a href="/docs/snapcraft-overview" target="_blank" class="p-link--external">Install Snapcraft</a>, the command-line tool for building snaps:
               </span>
             </h4>
             <span class="p-stepped-list__content">

--- a/templates/first-snap/package.html
+++ b/templates/first-snap/package.html
@@ -63,7 +63,7 @@
             <div class="p-strip is-shallow">
               <div class="row">
                 <div class="col-9">
-                  <p>A <a href="https://docs.snapcraft.io/snapcraft-format">snapcraft.yaml file</a> holds the basic meta data for the snap.</p>
+                  <p>A <a href="/docs/snapcraft-format">snapcraft.yaml file</a> holds the basic meta data for the snap.</p>
                   <p>You can edit the meta data later on. For now we have generated an example snapcraft.yaml for you using the snap name you have chosen.</p>
                   <p>To discover more about the <code>snapcraft.yaml</code>, mouse over each piece of metadata in the interactive <code>.yaml</code> viewer below:</p>
                   <div class="p-annotated-code">

--- a/templates/home/_fsf_electron.html
+++ b/templates/home/_fsf_electron.html
@@ -11,7 +11,7 @@
 
     <div class="p-flow-details__continue">
       <p>In just a few steps, you’ll have an example Electron app in the Snap Store.</p>
-      <a class="p-button--positive" href="https://docs.snapcraft.io/build-snaps/electron">Continue &rsaquo;</a>
+      <a class="p-button--positive" href="/docs/build-snaps/electron">Continue &rsaquo;</a>
     </div>
   </div>
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -141,37 +141,37 @@
     </div>
     <div class="col-6">
       <p>Snaps work across Linux on any distribution or version. Bundle your dependencies and assets, simplifying installs to a single standard command.</p>
-      <p><a href="https://docs.snapcraft.io/core/install">See all supported distributions</a></p>
+      <p><a href="/docs/installing-snapd">See all supported distributions</a></p>
     </div>
   </div>
   <div class="row">
     <div class="col-small-2 col-medium-2 col-2 col-logo">
-      <a class="p-logo-link" href="https://docs.snapcraft.io/core/install-ubuntu">
+      <a class="p-logo-link" href="/docs/installing-snap-on-ubuntu">
         <img src="https://assets.ubuntu.com/v1/4e18e57c-logo-ubuntu--in-card.png" alt="" />
       </a>
     </div>
     <div class="col-small-2 col-medium-2 col-2 col-logo">
-      <a class="p-logo-link" href="https://docs.snapcraft.io/core/install-debian">
+      <a class="p-logo-link" href="/docs/installing-snap-on-debian">
         <img src="https://assets.ubuntu.com/v1/f7f680fb-debian.png" alt="" />
       </a>
     </div>
     <div class="col-small-2 col-medium-2 col-2 col-logo">
-      <a class="p-logo-link" href="https://docs.snapcraft.io/core/install-linux-mint">
+      <a class="p-logo-link" href="/docs/installing-snap-on-linux-mint">
         <img src="https://assets.ubuntu.com/v1/2ce868d9-mint.png" alt="" />
       </a>
     </div>
     <div class="col-small-2 col-medium-2 col-2 col-logo">
-      <a class="p-logo-link" href="https://docs.snapcraft.io/core/install-raspbian">
+      <a class="p-logo-link" href="/docs/installing-snap-on-raspbian">
         <img src="https://assets.ubuntu.com/v1/eccf1818-raspberrypi.png" alt="" />
       </a>
     </div>
     <div class="col-small-2 col-medium-2 col-2 col-logo col-logo--pushed">
-      <a class="p-logo-link" href="https://docs.snapcraft.io/core/install-arch-linux">
+      <a class="p-logo-link" href="/docs/installing-snap-on-arch-linux">
         <img src="https://assets.ubuntu.com/v1/44789cf1-arch.png" alt="" />
       </a>
     </div>
     <div class="col-small-2 col-medium-2 col-2 col-logo">
-      <a class="p-logo-link" href="https://docs.snapcraft.io/core/install-fedora">
+      <a class="p-logo-link" href="/docs/installing-snap-on-fedora">
         <img src="https://assets.ubuntu.com/v1/f24733d2-fedora.png" alt="" />
       </a>
     </div>

--- a/templates/partials/fsf_language.html
+++ b/templates/partials/fsf_language.html
@@ -48,7 +48,7 @@
     </a>
   </div>
   <div class="col-small-2 col-medium-3 col-2 col-lang-select">
-    <a class="p-logo-link p-card p-flow-link" href="https://docs.snapcraft.io/build-snaps/electron" data-flow-link="electron">
+    <a class="p-logo-link p-card p-flow-link" href="/docs/build-snaps/electron" data-flow-link="electron">
       <header class="p-card__header">
         <img src="https://assets.ubuntu.com/v1/4ab5c788-logo-electron.svg" alt="">
       </header>

--- a/templates/publisher/account-snaps.html
+++ b/templates/publisher/account-snaps.html
@@ -71,7 +71,7 @@ My published snaps — Linux software in the Snap Store
     <div class="col-6">
       <h3 class="p-heading--five">Snapcraft documentation</h3>
       <p>All you need to know about snaps, snapcraft and everything in between.</p>
-      <p><a href="https://docs.snapcraft.io">Read the docs &rsaquo;</a></p>
+      <p><a href="/docs">Read the docs &rsaquo;</a></p>
     </div>
     <div class="col-6">
       <h3 class="p-heading--five">Join the community</h3>
@@ -102,7 +102,7 @@ My published snaps — Linux software in the Snap Store
           {% if not snaps[snap].latest_release %}
           <br />
           Is your snap ready to release?
-          <a href="https://docs.snapcraft.io/build-snaps/release" target="_blank">Release it</a>
+          <a href="/docs/releasing-your-app" target="_blank">Release it</a>
           {% endif %}
         </p>
       </div>
@@ -210,7 +210,7 @@ My published snaps — Linux software in the Snap Store
             {% if dispute_pending %}
             <span class="p-snapcraft-dispute-list__muted">(Name dispute in progress)</span>
             {% else %}
-            <a href="https://docs.snapcraft.io/releasing-your-app" target="_blank" class="p-link--external p-snapcraft-dispute-list__link u-float-right">Publish to this name</a>
+            <a href="/docs/releasing-your-app" target="_blank" class="p-link--external p-snapcraft-dispute-list__link u-float-right">Publish to this name</a>
             {% endif %}
           </td>
         </tr>

--- a/templates/store/categories/iot.html
+++ b/templates/store/categories/iot.html
@@ -16,7 +16,7 @@
       <div class="col-7">
         <h1 class="p-heading--two">Internet of Things</h1>
         <p>Transactional updates, airtight security, and compatibility across architectures and OSes make snaps a perfect fit for IoT.</p>
-        <p><a href="https://docs.snapcraft.io/build-snaps/languages">Publish IoT applications with Snapcraft &rsaquo;</a></p>
+        <p><a href="/docs/creating-a-snap">Publish IoT applications with Snapcraft &rsaquo;</a></p>
       </div>
       <div class="col-5">
         <img src="https://assets.ubuntu.com/v1/2c5e93c5-fast-easy-safe-illustration.svg" />

--- a/templates/store/snap-details/_channel_map.html
+++ b/templates/store/snap-details/_channel_map.html
@@ -13,7 +13,7 @@
           data-js="open-desktop">
             View in Desktop store
         </button>
-        <p class="p-form-help-text">Make sure <a href="https://docs.snapcraft.io/core/install">snap support</a> is enabled in your Desktop store.</p>
+        <p class="p-form-help-text">Make sure <a href="/docs/installing-snapd">snap support</a> is enabled in your Desktop store.</p>
       </div>
       <div class="u-fixed-width">
         <hr />
@@ -36,7 +36,7 @@
           </button>
         </div>
         <p class="p-form-help-text">
-          Don't have snapd? <a href="https://docs.snapcraft.io/core/install">Get set up for snaps</a>.
+          Don't have snapd? <a href="/docs/installing-snapd">Get set up for snaps</a>.
         </p>
       </div>
     </div>
@@ -117,7 +117,7 @@
     <p class="p-heading--four">Install ${channel} of {{ snap_title }}</p>
     <label>Ubuntu 16.04 or later?</label>
     <button data-snap="{{ package_name }}?channel=${channel}" class="p-view-store-button" data-js="open-desktop">View in Desktop store</button>
-    <p class="p-form-help-text">Make sure <a href="https://docs.snapcraft.io/core/install">snap support</a> is enabled in your Desktop store.</p>
+    <p class="p-form-help-text">Make sure <a href="/docs/installing-snapd">snap support</a> is enabled in your Desktop store.</p>
   </div>
   <div class="u-fixed-width">
     <hr />
@@ -138,7 +138,7 @@
       </button>
     </div>
     <p class="p-form-help-text">
-      Don't have snapd? <a href="https://docs.snapcraft.io/core/install">Get set up for snaps</a>.
+      Don't have snapd? <a href="/docs/installing-snapd">Get set up for snaps</a>.
     </p>
   </div>
 </script>

--- a/templates/store/snap-distro-install.html
+++ b/templates/store/snap-distro-install.html
@@ -208,7 +208,7 @@
       </div>
       <div class="col-6">
         <div class="p-card--highlighted">
-          <a href="https://docs.snapcraft.io">
+          <a href="/docs">
             <img src="https://assets.ubuntu.com/v1/8d00f749-distro_img_02.svg" width="100%" alt="" />
           </a>
           <h4 class="p-card__title">


### PR DESCRIPTION
Fixes https://github.com/canonical-web-and-design/snapcraft.io/issues/2172

## QA
- Pull the branch
- `./run`
- Ensure links to docs go to 0.0.0.0:8004/docs not docs.snapcraft.io
- Visit http://0.0.0.0:8004/<snap>/releases
- Visit http://0.0.0.0:8004/asdvkjhfdbkjh
- Visit http://0.0.0.0:8004/first-snap/python
  - Make sure both linux and MacOS links work
- Visit http://0.0.0.0:8004/first-snap/python/linux/package
  - Make sure the link under step 3 is correct
- Visit http://0.0.0.0:8004/first-snap#electron
  - Make sure continue button goes to the right place
- Visit http://0.0.0.0:8004
  - Links to "Available distro's" should be correct
- Visit http://0.0.0.0:8004/iot
- Visit http://0.0.0.0:8004/spotify
  - Make sure channel-map help links go to the right place
  - Make sure the install on distro link to installing snapd goes to the right place