### PR TITLE
Drag'n'drop updates for revision attributes support

### DIFF
--- a/static/js/publisher/release/components/dnd.js
+++ b/static/js/publisher/release/components/dnd.js
@@ -1,7 +1,6 @@
 import React, { useState, useEffect } from "react";
 import { useDrag, useDrop } from "react-dnd";
 
-export const DND_ITEM_CHANNEL = "DND_ITEM_CHANNEL";
 export const DND_ITEM_REVISIONS = "DND_ITEM_REVISIONS";
 
 export const Handle = () => (

--- a/static/js/publisher/release/components/dnd.js
+++ b/static/js/publisher/release/components/dnd.js
@@ -1,9 +1,8 @@
 import React, { useState, useEffect } from "react";
 import { useDrag, useDrop } from "react-dnd";
 
-export const DND_ITEM_REVISION = "DND_ITEM_REVISION";
 export const DND_ITEM_CHANNEL = "DND_ITEM_CHANNEL";
-export const DND_ITEM_BUILDSET = "DND_ITEM_BUILDSET";
+export const DND_ITEM_REVISIONS = "DND_ITEM_REVISIONS";
 
 export const Handle = () => (
   <span className="p-drag-handle">

--- a/static/js/publisher/release/components/releasesTableCell.js
+++ b/static/js/publisher/release/components/releasesTableCell.js
@@ -13,12 +13,7 @@ import {
   getBuildId,
   getRevisionsArchitectures
 } from "../helpers";
-import {
-  useDragging,
-  DND_ITEM_REVISION,
-  DND_ITEM_BUILDSET,
-  Handle
-} from "./dnd";
+import { useDragging, DND_ITEM_REVISIONS, Handle } from "./dnd";
 
 import { toggleHistory } from "../actions/history";
 import { promoteRevision, undoRelease } from "../actions/pendingReleases";
@@ -183,24 +178,20 @@ const ReleasesTableCell = props => {
 
   if (buildId) {
     buildSet = props.getRevisionsFromBuild(buildId);
+  } else if (currentRevision) {
+    buildSet = [currentRevision];
   }
+
   const canDrag = currentRevision && !isChannelPendingClose;
 
-  const item = buildSet.length
-    ? {
-        revisions: buildSet,
-        architectures: getRevisionsArchitectures(buildSet),
-        risk,
-        branch,
-        type: DND_ITEM_BUILDSET
-      }
-    : {
-        revision: currentRevision,
-        arch,
-        risk,
-        branch,
-        type: DND_ITEM_REVISION
-      };
+  const item = {
+    revisions: buildSet,
+    architectures: getRevisionsArchitectures(buildSet),
+    risk,
+    branch,
+    type: DND_ITEM_REVISIONS
+  };
+
   const [isDragging, isGrabbing, drag] = useDragging({
     item,
     canDrag
@@ -215,7 +206,6 @@ const ReleasesTableCell = props => {
     props.undoRelease(revision, channel);
   }
 
-  // TODO: still needed?
   const [isHovered, setIsHovered] = useState(false);
   const onMouseEnter = () => {
     setIsHovered(true);

--- a/static/js/publisher/release/components/releasesTableRow.js
+++ b/static/js/publisher/release/components/releasesTableRow.js
@@ -16,8 +16,7 @@ import {
   useDragging,
   useDrop,
   DND_ITEM_CHANNEL,
-  DND_ITEM_BUILDSET,
-  DND_ITEM_REVISION,
+  DND_ITEM_REVISIONS,
   Handle
 } from "./dnd";
 
@@ -133,8 +132,7 @@ const ReleasesTableRow = props => {
 
   const [{ isOver, canDrop, item }, drop] = useDrop({
     // accept all the types to trigger isOver when hovering
-    // but for some reason DND_ITEM_BUILDSET only works if DND_ITEM_REVISION is on the list as well...
-    accept: [DND_ITEM_CHANNEL, DND_ITEM_REVISION, DND_ITEM_BUILDSET],
+    accept: [DND_ITEM_CHANNEL, DND_ITEM_REVISIONS],
     drop: item => {
       if (item.type === DND_ITEM_CHANNEL) {
         props.promoteChannel(
@@ -142,21 +140,14 @@ const ReleasesTableRow = props => {
           channel
         );
       }
-      if (item.type === DND_ITEM_BUILDSET) {
+      if (item.type === DND_ITEM_REVISIONS) {
         item.revisions.forEach(r => props.promoteRevision(r, channel));
-      }
-      if (item.type === DND_ITEM_REVISION) {
-        props.promoteRevision(item.revision, channel);
       }
     },
     canDrop: item => {
       let draggedRevisions = [];
 
-      if (item.type === DND_ITEM_REVISION) {
-        draggedRevisions = [item.revision];
-      }
-
-      if (item.type === DND_ITEM_BUILDSET) {
+      if (item.type === DND_ITEM_REVISIONS) {
         draggedRevisions = [...item.revisions];
       }
 
@@ -222,7 +213,7 @@ const ReleasesTableRow = props => {
   if (item && isOver) {
     const draggedChannel = getChannelName(currentTrack, item.risk, item.branch);
     switch (item.type) {
-      case DND_ITEM_BUILDSET:
+      case DND_ITEM_REVISIONS:
         draggedArchs = item.architectures;
         break;
       case DND_ITEM_CHANNEL:
@@ -231,9 +222,6 @@ const ReleasesTableRow = props => {
             Object.values(pendingChannelMap[draggedChannel])
           );
         }
-        break;
-      case DND_ITEM_REVISION:
-        draggedArchs = getRevisionsArchitectures([item.revision]);
         break;
     }
   }

--- a/static/js/publisher/release/components/revisionsListRow.js
+++ b/static/js/publisher/release/components/revisionsListRow.js
@@ -5,7 +5,7 @@ import { connect } from "react-redux";
 import distanceInWords from "date-fns/distance_in_words_strict";
 import format from "date-fns/format";
 
-import { useDragging, DND_ITEM_REVISION, Handle } from "./dnd";
+import { useDragging, DND_ITEM_REVISIONS, Handle } from "./dnd";
 import { toggleRevision } from "../actions/channelMap";
 import { getSelectedRevisions, hasBuildRequestId } from "../selectors";
 
@@ -33,12 +33,10 @@ const RevisionsListRow = props => {
 
   const [isDragging, isGrabbing, drag] = useDragging({
     item: {
-      revision: revision,
-      // TODO:
-      // we are assuming single arcitecture here,
-      // this may be trickier for revisions in multiple architectures
-      arch: revision.architectures[0],
-      type: DND_ITEM_REVISION
+      // TODO: get all revisions from build set
+      revisions: [revision],
+      architectures: revision.architectures,
+      type: DND_ITEM_REVISIONS
     }
   });
 


### PR DESCRIPTION
Updates release UI drag'n'drop functionality for better handling of build sets.

- removes different drag types implementations - anything being dragged is treated as set of revisions (revision, build set or channel)
- removes single cells as drop targets, making it possible to drop everything on channel level (it will end up in correct architecture anyway)
- during dragging highlights all architectures that will be affected by the drop in given channel

### QA
- ./run or https://snapcraft-io-canonical-web-and-design-pr-2262.run.demo.haus/
- go to releases page of any snap (ideally with some revisions build in Launchpad)
- try promoting a single revision to some channel (from releases table)
- try promoting single revision to some channel (from revisions history of any channel)
- try promoting a revision being part of a build set from launchpad (all revisions should be promoted)
- try promoting whole channel (all revisions from channel should be promoted)
- make sure that other Release functionality still works (history, closing channel, branches, etc)

<img width="1367" alt="Screenshot 2019-09-19 at 08 20 44" src="https://user-images.githubusercontent.com/83575/65218318-831b0580-dab6-11e9-9cb4-10f80298ddbc.png">
