### PR TITLE
Move scripts loading from bottom of the page to `<head>`

### DIFF
--- a/static/js/base/dropdown-menu-toggle.js
+++ b/static/js/base/dropdown-menu-toggle.js
@@ -56,5 +56,7 @@
     }
   }
 
-  toggle(".p-subnav__toggle");
+  window.addEventListener("DOMContentLoaded", () => {
+    toggle(".p-subnav__toggle");
+  });
 })();

--- a/templates/_layout-brandstore.html
+++ b/templates/_layout-brandstore.html
@@ -26,6 +26,19 @@
       </style>
     {% endif %}
 
+    {% block scripts_modules %}{% endblock %}
+    <script src="{{ static_url('js/modules/raven.min.js') }}"></script>
+    <script>
+      Raven.config('{{ SENTRY_DSN }}', {
+        whitelistUrls: ['staging.snapcraft.io', 'snapcraft.io'],
+        release: '{{ COMMIT_ID }}',
+        environment: '{{ ENVIRONMENT }}'
+      }).install();
+    </script>
+
+    <script src="{{ static_url('js/dist/base.js') }}"></script>
+    {% block scripts_includes %}{% endblock %}
+
     <meta name="description" content="{% block meta_description %}Snaps are containerised software packages that are simple to create and install. They auto-update and are safe to run. And because they bundle their dependencies, they work on all major Linux systems without modification.{% endblock %}">
     <meta name="robots" content="noindex">
 
@@ -58,17 +71,6 @@
 
     {% include "_footer-brandstore.html" %}
 
-    {% block scripts_modules %}{% endblock %}
-    <script src="{{ static_url('js/modules/raven.min.js') }}"></script>
-    <script>
-      Raven.config('{{ SENTRY_DSN }}', {
-        whitelistUrls: ['staging.snapcraft.io', 'snapcraft.io'],
-        release: '{{ COMMIT_ID }}',
-        environment: '{{ ENVIRONMENT }}'
-      }).install();
-    </script>
-
-    <script src="{{ static_url('js/dist/base.js') }}"></script>
     {% block scripts %}{% endblock %}
 
     <script type="application/ld+json">

--- a/templates/_layout-brandstore.html
+++ b/templates/_layout-brandstore.html
@@ -27,16 +27,18 @@
     {% endif %}
 
     {% block scripts_modules %}{% endblock %}
-    <script src="{{ static_url('js/modules/raven.min.js') }}"></script>
+    <script src="{{ static_url('js/modules/raven.min.js') }}" defer></script>
     <script>
-      Raven.config('{{ SENTRY_DSN }}', {
-        whitelistUrls: ['staging.snapcraft.io', 'snapcraft.io'],
-        release: '{{ COMMIT_ID }}',
-        environment: '{{ ENVIRONMENT }}'
-      }).install();
+      window.addEventListener("DOMContentLoaded", function() {
+        Raven.config('{{ SENTRY_DSN }}', {
+          whitelistUrls: ['staging.snapcraft.io', 'snapcraft.io'],
+          release: '{{ COMMIT_ID }}',
+          environment: '{{ ENVIRONMENT }}'
+        }).install();
+      });
     </script>
 
-    <script src="{{ static_url('js/dist/base.js') }}"></script>
+    <script src="{{ static_url('js/dist/base.js') }}" defer></script>
     {% block scripts_includes %}{% endblock %}
 
     <meta name="description" content="{% block meta_description %}Snaps are containerised software packages that are simple to create and install. They auto-update and are safe to run. And because they bundle their dependencies, they work on all major Linux systems without modification.{% endblock %}">

--- a/templates/_layout-embedded.html
+++ b/templates/_layout-embedded.html
@@ -13,6 +13,9 @@
 
     <link rel="stylesheet" href="{{ static_url('css/styles-embedded.css') }}" />
 
+    {% block scripts_modules %}{% endblock %}
+    {% block scripts_includes %}{% endblock %}
+
     <meta name="description" content="{% block meta_description %}Snaps are containerised software packages that are simple to create and install. They auto-update and are safe to run. And because they bundle their dependencies, they work on all major Linux systems without modification.{% endblock %}">
     <meta name="google-site-verification" content="Y1JayrP2iS6jS6Rd7uGX3Kzgm0oD8rV5R6TkzteLbQg" />
     <meta name="robots" content="noindex">
@@ -40,7 +43,6 @@
   <body>
     {% block content %}{% endblock %}
 
-    {% block scripts_modules %}{% endblock %}
     {% block scripts %}{% endblock %}
 
     <script type="application/ld+json">

--- a/templates/_layout.html
+++ b/templates/_layout.html
@@ -22,17 +22,19 @@
     <link rel="stylesheet" href="{{ static_url('css/styles.css') }}" />
 
     {% block scripts_modules %}{% endblock %}
-    <script src="{{ static_url('js/modules/raven.min.js') }}"></script>
+    <script src="{{ static_url('js/modules/raven.min.js') }}" defer></script>
     <script>
-      Raven.config('{{ SENTRY_DSN }}', {
-        whitelistUrls: ['staging.snapcraft.io/static/js', 'snapcraft.io/static/js/'],
-        ignoreUrls: ['staging.snapcraft.io/static/js/modules', 'snapcraft.io/static/js/modules'],
-        release: '{{ COMMIT_ID }}',
-        environment: '{{ ENVIRONMENT }}'
-      }).install();
+      window.addEventListener("DOMContentLoaded", function() {
+        Raven.config('{{ SENTRY_DSN }}', {
+          whitelistUrls: ['staging.snapcraft.io/static/js', 'snapcraft.io/static/js/'],
+          ignoreUrls: ['staging.snapcraft.io/static/js/modules', 'snapcraft.io/static/js/modules'],
+          release: '{{ COMMIT_ID }}',
+          environment: '{{ ENVIRONMENT }}'
+        }).install();
+      });
     </script>
 
-    <script src="{{ static_url('js/dist/base.js') }}"></script>
+    <script src="{{ static_url('js/dist/base.js') }}" defer></script>
     {% block scripts_includes %}{% endblock %}
 
     <meta name="description" content="{% block meta_description %}Snaps are containerised software packages that are simple to create and install. They auto-update and are safe to run. And because they bundle their dependencies, they work on all major Linux systems without modification.{% endblock %}">

--- a/templates/_layout.html
+++ b/templates/_layout.html
@@ -21,6 +21,20 @@
 
     <link rel="stylesheet" href="{{ static_url('css/styles.css') }}" />
 
+    {% block scripts_modules %}{% endblock %}
+    <script src="{{ static_url('js/modules/raven.min.js') }}"></script>
+    <script>
+      Raven.config('{{ SENTRY_DSN }}', {
+        whitelistUrls: ['staging.snapcraft.io/static/js', 'snapcraft.io/static/js/'],
+        ignoreUrls: ['staging.snapcraft.io/static/js/modules', 'snapcraft.io/static/js/modules'],
+        release: '{{ COMMIT_ID }}',
+        environment: '{{ ENVIRONMENT }}'
+      }).install();
+    </script>
+
+    <script src="{{ static_url('js/dist/base.js') }}"></script>
+    {% block scripts_includes %}{% endblock %}
+
     <meta name="description" content="{% block meta_description %}Snaps are containerised software packages that are simple to create and install. They auto-update and are safe to run. And because they bundle their dependencies, they work on all major Linux systems without modification.{% endblock %}">
     <meta name="copydoc" content="{% block meta_copydoc %}https://drive.google.com/drive/folders/1q9ia7iDuWQlCaJ7nfKVeQ5G-FPyJbP-H{% endblock %}">
     <meta name="google-site-verification" content="Y1JayrP2iS6jS6Rd7uGX3Kzgm0oD8rV5R6TkzteLbQg" />
@@ -62,18 +76,6 @@
 
     {% include "_footer.html" %}
 
-    {% block scripts_modules %}{% endblock %}
-    <script src="{{ static_url('js/modules/raven.min.js') }}"></script>
-    <script>
-      Raven.config('{{ SENTRY_DSN }}', {
-        whitelistUrls: ['staging.snapcraft.io/static/js', 'snapcraft.io/static/js/'],
-        ignoreUrls: ['staging.snapcraft.io/static/js/modules', 'snapcraft.io/static/js/modules'],
-        release: '{{ COMMIT_ID }}',
-        environment: '{{ ENVIRONMENT }}'
-      }).install();
-    </script>
-
-    <script src="{{ static_url('js/dist/base.js') }}"></script>
     {% block scripts %}{% endblock %}
 
     <script type="application/ld+json">

--- a/templates/blog/article.html
+++ b/templates/blog/article.html
@@ -107,17 +107,19 @@
 {% endblock %}
 
 {% block scripts_includes %}
-  <script src="{{ static_url('js/dist/public.js') }}"></script>
+  <script src="{{ static_url('js/dist/public.js') }}" defer></script>
 {% endblock %}
 
 {% block scripts %}
   <script>
-    Raven.context(function () {
-      {% if is_in_series %}
+    window.addEventListener("DOMContentLoaded", function() {
+      Raven.context(function () {
+        {% if is_in_series %}
         snapcraft.public.seriesPosts('[data-js="blog-series"]', '#blog-series-item-template');
-      {% endif %}
+        {% endif %}
 
-      snapcraft.public.newsletter();
+        snapcraft.public.newsletter();
+      });
     });
   </script>
 {% endblock %}

--- a/templates/blog/article.html
+++ b/templates/blog/article.html
@@ -106,8 +106,11 @@
 </script>
 {% endblock %}
 
-{% block scripts %}
+{% block scripts_includes %}
   <script src="{{ static_url('js/dist/public.js') }}"></script>
+{% endblock %}
+
+{% block scripts %}
   <script>
     Raven.context(function () {
       {% if is_in_series %}

--- a/templates/blog/index.html
+++ b/templates/blog/index.html
@@ -137,9 +137,11 @@
 
 {% endblock %}
 
+{% block scripts_includes %}
+  <script src="{{ static_url('js/dist/public.js') }}"></script>
+{% endblock %}
 
 {% block scripts %}
-  <script src="{{ static_url('js/dist/public.js') }}"></script>
   <script>
     Raven.context(function () {
       {% if categories %}

--- a/templates/blog/index.html
+++ b/templates/blog/index.html
@@ -138,21 +138,23 @@
 {% endblock %}
 
 {% block scripts_includes %}
-  <script src="{{ static_url('js/dist/public.js') }}"></script>
+  <script src="{{ static_url('js/dist/public.js') }}" defer></script>
 {% endblock %}
 
 {% block scripts %}
   <script>
-    Raven.context(function () {
-      {% if categories %}
-        var filter = document.getElementById('filter');
-        var filterForm = document.querySelector('[data-js="filterForm"]');
-        filter.addEventListener('change', function(e) {
-          filterForm.submit();
-        });
-      {% endif %}
+    window.addEventListener("DOMContentLoaded", function() {
+      Raven.context(function () {
+        {% if categories %}
+          var filter = document.getElementById('filter');
+          var filterForm = document.querySelector('[data-js="filterForm"]');
+          filter.addEventListener('change', function(e) {
+            filterForm.submit();
+          });
+        {% endif %}
 
-      snapcraft.public.newsletter();
+        snapcraft.public.newsletter();
+      });
     });
   </script>
 {% endblock %}

--- a/templates/brand-store/search.html
+++ b/templates/brand-store/search.html
@@ -118,8 +118,11 @@
   {% endif %}
 {% endblock %}
 
-{% block scripts %}
+{% block scripts_includes %}
   <script src="{{ static_url('js/dist/public.js') }}"></script>
+{% endblock %}
+
+{% block scripts %}
   <script>
     Raven.context(function () {
       snapcraft.public.storeCategories();

--- a/templates/brand-store/search.html
+++ b/templates/brand-store/search.html
@@ -119,13 +119,15 @@
 {% endblock %}
 
 {% block scripts_includes %}
-  <script src="{{ static_url('js/dist/public.js') }}"></script>
+  <script src="{{ static_url('js/dist/public.js') }}" defer></script>
 {% endblock %}
 
 {% block scripts %}
   <script>
-    Raven.context(function () {
-      snapcraft.public.storeCategories();
+    window.addEventListener("DOMContentLoaded", function() {
+      Raven.context(function () {
+        snapcraft.public.storeCategories();
+      });
     });
   </script>
 {% endblock %}

--- a/templates/brand-store/store.html
+++ b/templates/brand-store/store.html
@@ -66,8 +66,11 @@ sudo service snapd restart</code></pre>
   </section>
 {% endblock %}
 
-{% block scripts %}
+{% block scripts_includes %}
   <script src="{{ static_url('js/dist/public.js') }}"></script>
+{% endblock %}
+
+{% block scripts %}
   <script>
     Raven.context(function () {
       snapcraft.public.storeCategories();

--- a/templates/brand-store/store.html
+++ b/templates/brand-store/store.html
@@ -67,13 +67,15 @@ sudo service snapd restart</code></pre>
 {% endblock %}
 
 {% block scripts_includes %}
-  <script src="{{ static_url('js/dist/public.js') }}"></script>
+  <script src="{{ static_url('js/dist/public.js') }}" defer></script>
 {% endblock %}
 
 {% block scripts %}
   <script>
-    Raven.context(function () {
-      snapcraft.public.storeCategories();
+    window.addEventListener("DOMContentLoaded", function() {
+      Raven.context(function () {
+        snapcraft.public.storeCategories();
+      });
     });
   </script>
 {% endblock %}

--- a/templates/docs/base.html
+++ b/templates/docs/base.html
@@ -22,22 +22,24 @@
 
 {% block scripts %}
 <script>
-  Raven.context(function() {
-    const path = window.location.pathname;
-    const active = document.querySelector(`.p-sidebar a[href="${path}"]`);
-    if (active) {
-      active.classList.add("is-active");
-    }
+  window.addEventListener("DOMContentLoaded", function() {
+    Raven.context(function() {
+      const path = window.location.pathname;
+      const active = document.querySelector(`.p-sidebar a[href="${path}"]`);
+      if (active) {
+        active.classList.add("is-active");
+      }
 
-    const toggleSidebar = document.querySelector(".p-sidebar__toggle");
-    const sidebar = document.querySelector(".p-sidebar__content");
-    if (toggleSidebar) {
-      toggleSidebar.addEventListener("click", function(e) {
-        sidebar.classList.toggle("u-hide--small");
-        toggleSidebar.classList.toggle("p-icon--close");
-        toggleSidebar.classList.toggle("p-icon--menu");
-      });
-    }
+      const toggleSidebar = document.querySelector(".p-sidebar__toggle");
+      const sidebar = document.querySelector(".p-sidebar__content");
+      if (toggleSidebar) {
+        toggleSidebar.addEventListener("click", function(e) {
+          sidebar.classList.toggle("u-hide--small");
+          toggleSidebar.classList.toggle("p-icon--close");
+          toggleSidebar.classList.toggle("p-icon--menu");
+        });
+      }
+    });
   });
 </script>
 {% endblock %}

--- a/templates/docs/base.html
+++ b/templates/docs/base.html
@@ -22,20 +22,22 @@
 
 {% block scripts %}
 <script>
-  const path = window.location.pathname;
-  const active = document.querySelector(`.p-sidebar a[href="${path}"]`);
-  if (active) {
-    active.classList.add("is-active");
-  }
+  Raven.context(function() {
+    const path = window.location.pathname;
+    const active = document.querySelector(`.p-sidebar a[href="${path}"]`);
+    if (active) {
+      active.classList.add("is-active");
+    }
 
-  const toggleSidebar = document.querySelector(".p-sidebar__toggle");
-  const sidebar = document.querySelector(".p-sidebar__content");
-  if (toggleSidebar) {
-    toggleSidebar.addEventListener("click", function(e) {
-      sidebar.classList.toggle("u-hide--small");
-      toggleSidebar.classList.toggle("p-icon--close");
-      toggleSidebar.classList.toggle("p-icon--menu");
-    });
-  }
+    const toggleSidebar = document.querySelector(".p-sidebar__toggle");
+    const sidebar = document.querySelector(".p-sidebar__content");
+    if (toggleSidebar) {
+      toggleSidebar.addEventListener("click", function(e) {
+        sidebar.classList.toggle("u-hide--small");
+        toggleSidebar.classList.toggle("p-icon--close");
+        toggleSidebar.classList.toggle("p-icon--menu");
+      });
+    }
+  });
 </script>
 {% endblock %}

--- a/templates/first-snap/_layout_fsf.html
+++ b/templates/first-snap/_layout_fsf.html
@@ -28,6 +28,10 @@
   <!-- end intercom live embed code -->
 {% endblock %}
 
+{% block scripts_includes %}
+  <script src="{{ static_url('js/dist/public.js') }}"></script>
+{% endblock %}
+
 {% block scripts %}
   <script>
     Raven.context(function() {

--- a/templates/first-snap/_layout_fsf.html
+++ b/templates/first-snap/_layout_fsf.html
@@ -17,7 +17,7 @@
 {% endblock %}
 
 {% block scripts_modules %}
-  <script src="{{ static_url('js/modules/clipboard.min.js') }}"></script>
+  <script src="{{ static_url('js/modules/clipboard.min.js') }}" defer></script>
   <!-- begin intercom live embed code -->
   <script>
     window.intercomSettings = {
@@ -29,15 +29,17 @@
 {% endblock %}
 
 {% block scripts_includes %}
-  <script src="{{ static_url('js/dist/public.js') }}"></script>
+  <script src="{{ static_url('js/dist/public.js') }}" defer></script>
 {% endblock %}
 
 {% block scripts %}
   <script>
-    Raven.context(function() {
-      if (typeof ClipboardJS !== 'undefined') {
-        new ClipboardJS('.js-clipboard-copy');
-      }
+    window.addEventListener("DOMContentLoaded", function() {
+      Raven.context(function() {
+        if (typeof ClipboardJS !== 'undefined') {
+          new ClipboardJS('.js-clipboard-copy');
+        }
+      });
     });
   </script>
 {% endblock %}

--- a/templates/first-snap/install-snapcraft.html
+++ b/templates/first-snap/install-snapcraft.html
@@ -15,7 +15,7 @@
         <span>Linux</span>
       </span>
     </div>
-    <div class="col-small-2 col-medium-2 col-2 col-logo">  
+    <div class="col-small-2 col-medium-2 col-2 col-logo">
       <span class="p-logo-link p-card u-align-text--center js-os-select" data-os="macos">
         <header class="p-card__header">
           <img src="https://assets.ubuntu.com/v1/236f314d-macos.svg" alt="">
@@ -49,7 +49,6 @@
 {% endblock %}
 
 {% block scripts %}
-  <script src="{{ static_url('js/dist/public.js') }}"></script>
   <script>
     Raven.context(function() {
       snapcraft.public.firstSnapFlow.install({{ language|tojson }});

--- a/templates/first-snap/install-snapcraft.html
+++ b/templates/first-snap/install-snapcraft.html
@@ -50,8 +50,10 @@
 
 {% block scripts %}
   <script>
-    Raven.context(function() {
-      snapcraft.public.firstSnapFlow.install({{ language|tojson }});
+    window.addEventListener("DOMContentLoaded", function() {
+      Raven.context(function() {
+        snapcraft.public.firstSnapFlow.install({{ language|tojson }});
+      });
     });
   </script>
   {{ super() }}

--- a/templates/first-snap/language.html
+++ b/templates/first-snap/language.html
@@ -11,8 +11,10 @@
 
 {% block scripts %}
 <script>
-  Raven.context(function () {
-    snapcraft.public.initFSFLanguageSelect(document.querySelector('.js-fsf-language-select'));
+  window.addEventListener("DOMContentLoaded", function() {
+    Raven.context(function () {
+      snapcraft.public.initFSFLanguageSelect(document.querySelector('.js-fsf-language-select'));
+    });
   });
 </script>
 {{ super() }}

--- a/templates/first-snap/language.html
+++ b/templates/first-snap/language.html
@@ -10,7 +10,6 @@
 {% endblock %}
 
 {% block scripts %}
-<script src="{{ static_url('js/dist/public.js') }}"></script>
 <script>
   Raven.context(function () {
     snapcraft.public.initFSFLanguageSelect(document.querySelector('.js-fsf-language-select'));

--- a/templates/first-snap/package.html
+++ b/templates/first-snap/package.html
@@ -108,7 +108,6 @@
 {% endblock %}
 
 {% block scripts %}
-  <script src="{{ static_url('js/dist/public.js') }}"></script>
   <script>
     Raven.context(function() {
       snapcraft.public.firstSnapFlow.initChooseName(

--- a/templates/first-snap/package.html
+++ b/templates/first-snap/package.html
@@ -109,15 +109,17 @@
 
 {% block scripts %}
   <script>
-    Raven.context(function() {
-      snapcraft.public.firstSnapFlow.initChooseName(
-        document.getElementById("choose-name-form"),
-         "{{language}}"
-      );
-      snapcraft.public.initAccordion('.p-accordion__list');
-      snapcraft.public.initAccordionButtons(
-        document.getElementById("js-clone-continue-button")
-      );
+    window.addEventListener("DOMContentLoaded", function() {
+      Raven.context(function() {
+        snapcraft.public.firstSnapFlow.initChooseName(
+          document.getElementById("choose-name-form"),
+           "{{language}}"
+        );
+        snapcraft.public.initAccordion('.p-accordion__list');
+        snapcraft.public.initAccordionButtons(
+          document.getElementById("js-clone-continue-button")
+        );
+      });
     });
   </script>
   {{ super() }}

--- a/templates/first-snap/push.html
+++ b/templates/first-snap/push.html
@@ -136,16 +136,18 @@
 
 {% block scripts %}
   <script>
-    Raven.context(function() {
-      {% if user %}
-        snapcraft.public.firstSnapFlow.initRegisterName(
-          document.getElementById("register-name-form"),
-          document.getElementById("register-name-notification"),
-          document.getElementById("register-name-success")
-        );
-        snapcraft.public.firstSnapFlow.push({{ language|tojson }});
-      {% endif %}
-      snapcraft.public.initAccordion('.p-accordion__list');
+    window.addEventListener("DOMContentLoaded", function() {
+      Raven.context(function() {
+        {% if user %}
+          snapcraft.public.firstSnapFlow.initRegisterName(
+            document.getElementById("register-name-form"),
+            document.getElementById("register-name-notification"),
+            document.getElementById("register-name-success")
+          );
+          snapcraft.public.firstSnapFlow.push({{ language|tojson }});
+        {% endif %}
+        snapcraft.public.initAccordion('.p-accordion__list');
+      });
     });
   </script>
   {{ super() }}

--- a/templates/first-snap/push.html
+++ b/templates/first-snap/push.html
@@ -135,7 +135,6 @@
 {% endblock %}
 
 {% block scripts %}
-  <script src="{{ static_url('js/dist/public.js') }}"></script>
   <script>
     Raven.context(function() {
       {% if user %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -213,21 +213,23 @@
 {% endblock %}
 
 {% block scripts_includes %}
-<script src="{{ static_url('js/dist/public.js') }}"></script>
-<script src="{{ static_url('js/dist/publisher.js') }}"></script>
+<script src="{{ static_url('js/dist/public.js') }}" defer></script>
+<script src="{{ static_url('js/dist/publisher.js') }}" defer></script>
 {% if nps %}
-  <script src="//app-sjg.marketo.com/js/forms2/js/forms2.min.js"></script>
+  <script src="//app-sjg.marketo.com/js/forms2/js/forms2.min.js" defer></script>
 {% endif %}
 {% endblock %}
 
 {% block scripts %}
 <script>
-  Raven.context(function () {
-    snapcraft.public.initFSFLanguageSelect(document.querySelector('.js-fsf-language-select'));
+  window.addEventListener("DOMContentLoaded", function() {
+    Raven.context(function () {
+      snapcraft.public.initFSFLanguageSelect(document.querySelector('.js-fsf-language-select'));
 
-    {% if nps %}
-      snapcraft.public.nps();
-    {% endif %}
+      {% if nps %}
+        snapcraft.public.nps();
+      {% endif %}
+    });
   });
 </script>
 {% endblock %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -212,12 +212,15 @@
 </section>
 {% endblock %}
 
-{% block scripts %}
+{% block scripts_includes %}
 <script src="{{ static_url('js/dist/public.js') }}"></script>
 <script src="{{ static_url('js/dist/publisher.js') }}"></script>
 {% if nps %}
   <script src="//app-sjg.marketo.com/js/forms2/js/forms2.min.js"></script>
 {% endif %}
+{% endblock %}
+
+{% block scripts %}
 <script>
   Raven.context(function () {
     snapcraft.public.initFSFLanguageSelect(document.querySelector('.js-fsf-language-select'));

--- a/templates/publisher/account-details.html
+++ b/templates/publisher/account-details.html
@@ -97,9 +97,12 @@ Account details — Linux software in the Snap Store
 </section>
 {% endblock %}
 
+{% block scripts_includes %}
+<script src="{{ static_url('js/dist/publisher.js') }}"></script>
+{% endblock %}
+
 {% block scripts %}
 {% if subscriptions %}
-<script src="{{ static_url('js/dist/publisher.js') }}"></script>
 <script>
   Raven.context(function () {
     snapcraft.publisher.submitEnabler(".js-preferences-form", [".js-preferences-form button[type='submit']"]);

--- a/templates/publisher/account-details.html
+++ b/templates/publisher/account-details.html
@@ -98,14 +98,16 @@ Account details — Linux software in the Snap Store
 {% endblock %}
 
 {% block scripts_includes %}
-<script src="{{ static_url('js/dist/publisher.js') }}"></script>
+<script src="{{ static_url('js/dist/publisher.js') }}" defer></script>
 {% endblock %}
 
 {% block scripts %}
 {% if subscriptions %}
 <script>
-  Raven.context(function () {
-    snapcraft.publisher.submitEnabler(".js-preferences-form", [".js-preferences-form button[type='submit']"]);
+  window.addEventListener("DOMContentLoaded", function() {
+    Raven.context(function () {
+      snapcraft.publisher.submitEnabler(".js-preferences-form", [".js-preferences-form button[type='submit']"]);
+    });
   });
 </script>
 {% endif %}

--- a/templates/publisher/account-snaps.html
+++ b/templates/publisher/account-snaps.html
@@ -224,19 +224,21 @@ My published snaps — Linux software in the Snap Store
 {% endblock %}
 
 {% block scripts_includes %}
-<script src="{{ static_url('js/dist/publisher.js') }}"></script>
+<script src="{{ static_url('js/dist/publisher.js') }}" defer></script>
 {% endblock %}
 
 {% block scripts %}
 {% if snaps %}
 <script>
-  Raven.context(function () {
-    var options = {
-      snaps: { {% for name, snap in snaps.items()|sort %} "{{name}}": "{{snap['snap-id']}}",{% endfor %} },
-      selector: ".snap-installs-container",
-      token: {{ csrf_token()|tojson }},
-    };
-    snapcraft.publisher.metrics.renderPublisherMetrics(options);
+  window.addEventListener("DOMContentLoaded", function() {
+    Raven.context(function () {
+      var options = {
+        snaps: { {% for name, snap in snaps.items()|sort %} "{{name}}": "{{snap['snap-id']}}",{% endfor %} },
+        selector: ".snap-installs-container",
+        token: {{ csrf_token()|tojson }},
+      };
+      snapcraft.publisher.metrics.renderPublisherMetrics(options);
+    });
   });
 </script>
 {% endif %}

--- a/templates/publisher/account-snaps.html
+++ b/templates/publisher/account-snaps.html
@@ -223,9 +223,12 @@ My published snaps — Linux software in the Snap Store
 {% endif %}
 {% endblock %}
 
+{% block scripts_includes %}
+<script src="{{ static_url('js/dist/publisher.js') }}"></script>
+{% endblock %}
+
 {% block scripts %}
 {% if snaps %}
-<script src="{{ static_url('js/dist/publisher.js') }}"></script>
 <script>
   Raven.context(function () {
     var options = {

--- a/templates/publisher/developer_programme_agreement.html
+++ b/templates/publisher/developer_programme_agreement.html
@@ -44,16 +44,18 @@
 
 {% block scripts %}
 <script>
- Raven.context(function() {
-   var checkbox = document.querySelector('#id_i_agree');
-   var button = document.querySelector('button[type="submit"]');
-   checkbox.addEventListener('change', function (event) {
-     if (this.checked) {
-       button.removeAttribute('disabled');
-     } else {
-       button.setAttribute('disabled', 'disabled');
-     }
+  window.addEventListener("DOMContentLoaded", function() {
+   Raven.context(function() {
+     var checkbox = document.querySelector('#id_i_agree');
+     var button = document.querySelector('button[type="submit"]');
+     checkbox.addEventListener('change', function (event) {
+       if (this.checked) {
+         button.removeAttribute('disabled');
+       } else {
+         button.setAttribute('disabled', 'disabled');
+       }
+     });
    });
- });
+  });
 </script>
 {% endblock %}

--- a/templates/publisher/listing.html
+++ b/templates/publisher/listing.html
@@ -478,8 +478,11 @@ Listing details for {% if display_title %}{{ display_title }}{% else %}{{ snap_t
 <div id="tour-container"></div>
 {% endblock %}
 
-{% block scripts %}
+{% block scripts_includes %}
 <script src="{{ static_url('js/dist/publisher.js') }}"></script>
+{% endblock %}
+
+{% block scripts %}
 <script>
   Raven.context(function () {
     snapcraft.publisher.initMultiselect('.js-license', {{ licenses|tojson }}, ' OR ');

--- a/templates/publisher/listing.html
+++ b/templates/publisher/listing.html
@@ -479,66 +479,68 @@ Listing details for {% if display_title %}{{ display_title }}{% else %}{{ snap_t
 {% endblock %}
 
 {% block scripts_includes %}
-<script src="{{ static_url('js/dist/publisher.js') }}"></script>
+<script src="{{ static_url('js/dist/publisher.js') }}" defer></script>
 {% endblock %}
 
 {% block scripts %}
 <script>
-  Raven.context(function () {
-    snapcraft.publisher.initMultiselect('.js-license', {{ licenses|tojson }}, ' OR ');
+  window.addEventListener("DOMContentLoaded", function() {
+    Raven.context(function () {
+      snapcraft.publisher.initMultiselect('.js-license', {{ licenses|tojson }}, ' OR ');
 
-    const formFields = {
-      snap_name: {{ snap_name|tojson }},
-      title: {{ snap_title|tojson }},
-      summary: {{ summary|tojson }},
-      description: {{ description|tojson }},
-      website: {{ website|tojson }},
-      contact: {{ contact|tojson }},
-      categories: {{ snap_categories.categories|tojson }},
-      images: [
-        {% if icon_url %}
-        { url: {{ icon_url|tojson }}, type: "icon", status: "uploaded" },
-        {% endif %}
-        {% for screenshot_url in screenshot_urls %}
-        { url: {{ screenshot_url|tojson }}, type: "screenshot", status: "uploaded" },
-        {% endfor %}
-        {% if banner_urls[0] %}
-        { url: {{ banner_urls[0]|tojson }}, type: "banner", status: "uploaded" },
-        {% endif %}
-      ],
-      'public_metrics_enabled': {{ public_metrics_enabled|tojson }},
-      'public_metrics_blacklist': {{ join(public_metrics_blacklist, ',')|tojson }},
-      'license': {{ license|tojson }},
-      'video_urls': {% if video_urls %}{{ video_urls[0]|tojson }}{% else %}""{% endif %}
-    };
-
-    const formErrors = {% if error_list %}{{ error_list|tojson}}{% else %}null{% endif %};
-
-    snapcraft.publisher.market.initForm(
-      {
-        snapIconHolder: ".js-icon-holder",
-        bannerHolder: ".js-banner",
-        form: "market-form",
-        formNotification: "market-form-status",
-        licenseRadioContent: [
-          document.getElementById('license-simple-input'),
-          document.getElementById('license-custom-input')
+      const formFields = {
+        snap_name: {{ snap_name|tojson }},
+        title: {{ snap_title|tojson }},
+        summary: {{ summary|tojson }},
+        description: {{ description|tojson }},
+        website: {{ website|tojson }},
+        contact: {{ contact|tojson }},
+        categories: {{ snap_categories.categories|tojson }},
+        images: [
+          {% if icon_url %}
+          { url: {{ icon_url|tojson }}, type: "icon", status: "uploaded" },
+          {% endif %}
+          {% for screenshot_url in screenshot_urls %}
+          { url: {{ screenshot_url|tojson }}, type: "screenshot", status: "uploaded" },
+          {% endfor %}
+          {% if banner_urls[0] %}
+          { url: {{ banner_urls[0]|tojson }}, type: "banner", status: "uploaded" },
+          {% endif %}
         ],
-        mediaHolder: ".js-media-holder",
-      },
-      formFields,
-      formErrors
-    );
+        'public_metrics_enabled': {{ public_metrics_enabled|tojson }},
+        'public_metrics_blacklist': {{ join(public_metrics_blacklist, ',')|tojson }},
+        'license': {{ license|tojson }},
+        'video_urls': {% if video_urls %}{{ video_urls[0]|tojson }}{% else %}""{% endif %}
+      };
 
-    snapcraft.publisher.stickyListingBar();
-    snapcraft.publisher.markdownToggle();
-    snapcraft.publisher.initCategories();
+      const formErrors = {% if error_list %}{{ error_list|tojson}}{% else %}null{% endif %};
 
-    snapcraft.publisher.tour.initListingTour({
-      snapName: {{ snap_name|tojson }},
-      container: document.getElementById("tour-container"),
-      steps: {{ tour_steps|tojson }},
-      formFields: formFields
+      snapcraft.publisher.market.initForm(
+        {
+          snapIconHolder: ".js-icon-holder",
+          bannerHolder: ".js-banner",
+          form: "market-form",
+          formNotification: "market-form-status",
+          licenseRadioContent: [
+            document.getElementById('license-simple-input'),
+            document.getElementById('license-custom-input')
+          ],
+          mediaHolder: ".js-media-holder",
+        },
+        formFields,
+        formErrors
+      );
+
+      snapcraft.publisher.stickyListingBar();
+      snapcraft.publisher.markdownToggle();
+      snapcraft.publisher.initCategories();
+
+      snapcraft.publisher.tour.initListingTour({
+        snapName: {{ snap_name|tojson }},
+        container: document.getElementById("tour-container"),
+        steps: {{ tour_steps|tojson }},
+        formFields: formFields
+      });
     });
   });
 </script>

--- a/templates/publisher/metrics.html
+++ b/templates/publisher/metrics.html
@@ -92,8 +92,11 @@ Publisher metrics for {{ snap_title }}
   </div>
 {% endblock %}
 
-{% block scripts %}
+{% block scripts_includes %}
   <script src="{{ static_url('js/dist/publisher.js') }}"></script>
+{% endblock %}
+
+{% block scripts %}
   <script>
     Raven.context(function () {
       snapcraft.publisher.selector('.metrics-period', 'period');

--- a/templates/publisher/metrics.html
+++ b/templates/publisher/metrics.html
@@ -93,26 +93,28 @@ Publisher metrics for {{ snap_title }}
 {% endblock %}
 
 {% block scripts_includes %}
-  <script src="{{ static_url('js/dist/publisher.js') }}"></script>
+  <script src="{{ static_url('js/dist/publisher.js') }}" defer></script>
 {% endblock %}
 
 {% block scripts %}
   <script>
-    Raven.context(function () {
-      snapcraft.publisher.selector('.metrics-period', 'period');
-      snapcraft.publisher.selector('.active-devices', 'active-devices');
-      snapcraft.publisher.metrics.renderMetrics({
-        defaultTrack: {{ default_track|tojson }},
-        activeDevices: {
-          selector: '#activeDevices',
-          metrics: {{ active_devices|safe }},
-          annotations: {{ active_devices_annotations|safe }},
-          type: '{{ active_device_metric }}'
-        },
-        territories: {
-          selector: '#territories',
-          metrics: {{ territories|safe }}
-        }
+    window.addEventListener("DOMContentLoaded", function() {
+      Raven.context(function () {
+        snapcraft.publisher.selector('.metrics-period', 'period');
+        snapcraft.publisher.selector('.active-devices', 'active-devices');
+        snapcraft.publisher.metrics.renderMetrics({
+          defaultTrack: {{ default_track|tojson }},
+          activeDevices: {
+            selector: '#activeDevices',
+            metrics: {{ active_devices|safe }},
+            annotations: {{ active_devices_annotations|safe }},
+            type: '{{ active_device_metric }}'
+          },
+          territories: {
+            selector: '#territories',
+            metrics: {{ territories|safe }}
+          }
+        });
       });
     });
   </script>

--- a/templates/publisher/publicise/embedded_cards.html
+++ b/templates/publisher/publicise/embedded_cards.html
@@ -69,8 +69,11 @@
 <script src="{{ static_url('js/modules/clipboard.min.js') }}"></script>
 {% endblock %}
 
-{% block scripts %}
+{% block scripts_includes %}
 <script src="{{ static_url('js/dist/publisher.js') }}"></script>
+{% endblock %}
+
+{% block scripts %}
 <script>
   Raven.context(function () {
     snapcraft.publisher.publicise.initEmbeddedCardPicker({

--- a/templates/publisher/publicise/embedded_cards.html
+++ b/templates/publisher/publicise/embedded_cards.html
@@ -66,27 +66,29 @@
 {% endblock %}
 
 {% block scripts_modules %}
-<script src="{{ static_url('js/modules/clipboard.min.js') }}"></script>
+<script src="{{ static_url('js/modules/clipboard.min.js') }}" defer></script>
 {% endblock %}
 
 {% block scripts_includes %}
-<script src="{{ static_url('js/dist/publisher.js') }}"></script>
+<script src="{{ static_url('js/dist/publisher.js') }}" defer></script>
 {% endblock %}
 
 {% block scripts %}
 <script>
-  Raven.context(function () {
-    snapcraft.publisher.publicise.initEmbeddedCardPicker({
-      snapName: "{{ snap_name }}",
-      previewFrame: document.getElementById('embedded-card-frame'),
-      codeElement: document.getElementById('snippet-card-html'),
-      buttonRadios: document.querySelectorAll("input[name=store-button]"),
-      optionButtons: document.querySelectorAll("#js-options input[type=checkbox]")
-    });
+  window.addEventListener("DOMContentLoaded", function() {
+    Raven.context(function () {
+      snapcraft.publisher.publicise.initEmbeddedCardPicker({
+        snapName: "{{ snap_name }}",
+        previewFrame: document.getElementById('embedded-card-frame'),
+        codeElement: document.getElementById('snippet-card-html'),
+        buttonRadios: document.querySelectorAll("input[name=store-button]"),
+        optionButtons: document.querySelectorAll("#js-options input[type=checkbox]")
+      });
 
-    if (typeof ClipboardJS !== 'undefined') {
-      new ClipboardJS('.js-clipboard-copy');
-    }
+      if (typeof ClipboardJS !== 'undefined') {
+        new ClipboardJS('.js-clipboard-copy');
+      }
+    });
   });
 </script>
 {% endblock %}

--- a/templates/publisher/publicise/github_badges.html
+++ b/templates/publisher/publicise/github_badges.html
@@ -47,15 +47,17 @@
 {% endblock %}
 
 {% block scripts_modules %}
-<script src="{{ static_url('js/modules/clipboard.min.js') }}"></script>
+<script src="{{ static_url('js/modules/clipboard.min.js') }}" defer></script>
 {% endblock %}
 
 {% block scripts %}
 <script>
-  Raven.context(function () {
-    if (typeof ClipboardJS !== 'undefined') {
-      new ClipboardJS('.js-clipboard-copy');
-    }
+  window.addEventListener("DOMContentLoaded", function() {
+    Raven.context(function () {
+      if (typeof ClipboardJS !== 'undefined') {
+        new ClipboardJS('.js-clipboard-copy');
+      }
+    });
   });
 </script>
 {% endblock %}

--- a/templates/publisher/publicise/store_buttons.html
+++ b/templates/publisher/publicise/store_buttons.html
@@ -141,8 +141,11 @@
 <script src="{{ static_url('js/modules/clipboard.min.js') }}"></script>
 {% endblock %}
 
-{% block scripts %}
+{% block scripts_includes %}
   <script src="{{ static_url('js/dist/publisher.js') }}"></script>
+{% endblock %}
+
+{% block scripts %}
   <script>
     Raven.context(function () {
       snapcraft.publisher.publicise.initSnapButtonsPicker();

--- a/templates/publisher/publicise/store_buttons.html
+++ b/templates/publisher/publicise/store_buttons.html
@@ -138,21 +138,23 @@
 {% endblock %}
 
 {% block scripts_modules %}
-<script src="{{ static_url('js/modules/clipboard.min.js') }}"></script>
+<script src="{{ static_url('js/modules/clipboard.min.js') }}" defer></script>
 {% endblock %}
 
 {% block scripts_includes %}
-  <script src="{{ static_url('js/dist/publisher.js') }}"></script>
+  <script src="{{ static_url('js/dist/publisher.js') }}" defer></script>
 {% endblock %}
 
 {% block scripts %}
   <script>
-    Raven.context(function () {
-      snapcraft.publisher.publicise.initSnapButtonsPicker();
+    window.addEventListener("DOMContentLoaded", function() {
+      Raven.context(function () {
+        snapcraft.publisher.publicise.initSnapButtonsPicker();
 
-      if (typeof ClipboardJS !== 'undefined') {
-        new ClipboardJS('.js-clipboard-copy');
-      }
+        if (typeof ClipboardJS !== 'undefined') {
+          new ClipboardJS('.js-clipboard-copy');
+        }
+      });
     });
   </script>
 {% endblock %}

--- a/templates/publisher/release-history.html
+++ b/templates/publisher/release-history.html
@@ -29,21 +29,25 @@ Releases and revision history for {% if snap_title %}{{ snap_title }}{% else %}{
 {% endblock %}
 
 {% block scripts_includes %}
-  <script src="{{ static_url('js/dist/release.js') }}"></script>
+  <script src="{{ static_url('js/dist/release.js') }}" defer></script>
 {% endblock %}
 
 {% block scripts %}
   {% if "error-list" not in release_history %}
     <script>
-      snapcraft.release.initReleases('#release-history',
-        {{ snap_name|tojson }},
-        {{ release_history|tojson }},
-        {{ channel_maps_list|tojson }},
-        {
-          defaultTrack: {% if default_track %}{{ default_track|tojson }}{% else %}"latest"{% endif %},
-          csrfToken: {{ csrf_token()|tojson }}
-        }
-      );
+      window.addEventListener("DOMContentLoaded", function() {
+        Raven.context(function () {
+          snapcraft.release.initReleases('#release-history',
+            {{ snap_name|tojson }},
+            {{ release_history|tojson }},
+            {{ channel_maps_list|tojson }},
+            {
+              defaultTrack: {% if default_track %}{{ default_track|tojson }}{% else %}"latest"{% endif %},
+              csrfToken: {{ csrf_token()|tojson }}
+            }
+          );
+        });
+      });
     </script>
   {% endif %}
 {% endblock %}

--- a/templates/publisher/release-history.html
+++ b/templates/publisher/release-history.html
@@ -28,10 +28,12 @@ Releases and revision history for {% if snap_title %}{{ snap_title }}{% else %}{
 
 {% endblock %}
 
+{% block scripts_includes %}
+  <script src="{{ static_url('js/dist/release.js') }}"></script>
+{% endblock %}
 
 {% block scripts %}
   {% if "error-list" not in release_history %}
-    <script src="{{ static_url('js/dist/release.js') }}"></script>
     <script>
       snapcraft.release.initReleases('#release-history',
         {{ snap_name|tojson }},

--- a/templates/publisher/settings.html
+++ b/templates/publisher/settings.html
@@ -222,44 +222,46 @@ Settings for {% if display_title %}{{ display_title }}{% else %}{{ snap_title }}
 {% endblock %}
 
 {% block scripts_includes %}
-<script src="{{ static_url('js/dist/publisher.js') }}"></script>
+<script src="{{ static_url('js/dist/publisher.js') }}" defer></script>
 {% endblock %}
 
 {% block scripts %}
 <script>
-  Raven.context(function () {
-    snapcraft.publisher.initMultiselect('.js-whitelist', {{ countries|tojson }});
-    snapcraft.publisher.initMultiselect('.js-blacklist', {{ countries|tojson }});
+  window.addEventListener("DOMContentLoaded", function() {
+    Raven.context(function () {
+      snapcraft.publisher.initMultiselect('.js-whitelist', {{ countries|tojson }});
+      snapcraft.publisher.initMultiselect('.js-blacklist', {{ countries|tojson }});
 
-    snapcraft.publisher.market.initForm({
-      form: "settings-form",
-      formNotification: "settings-form-status",
-    }, {
-      'private': {{ private|tojson }},
-      'unlisted': {{ unlisted|tojson }},
-      'whitelist_countries': {{ whitelist_country_codes|tojson }},
-      'blacklist_countries': {{ blacklist_country_codes|tojson }}
-    },
-    {% if error_list %}
-      {{ error_list|tojson}}
-    {% else %}
-      null
-    {% endif %}
-    );
-
-    document
-      .getElementById('settings-form')
-      .addEventListener(
-        'change',
-        snapcraft.publisher.settings.changeHandler
+      snapcraft.publisher.market.initForm({
+        form: "settings-form",
+        formNotification: "settings-form-status",
+      }, {
+        'private': {{ private|tojson }},
+        'unlisted': {{ unlisted|tojson }},
+        'whitelist_countries': {{ whitelist_country_codes|tojson }},
+        'blacklist_countries': {{ blacklist_country_codes|tojson }}
+      },
+      {% if error_list %}
+        {{ error_list|tojson}}
+      {% else %}
+        null
+      {% endif %}
       );
 
-    snapcraft.publisher.stickyListingBar();
-    {% if whitelist_country_codes or not blacklist_country_codes %}
-      snapcraft.publisher.settings.enableInput('whitelist');
-    {% elif blacklist_country_codes %}
-      snapcraft.publisher.settings.enableInput('blacklist');
-    {% endif %}
+      document
+        .getElementById('settings-form')
+        .addEventListener(
+          'change',
+          snapcraft.publisher.settings.changeHandler
+        );
+
+      snapcraft.publisher.stickyListingBar();
+      {% if whitelist_country_codes or not blacklist_country_codes %}
+        snapcraft.publisher.settings.enableInput('whitelist');
+      {% elif blacklist_country_codes %}
+        snapcraft.publisher.settings.enableInput('blacklist');
+      {% endif %}
+    });
   });
 </script>
 {% endblock %}

--- a/templates/publisher/settings.html
+++ b/templates/publisher/settings.html
@@ -221,8 +221,11 @@ Settings for {% if display_title %}{{ display_title }}{% else %}{{ snap_title }}
 </div>
 {% endblock %}
 
-{% block scripts %}
+{% block scripts_includes %}
 <script src="{{ static_url('js/dist/publisher.js') }}"></script>
+{% endblock %}
+
+{% block scripts %}
 <script>
   Raven.context(function () {
     snapcraft.publisher.initMultiselect('.js-whitelist', {{ countries|tojson }});

--- a/templates/store/publisher-details.html
+++ b/templates/store/publisher-details.html
@@ -142,19 +142,21 @@
 
 {% block scripts_includes %}
   {% if blog_slug %}
-    <script src="{{ static_url('js/dist/public.js') }}"></script>
+    <script src="{{ static_url('js/dist/public.js') }}" defer></script>
   {% endif %}
 {% endblock %}
 
 {% block scripts %}
   {% if blog_slug %}
     <script>
-      Raven.context(function () {
-        try {
-          snapcraft.public.snapDetailsPosts('[data-js="blog-article-list"]', '#blog-article-template', '[data-js="blog-articles"]');
-        } catch(e) {
-          Raven.captureException(e);
-        }
+      window.addEventListener("DOMContentLoaded", function() {
+        Raven.context(function () {
+          try {
+            snapcraft.public.snapDetailsPosts('[data-js="blog-article-list"]', '#blog-article-template', '[data-js="blog-articles"]');
+          } catch(e) {
+            Raven.captureException(e);
+          }
+        });
       });
     </script>
   {% endif %}

--- a/templates/store/publisher-details.html
+++ b/templates/store/publisher-details.html
@@ -140,9 +140,14 @@
 
 {% endblock %}
 
-{% block scripts %}
+{% block scripts_includes %}
   {% if blog_slug %}
     <script src="{{ static_url('js/dist/public.js') }}"></script>
+  {% endif %}
+{% endblock %}
+
+{% block scripts %}
+  {% if blog_slug %}
     <script>
       Raven.context(function () {
         try {

--- a/templates/store/search.html
+++ b/templates/store/search.html
@@ -103,18 +103,20 @@
 {% endblock %}
 
 {% block scripts_includes %}
-  <script src="{{ static_url('js/dist/public.js') }}"></script>
+  <script src="{{ static_url('js/dist/public.js') }}" defer></script>
 {% endblock %}
 
 {% block scripts %}
   {% if page == 1 %}
     <script>
-      Raven.context(function () {
-        snapcraft.public.getColour(
-          document.querySelector(".js-store-category"),
-          ".p-featured-snap__icon img",
-          ".p-featured-snap"
-        );
+      window.addEventListener("DOMContentLoaded", function() {
+        Raven.context(function () {
+          snapcraft.public.getColour(
+            document.querySelector(".js-store-category"),
+            ".p-featured-snap__icon img",
+            ".p-featured-snap"
+          );
+        });
       });
     </script>
   {% endif %}

--- a/templates/store/search.html
+++ b/templates/store/search.html
@@ -102,9 +102,12 @@
   {% endif %}
 {% endblock %}
 
+{% block scripts_includes %}
+  <script src="{{ static_url('js/dist/public.js') }}"></script>
+{% endblock %}
+
 {% block scripts %}
   {% if page == 1 %}
-    <script src="{{ static_url('js/dist/public.js') }}"></script>
     <script>
       Raven.context(function () {
         snapcraft.public.getColour(

--- a/templates/store/snap-details.html
+++ b/templates/store/snap-details.html
@@ -295,84 +295,83 @@
 {% endblock %}
 
 {% block scripts_modules %}
-  <script src="{{ static_url('js/modules/clipboard.min.js') }}"></script>
+  <script src="{{ static_url('js/modules/clipboard.min.js') }}" defer></script>
 {% endblock %}
 
 {% block scripts_includes %}
-  <script src="{{ static_url('js/dist/public.js') }}"></script>
+  <script src="{{ static_url('js/dist/public.js') }}" defer></script>
   {% if is_preview %}
-    <script src="{{ static_url('js/dist/publisher.js') }}"></script>
+    <script src="{{ static_url('js/dist/publisher.js') }}" defer></script>
   {% endif %}
 {% endblock %}
 
 {% block scripts %}
   <script>
-    Raven.context(function () {
-      {% if not is_preview %}
-      try {
-        snapcraft.public.screenshots('#js-snap-screenshots');
-      } catch(e) {
-        Raven.captureException(e);
-      }
-      {% endif %}
-
-      try {
-        snapcraft.public.videos('.js-video-slide');
-      } catch(e) {
-        Raven.captureException(e);
-      }
-
-      try {
-        snapcraft.public.snapDetailsPosts('[data-js="blog-article-list"]', '#blog-article-template', '[data-js="blog-articles"]');
-      } catch(e) {
-        Raven.captureException(e);
-      }
-
-      {% if not is_preview and not IS_BRAND_STORE %}
-      try {
-        snapcraft.public.initReportSnap(
-          '{{ package_name }}', '.js-modal-open', '#report-snap-modal',
-          document.getElementById('report-snap-form').action
-        );
-      } catch(e) {
-        Raven.captureException(e);
-      }
-
-      try {
-        snapcraft.public.initEmbeddedCardModal('{{ package_name }}');
-      } catch(e) {
-        Raven.captureException(e);
-      }
-      {% endif %}
-
-      {% if countries %}
+    window.addEventListener("DOMContentLoaded", function() {
+      Raven.context(function () {
+        {% if not is_preview %}
         try {
-          snapcraft.public.map('#js-snap-map', {{ countries | tojson }});
+          snapcraft.public.screenshots('#js-snap-screenshots');
         } catch(e) {
           Raven.captureException(e);
-          document.querySelector('.js-snap-map-holder').style.display = 'none';
         }
-      {% endif %}
+        {% endif %}
 
-      {% if not IS_BRAND_STORE and channel_map %}
         try {
-          document.addEventListener('DOMContentLoaded', function() {
-            snapcraft.public.channelMap('#js-channel-map', {{ package_name|tojson }}, {{ channel_map | tojson }}, "{{ default_track }}");
-          });
+          snapcraft.public.videos('.js-video-slide');
         } catch(e) {
-          console.log(e);
           Raven.captureException(e);
-          document.querySelector('.js-open-channel-map').style.display = 'none';
         }
-      {% endif %}
 
-      if (typeof ClipboardJS !== 'undefined') {
-        new ClipboardJS('.js-clipboard-copy');
-      }
+        try {
+          snapcraft.public.snapDetailsPosts('[data-js="blog-article-list"]', '#blog-article-template', '[data-js="blog-articles"]');
+        } catch(e) {
+          Raven.captureException(e);
+        }
 
-      {% if is_preview %}
-        snapcraft.publisher.preview({{ package_name|tojson }});
-      {% endif %}
+        {% if not is_preview and not IS_BRAND_STORE %}
+        try {
+          snapcraft.public.initReportSnap(
+            '{{ package_name }}', '.js-modal-open', '#report-snap-modal',
+            document.getElementById('report-snap-form').action
+          );
+        } catch(e) {
+          Raven.captureException(e);
+        }
+
+        try {
+          snapcraft.public.initEmbeddedCardModal('{{ package_name }}');
+        } catch(e) {
+          Raven.captureException(e);
+        }
+        {% endif %}
+
+        {% if countries %}
+          try {
+            snapcraft.public.map('#js-snap-map', {{ countries | tojson }});
+          } catch(e) {
+            Raven.captureException(e);
+            document.querySelector('.js-snap-map-holder').style.display = 'none';
+          }
+        {% endif %}
+
+        {% if not IS_BRAND_STORE and channel_map %}
+          try {
+              snapcraft.public.channelMap('#js-channel-map', {{ package_name|tojson }}, {{ channel_map | tojson }}, "{{ default_track }}");
+          } catch(e) {
+            Raven.captureException(e);
+            document.querySelector('.js-open-channel-map').style.display = 'none';
+          }
+        {% endif %}
+
+        if (typeof ClipboardJS !== 'undefined') {
+          new ClipboardJS('.js-clipboard-copy');
+        }
+
+        {% if is_preview %}
+          snapcraft.publisher.preview({{ package_name|tojson }});
+        {% endif %}
+      });
     });
   </script>
 {% endblock %}

--- a/templates/store/snap-details.html
+++ b/templates/store/snap-details.html
@@ -298,11 +298,14 @@
   <script src="{{ static_url('js/modules/clipboard.min.js') }}"></script>
 {% endblock %}
 
-{% block scripts %}
+{% block scripts_includes %}
   <script src="{{ static_url('js/dist/public.js') }}"></script>
   {% if is_preview %}
     <script src="{{ static_url('js/dist/publisher.js') }}"></script>
   {% endif %}
+{% endblock %}
+
+{% block scripts %}
   <script>
     Raven.context(function () {
       {% if not is_preview %}

--- a/templates/store/snap-distro-install.html
+++ b/templates/store/snap-distro-install.html
@@ -224,48 +224,50 @@
 {% endblock %}
 
 {% block scripts_modules %}
-  <script src="{{ static_url('js/modules/clipboard.min.js') }}"></script>
+  <script src="{{ static_url('js/modules/clipboard.min.js') }}" defer></script>
 {% endblock %}
 
 {% block scripts_includes %}
-  <script src="{{ static_url('js/dist/public.js') }}"></script>
+  <script src="{{ static_url('js/dist/public.js') }}" defer></script>
 {% endblock %}
 {% block scripts %}
   <script>
-    Raven.context(function () {
-      try {
-        snapcraft.public.initLinkScroll(document.querySelector(".js-install"), { offset: 20 });
-      } catch(e) {
-        Raven.captureException(e);
-      }
+    window.addEventListener("DOMContentLoaded", function() {
+      Raven.context(function () {
+        try {
+          snapcraft.public.initLinkScroll(document.querySelector(".js-install"), { offset: 20 });
+        } catch(e) {
+          Raven.captureException(e);
+        }
 
-      try {
-        snapcraft.public.triggerEventWhenVisible("#snippet-snap-install-stable")
-      } catch(e) {
-        Raven.captureException(e);
-      }
+        try {
+          snapcraft.public.triggerEventWhenVisible("#snippet-snap-install-stable")
+        } catch(e) {
+          Raven.captureException(e);
+        }
 
-      try {
-        snapcraft.public.initExpandableSnapDetails();
-      } catch(e) {
-        Raven.captureException(e);
-      }
+        try {
+          snapcraft.public.initExpandableSnapDetails();
+        } catch(e) {
+          Raven.captureException(e);
+        }
 
-      try {
-        snapcraft.public.screenshots('#js-snap-screenshots');
-      } catch(e) {
-        Raven.captureException(e);
-      }
+        try {
+          snapcraft.public.screenshots('#js-snap-screenshots');
+        } catch(e) {
+          Raven.captureException(e);
+        }
 
-      try {
-        snapcraft.public.videos('.js-video-slide');
-      } catch(e) {
-        Raven.captureException(e);
-      }
+        try {
+          snapcraft.public.videos('.js-video-slide');
+        } catch(e) {
+          Raven.captureException(e);
+        }
 
-      if (typeof ClipboardJS !== 'undefined') {
-        new ClipboardJS('.js-clipboard-copy');
-      }
+        if (typeof ClipboardJS !== 'undefined') {
+          new ClipboardJS('.js-clipboard-copy');
+        }
+      });
     });
   </script>
 {% endblock %}

--- a/templates/store/snap-distro-install.html
+++ b/templates/store/snap-distro-install.html
@@ -227,8 +227,10 @@
   <script src="{{ static_url('js/modules/clipboard.min.js') }}"></script>
 {% endblock %}
 
-{% block scripts %}
+{% block scripts_includes %}
   <script src="{{ static_url('js/dist/public.js') }}"></script>
+{% endblock %}
+{% block scripts %}
   <script>
     Raven.context(function () {
       try {

--- a/templates/store/store.html
+++ b/templates/store/store.html
@@ -77,8 +77,11 @@
   </section>
 {% endblock %}
 
-{% block scripts %}
+{% block scripts_includes %}
   <script src="{{ static_url('js/dist/public.js') }}"></script>
+{% endblock %}
+
+{% block scripts %}
   <script>
     Raven.context(function () {
       snapcraft.public.storeCategories();

--- a/templates/store/store.html
+++ b/templates/store/store.html
@@ -78,13 +78,15 @@
 {% endblock %}
 
 {% block scripts_includes %}
-  <script src="{{ static_url('js/dist/public.js') }}"></script>
+  <script src="{{ static_url('js/dist/public.js') }}" defer></script>
 {% endblock %}
 
 {% block scripts %}
   <script>
-    Raven.context(function () {
-      snapcraft.public.storeCategories();
+    window.addEventListener("DOMContentLoaded", function() {
+      Raven.context(function () {
+        snapcraft.public.storeCategories();
+      });
     });
   </script>
 {% endblock %}


### PR DESCRIPTION
Follow up to #2292 (merge that one first)

Fixes #2287 
Moves loading scripts (public.js publisher.js, etc) from the bottom of the body to head.

### QA
- ./run or demo
- make sure scripts are loaded early
- make sure pages still work, there are no errors in console (check EVERYTHING!)