### PR TITLE
Defend against no graph data being present on dashboard

### DIFF
--- a/static/js/publisher/metrics/metrics.js
+++ b/static/js/publisher/metrics/metrics.js
@@ -156,7 +156,12 @@ function renderPublisherMetrics(options) {
 
   function getChunk(chunks) {
     if (chunks.length === 0) {
-      if (_graph.rawData.buckets.length === 0) {
+      if (
+        !_graph ||
+        !_graph.rawData ||
+        !_graph.rawData.buckets ||
+        _graph.rawData.buckets.length === 0
+      ) {
         document
           .querySelector(`[data-js="dashboard-metrics"]`)
           .classList.add("u-hide");


### PR DESCRIPTION
Fixes https://github.com/canonical-web-and-design/snapcraft.io/issues/2236

## QA
- Pull branch
- `./run`
- Visit http://0.0.0.0:8004/snaps with only 1 snap that has no data/ has not been released
- Console should contain no errors