### PR TITLE
Fix selecting same version in all archs in release UI

### DIFF
--- a/static/js/publisher/release/components/revisionsList.js
+++ b/static/js/publisher/release/components/revisionsList.js
@@ -13,7 +13,7 @@ import { getChannelName, isInDevmode } from "../helpers";
 
 import RevisionsListRow from "./revisionsListRow";
 import { closeHistory } from "../actions/history";
-import { toggleRevision, clearSelectedRevisions } from "../actions/channelMap";
+import { toggleRevision } from "../actions/channelMap";
 import {
   getFilteredReleaseHistory,
   getPendingChannelMap,
@@ -34,7 +34,6 @@ class RevisionsList extends Component {
   }
 
   selectVersionClick(revisions) {
-    this.props.clearSelectedRevisions();
     revisions.forEach(revision => this.props.toggleRevision(revision));
   }
 
@@ -261,12 +260,12 @@ class RevisionsList extends Component {
               <div className="p-releases-confirm__buttons">
                 <button
                   className="p-button--positive is-inline u-no-margin--bottom"
-                  onClick={this.selectVersionClick.bind(this, [
-                    selectedRevision,
-                    ...selectedVersionRevisions
-                  ])}
+                  onClick={this.selectVersionClick.bind(
+                    this,
+                    selectedVersionRevisions
+                  )}
                 >
-                  {"Select in all architectures"}
+                  {"Select in available architectures"}
                 </button>
               </div>
             </div>
@@ -350,7 +349,6 @@ RevisionsList.propTypes = {
 
   // actions
   closeHistoryPanel: PropTypes.func.isRequired,
-  clearSelectedRevisions: PropTypes.func.isRequired,
   toggleRevision: PropTypes.func.isRequired
 };
 
@@ -379,7 +377,6 @@ const mapStateToProps = state => {
 const mapDispatchToProps = dispatch => {
   return {
     closeHistoryPanel: () => dispatch(closeHistory()),
-    clearSelectedRevisions: () => dispatch(clearSelectedRevisions()),
     toggleRevision: revision => dispatch(toggleRevision(revision))
   };
 };


### PR DESCRIPTION
Fixes #2230 

Fixes the issue where revisions from the same architecture were unselected.

### QA
- ./run or https://snapcraft-io-canonical-web-and-design-pr-2232.run.demo.haus/
- go to releases page of a snap with multiple architectures (and multiple versions)
- show "All revisions" in available revisions
- select same version in all architectures
- unselect one architecture
- open history of another architecture, there should be a button 'Select in all architectures'
- clicking on it should select the missing architecture, but not unselect any
- try different combinations of selected revisions: all selected from different versions, all unselected, etc, make sure that behaviour of selecting same version in all architectures works as expected in different cases

<img width="1171" alt="Screenshot 2019-09-05 at 17 18 14" src="https://user-images.githubusercontent.com/83575/64355256-2c66f380-d001-11e9-8d2f-c2d4471be6ed.png">
