### PR TITLE
Simplify environment variables

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,9 +3,6 @@
 defaults: &defaults
   docker:
     - image: canonicalwebteam/dev
-  environment:
-    BLOG_ENABLED: True
-    WEBAPP: snapcraft
   working_directory: ~/project
 
 version: 2

--- a/.env
+++ b/.env
@@ -1,9 +1,5 @@
 PORT=8004
-FLASK_DEBUG=true
-SECRET_KEY=local_development_fake_key
 ENVIRONMENT=devel
+FLASK_DEBUG=true
 DEVEL=True
-BLOG_ENABLED=true
-BLOG_CATEGORIES_ENABLED=false
-WEBAPP=snapcraft
-BSI_URL=https://build.snapcraft.io
+SECRET_KEY=local_development_fake_key

--- a/templates/_layout-brandstore.html
+++ b/templates/_layout-brandstore.html
@@ -64,7 +64,7 @@
     {% block scripts_modules %}{% endblock %}
     <script src="{{ static_url('js/modules/raven.min.js') }}"></script>
     <script>
-      Raven.config('{{ SENTRY_PUBLIC_DSN }}', {
+      Raven.config('{{ SENTRY_DSN }}', {
         whitelistUrls: ['staging.snapcraft.io', 'snapcraft.io'],
         release: '{{ COMMIT_ID }}',
         environment: '{{ ENVIRONMENT }}'

--- a/templates/_layout.html
+++ b/templates/_layout.html
@@ -67,7 +67,7 @@
     {% block scripts_modules %}{% endblock %}
     <script src="{{ static_url('js/modules/raven.min.js') }}"></script>
     <script>
-      Raven.config('{{ SENTRY_PUBLIC_DSN }}', {
+      Raven.config('{{ SENTRY_DSN }}', {
         whitelistUrls: ['staging.snapcraft.io/static/js', 'snapcraft.io/static/js/'],
         ignoreUrls: ['staging.snapcraft.io/static/js/modules', 'snapcraft.io/static/js/modules'],
         release: '{{ COMMIT_ID }}',

--- a/tests/api/test_marketo_api.py
+++ b/tests/api/test_marketo_api.py
@@ -1,7 +1,13 @@
+# Standard library
+import os
 import unittest
+
+# Packages
 import responses
 
+# Local modules
 import webapp.api.marketo as marketo_api
+
 
 responses.mock.assert_all_requests_are_fired = True
 
@@ -11,7 +17,7 @@ class MarketoApi(unittest.TestCase):
     def test_auth(self):
         marketo_auth_url = "".join(
             [
-                "https://test.com/",
+                "https://066-eov-335.mktorest.com/",
                 "identity/oauth/token?",
                 "grant_type=client_credentials&client_id=123",
                 "&client_secret=321",
@@ -29,7 +35,7 @@ class MarketoApi(unittest.TestCase):
 
         marketo_leads_url = "".join(
             [
-                "https://test.com/",
+                "https://066-eov-335.mktorest.com/",
                 "rest/v1/leads.json?",
                 "access_token=test&filterType=email",
                 "&filterValues=testing@testing.com&fields=id",
@@ -45,6 +51,8 @@ class MarketoApi(unittest.TestCase):
             status=200,
         )
 
+        os.environ["MARKETO_CLIENT_ID"] = "fake_id"
+        os.environ["MARKETO_CLIENT_SECRET"] = "fake_secret"
         marketo = marketo_api.MarketoApi()
         user = marketo.get_user("testing@testing.com")
 
@@ -54,7 +62,7 @@ class MarketoApi(unittest.TestCase):
     def test_get_user(self):
         marketo_leads_url = "".join(
             [
-                "https://test.com/",
+                "https://066-eov-335.mktorest.com/",
                 "rest/v1/leads.json?",
                 "access_token=test&filterType=email",
                 "&filterValues=testing@testing.com&fields=id",
@@ -80,7 +88,7 @@ class MarketoApi(unittest.TestCase):
     def test_get_newsletter_subscription(self):
         marketo_lead_url = "".join(
             [
-                "https://test.com/",
+                "https://066-eov-335.mktorest.com/",
                 "rest/v1/lead/test.json?",
                 "access_token=test&fields=id,email,snapcraftnewsletter",
             ]
@@ -105,7 +113,7 @@ class MarketoApi(unittest.TestCase):
     def test_get_newsletter_subscription_bad_response(self):
         marketo_lead_url = "".join(
             [
-                "https://test.com/",
+                "https://066-eov-335.mktorest.com/",
                 "rest/v1/lead/test.json?",
                 "access_token=test&fields=id,email,snapcraftnewsletter",
             ]
@@ -130,7 +138,7 @@ class MarketoApi(unittest.TestCase):
     def test_set_newsletter_subscription(self):
         marketo_set_subscription_url = "".join(
             [
-                "https://test.com/",
+                "https://066-eov-335.mktorest.com/",
                 "rest/v1/leads.json?",
                 "access_token=test&filterType=email",
                 "&filterValues=testing@testing.com&fields=id",
@@ -151,7 +159,7 @@ class MarketoApi(unittest.TestCase):
     def test_token_refresh(self):
         marketo_leads_url = "".join(
             [
-                "https://test.com/",
+                "https://066-eov-335.mktorest.com/",
                 "rest/v1/leads.json?",
                 "access_token=test&filterType=email",
                 "&filterValues=testing@testing.com&fields=id",
@@ -164,7 +172,7 @@ class MarketoApi(unittest.TestCase):
 
         marketo_auth_url = "".join(
             [
-                "https://test.com/",
+                "https://066-eov-335.mktorest.com/",
                 "identity/oauth/token?",
                 "grant_type=client_credentials&client_id=123",
                 "&client_secret=321",

--- a/webapp/api/marketo.py
+++ b/webapp/api/marketo.py
@@ -7,43 +7,19 @@ from webapp.api.exceptions import (
     ApiResponseErrorList,
 )
 
-MARKETO_URL = os.getenv("MARKETO_URL", "test.com/")
-MARKETO_CLIENT_ID = os.getenv("MARKETO_CLIENT_ID", "123")
-MARKETO_CLIENT_SECRET = os.getenv("MARKETO_CLIENT_SECRET", "321")
+BASE_URL = "https://066-EOV-335.mktorest.com/"
 
-AUTH_URL = "".join(
-    [
-        "https://",
-        MARKETO_URL,
-        "identity/oauth/token?grant_type=client_credentials&client_id=",
-        MARKETO_CLIENT_ID,
-        "&client_secret=",
-        MARKETO_CLIENT_SECRET,
-    ]
+LEAD_BY_EMAIL = BASE_URL + (
+    "rest/v1/leads.json?access_token={token}"
+    "&filterType=email&filterValues={email}&fields=id"
 )
 
-LEAD_BY_EMAIL = "".join(
-    [
-        "https://",
-        MARKETO_URL,
-        "rest/v1/leads.json?access_token={token}",
-        "&filterType=email&filterValues={email}&fields=id",
-    ]
+LEAD_NEWSLETTER_SUBSCRIPTION = BASE_URL + (
+    "rest/v1/lead/{lead_id}.json?access_token={token}"
+    "&fields=id,email,snapcraftnewsletter"
 )
 
-LEAD_NEWSLETTER_SUBSCRIPTION = "".join(
-    [
-        "https://",
-        MARKETO_URL,
-        "rest/v1/",
-        "lead/{lead_id}.json?access_token={token}",
-        "&fields=id,email,snapcraftnewsletter",
-    ]
-)
-
-LEADS = "".join(
-    ["https://", MARKETO_URL, "rest/v1/", "leads.json?access_token={token}"]
-)
+LEADS = BASE_URL + "rest/v1/leads.json?access_token={token}"
 
 
 class MarketoApi:
@@ -54,7 +30,13 @@ class MarketoApi:
         self.token = None
 
     def _authenticate(self):
-        request = self.api_session.get(AUTH_URL)
+        client_id = os.environ["MARKETO_CLIENT_ID"]
+        client_secret = os.environ["MARKETO_CLIENT_SECRET"]
+        auth_url = BASE_URL + (
+            "identity/oauth/token?grant_type=client_credentials&"
+            f"client_id={client_id}&client_secret={client_secret}"
+        )
+        request = self.api_session.get(auth_url)
         response = self._process_response(request)
         self.token = response["access_token"]
 

--- a/webapp/config.py
+++ b/webapp/config.py
@@ -6,20 +6,15 @@ class ConfigurationError(Exception):
 
 
 SECRET_KEY = os.getenv("SECRET_KEY")
-
 LOGIN_URL = os.getenv("LOGIN_URL", "https://login.ubuntu.com")
-
 BSI_URL = os.getenv("BSI_URL", "https://build.snapcraft.io")
-
 ENVIRONMENT = os.getenv("ENVIRONMENT", "devel")
 COMMIT_ID = os.getenv("COMMIT_ID", "commit_id")
-
-SENTRY_PUBLIC_DSN = os.getenv("SENTRY_PUBLIC_DSN", "").strip()
+SENTRY_DSN = os.getenv("SENTRY_DSN", "").strip()
 SENTRY_CONFIG = {"release": COMMIT_ID, "environment": ENVIRONMENT}
 
-BLOG_CATEGORIES_ENABLED = os.getenv("BLOG_CATEGORIES_ENABLED", "true")
+WEBAPP = os.getenv("WEBAPP", "snapcraft")
 
-WEBAPP = os.getenv("WEBAPP")
 if not WEBAPP:
     raise ConfigurationError("`WEBAPP` is not configured")
 

--- a/webapp/configs/snapcraft.py
+++ b/webapp/configs/snapcraft.py
@@ -5,5 +5,3 @@ WEBAPP_CONFIG = {"LAYOUT": "_layout.html", "STORE_NAME": "Snap store"}
 FEATURED_BANNERS_ENABLED = os.getenv(
     "FEATURED_BANNERS_ENABLED", "false"
 ).lower() in ["1", "t", "true"]
-
-BLOG_CATEGORIES_ENABLED = os.getenv("BLOG_CATEGORIES_ENABLED", "false")

--- a/webapp/handlers.py
+++ b/webapp/handlers.py
@@ -41,7 +41,7 @@ def set_handlers(app):
         return {
             # Variables
             "LOGIN_URL": app.config["LOGIN_URL"],
-            "SENTRY_PUBLIC_DSN": app.config["SENTRY_PUBLIC_DSN"],
+            "SENTRY_DSN": app.config["SENTRY_DSN"],
             "COMMIT_ID": app.config["COMMIT_ID"],
             "ENVIRONMENT": app.config["ENVIRONMENT"],
             "host_url": flask.request.host_url,


### PR DESCRIPTION
- Remove MARKETO_URL by hard-coding it into marketo.py
- Explicitly require MARKETO_CLIENT_ID and MARKETO_CLIENT_SECRET - as in don't use fake fallbacks
- Since SENTRY_DSN will be a public key anyway (I went and changed this in the k8s secrets), there's no need for SENTRY_PUBLIC_DSN
- Remove mentions of BLOG_ENABLED, which hasn't been used since #879
- Remove mentions of BLOG_CATEGORIES_ENABLED, which hasn't been used since #2119

Fixes https://github.com/canonical-web-and-design/snapcraft.io/issues/2265

Also see ^ for more explanation

QA
--

`./run`, check the site works. Especially check the publisher details page loads fine.