### PR TITLE
Fix closing channels in latest track

### DIFF
--- a/static/js/publisher/release/releasesController.js
+++ b/static/js/publisher/release/releasesController.js
@@ -217,7 +217,7 @@ class ReleasesController extends Component {
       if (json.closed_channels && json.closed_channels.length > 0) {
         json.closed_channels.forEach(channel => {
           // make sure channels without track name get prefixed with 'latest'
-          if (RISKS.indexOf(channel.split("/")[0]) === 0) {
+          if (RISKS.indexOf(channel.split("/")[0]) !== -1) {
             // TODO: This should be the default track, not latest
             channel = `latest/${channel}`;
           }


### PR DESCRIPTION
Fixes #2260 

### QA
- ./run or https://snapcraft-io-canonical-web-and-design-pr-2261.run.demo.haus/
- go to release UI of any snap you own
- have a channel to close (or release something to a channel) in latest track
- mark channel to be closed
- click apply
- closed channel should be updated to empty without reloading the page