### PR TITLE
[WIP] Set phased release on promotion, show phased release in table

### DIFF
--- a/static/js/libs/channels.js
+++ b/static/js/libs/channels.js
@@ -258,4 +258,4 @@ function sortChannels(channels, options) {
   };
 }
 
-export { sortChannels, parseChannel, createChannelTree, sortAlphaNum };
+export { RISKS, sortChannels, parseChannel, createChannelTree, sortAlphaNum };

--- a/static/js/publisher/release/components/devmodeRevision.js
+++ b/static/js/publisher/release/components/devmodeRevision.js
@@ -1,12 +1,25 @@
-import React from "react";
+import React, { Fragment } from "react";
 import PropTypes from "prop-types";
 
 import { isInDevmode } from "../helpers";
 
-export default function DevmodeRevision({ revision, showTooltip, from }) {
-  const revisionString = from
-    ? `${from} → ${revision.revision}`
-    : revision.revision;
+export default function DevmodeRevision({
+  revision,
+  showTooltip,
+  phasedState
+}) {
+  const revisionString =
+    phasedState && phasedState.from ? (
+      <Fragment>
+        {phasedState.from} → {revision.revision}{" "}
+        <small>
+          ({phasedState.percentage}
+          %)
+        </small>
+      </Fragment>
+    ) : (
+      revision.revision
+    );
 
   if (isInDevmode(revision)) {
     return (
@@ -39,5 +52,6 @@ export default function DevmodeRevision({ revision, showTooltip, from }) {
 
 DevmodeRevision.propTypes = {
   revision: PropTypes.object.isRequired,
-  showTooltip: PropTypes.bool
+  showTooltip: PropTypes.bool,
+  phasedState: PropTypes.object
 };

--- a/static/js/publisher/release/components/devmodeRevision.js
+++ b/static/js/publisher/release/components/devmodeRevision.js
@@ -3,14 +3,18 @@ import PropTypes from "prop-types";
 
 import { isInDevmode } from "../helpers";
 
-export default function DevmodeRevision({ revision, showTooltip }) {
+export default function DevmodeRevision({ revision, showTooltip, from }) {
+  const revisionString = from
+    ? `${from} → ${revision.revision}`
+    : revision.revision;
+
   if (isInDevmode(revision)) {
     return (
       <span
         className="p-tooltip p-tooltip--btm-center"
         aria-describedby={`revision-devmode-${revision.revision}`}
       >
-        {revision.revision}*
+        {revisionString}*
         {showTooltip && (
           <span
             className="p-tooltip__message u-align--center"
@@ -30,7 +34,7 @@ export default function DevmodeRevision({ revision, showTooltip }) {
     );
   }
 
-  return revision.revision;
+  return revisionString;
 }
 
 DevmodeRevision.propTypes = {

--- a/static/js/publisher/release/components/historyPanel.js
+++ b/static/js/publisher/release/components/historyPanel.js
@@ -1,11 +1,28 @@
 import React, { Component } from "react";
+import PropTypes from "prop-types";
+import { connect } from "react-redux";
+
+import { closeHistory } from "../actions/history";
 
 import RevisionsList from "./revisionsList";
+import ProgressiveReleaseInfo from "./progressiveReleaseInfo";
 
-export default class HistoryPanel extends Component {
+class HistoryPanel extends Component {
+  onCloseClick(event) {
+    event.preventDefault();
+    this.props.closeHistoryPanel();
+  }
+
   render() {
     return (
       <div className="p-history-panel">
+        <a
+          style={{ position: "absolute", right: 0, top: "2rem", zIndex: 1 }}
+          href="#"
+          onClick={this.onCloseClick.bind(this)}
+          className="p-icon--close u-float-right"
+        />
+        <ProgressiveReleaseInfo />
         <div className="p-strip is-shallow">
           <RevisionsList />
         </div>
@@ -13,3 +30,18 @@ export default class HistoryPanel extends Component {
     );
   }
 }
+
+HistoryPanel.propTypes = {
+  closeHistoryPanel: PropTypes.func.isRequired
+};
+
+const mapDispatchToProps = dispatch => {
+  return {
+    closeHistoryPanel: () => dispatch(closeHistory())
+  };
+};
+
+export default connect(
+  null,
+  mapDispatchToProps
+)(HistoryPanel);

--- a/static/js/publisher/release/components/progressiveReleaseInfo.js
+++ b/static/js/publisher/release/components/progressiveReleaseInfo.js
@@ -1,0 +1,98 @@
+import React, { Component } from "react";
+import PropTypes from "prop-types";
+import { connect } from "react-redux";
+
+import { getPhasedState, getFilteredReleaseHistory } from "../selectors";
+
+class ProgressiveReleaseInfo extends Component {
+  constructor(props) {
+    super(props);
+
+    this.percentageInput = React.createRef();
+
+    this.state = {
+      percentage: null
+    };
+  }
+
+  percentageChangeHandler() {
+    const val = this.percentageInput.current.value;
+    this.setState({
+      percentage: val
+    });
+  }
+
+  render() {
+    const { getPhasedState, filters, filteredReleaseHistory } = this.props;
+    const { percentage } = this.state;
+
+    const channel = `${filters.track}/${filters.risk}${
+      filters.branch ? `/${filters.branch}` : ""
+    }`;
+
+    const phasedState = getPhasedState(channel, filters.arch);
+
+    if (!phasedState) {
+      return false;
+    }
+
+    const revision_to = filteredReleaseHistory[0].revision;
+    const revision_from = phasedState.from;
+    const release_percentage = phasedState.percentage;
+    return (
+      <div className="p-strip is-shallow">
+        <h4 className="u-float--left" style={{ maxWidth: "100%" }}>
+          Progressive Release from revision <b>{revision_from}</b> to{" "}
+          <b>{revision_to}</b> is currently at <b>{release_percentage}%</b>
+        </h4>
+        <div className="row p-form p-form--inline">
+          <div className="col-6">
+            <div className="p-form__group">
+              <label htmlFor="percentage" className="p-form__label">
+                Release to:
+              </label>
+              <input
+                type="number"
+                min="1"
+                max="100"
+                id="percentage"
+                name="percentage"
+                value={percentage || release_percentage}
+                className="p-form__control"
+                style={{
+                  width: "3rem",
+                  minWidth: "3rem"
+                }}
+                onChange={this.percentageChangeHandler.bind(this)}
+                ref={this.percentageInput}
+              />
+            </div>
+          </div>
+          <div className="col-6">
+            <button className="p-button--positive">Save</button>
+            {phasedState.paused && <button className="p-button">Resume</button>}
+            {!phasedState.paused && <button className="p-button">Pause</button>}
+            <button className="p-button">Revert all to {revision_from}</button>
+            <button className="p-button">Advance all to {revision_to}</button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+}
+
+ProgressiveReleaseInfo.propTypes = {
+  filters: PropTypes.object,
+  getPhasedState: PropTypes.func,
+  filteredReleaseHistory: PropTypes.array
+};
+
+const mapStateToProps = state => {
+  return {
+    filters: state.history.filters,
+    filteredReleaseHistory: getFilteredReleaseHistory(state),
+    getPhasedState: (channel, arch) => getPhasedState(state, channel, arch)
+  };
+};
+
+export default connect(mapStateToProps)(ProgressiveReleaseInfo);

--- a/static/js/publisher/release/components/releasesConfirm.js
+++ b/static/js/publisher/release/components/releasesConfirm.js
@@ -117,6 +117,8 @@ class ReleasesConfirm extends Component {
                 <input
                   className="p-releases-confirm__rollout-percentage"
                   type="number"
+                  max="100"
+                  min="1"
                   name="rollout-percentage"
                   value={rolloutPercentage}
                   onChange={this.onRolloutPercentageChange.bind(this)}

--- a/static/js/publisher/release/components/releasesConfirm.js
+++ b/static/js/publisher/release/components/releasesConfirm.js
@@ -21,7 +21,7 @@ class ReleasesConfirm extends Component {
   onApplyClick() {
     const { rolloutType, rolloutPercentage } = this.state;
     this.props.releaseRevisions(
-      rolloutType === "percentage" ? rolloutPercentage : undefined
+      rolloutType === "percentage" ? rolloutPercentage : 100
     );
   }
 

--- a/static/js/publisher/release/components/releasesConfirm.js
+++ b/static/js/publisher/release/components/releasesConfirm.js
@@ -5,64 +5,128 @@ import { connect } from "react-redux";
 import { cancelPendingReleases } from "../actions/pendingReleases";
 
 class ReleasesConfirm extends Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      rolloutType: "all",
+      rolloutPercentage: 10
+    };
+  }
+
   onRevertClick() {
     this.props.cancelPendingReleases();
   }
 
   onApplyClick() {
-    this.props.releaseRevisions();
+    const { rolloutType, rolloutPercentage } = this.state;
+    this.props.releaseRevisions(
+      rolloutType === "percentage" ? rolloutPercentage : undefined
+    );
+  }
+
+  onRolloutTypeClick(type) {
+    this.setState({
+      rolloutType: type
+    });
+  }
+
+  onRolloutPercentageChange() {
+    this.setState({
+      rolloutPercentage: parseInt(this.percentageInput.value)
+    });
   }
 
   render() {
     const { pendingReleases, pendingCloses, isLoading } = this.props;
+    const { rolloutType, rolloutPercentage } = this.state;
     const releasesCount = Object.keys(pendingReleases).length;
     const closesCount = pendingCloses.length;
 
     return (
       (releasesCount > 0 || closesCount > 0) && (
         <div className="p-releases-confirm">
-          {releasesCount > 0 && (
-            <Fragment>
-              <span className="p-tooltip">
-                <span className="p-help">
-                  {releasesCount} revision
-                  {releasesCount > 1 ? "s" : ""}
-                </span>
-                <span className="p-tooltip__message" role="tooltip">
-                  Release revisions:
-                  <br />
-                  {Object.keys(pendingReleases).map(revId => {
-                    const release = pendingReleases[revId];
+          <p className="u-no-margin--bottom">
+            {closesCount > 0 && (
+              <Fragment>
+                <span className="p-tooltip">
+                  <span className="p-help">
+                    {closesCount} channel
+                    {closesCount > 1 ? "s" : ""}
+                  </span>
+                  <span className="p-tooltip__message" role="tooltip">
+                    Close channels: {pendingCloses.join(", ")}
+                  </span>
+                </span>{" "}
+                to close.
+              </Fragment>
+            )}{" "}
+            {releasesCount > 0 && (
+              <Fragment>
+                <span className="p-tooltip">
+                  <span className="p-help">
+                    {releasesCount} revision
+                    {releasesCount > 1 ? "s" : ""}
+                  </span>
+                  <span className="p-tooltip__message" role="tooltip">
+                    Release revisions:
+                    <br />
+                    {Object.keys(pendingReleases).map(revId => {
+                      const release = pendingReleases[revId];
 
-                    return (
-                      <span key={revId}>
-                        <b>{release.revision.revision}</b> (
-                        {release.revision.version}){" "}
-                        {release.revision.architectures.join(", ")} to{" "}
-                        {release.channels.join(", ")}
-                        {"\n"}
-                      </span>
-                    );
-                  })}
-                </span>
-              </span>{" "}
-              to release.
-            </Fragment>
-          )}{" "}
-          {closesCount > 0 && (
-            <Fragment>
-              <span className="p-tooltip">
-                <span className="p-help">
-                  {closesCount} channel
-                  {closesCount > 1 ? "s" : ""}
-                </span>
-                <span className="p-tooltip__message" role="tooltip">
-                  Close channels: {pendingCloses.join(", ")}
-                </span>
-              </span>{" "}
-              to close.
-            </Fragment>
-          )}{" "}
+                      return (
+                        <span key={revId}>
+                          <b>{release.revision.revision}</b> (
+                          {release.revision.version}){" "}
+                          {release.revision.architectures.join(", ")} to{" "}
+                          {release.channels.join(", ")}
+                          {"\n"}
+                        </span>
+                      );
+                    })}
+                  </span>
+                </span>{" "}
+                to release.
+              </Fragment>
+            )}{" "}
+          </p>
+          {releasesCount > 0 && (
+            <div className="p-releases-confirm__rollout">
+              <p className="u-no-margin--bottom">
+                Release {releasesCount} revision
+                {releasesCount > 1 ? "s" : ""} to:
+              </p>
+              <input
+                type="radio"
+                id="all-devices"
+                name="rollout"
+                value="all"
+                checked={rolloutType === "all"}
+                onChange={this.onRolloutTypeClick.bind(this, "all")}
+              />
+              <label htmlFor="all-devices">all devices</label>
+              <input
+                type="radio"
+                id="rollout"
+                name="rollout"
+                value="percentage"
+                checked={rolloutType === "percentage"}
+                onChange={this.onRolloutTypeClick.bind(this, "percentage")}
+              />
+              <label htmlFor="rollout">
+                <input
+                  className="p-releases-confirm__rollout-percentage"
+                  type="number"
+                  name="rollout-percentage"
+                  value={rolloutPercentage}
+                  onChange={this.onRolloutPercentageChange.bind(this)}
+                  onFocus={this.onRolloutTypeClick.bind(this, "percentage")}
+                  ref={input => (this.percentageInput = input)}
+                />
+                % of devices
+              </label>
+            </div>
+          )}
           <div className="p-releases-confirm__buttons">
             <button
               className="p-button--positive is-inline u-no-margin--bottom"

--- a/static/js/publisher/release/components/releasesConfirm.js
+++ b/static/js/publisher/release/components/releasesConfirm.js
@@ -21,7 +21,7 @@ class ReleasesConfirm extends Component {
   onApplyClick() {
     const { rolloutType, rolloutPercentage } = this.state;
     this.props.releaseRevisions(
-      rolloutType === "percentage" ? rolloutPercentage : 100
+      rolloutType === "percentage" ? rolloutPercentage : null
     );
   }
 

--- a/static/js/publisher/release/components/releasesTableCell.js
+++ b/static/js/publisher/release/components/releasesTableCell.js
@@ -75,7 +75,7 @@ const RevisionInfo = ({ revision, isPending, showVersion, phasedState }) => {
           <DevmodeRevision
             revision={revision}
             showTooltip={false}
-            from={from}
+            phasedState={phasedState}
           />
         </span>
         {showVersion && (
@@ -102,15 +102,22 @@ const RevisionInfo = ({ revision, isPending, showVersion, phasedState }) => {
             </Fragment>
           )}
           <br />
-          Revision:{" "}
-          <b>
-            {from ? `${from} → ` : ""}
-            {revision.revision}
-          </b>
           {from && (
             <Fragment>
+              <b>Rollout of revision {revision.revision} in progress</b>
               <br />
-              Rolled out to <b>{phasedState.percentage}%</b> of devices
+              Revision: <b>{from}</b>
+              {phasedState
+                ? ` (${100 - phasedState.percentage}% of devices)`
+                : ""}
+              <br />
+              Revision: <b>{revision.revision}</b> ({phasedState.percentage}% of
+              devices)
+            </Fragment>
+          )}
+          {!from && (
+            <Fragment>
+              Revision: <b>{revision.revision}</b>
             </Fragment>
           )}
         </div>

--- a/static/js/publisher/release/components/releasesTableCell.js
+++ b/static/js/publisher/release/components/releasesTableCell.js
@@ -216,6 +216,16 @@ const ReleasesTableCell = props => {
         return false;
       }
 
+      // can't drop is phasing
+      const targetIsPhasing = props.getPhasedState(
+        `${props.branch ? `${props.branch}/` : ""}${props.track}/${props.risk}`,
+        props.arch
+      );
+
+      if (targetIsPhasing) {
+        return false;
+      }
+
       return true;
     },
     collect: monitor => ({

--- a/static/js/publisher/release/components/revisionsList.js
+++ b/static/js/publisher/release/components/revisionsList.js
@@ -12,7 +12,6 @@ import {
 import { getChannelName, isInDevmode } from "../helpers";
 
 import RevisionsListRow from "./revisionsListRow";
-import { closeHistory } from "../actions/history";
 import { toggleRevision } from "../actions/channelMap";
 import {
   getFilteredReleaseHistory,
@@ -63,11 +62,6 @@ class RevisionsList extends Component {
         isActive
       );
     });
-  }
-
-  onCloseClick(event) {
-    event.preventDefault();
-    this.props.closeHistoryPanel();
   }
 
   showAllRevisions(key) {
@@ -221,12 +215,6 @@ class RevisionsList extends Component {
       <Fragment>
         <div className="u-clearfix">
           <h4 className="u-float-left">{title}</h4>
-          <a
-            style={{ marginTop: "0.5rem" }}
-            href="#"
-            onClick={this.onCloseClick.bind(this)}
-            className="p-icon--close u-float-right"
-          />
         </div>
         {hasDevmodeRevisions && (
           <Notification>
@@ -348,7 +336,6 @@ RevisionsList.propTypes = {
   pendingChannelMap: PropTypes.object,
 
   // actions
-  closeHistoryPanel: PropTypes.func.isRequired,
   toggleRevision: PropTypes.func.isRequired
 };
 
@@ -376,7 +363,6 @@ const mapStateToProps = state => {
 
 const mapDispatchToProps = dispatch => {
   return {
-    closeHistoryPanel: () => dispatch(closeHistory()),
     toggleRevision: revision => dispatch(toggleRevision(revision))
   };
 };

--- a/static/js/publisher/release/releasesController.js
+++ b/static/js/publisher/release/releasesController.js
@@ -277,18 +277,24 @@ class ReleasesController extends Component {
     const releases = Object.keys(pendingReleases).map(id => {
       const pendingRelease = pendingReleases[id];
 
-      return {
+      const release = {
         id,
         revision: pendingRelease.revision,
         channels: pendingRelease.channels,
-        phasing: {
+        phasing: null
+      };
+
+      if (phasingPercentage) {
+        release.phasing = {
           phasing_percentage: phasingPercentage,
           phasing_key: `${id}-${pendingRelease.channels.join(
             "_"
           )}-${new Date().getTime()}`,
           phasing_paused: false
-        }
-      };
+        };
+      }
+
+      return release;
     });
 
     this.setState({ isLoading: true });

--- a/static/js/publisher/release/selectors/index.js
+++ b/static/js/publisher/release/selectors/index.js
@@ -259,12 +259,7 @@ export function getPhasedState(state, channel, arch) {
 
   let phasing = null;
 
-  if (
-    release.length > 1 &&
-    release[0] &&
-    release[0].phasing.key &&
-    release[0].phasing.percentage < 100
-  ) {
+  if (release.length > 1 && release[0] && release[0].phasing.key) {
     phasing = release[0].phasing;
     phasing.from = release[1].revision;
   }

--- a/static/js/publisher/release/selectors/index.js
+++ b/static/js/publisher/release/selectors/index.js
@@ -254,11 +254,17 @@ export function getPhasedState(state, channel, arch) {
     ) {
       return item;
     }
+    return false;
   });
 
   let phasing = null;
 
-  if (release.length > 1 && release[0] && release[0].phasing.key) {
+  if (
+    release.length > 1 &&
+    release[0] &&
+    release[0].phasing.key &&
+    release[0].phasing.percentage < 100
+  ) {
     phasing = release[0].phasing;
     phasing.from = release[1].revision;
   }

--- a/static/js/publisher/release/selectors/index.js
+++ b/static/js/publisher/release/selectors/index.js
@@ -242,3 +242,26 @@ export function getTrackRevisions({ channelMap }, track) {
   );
   return trackKeys.map(trackName => channelMap[trackName]);
 }
+
+export function getPhasedState(state, channel, arch) {
+  const { releases } = state;
+  const release = releases.filter(item => {
+    if (
+      channel ===
+        `${item.track}/${item.risk}${item.branch ? `/${item.branch}` : ""}` &&
+      arch === item.architecture &&
+      item.revision
+    ) {
+      return item;
+    }
+  });
+
+  let phasing = null;
+
+  if (release.length > 1 && release[0] && release[0].phasing.key) {
+    phasing = release[0].phasing;
+    phasing.from = release[1].revision;
+  }
+
+  return phasing;
+}

--- a/static/js/publisher/release/selectors/selectors.test.js
+++ b/static/js/publisher/release/selectors/selectors.test.js
@@ -17,7 +17,8 @@ import {
   getArchitectures,
   getTracks,
   getTrackRevisions,
-  getBranches
+  getBranches,
+  getPhasedState
 } from "./index";
 
 import reducers from "../reducers";
@@ -675,5 +676,53 @@ describe("getBranches", () => {
         when: lessThan30DaysAgo
       }
     ]);
+  });
+});
+
+describe("getPhasedState", () => {
+  it("should return the phasing of a channel and architecture", () => {
+    const state = {
+      releases: [
+        {
+          architecture: "arch1",
+          branch: null,
+          track: "latest",
+          risk: "stable",
+          revision: "1",
+          phasing: null
+        },
+        {
+          architecture: "arch2",
+          branch: null,
+          track: "latest",
+          risk: "stable",
+          revision: "3",
+          phasing: {
+            key: "phasingkey",
+            percentage: 60,
+            paused: false
+          }
+        },
+        {
+          architecture: "arch2",
+          branch: null,
+          track: "latest",
+          risk: "stable",
+          revision: "2",
+          phasing: {
+            key: "phasingkey",
+            percentage: 50,
+            paused: false
+          }
+        }
+      ]
+    };
+
+    expect(getPhasedState(state, "latest/stable", "arch2")).toEqual({
+      from: "2",
+      key: "phasingkey",
+      paused: false,
+      percentage: 60
+    });
   });
 });

--- a/static/sass/_snapcraft_release.scss
+++ b/static/sass/_snapcraft_release.scss
@@ -335,6 +335,12 @@
     font-size: .8rem;
   }
 
+  // REVISION HISTORY
+
+  .p-history-panel {
+    position: relative;
+  }
+
   // REVISIONS LIST
 
   .p-revisions-list {

--- a/static/sass/_snapcraft_release.scss
+++ b/static/sass/_snapcraft_release.scss
@@ -7,15 +7,37 @@
 
   .p-releases-confirm {
     background: $color-light;
+    display: flex;
+    justify-content: space-between;
     margin-bottom: 1em;
     padding: 1em;
     position: relative;
   }
 
   .p-releases-confirm__buttons {
-    position: absolute;
-    right: 1em;
-    top: 10px;
+    justify-self: end;
+  }
+
+  .p-releases-confirm__rollout {
+    display: flex;
+    flex-grow: 1;
+    justify-content: end;
+    margin-right: 1rem;
+
+    label {
+      align-items: center;
+      display: flex;
+      padding-left: 1.5rem;
+      padding-top: 0;
+      margin-bottom: 0;
+      margin-left: 1rem;
+    }
+
+    &-percentage {
+      margin-bottom: 0;
+      min-width: 3rem;
+      width: 3rem;
+    }
   }
 
   // RELEASES TABLE

--- a/static/sass/_snapcraft_release.scss
+++ b/static/sass/_snapcraft_release.scss
@@ -21,7 +21,7 @@
   .p-releases-confirm__rollout {
     display: flex;
     flex-grow: 1;
-    justify-content: end;
+    justify-content: flex-end;
     margin-right: 1rem;
 
     label {
@@ -35,8 +35,9 @@
 
     &-percentage {
       margin-bottom: 0;
-      min-width: 3rem;
-      width: 3rem;
+      margin-right: .5rem;
+      min-width: 3.5rem;
+      width: 3.5rem;
     }
   }
 


### PR DESCRIPTION
Fixes https://github.com/canonical-web-and-design/snapcraft.io/issues/2239
Fixes https://github.com/canonical-web-and-design/snapcraft.io/issues/2240

## QA
- Pull the branch
- `./run`
- Visit http://0.0.0.0:8004/snap/releases
- Drag a revision to a different channel
- The confirmation bar should show some options
- Set the % (or don't) and see if what happens when you release is expected
- Do the same for multiple revisions
- Generally use the feature and see what happens

## TO NOTE
- You should only get the option to phase if there is already a release in a channel & arch
  - On this note, if rev 3 is on latest/edge and there is no rev on latest/beta and you drag rev 3 onto both latest/edge and latest/beta the phasing dialog should display "Release 1 revision to..."
  - IF however you have rev 2 in latest/beta the dialog should display "Release 2 revisions to..." and the tooltip should list each channel separately.
- You should not be able to drag any single revision onto a channel & arch that is being phased
- You should not be able to drag an entire channel (or use the context menu) to a channel that has a phased release in progress - the context menu should give you the reason why.

## TODO
- [x] Prevent showing phasing options for the following cases:
  - [x] The channel has never had anything released before or is closed
  - [x] You're promoting a revision to a closed channel that is already tracking the same revision in a lower risk
- [ ] Phasing can never truly be 100%, this is a hard concept to explain succinctly in the UI - should we display "99.99%"?
- [x] Preventing dragging of revisions to channel/arch's that are already being phased