### PR TITLE
Revision attributes cleanup

### DIFF
--- a/static/js/publisher/release/components/dnd.js
+++ b/static/js/publisher/release/components/dnd.js
@@ -11,7 +11,14 @@ export const Handle = () => (
 
 // it's a wrapper around react-dnd useDrag hook
 // with some added functionality and workaround for a bug
-export const useDragging = options => {
+export const useDragging = ({ item, canDrag }) => {
+  // default canDrag to true, make sure it's boolean
+  if (typeof canDrag === "undefined") {
+    canDrag = true;
+  } else {
+    canDrag = !!canDrag;
+  }
+
   const [isGrabbing, setIsGrabbing] = useState(false);
 
   // Calling useDrag end callback after history is closed (because promoting revisions closes history panel)
@@ -31,8 +38,8 @@ export const useDragging = options => {
   });
 
   const [{ isDragging }, drag, preview] = useDrag({
-    item: options.item,
-    canDrag: () => options.canDrag || true,
+    item: item,
+    canDrag: () => canDrag,
     collect: monitor => ({
       isDragging: !!monitor.isDragging()
     }),

--- a/static/js/publisher/release/components/releasesTableCell.js
+++ b/static/js/publisher/release/components/releasesTableCell.js
@@ -9,9 +9,7 @@ import HistoryIcon from "./historyIcon";
 import {
   getChannelName,
   isInDevmode,
-  isRevisionBuiltOnLauchpad,
-  getBuildId,
-  getRevisionsArchitectures
+  isRevisionBuiltOnLauchpad
 } from "../helpers";
 import { useDragging, DND_ITEM_REVISIONS, Handle } from "./dnd";
 
@@ -170,20 +168,11 @@ const ReleasesTableCell = props => {
   const trackingChannel = getTrackingChannel(channelMap, track, risk, arch);
   const availableCount = props.getAvailableCount(arch);
 
-  const buildId = getBuildId(currentRevision);
-  let buildSet = [];
-
-  if (buildId) {
-    buildSet = props.getRevisionsFromBuild(buildId);
-  } else if (currentRevision) {
-    buildSet = [currentRevision];
-  }
-
   const canDrag = currentRevision && !isChannelPendingClose;
 
   const item = {
-    revisions: buildSet,
-    architectures: getRevisionsArchitectures(buildSet),
+    revisions: [currentRevision],
+    architectures: currentRevision ? currentRevision.architectures : [],
     risk,
     branch,
     type: DND_ITEM_REVISIONS

--- a/static/js/publisher/release/components/releasesTableCell.js
+++ b/static/js/publisher/release/components/releasesTableCell.js
@@ -1,4 +1,4 @@
-import React, { Fragment, useState } from "react";
+import React, { Fragment } from "react";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
 
@@ -144,9 +144,7 @@ const ReleasesTableCell = props => {
     pendingChannelMap,
     pendingCloses,
     filters,
-    isOverParent,
-    setHoveredBuild,
-    hoveredBuild
+    isOverParent
   } = props;
 
   const branchName = branch ? branch.branch : null;
@@ -205,24 +203,10 @@ const ReleasesTableCell = props => {
     props.undoRelease(revision, channel);
   }
 
-  const [isHovered, setIsHovered] = useState(false);
-  const onMouseEnter = () => {
-    setIsHovered(true);
-    if (buildId) {
-      setHoveredBuild(buildId);
-    }
-  };
-
-  const onMouseLeave = () => {
-    setIsHovered(false);
-    setHoveredBuild(null);
-  };
-
   const className = [
     "p-releases-table__cell",
     isUnassigned ? "is-unassigned" : "",
     isActive ? "is-active" : "",
-    isHovered || (buildId && buildId === hoveredBuild) ? "is-hovered" : "",
     isHighlighted ? "is-highlighted" : "",
     isPending ? "is-pending" : "",
     isGrabbing ? "is-grabbing" : "",
@@ -232,11 +216,7 @@ const ReleasesTableCell = props => {
   ].join(" ");
 
   return (
-    <div
-      className={className}
-      onMouseEnter={onMouseEnter}
-      onMouseLeave={onMouseLeave}
-    >
+    <div className={className}>
       <div
         ref={drag}
         className="p-release-data p-tooltip p-tooltip--btm-center"
@@ -304,9 +284,7 @@ ReleasesTableCell.propTypes = {
   arch: PropTypes.string,
   showVersion: PropTypes.bool,
   branch: PropTypes.object,
-  isOverParent: PropTypes.bool,
-  setHoveredBuild: PropTypes.func,
-  hoveredBuild: PropTypes.string
+  isOverParent: PropTypes.bool
 };
 
 const mapStateToProps = state => {

--- a/static/js/publisher/release/components/releasesTableCell.js
+++ b/static/js/publisher/release/components/releasesTableCell.js
@@ -81,10 +81,8 @@ const RevisionInfo = ({ revision, isPending, showVersion }) => {
         <span className="p-release-data__title">
           <DevmodeRevision revision={revision} showTooltip={false} />
         </span>
-        {(showVersion || buildIcon) && (
-          <span className="p-release-data__meta">
-            {showVersion && revision.version} {buildIcon}
-          </span>
+        {showVersion && (
+          <span className="p-release-data__meta">{revision.version}</span>
         )}
       </span>
       <span className="p-tooltip__message">
@@ -98,7 +96,8 @@ const RevisionInfo = ({ revision, isPending, showVersion }) => {
             revision.attributes["build-request-id"] && (
               <Fragment>
                 <br />
-                Build: <b>{revision.attributes["build-request-id"]}</b>
+                Build: {buildIcon}{" "}
+                <b>{revision.attributes["build-request-id"]}</b>
               </Fragment>
             )}
           {isInDevmode(revision) && (

--- a/static/js/publisher/release/components/releasesTableRow.js
+++ b/static/js/publisher/release/components/releasesTableRow.js
@@ -114,7 +114,9 @@ const ReleasesTableRow = props => {
 
   const hasOpenBranches = openBranches.includes(channel);
 
-  const canDrag = !!pendingChannelMap[channel];
+  const canDrag = !(
+    !pendingChannelMap[channel] || props.pendingCloses.includes(channel)
+  );
 
   const draggedRevisions = canDrag
     ? Object.values(pendingChannelMap[channel])

--- a/static/js/publisher/release/components/releasesTableRow.js
+++ b/static/js/publisher/release/components/releasesTableRow.js
@@ -360,7 +360,7 @@ const ReleasesTableRow = props => {
             <br />
             {isLaunchpadBuild && (
               <Fragment>
-                Build: <b>{channelBuild}</b>
+                Build: <i className="p-icon--lp" /> <b>{channelBuild}</b>
               </Fragment>
             )}
           </span>
@@ -421,11 +421,8 @@ const ReleasesTableRow = props => {
                 <span className="p-release-data__title" title={channel}>
                   {rowTitle}
                 </span>
-                {(risk !== AVAILABLE || isLaunchpadBuild) && (
-                  <span className="p-release-data__meta">
-                    {risk !== AVAILABLE && channelVersion}{" "}
-                    {isLaunchpadBuild && <i className="p-icon--lp" />}
-                  </span>
+                {risk !== AVAILABLE && (
+                  <span className="p-release-data__meta">{channelVersion}</span>
                 )}
                 {channelVersion && (
                   <span className="p-tooltip__message">

--- a/static/js/publisher/release/components/releasesTableRow.js
+++ b/static/js/publisher/release/components/releasesTableRow.js
@@ -1,4 +1,4 @@
-import React, { Fragment, useState } from "react";
+import React, { Fragment } from "react";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
 import { parse, distanceInWordsToNow, addDays } from "date-fns";
@@ -385,8 +385,6 @@ const ReleasesTableRow = props => {
     timeUntilExpiration = distanceInWordsToNow(end);
   }
 
-  const [hoveredBuild, setHoveredBuild] = useState(null);
-
   return (
     <Fragment>
       {risk === AVAILABLE && (
@@ -476,8 +474,6 @@ const ReleasesTableRow = props => {
               isOverParent={
                 isOver && canDrop && item.architectures.indexOf(arch) !== -1
               }
-              setHoveredBuild={setHoveredBuild}
-              hoveredBuild={hoveredBuild}
             />
           ))}
         </div>

--- a/static/js/publisher/release/components/revisionsListRow.js
+++ b/static/js/publisher/release/components/revisionsListRow.js
@@ -33,7 +33,6 @@ const RevisionsListRow = props => {
 
   const [isDragging, isGrabbing, drag] = useDragging({
     item: {
-      // TODO: get all revisions from build set
       revisions: [revision],
       architectures: revision.architectures,
       type: DND_ITEM_REVISIONS

--- a/static/sass/_snapcraft_release.scss
+++ b/static/sass/_snapcraft_release.scss
@@ -226,23 +226,6 @@
     &.is-highlighted {
       background: $color-highlighted;
     }
-
-    &.is-hovered {
-      background: darken($color-light, 10%);
-    }
-
-    // if one hovered cell is followed by another,
-    // cover the spacing between them with hover color
-    // so they look joined
-    &.is-hovered + &.is-hovered::before {
-      background: darken($color-light, 10%);
-      bottom: -3px; // compensate for bottom border
-      content: "";
-      left: -2px;
-      position: absolute;
-      top: 0;
-      width: 2px;
-    }
   }
 
   .p-releases-table__arch {


### PR DESCRIPTION
Fixes #2270 

As discussed in Paris we remove some of the special treatment of build sets.

- removed LP icons from cells and rows
- removed dragging whole build set together (with hover effect)
- fixes some regression issues around drag'n'drop

### QA

- ./run or https://snapcraft-io-canonical-web-and-design-pr-2272.run.demo.haus/
- go to releases page of any snap with Lauchpad builds
- there should be no icons in rows or cells with LP revisions
- there should be icons in tooltips for LP revisions
- hovering over LP revision should not hover all builds from same revision
- dragging revision from build set should promote only single revision, not whole build set

For a regression of previous functionality make sure:
- everything (channel row, single revision, revision from the history) can be dragged and promoted
- empty cell (no revision) can't be dragged
- empty channel can't be dragged
- channel with pending close (closed in UI but not saved) can't be dragged nor any revisions in it

<img width="1169" alt="Screenshot 2019-09-24 at 15 52 21" src="https://user-images.githubusercontent.com/83575/65518109-0fc52980-dee4-11e9-9c83-95094200dbde.png">
