### PR TITLE
Make banners live

### DIFF
--- a/templates/store/_category-partial.html
+++ b/templates/store/_category-partial.html
@@ -5,8 +5,8 @@
         <a class="p-featured-snap--banner" href="/{{ snaps[0].package_name }}">     
           {{
             image(
-              url="{{ snaps[0].banner_url }}",
-              alt="{{ snaps[0].title }}",
+              url=snaps[0].banner_url,
+              alt=snaps[0].title,
               width="1104",
               height="368",
               hi_def=True,

--- a/tests/store/tests_search.py
+++ b/tests/store/tests_search.py
@@ -192,10 +192,10 @@ class GetSearchViewTest(TestCase):
     @responses.activate
     def test_search_q_with_category(self):
         snap_list = [
-            {"package_name": "toto", "icon_url": ""},
-            {"package_name": "tata", "icon_url": "tata.jpg"},
-            {"package_name": "tutu", "icon_url": "tutu.jpg"},
-            {"package_name": "tete", "icon_url": ""},
+            {"package_name": "toto", "icon_url": "", "media": []},
+            {"package_name": "tata", "icon_url": "tata.jpg", "media": []},
+            {"package_name": "tutu", "icon_url": "tutu.jpg", "media": []},
+            {"package_name": "tete", "icon_url": "", "media": []},
         ]
 
         for i in range(0, 144):
@@ -302,10 +302,10 @@ class GetSearchViewTest(TestCase):
     @responses.activate
     def test_search_q_with_category_featured(self):
         snap_list = [
-            {"package_name": "toto", "icon_url": ""},
-            {"package_name": "tata", "icon_url": "tata.jpg"},
-            {"package_name": "tutu", "icon_url": "tutu.jpg"},
-            {"package_name": "tete", "icon_url": ""},
+            {"package_name": "toto", "icon_url": "", "media": []},
+            {"package_name": "tata", "icon_url": "tata.jpg", "media": []},
+            {"package_name": "tutu", "icon_url": "tutu.jpg", "media": []},
+            {"package_name": "tete", "icon_url": "", "media": []},
         ]
 
         for i in range(0, 44):

--- a/webapp/configs/snapcraft.py
+++ b/webapp/configs/snapcraft.py
@@ -1,7 +1,1 @@
-import os
-
 WEBAPP_CONFIG = {"LAYOUT": "_layout.html", "STORE_NAME": "Snap store"}
-
-FEATURED_BANNERS_ENABLED = os.getenv(
-    "FEATURED_BANNERS_ENABLED", "false"
-).lower() in ["1", "t", "true"]

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -209,6 +209,8 @@ def store_blueprint(store_query=None, testing=False):
                 if snaps_results[0]["icon_url"] == "":
                     snaps_results = logic.promote_snap_with_icon(snaps_results)
 
+                snaps_results[0] = logic.get_snap_banner_url(snaps_results[0])
+
                 if (
                     snap_category == "featured"
                     or len(snaps_results) < number_of_featured_snaps

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -82,15 +82,10 @@ def store_blueprint(store_query=None, testing=False):
         if len(featured_snaps) == 10 and featured_snaps[0]["icon_url"] == "":
             featured_snaps = featured_snaps[:-1]
 
-        featured_banners_enabled = flask.current_app.config.get(
-            "FEATURED_BANNERS_ENABLED"
-        )
-
-        if featured_banners_enabled:
-            for index in range(len(featured_snaps)):
-                featured_snaps[index] = logic.get_snap_banner_url(
-                    featured_snaps[index]
-                )
+        for index in range(len(featured_snaps)):
+            featured_snaps[index] = logic.get_snap_banner_url(
+                featured_snaps[index]
+            )
 
         livestream = snapcraft_logic.get_livestreams()
 
@@ -328,15 +323,10 @@ def store_blueprint(store_query=None, testing=False):
         if len(snaps_results) == 10 and snaps_results[0]["icon_url"] == "":
             snaps_results = snaps_results[:-1]
 
-        featured_banners_enabled = flask.current_app.config.get(
-            "FEATURED_BANNERS_ENABLED"
-        )
-
-        if featured_banners_enabled:
-            for index in range(len(snaps_results)):
-                snaps_results[index] = logic.get_snap_banner_url(
-                    snaps_results[index]
-                )
+        for index in range(len(snaps_results)):
+            snaps_results[index] = logic.get_snap_banner_url(
+                snaps_results[index]
+            )
 
         context = {
             "category": category,


### PR DESCRIPTION
Fixes https://github.com/canonical-web-and-design/snapcraft.io/issues/2285

## QA
- Pull the branch
- `./run`
- Visit https://0.0.0.0:8004/store
- The featured section should have a banner
- All other sections aside from "Art and design" should have the generated banner
- Click on the banner should go to the snap being promoted
- Clicking on "See more..." should show a category page (including the banner again)