### PR TITLE
Show disabled publicise page for private snaps

### DIFF
--- a/static/sass/_utilities_disabled.scss
+++ b/static/sass/_utilities_disabled.scss
@@ -1,0 +1,8 @@
+@mixin u-disabled {
+  // make anything look disabled (grayed out and not interactive)
+  .u-disabled {
+    filter: grayscale(1);
+    opacity: .6;
+    pointer-events: none;
+  }
+}

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -222,5 +222,8 @@ $color-social-icon-foreground: $color-light;
 @import 'utilities_flex';
 @include u-flex;
 
+@import 'utilities_disabled';
+@include u-disabled;
+
 @import 'snapcraft_tour';
 @include snapcraft-tour;

--- a/templates/publisher/_header.html
+++ b/templates/publisher/_header.html
@@ -55,9 +55,8 @@
           </a>
         </li>
         <li
-          class="p-tabs__item {% if private %}is--disabled p-tooltip p-tooltip--btm-center{% endif %}"
+          class="p-tabs__item"
           role="presentation"
-          {% if private %} aria-describedby="publicise-tooltip"{% endif %}
           >
           <a
             href="/{{ snap_name }}/publicise"
@@ -70,9 +69,6 @@
             >
             Publicise
           </a>
-          {% if private %}
-          <span class="p-tooltip__message" role="tooltip" id="publicise-tooltip">Your snap needs to be public in order to publicise.</span>
-          {% endif %}
         </li>
         <li class="p-tabs__item" role="presentation">
           <a

--- a/templates/publisher/publicise/_publisher_publicise_layout.html
+++ b/templates/publisher/publicise/_publisher_publicise_layout.html
@@ -9,7 +9,20 @@ Publicise {% if display_title %}{{ display_title }}{% else %}{{ snap_title }}{% 
   {% set selected_tab='publicise' %}
   {% include "publisher/_header.html" %}
 
-  <div class="p-strip is-shallow">
+  {% if private %}
+    <section class="p-strip--light is-shallow">
+      <div class="row">
+        <div class="col-6">
+          <h2 class="p-heading--four">Share and promote your snap</h2>
+        </div>
+        <div class="col-6">
+          <p>When your snap is public, you'll be able to share it using Store buttons, badges and embeddable cards.</p>
+        </div>
+      </div>
+    </section>
+  {% endif %}
+
+  <div class="p-strip is-shallow {% if private %}u-disabled{% endif %}">
     <div class="row">
       <div class="col-3">
         <div class="p-navigation--sidebar">

--- a/templates/publisher/publicise/_publisher_publicise_layout.html
+++ b/templates/publisher/publicise/_publisher_publicise_layout.html
@@ -17,6 +17,7 @@ Publicise {% if display_title %}{{ display_title }}{% else %}{{ snap_title }}{% 
         </div>
         <div class="col-6">
           <p>When your snap is public, you'll be able to share it using Store buttons, badges and embeddable cards.</p>
+          <p>Make your snap public in <a href="/{{ snap_name }}/settings">its settings page.</p>
         </div>
       </div>
     </section>

--- a/tests/publisher/snaps/tests_publicise.py
+++ b/tests/publisher/snaps/tests_publicise.py
@@ -81,5 +81,7 @@ class GetPublicisePage(BaseTestCases.EndpointLoggedInErrorHandling):
 
         self.check_call_by_api_url(responses.calls)
 
-        assert response.status_code == 404
-        self.assert_template_used("404.html")
+        assert response.status_code == 200
+        self.assert_template_used("publisher/publicise/store_buttons.html")
+
+        self.assert_context("private", True)

--- a/webapp/publisher/snaps/views.py
+++ b/webapp/publisher/snaps/views.py
@@ -1157,9 +1157,6 @@ def get_publicise(snap_name):
     except ApiError as api_error:
         return _handle_errors(api_error)
 
-    if snap_details["private"]:
-        return flask.abort(404, "No snap named {}".format(snap_name))
-
     available_languages = {
         "de": {"title": "Deutsch", "text": "Installieren vom Snap Store"},
         "en": {"title": "English", "text": "Get it from the Snap Store"},
@@ -1177,6 +1174,7 @@ def get_publicise(snap_name):
     }
 
     context = {
+        "private": snap_details["private"],
         "snap_name": snap_details["snap_name"],
         "snap_title": snap_details["title"],
         "snap_id": snap_details["snap_id"],


### PR DESCRIPTION
Fixes https://github.com/canonical-web-and-design/snap-squad/issues/1108

Fixes 404 error when accessing publicise page on private snap

### QA
- ./run or https://snapcraft-io-canonical-web-and-design-pr-2233.run.demo.haus/
- sign in, go it any snap that is private
- Publicise tab should be available
- going to publicise page should show a grayed out and not interactive publicise page with a message on top
- try to go directly to other pages (via URL) /publicise/badges or publicise/cards - these should 404

<img width="1168" alt="Screenshot 2019-09-06 at 10 25 41" src="https://user-images.githubusercontent.com/83575/64413101-2e789300-d091-11e9-8761-6839169fb6b2.png">
