### PR TITLE
Load categories after page load instead of DOM ready

### DIFF
--- a/templates/store/store.html
+++ b/templates/store/store.html
@@ -83,7 +83,7 @@
 
 {% block scripts %}
   <script>
-    window.addEventListener("DOMContentLoaded", function() {
+    window.addEventListener("load", function() {
       Raven.context(function () {
         snapcraft.public.storeCategories();
       });


### PR DESCRIPTION
Fixes #2290 

Postpones loading of additional categories to page load event

### QA
- ./run or demo
- go to /store page
- categories should load as expected, but performance metrics should improve (as page load should not wait for categories now)