### PR TITLE
Increase space allowed for details screenshots

### DIFF
--- a/static/sass/_snapcraft_snap-details.scss
+++ b/static/sass/_snapcraft_snap-details.scss
@@ -21,12 +21,18 @@
         flex-grow: 0;
         height: auto;
         margin-bottom: $spv-outer--medium;
-        max-height: 112px;
+        max-height: 90px;
         overflow: hidden;
       }
 
-      .p-carousel__item-screenshot img,
-      .p-carousel__item-screenshot video {
+      &.is-small {
+        .p-carousel__item--screenshot {
+          max-height: 128px;
+        }
+      }
+
+      .p-carousel__item--screenshot img,
+      .p-carousel__item--screenshot video {
         align-self: center;
         width: 100%;
       }
@@ -34,7 +40,6 @@
       @media screen and (max-width: $breakpoint-medium) {
         flex-direction: row;
         flex-wrap: wrap;
-        justify-content: flex-start;
         margin-bottom: -$spv-outer--medium;
         margin-right: -$sph-outer;
         margin-top: $spv-outer--medium;
@@ -50,16 +55,6 @@
       @media screen and (max-width: $breakpoint-x-small) {
         .p-carousel__item--screenshot {
           max-width: calc(50% - 1rem);
-        }
-      }
-    }
-
-    .p-snap-details__media-items--distributed {
-      @media screen and (min-width: $breakpoint-medium) {
-        justify-content: space-between;
-
-        .p-carousel__item--screenshot {
-          margin-bottom: 0;
         }
       }
     }

--- a/templates/partials/_snap-details-video-layout.html
+++ b/templates/partials/_snap-details-video-layout.html
@@ -1,3 +1,4 @@
+
 <div class="row p-snap-details__media u-equal-height">
   {# TODO: u-align--center should be u-align-text--center
    see https://github.com/canonical-web-and-design/vanilla-framework/issues/2448 #}
@@ -9,7 +10,7 @@
     {% endfor %}
   </div>
   {% if screenshots %}
-    <div class="col-2 p-snap-details__media-items{% if screenshots|length > 3 %} p-snap-details__media-items--distributed{% endif %}">
+    <div class="col-2 p-snap-details__media-items {% if screenshots|length < 5 %}is-small{% endif %}">
       {% for screenshot in screenshots %}
         {% include "partials/_snap-screenshot.html" %}
       {% endfor %}


### PR DESCRIPTION
Fixes https://github.com/canonical-web-and-design/snapcraft.io/issues/2250

This bug affects details pages with a video and screenshots.

## QA

- Pull branch
- `./run`
- Visit http://0.0.0.0:8004/juju
- Visit http://0.0.0.0:8004/postman
- Visit http://0.0.0.0:8004/toto
- Screenshots next to the video should not be squashed