### PR TITLE
Revision attributes sets

### DIFF
--- a/static/js/publisher/release/components/availableRevisionsMenu.js
+++ b/static/js/publisher/release/components/availableRevisionsMenu.js
@@ -89,7 +89,19 @@ export class AvailableRevisionsMenu extends Component {
   }
 
   renderItems() {
-    const items = Object.keys(menuLabels);
+    let items = Object.keys(menuLabels);
+
+    items = items.filter(item => {
+      // remove Launchpad menu option if there are no LP builds
+      if (
+        item === AVAILABLE_REVISIONS_SELECT_LAUNCHPAD &&
+        this.props.getFilteredCount(AVAILABLE_REVISIONS_SELECT_LAUNCHPAD) === 0
+      ) {
+        return false;
+      }
+
+      return true;
+    });
 
     return (
       <span className="p-contextual-menu__group">

--- a/static/js/publisher/release/components/dnd.js
+++ b/static/js/publisher/release/components/dnd.js
@@ -3,6 +3,7 @@ import { useDrag, useDrop } from "react-dnd";
 
 export const DND_ITEM_REVISION = "DND_ITEM_REVISION";
 export const DND_ITEM_CHANNEL = "DND_ITEM_CHANNEL";
+export const DND_ITEM_BUILDSET = "DND_ITEM_BUILDSET";
 
 export const Handle = () => (
   <span className="p-drag-handle">

--- a/static/js/publisher/release/components/releasesTableCell.js
+++ b/static/js/publisher/release/components/releasesTableCell.js
@@ -150,7 +150,8 @@ const ReleasesTableCell = props => {
     channelMap,
     pendingChannelMap,
     pendingCloses,
-    filters
+    filters,
+    isOverParent
   } = props;
 
   const branchName = branch ? branch.branch : null;
@@ -188,11 +189,15 @@ const ReleasesTableCell = props => {
     ? {
         revisions: buildSet,
         architectures: getRevisionsArchitectures(buildSet),
+        risk,
+        branch,
         type: DND_ITEM_BUILDSET
       }
     : {
         revision: currentRevision,
-        arch: arch,
+        arch,
+        risk,
+        branch,
         type: DND_ITEM_REVISION
       };
   const [isDragging, isGrabbing, drag] = useDragging({
@@ -221,7 +226,12 @@ const ReleasesTableCell = props => {
           return false;
         }
 
-        // TODO: can't drop if devmode
+        // can't drop devmode to stable/candidate
+        if (risk === STABLE || risk === CANDIDATE) {
+          if (item.revisions.some(isInDevmode)) {
+            return false;
+          }
+        }
 
         // can't drop if same revision is part of build set
         if (
@@ -282,7 +292,7 @@ const ReleasesTableCell = props => {
     isGrabbing ? "is-grabbing" : "",
     isDragging ? "is-dragging" : "",
     canDrag ? "is-draggable" : "",
-    canDrop && isOver ? "is-over" : "",
+    (canDrop && isOver) || (canDrop && isOverParent) ? "is-over" : "",
     canDrop ? "can-drop" : ""
   ].join(" ");
 
@@ -354,7 +364,8 @@ ReleasesTableCell.propTypes = {
   risk: PropTypes.string,
   arch: PropTypes.string,
   showVersion: PropTypes.bool,
-  branch: PropTypes.object
+  branch: PropTypes.object,
+  isOverParent: PropTypes.bool
 };
 
 const mapStateToProps = state => {

--- a/static/js/publisher/release/helpers.js
+++ b/static/js/publisher/release/helpers.js
@@ -12,10 +12,27 @@ export function getChannelName(track, risk, branch) {
   return name;
 }
 
-export function isRevisionBuiltOnLauchpad(revision) {
-  return !!(
-    revision.attributes &&
-    revision.attributes["build-request-id"] &&
-    revision.attributes["build-request-id"].indexOf("lp-") === 0
+export function getBuildId(revision) {
+  return (
+    revision && revision.attributes && revision.attributes["build-request-id"]
   );
+}
+
+export function isRevisionBuiltOnLauchpad(revision) {
+  const buildId = getBuildId(revision);
+  return !!(buildId && buildId.indexOf("lp-") === 0);
+}
+
+export function getRevisionsArchitectures(revisions) {
+  let archs = [];
+
+  // get all architectures from all revisions
+  revisions.forEach(revision => {
+    archs = archs.concat(revision.architectures);
+  });
+
+  // make archs unique and sorted
+  archs = archs.filter((item, i, ar) => ar.indexOf(item) === i).sort();
+
+  return archs;
 }

--- a/static/js/publisher/release/helpers.test.js
+++ b/static/js/publisher/release/helpers.test.js
@@ -1,5 +1,9 @@
 import { AVAILABLE } from "./constants";
-import { getChannelName, isRevisionBuiltOnLauchpad } from "./helpers";
+import {
+  getChannelName,
+  isRevisionBuiltOnLauchpad,
+  getRevisionsArchitectures
+} from "./helpers";
 
 describe("getChannelName", () => {
   it("should return track/risk pair as a name", () => {
@@ -39,5 +43,22 @@ describe("isRevisionBuiltOnLauchpad", () => {
         attributes: { "build-request-id": "lp-123" }
       })
     ).toBe(true);
+  });
+});
+
+describe("getRevisionsArchitectures", () => {
+  it("should return unique and sorted list of architectures from all revisoins", () => {
+    const revisions = [
+      { architectures: ["test4"] },
+      { architectures: ["test2"] },
+      { architectures: ["test3", "test2", "test1"] },
+      { architectures: ["test3", "test4"] }
+    ];
+    expect(getRevisionsArchitectures(revisions)).toEqual([
+      "test1",
+      "test2",
+      "test3",
+      "test4"
+    ]);
   });
 });

--- a/static/js/publisher/release/selectors/index.js
+++ b/static/js/publisher/release/selectors/index.js
@@ -5,7 +5,7 @@ import {
   AVAILABLE_REVISIONS_SELECT_RECENT,
   AVAILABLE_REVISIONS_SELECT_LAUNCHPAD
 } from "../constants";
-import { isInDevmode, isRevisionBuiltOnLauchpad } from "../helpers";
+import { isInDevmode, getBuildId, isRevisionBuiltOnLauchpad } from "../helpers";
 import { sortAlphaNum } from "../../../libs/channels";
 
 // returns release history filtered by history filters
@@ -248,12 +248,16 @@ export function getTrackRevisions({ channelMap }, track) {
 
 // return true if any revision has build-request-id attribute
 export function hasBuildRequestId(state) {
-  return getAllRevisions(state).some(
-    revision => revision.attributes && revision.attributes["build-request-id"]
-  );
+  return getAllRevisions(state).some(revision => getBuildId(revision));
 }
 
 // return revisions built by launchpad
 export function getLaunchpadRevisions(state) {
   return getAllRevisions(state).filter(isRevisionBuiltOnLauchpad);
+}
+
+export function getRevisionsFromBuild(state, buildId) {
+  return getAllRevisions(state).filter(
+    revision => getBuildId(revision) === buildId
+  );
 }

--- a/static/js/publisher/release/selectors/selectors.test.js
+++ b/static/js/publisher/release/selectors/selectors.test.js
@@ -20,7 +20,8 @@ import {
   getTrackRevisions,
   getBranches,
   hasBuildRequestId,
-  getLaunchpadRevisions
+  getLaunchpadRevisions,
+  getRevisionsFromBuild
 } from "./index";
 
 import reducers from "../reducers";
@@ -759,6 +760,46 @@ describe("getLaunchpadRevisions", () => {
       stateWithLauchpadBuilds.revisions[2]
     );
     expect(getLaunchpadRevisions(stateWithLauchpadBuilds)).toContain(
+      stateWithLauchpadBuilds.revisions[3],
+      stateWithLauchpadBuilds.revisions[4]
+    );
+  });
+});
+
+describe("getRevisionsFromBuild", () => {
+  const initialState = reducers(undefined, {});
+  const stateWithLauchpadBuilds = {
+    ...initialState,
+    revisions: {
+      1: { revision: 1, version: "1" },
+      2: { revision: 2, version: "2" },
+      3: {
+        revision: 3,
+        version: "3",
+        attributes: { "build-request-id": "lp-1234" }
+      },
+      4: {
+        revision: 4,
+        version: "4",
+        attributes: { "build-request-id": "lp-1234" }
+      },
+      5: {
+        revision: 5,
+        version: "5",
+        attributes: { "build-request-id": "lp-5432" }
+      }
+    }
+  };
+
+  it("should return only revisions with given build id", () => {
+    const revisions = getRevisionsFromBuild(stateWithLauchpadBuilds, "lp-1234");
+    expect(revisions.length).toEqual(2);
+    expect(revisions).not.toContain(
+      stateWithLauchpadBuilds.revisions[1],
+      stateWithLauchpadBuilds.revisions[2],
+      stateWithLauchpadBuilds.revisions[5]
+    );
+    expect(revisions).toContain(
       stateWithLauchpadBuilds.revisions[3],
       stateWithLauchpadBuilds.revisions[4]
     );


### PR DESCRIPTION
Fixes #2225 

Allows promoting all revisions in same build set at once.
Removes Launchpad option from "Available revisions" menu when there are no lauchpad builds.

### QA
- ./run or https://snapcraft-io-canonical-web-and-design-pr-2249.run.demo.haus/
- go to releases page of any snap with Launchpad builds (like [surl](https://snapcraft-io-canonical-web-and-design-pr-2249.run.demo.haus/surl/releases))
- find any release that is part of a build set (has LP icon)
- try to drag it to promote to different channel
- while dragging architectures of all revisions in the build set should highlight
- you should be able to drop the set on ANY architecture from the set
- when you drop build set all revisions from the set should be promoted to given channel

<img width="1145" alt="Screenshot 2019-09-10 at 16 12 37" src="https://user-images.githubusercontent.com/83575/64621663-57c55600-d3e6-11e9-9df0-a8d76dcd9b7f.png">
