### PR TITLE
Update raven and talisker

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,23 +9,20 @@ Flask-OpenID-Stateless==1.2.6
 Flask-WTF==0.14.2
 humanize==0.5.1
 Markdown==3.0.1
-prometheus_client==0.3.1
 mistune==0.8.4
 pybadges==1.1.0
 pybreaker==0.4.4
 pycountry==17.9.23
 pymacaroons==0.12.0
 python-dateutil==2.6.1
-raven[flask]==6.5.0
 requests==2.21.0
 requests-cache==0.4.13
 responses==0.9.0
 ruamel.yaml==0.15.72
-talisker[gunicorn]==0.14.3
+talisker[flask,gunicorn,raven,prometheus]==0.15.0
 
 # Temporary fix to SSO redirect issue
 Werkzeug==0.14.1
 
 # Development dependencies
-black==18.6b4
 Flask-Testing==0.6.2


### PR DESCRIPTION
This makes snapcraft.io work with newer-format SENTRY_DSN keys.

QA
--

Check tests pass.

Then try running the site with:

``` bash
./run --env SENTRY_DSN=https://1e82fd54e08142c9978f623cb746b965@sentry.is.canonical.com//3
```