### PR TITLE
View progressive releases

### DIFF
--- a/static/js/libs/channels.js
+++ b/static/js/libs/channels.js
@@ -265,7 +265,7 @@ function sortChannels(channels, options) {
  * @returns string
  */
 function getChannelString(channelObj) {
-  return `${channelObj.track}/${channelObj.risk}${
+  return `${channelObj.track ? `${channelObj.track}/` : ""}${channelObj.risk}${
     channelObj.branch ? `/${channelObj.branch}` : ""
   }`;
 }

--- a/static/js/libs/channels.js
+++ b/static/js/libs/channels.js
@@ -258,4 +258,22 @@ function sortChannels(channels, options) {
   };
 }
 
-export { sortChannels, parseChannel, createChannelTree, sortAlphaNum };
+/**
+ * Get a channel string based on an object containing track, risk and branch
+ *
+ * @param {track: string, risk: string, branch: string} channelObj
+ * @returns string
+ */
+function getChannelString(channelObj) {
+  return `${channelObj.track}/${channelObj.risk}${
+    channelObj.branch ? `/${channelObj.branch}` : ""
+  }`;
+}
+
+export {
+  sortChannels,
+  parseChannel,
+  createChannelTree,
+  sortAlphaNum,
+  getChannelString
+};

--- a/static/js/publisher/release/components/devmodeRevision.js
+++ b/static/js/publisher/release/components/devmodeRevision.js
@@ -3,14 +3,24 @@ import PropTypes from "prop-types";
 
 import { isInDevmode } from "../helpers";
 
-export default function DevmodeRevision({ revision, showTooltip }) {
+export default function DevmodeRevision({
+  revision,
+  showTooltip,
+  isProgressive
+}) {
+  let revisionLabel = revision.revision;
+
+  if (isProgressive) {
+    revisionLabel = `→ ${revisionLabel}`;
+  }
+
   if (isInDevmode(revision)) {
     return (
       <span
         className="p-tooltip p-tooltip--btm-center"
         aria-describedby={`revision-devmode-${revision.revision}`}
       >
-        {revision.revision}*
+        {revisionLabel}*
         {showTooltip && (
           <span
             className="p-tooltip__message u-align--center"
@@ -30,7 +40,7 @@ export default function DevmodeRevision({ revision, showTooltip }) {
     );
   }
 
-  return revision.revision;
+  return revisionLabel;
 }
 
 DevmodeRevision.propTypes = {

--- a/static/js/publisher/release/components/devmodeRevision.js
+++ b/static/js/publisher/release/components/devmodeRevision.js
@@ -45,5 +45,6 @@ export default function DevmodeRevision({
 
 DevmodeRevision.propTypes = {
   revision: PropTypes.object.isRequired,
-  showTooltip: PropTypes.bool
+  showTooltip: PropTypes.bool,
+  isProgressive: PropTypes.bool
 };

--- a/static/js/publisher/release/components/progressiveBar.js
+++ b/static/js/publisher/release/components/progressiveBar.js
@@ -1,7 +1,40 @@
 import React from "react";
 import PropTypes from "prop-types";
 
-class ProgressiveBar extends React.Component {
+const ProgressiveBar = ({ percentage, targetPercentage, readonly }) => (
+  <div className="progressive-bar p-tooltip--btm-center">
+    {!readonly && (
+      <div
+        className="progressive-bar__target"
+        style={{ width: `${targetPercentage}%` }}
+      >
+        <div className="progressive-bar__target-adjust" />
+      </div>
+    )}
+    <div
+      className="progressive-bar__target-value"
+      style={{
+        left: `${targetPercentage ? targetPercentage : percentage}%`
+      }}
+    >
+      <span className="p-tooltip__message" role="tooltip">
+        {targetPercentage ? targetPercentage : percentage}%
+      </span>
+    </div>
+    <div
+      className="progressive-bar__current"
+      style={{ width: `${percentage}%` }}
+    />
+  </div>
+);
+
+ProgressiveBar.propTypes = {
+  percentage: PropTypes.number,
+  targetPercentage: PropTypes.number,
+  readonly: PropTypes.bool
+};
+
+class InteractiveProgressiveBar extends React.Component {
   constructor(props) {
     super(props);
 
@@ -108,7 +141,7 @@ class ProgressiveBar extends React.Component {
   render() {
     const { readonly, inputName } = this.props;
     const { current, target, scrubTarget, scrubbing } = this.state;
-    const classes = ["progressive-bar p-tooltip--btm-center"];
+    const classes = ["progressive-bar_interactive-wrapper"];
     if (scrubbing) {
       classes.push("is-scrubbing");
     }
@@ -122,27 +155,10 @@ class ProgressiveBar extends React.Component {
         onMouseDown={!readonly && this.onMouseDownHandler}
         onWheel={!readonly && this.onWheelHandler}
       >
-        {!readonly && (
-          <div
-            className="progressive-bar__target"
-            style={{ width: `${scrubTarget}%` }}
-          >
-            <div className="progressive-bar__target-adjust" />
-          </div>
-        )}
-        <div
-          className="progressive-bar__target-value"
-          style={{
-            left: `${scrubTarget}%`
-          }}
-        >
-          <span className="p-tooltip__message" role="tooltip">
-            {scrubTarget}%
-          </span>
-        </div>
-        <div
-          className="progressive-bar__current"
-          style={{ width: `${current}%` }}
+        <ProgressiveBar
+          percentage={current}
+          targetPercentage={scrubTarget}
+          readonly={readonly}
         />
         <input type="hidden" name={inputName} value={target} />
       </div>
@@ -150,11 +166,11 @@ class ProgressiveBar extends React.Component {
   }
 }
 
-ProgressiveBar.propTypes = {
+InteractiveProgressiveBar.propTypes = {
   inputName: PropTypes.string,
   percentage: PropTypes.number,
   readonly: PropTypes.bool,
   singleDirection: PropTypes.number
 };
 
-export default ProgressiveBar;
+export { ProgressiveBar, InteractiveProgressiveBar };

--- a/static/js/publisher/release/components/progressiveBar.js
+++ b/static/js/publisher/release/components/progressiveBar.js
@@ -108,7 +108,7 @@ class ProgressiveBar extends React.Component {
   render() {
     const { readonly, inputName } = this.props;
     const { current, target, scrubTarget, scrubbing } = this.state;
-    const classes = ["progressive-bar"];
+    const classes = ["progressive-bar p-tooltip--btm-center"];
     if (scrubbing) {
       classes.push("is-scrubbing");
     }
@@ -119,8 +119,8 @@ class ProgressiveBar extends React.Component {
       <div
         className={classes.join(" ")}
         ref={this.barHolder}
-        onMouseDown={this.onMouseDownHandler}
-        onWheel={this.onWheelHandler}
+        onMouseDown={!readonly && this.onMouseDownHandler}
+        onWheel={!readonly && this.onWheelHandler}
       >
         {!readonly && (
           <div
@@ -136,7 +136,9 @@ class ProgressiveBar extends React.Component {
             left: `${scrubTarget}%`
           }}
         >
-          {scrubTarget}%
+          <span className="p-tooltip__message" role="tooltip">
+            {scrubTarget}%
+          </span>
         </div>
         <div
           className="progressive-bar__current"

--- a/static/js/publisher/release/components/progressiveBar.js
+++ b/static/js/publisher/release/components/progressiveBar.js
@@ -1,0 +1,158 @@
+import React from "react";
+import PropTypes from "prop-types";
+
+class ProgressiveBar extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.barHolder = React.createRef();
+
+    this.state = {
+      current: props.percentage,
+      target: props.percentage,
+      scrubTarget: props.percentage,
+      scrubbing: false,
+      mousePosition: 0
+    };
+
+    this.onMouseUpHandler = this.onMouseUpHandler.bind(this);
+    this.onMouseDownHandler = this.onMouseDownHandler.bind(this);
+    this.onMouseMoveHandler = this.onMouseMoveHandler.bind(this);
+
+    this.onWheelHandler = this.onWheelHandler.bind(this);
+
+    window.addEventListener("mouseup", this.onMouseUpHandler);
+    window.addEventListener("mousemove", this.onMouseMoveHandler);
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener("mouseup", this.onMouseUpHandler);
+    window.removeEventListener("mousemove", this.onMouseMoveHandler);
+  }
+
+  scrubTo(target, setTarget) {
+    const { current } = this.state;
+    const { singleDirection } = this.props;
+
+    if (singleDirection && singleDirection > 0) {
+      if (target < current) {
+        target = current;
+      }
+
+      if (target > 100) {
+        target = 100;
+      }
+    } else if (singleDirection && singleDirection < 0) {
+      if (target < 0) {
+        target = 0;
+      }
+
+      if (target > current) {
+        target = current;
+      }
+    } else {
+      if (target < 0) {
+        target = 0;
+      }
+
+      if (target > 100) {
+        target = 100;
+      }
+    }
+
+    const newState = {
+      scrubTarget: target
+    };
+
+    if (setTarget) {
+      newState.target = target;
+    }
+
+    this.setState(newState);
+  }
+
+  onMouseDownHandler(e) {
+    this.setState({
+      mousePosition: e.clientX,
+      scrubbing: true
+    });
+  }
+
+  onMouseMoveHandler(e) {
+    const { mousePosition, scrubbing, target } = this.state;
+    if (!scrubbing) {
+      return;
+    }
+    const diff = e.clientX - mousePosition;
+    const width = this.barHolder.current.clientWidth;
+    this.scrubTo(Math.round(target + (diff / width) * 100));
+  }
+
+  onMouseUpHandler() {
+    const { scrubbing, scrubTarget } = this.state;
+    if (!scrubbing) {
+      return;
+    }
+    this.setState({
+      scrubbing: false,
+      target: scrubTarget
+    });
+  }
+
+  onWheelHandler(e) {
+    const { scrubTarget } = this.state;
+    const direction = e.nativeEvent.deltaY > 0 ? -1 : 1;
+    this.scrubTo(Math.round(scrubTarget + direction), true);
+  }
+
+  render() {
+    const { readonly, inputName } = this.props;
+    const { current, target, scrubTarget, scrubbing } = this.state;
+    const classes = ["progressive-bar"];
+    if (scrubbing) {
+      classes.push("is-scrubbing");
+    }
+    if (!readonly) {
+      classes.push("is-interactive");
+    }
+    return (
+      <div
+        className={classes.join(" ")}
+        ref={this.barHolder}
+        onMouseDown={this.onMouseDownHandler}
+        onWheel={this.onWheelHandler}
+      >
+        {!readonly && (
+          <div
+            className="progressive-bar__target"
+            style={{ width: `${scrubTarget}%` }}
+          >
+            <div className="progressive-bar__target-adjust" />
+          </div>
+        )}
+        <div
+          className="progressive-bar__target-value"
+          style={{
+            left: `${scrubTarget}%`
+          }}
+        >
+          {scrubTarget}%
+        </div>
+        <div
+          className="progressive-bar__current"
+          style={{ width: `${current}%` }}
+        />
+        <input type="hidden" name={inputName} value={target} />
+      </div>
+    );
+  }
+}
+
+ProgressiveBar.propTypes = {
+  inputName: PropTypes.string,
+  percentage: PropTypes.number,
+  readonly: PropTypes.bool,
+  singleDirection: PropTypes.number
+};
+
+export default ProgressiveBar;

--- a/static/js/publisher/release/components/releasesTable/cellViews.js
+++ b/static/js/publisher/release/components/releasesTable/cellViews.js
@@ -1,7 +1,7 @@
 import React, { Fragment } from "react";
 import PropTypes from "prop-types";
 
-import DevmodeRevision from "../devmodeRevision";
+import RevisionLabel from "../revisionLabel";
 
 import { isInDevmode, isRevisionBuiltOnLauchpad } from "../../helpers";
 import { useDragging, Handle } from "../dnd";
@@ -69,7 +69,7 @@ export const RevisionInfo = ({
     <Fragment>
       <span className="p-release-data__info">
         <span className="p-release-data__title">
-          <DevmodeRevision
+          <RevisionLabel
             revision={revision}
             showTooltip={false}
             isProgressive={from ? true : false}

--- a/static/js/publisher/release/components/releasesTable/cellViews.js
+++ b/static/js/publisher/release/components/releasesTable/cellViews.js
@@ -48,18 +48,32 @@ EmptyInfo.propTypes = {
 };
 
 // contents of a cell with a revision
-export const RevisionInfo = ({ revision, isPending, showVersion }) => {
+export const RevisionInfo = ({
+  revision,
+  isPending,
+  showVersion,
+  progressiveState
+}) => {
+  let from = null;
   let buildIcon = null;
 
   if (isRevisionBuiltOnLauchpad(revision)) {
     buildIcon = <i className="p-icon--lp" />;
   }
 
+  if (progressiveState && progressiveState.from) {
+    from = progressiveState.from;
+  }
+
   return (
     <Fragment>
       <span className="p-release-data__info">
         <span className="p-release-data__title">
-          <DevmodeRevision revision={revision} showTooltip={false} />
+          <DevmodeRevision
+            revision={revision}
+            showTooltip={false}
+            isProgressive={from}
+          />
         </span>
         {showVersion && (
           <span className="p-release-data__meta">{revision.version}</span>
@@ -94,6 +108,22 @@ export const RevisionInfo = ({ revision, isPending, showVersion }) => {
               )}
             </Fragment>
           )}
+          <br />
+          {from && (
+            <Fragment>
+              <b>
+                Progressive release of revision {revision.revision} in progress
+              </b>
+              <br />
+              Revision: <b>{from}</b>
+              {progressiveState
+                ? ` (${100 - progressiveState.percentage}& of devices)`
+                : ""}
+              <br />
+              Revision: <b>{revision.revision}</b> (
+              {progressiveState.percentage}% of devices)
+            </Fragment>
+          )}
         </div>
 
         {isInDevmode(revision) && (
@@ -111,7 +141,8 @@ export const RevisionInfo = ({ revision, isPending, showVersion }) => {
 RevisionInfo.propTypes = {
   revision: PropTypes.object,
   isPending: PropTypes.bool,
-  showVersion: PropTypes.bool
+  showVersion: PropTypes.bool,
+  progressiveState: PropTypes.object
 };
 
 // generic draggable view of releases table cell

--- a/static/js/publisher/release/components/releasesTable/cellViews.js
+++ b/static/js/publisher/release/components/releasesTable/cellViews.js
@@ -72,7 +72,7 @@ export const RevisionInfo = ({
           <DevmodeRevision
             revision={revision}
             showTooltip={false}
-            isProgressive={from}
+            isProgressive={from ? true : false}
           />
         </span>
         {showVersion && (

--- a/static/js/publisher/release/components/releasesTable/cellViews.js
+++ b/static/js/publisher/release/components/releasesTable/cellViews.js
@@ -117,7 +117,7 @@ export const RevisionInfo = ({
               <br />
               Revision: <b>{from}</b>
               {progressiveState
-                ? ` (${100 - progressiveState.percentage}& of devices)`
+                ? ` (${100 - progressiveState.percentage}% of devices)`
                 : ""}
               <br />
               Revision: <b>{revision.revision}</b> (

--- a/static/js/publisher/release/components/releasesTable/releaseCell.js
+++ b/static/js/publisher/release/components/releasesTable/releaseCell.js
@@ -126,6 +126,7 @@ const ReleasesTableReleaseCell = props => {
         revision={currentRevision}
         isPending={isPendingRelease}
         showVersion={showVersion}
+        progressiveState={progressiveState}
       />
     );
   } else if (isUnassigned) {

--- a/static/js/publisher/release/components/releasesTable/releaseCell.js
+++ b/static/js/publisher/release/components/releasesTable/releaseCell.js
@@ -16,7 +16,8 @@ import {
   getPendingChannelMap,
   getFilteredAvailableRevisionsForArch,
   hasPendingRelease,
-  getRevisionsFromBuild
+  getRevisionsFromBuild,
+  getProgressiveState
 } from "../../selectors";
 
 import {
@@ -43,7 +44,8 @@ const ReleasesTableReleaseCell = props => {
     getAvailableCount,
     hasPendingRelease,
     undoRelease,
-    toggleHistoryPanel
+    toggleHistoryPanel,
+    getProgressiveState
   } = props;
 
   const branchName = branch ? branch.branch : null;
@@ -56,6 +58,12 @@ const ReleasesTableReleaseCell = props => {
 
   // check if there is a pending release in this cell
   const isPendingRelease = hasPendingRelease(channel, arch);
+
+  const progressiveState = getProgressiveState(
+    channel,
+    arch,
+    currentRevision ? currentRevision.revision : null
+  );
 
   const isChannelPendingClose = pendingCloses.includes(channel);
   const isPending = isPendingRelease || isChannelPendingClose;
@@ -147,6 +155,13 @@ const ReleasesTableReleaseCell = props => {
           branchName
         )}
       />
+      {progressiveState &&
+        progressiveState.percentage && (
+          <span
+            className="p-release__progressive-percentage"
+            style={{ width: `${progressiveState.percentage}%` }}
+          />
+        )}
     </ReleasesTableCellView>
   );
 };
@@ -161,6 +176,7 @@ ReleasesTableReleaseCell.propTypes = {
   getAvailableCount: PropTypes.func,
   hasPendingRelease: PropTypes.func,
   getRevisionsFromBuild: PropTypes.func,
+  getProgressiveState: PropTypes.func,
   // actions
   toggleHistoryPanel: PropTypes.func.isRequired,
   undoRelease: PropTypes.func.isRequired,
@@ -186,7 +202,9 @@ const mapStateToProps = state => {
       getFilteredAvailableRevisionsForArch(state, arch).length,
     hasPendingRelease: (channel, arch) =>
       hasPendingRelease(state, channel, arch),
-    getRevisionsFromBuild: buildId => getRevisionsFromBuild(state, buildId)
+    getRevisionsFromBuild: buildId => getRevisionsFromBuild(state, buildId),
+    getProgressiveState: (channel, arch) =>
+      getProgressiveState(state, channel, arch)
   };
 };
 

--- a/static/js/publisher/release/components/releasesTable/releaseCell.js
+++ b/static/js/publisher/release/components/releasesTable/releaseCell.js
@@ -59,11 +59,15 @@ const ReleasesTableReleaseCell = props => {
   // check if there is a pending release in this cell
   const isPendingRelease = hasPendingRelease(channel, arch);
 
-  const progressiveState = getProgressiveState(
-    channel,
-    arch,
-    currentRevision ? currentRevision.revision : null
-  );
+  let progressiveState = null;
+
+  if (currentRevision) {
+    progressiveState = getProgressiveState(
+      channel,
+      arch,
+      currentRevision.revision
+    );
+  }
 
   const isChannelPendingClose = pendingCloses.includes(channel);
   const isPending = isPendingRelease || isChannelPendingClose;
@@ -204,8 +208,8 @@ const mapStateToProps = state => {
     hasPendingRelease: (channel, arch) =>
       hasPendingRelease(state, channel, arch),
     getRevisionsFromBuild: buildId => getRevisionsFromBuild(state, buildId),
-    getProgressiveState: (channel, arch) =>
-      getProgressiveState(state, channel, arch)
+    getProgressiveState: (channel, arch, revision) =>
+      getProgressiveState(state, channel, arch, revision)
   };
 };
 

--- a/static/js/publisher/release/components/revisionLabel.js
+++ b/static/js/publisher/release/components/revisionLabel.js
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 
 import { isInDevmode } from "../helpers";
 
-export default function DevmodeRevision({
+export default function RevisionLabel({
   revision,
   showTooltip,
   isProgressive
@@ -43,7 +43,7 @@ export default function DevmodeRevision({
   return revisionLabel;
 }
 
-DevmodeRevision.propTypes = {
+RevisionLabel.propTypes = {
   revision: PropTypes.object.isRequired,
   showTooltip: PropTypes.bool,
   isProgressive: PropTypes.bool

--- a/static/js/publisher/release/components/revisionsList.js
+++ b/static/js/publisher/release/components/revisionsList.js
@@ -310,6 +310,7 @@ class RevisionsList extends Component {
               </th>
               <th scope="col">Version</th>
               {showBuildRequest && <th scope="col">Build Request</th>}
+              {!showChannels && <th scope="col">Progressive release status</th>}
               {showChannels && <th scope="col">Channels</th>}
               <th scope="col" width="130px" className="u-align--right">
                 {isReleaseHistory ? "Release date" : "Submission date"}

--- a/static/js/publisher/release/components/revisionsListRow.js
+++ b/static/js/publisher/release/components/revisionsListRow.js
@@ -10,8 +10,8 @@ import { useDragging, DND_ITEM_REVISIONS, Handle } from "./dnd";
 import { toggleRevision } from "../actions/channelMap";
 import { getSelectedRevisions, getProgressiveState } from "../selectors";
 
-import DevmodeRevision from "./devmodeRevision";
-import ProgressiveBar from "./progressiveBar";
+import RevisionLabel from "./revisionLabel";
+import { ProgressiveBar } from "./progressiveBar";
 
 const RevisionsListRow = props => {
   const {
@@ -85,12 +85,12 @@ const RevisionsListRow = props => {
               className="p-revisions-list__revision is-inline-label"
               htmlFor={id}
             >
-              <DevmodeRevision revision={revision} showTooltip={true} />
+              <RevisionLabel revision={revision} showTooltip={true} />
             </label>
           </Fragment>
         ) : (
           <span className="p-revisions-list__revision">
-            <DevmodeRevision revision={revision} showTooltip={true} />
+            <RevisionLabel revision={revision} showTooltip={true} />
           </span>
         )}
       </td>

--- a/static/js/publisher/release/components/revisionsListRow.js
+++ b/static/js/publisher/release/components/revisionsListRow.js
@@ -5,9 +5,10 @@ import { connect } from "react-redux";
 import distanceInWords from "date-fns/distance_in_words_strict";
 import format from "date-fns/format";
 
+import { getChannelString } from "../../../libs/channels.js";
 import { useDragging, DND_ITEM_REVISIONS, Handle } from "./dnd";
 import { toggleRevision } from "../actions/channelMap";
-import { getSelectedRevisions } from "../selectors";
+import { getSelectedRevisions, getProgressiveState } from "../selectors";
 
 import DevmodeRevision from "./devmodeRevision";
 
@@ -18,7 +19,8 @@ const RevisionsListRow = props => {
     showChannels,
     showBuildRequest,
     isPending,
-    isActive
+    isActive,
+    getProgressiveState
   } = props;
 
   const revisionDate = revision.release
@@ -29,6 +31,16 @@ const RevisionsListRow = props => {
 
   function revisionSelectChange() {
     props.toggleRevision(revision);
+  }
+
+  let progressiveState;
+
+  if (revision.release) {
+    progressiveState = getProgressiveState(
+      getChannelString(revision.release),
+      revision.release.architecture,
+      revision.revision
+    );
   }
 
   const [isDragging, isGrabbing, drag] = useDragging({
@@ -81,7 +93,10 @@ const RevisionsListRow = props => {
           </span>
         )}
       </td>
-      <td>{revision.version}</td>
+      <td>
+        {revision.version}
+        {progressiveState && <span>{progressiveState.percentage}%</span>}
+      </td>
       {showBuildRequest && (
         <td>
           {buildRequestId && (
@@ -126,6 +141,7 @@ RevisionsListRow.propTypes = {
 
   // computed state (selectors)
   selectedRevisions: PropTypes.array.isRequired,
+  getProgressiveState: PropTypes.func,
 
   // actions
   toggleRevision: PropTypes.func.isRequired
@@ -133,7 +149,9 @@ RevisionsListRow.propTypes = {
 
 const mapStateToProps = state => {
   return {
-    selectedRevisions: getSelectedRevisions(state)
+    selectedRevisions: getSelectedRevisions(state),
+    getProgressiveState: (channel, arch, revision) =>
+      getProgressiveState(state, channel, arch, revision)
   };
 };
 

--- a/static/js/publisher/release/components/revisionsListRow.js
+++ b/static/js/publisher/release/components/revisionsListRow.js
@@ -11,6 +11,7 @@ import { toggleRevision } from "../actions/channelMap";
 import { getSelectedRevisions, getProgressiveState } from "../selectors";
 
 import DevmodeRevision from "./devmodeRevision";
+import ProgressiveBar from "./progressiveBar";
 
 const RevisionsListRow = props => {
   const {
@@ -93,16 +94,23 @@ const RevisionsListRow = props => {
           </span>
         )}
       </td>
-      <td>
-        {revision.version}
-        {progressiveState && <span>{progressiveState.percentage}%</span>}
-      </td>
+      <td>{revision.version}</td>
       {showBuildRequest && (
         <td>
           {buildRequestId && (
             <Fragment>
               <i className="p-icon--lp" /> {buildRequestId}
             </Fragment>
+          )}
+        </td>
+      )}
+      {!showChannels && (
+        <td>
+          {progressiveState && (
+            <ProgressiveBar
+              percentage={progressiveState.percentage}
+              readonly={true}
+            />
           )}
         </td>
       )}

--- a/static/js/publisher/release/helpers.js
+++ b/static/js/publisher/release/helpers.js
@@ -6,17 +6,15 @@ export function isInDevmode(revision) {
 }
 
 export function getChannelName(track, risk, branch) {
-  const obj = {
+  if (risk === AVAILABLE) {
+    return AVAILABLE;
+  }
+
+  return getChannelString({
     track,
     risk,
     branch
-  };
-
-  if (risk === AVAILABLE) {
-    delete obj.track;
-  }
-
-  return getChannelString(obj);
+  });
 }
 
 export function getBuildId(revision) {

--- a/static/js/publisher/release/helpers.js
+++ b/static/js/publisher/release/helpers.js
@@ -1,15 +1,22 @@
 import { AVAILABLE } from "./constants";
+import { getChannelString } from "../../libs/channels";
 
 export function isInDevmode(revision) {
   return revision.confinement === "devmode" || revision.grade === "devel";
 }
 
 export function getChannelName(track, risk, branch) {
-  let name = risk === AVAILABLE ? risk : `${track}/${risk}`;
-  if (branch) {
-    name = `${name}/${branch}`;
+  const obj = {
+    track,
+    risk,
+    branch
+  };
+
+  if (risk === AVAILABLE) {
+    delete obj.track;
   }
-  return name;
+
+  return getChannelString(obj);
 }
 
 export function getBuildId(revision) {

--- a/static/js/publisher/release/selectors/index.js
+++ b/static/js/publisher/release/selectors/index.js
@@ -6,7 +6,7 @@ import {
   AVAILABLE_REVISIONS_SELECT_LAUNCHPAD
 } from "../constants";
 import { isInDevmode, getBuildId, isRevisionBuiltOnLauchpad } from "../helpers";
-import { sortAlphaNum } from "../../../libs/channels";
+import { sortAlphaNum, getChannelString } from "../../../libs/channels";
 
 // returns release history filtered by history filters
 export function getFilteredReleaseHistory(state) {
@@ -264,14 +264,14 @@ export function getRevisionsFromBuild(state, buildId) {
   );
 }
 
-export function getProgressiveState(state, channel, arch) {
+export function getProgressiveState(state, channel, arch, revision) {
   const { releases } = state;
   const release = releases.filter(item => {
     if (
-      channel ===
-        `${item.track}/${item.risk}${item.branch ? `/${item.branch}` : ""}` &&
+      channel === getChannelString(item) &&
       arch === item.architecture &&
-      item.revision
+      item.revision &&
+      (!revision || item.revision === revision)
     ) {
       return item;
     }

--- a/static/js/publisher/release/selectors/index.js
+++ b/static/js/publisher/release/selectors/index.js
@@ -278,12 +278,18 @@ export function getProgressiveState(state, channel, arch) {
     return false;
   });
 
-  let phasing = null;
+  let progressive = null;
 
-  if (release.length > 1 && release[0] && release[0].phasing.key) {
-    phasing = release[0].phasing;
-    phasing.from = release[1].revision;
+  if (
+    release.length > 1 &&
+    release[0] &&
+    release[0] &&
+    release[0].progressive &&
+    release[0].progressive.key
+  ) {
+    progressive = release[0].progressive;
+    progressive.from = release[1].revision;
   }
 
-  return phasing;
+  return progressive;
 }

--- a/static/js/publisher/release/selectors/index.js
+++ b/static/js/publisher/release/selectors/index.js
@@ -176,12 +176,14 @@ export function getArchitectures(state) {
 export function getTracks(state) {
   let tracks = [];
 
-  state.releases.map(t => t.track).forEach(track => {
-    // if we haven't saved it yet
-    if (tracks.indexOf(track) === -1) {
-      tracks.push(track);
-    }
-  });
+  state.releases
+    .map(t => t.track)
+    .forEach(track => {
+      // if we haven't saved it yet
+      if (tracks.indexOf(track) === -1) {
+        tracks.push(track);
+      }
+    });
 
   return sortAlphaNum(tracks, "latest");
 }
@@ -260,4 +262,28 @@ export function getRevisionsFromBuild(state, buildId) {
   return getAllRevisions(state).filter(
     revision => getBuildId(revision) === buildId
   );
+}
+
+export function getProgressiveState(state, channel, arch) {
+  const { releases } = state;
+  const release = releases.filter(item => {
+    if (
+      channel ===
+        `${item.track}/${item.risk}${item.branch ? `/${item.branch}` : ""}` &&
+      arch === item.architecture &&
+      item.revision
+    ) {
+      return item;
+    }
+    return false;
+  });
+
+  let phasing = null;
+
+  if (release.length > 1 && release[0] && release[0].phasing.key) {
+    phasing = release[0].phasing;
+    phasing.from = release[1].revision;
+  }
+
+  return phasing;
 }

--- a/static/js/publisher/release/selectors/index.js
+++ b/static/js/publisher/release/selectors/index.js
@@ -262,32 +262,27 @@ export function getRevisionsFromBuild(state, buildId) {
   );
 }
 
-// return the progressive release status based on channel, arch and optional revision
+// return the progressive release status based on channel, arch
 export function getProgressiveState(state, channel, arch, revision) {
   const { releases } = state;
-  const release = releases.filter(item => {
-    if (
-      channel === getChannelString(item) &&
-      arch === item.architecture &&
-      item.revision &&
-      (!revision || item.revision === revision)
-    ) {
-      return item;
-    }
-    return false;
-  });
+  const allReleases = releases.filter(
+    item => channel === getChannelString(item) && arch === item.architecture
+  );
+
+  const releaseIndex = allReleases.findIndex(
+    item => revision === item.revision
+  );
 
   let progressive = null;
 
-  if (
-    release.length > 1 &&
-    release[0] &&
-    release[0] &&
-    release[0].progressive &&
-    release[0].progressive.key
-  ) {
-    progressive = release[0].progressive;
-    progressive.from = release[1].revision;
+  const release = allReleases[releaseIndex];
+
+  if (release && release.progressive && release.progressive.key) {
+    progressive = release.progressive;
+
+    if (allReleases[releaseIndex + 1]) {
+      progressive.from = allReleases[releaseIndex + 1].revision;
+    }
   }
 
   return progressive;

--- a/static/js/publisher/release/selectors/index.js
+++ b/static/js/publisher/release/selectors/index.js
@@ -280,6 +280,8 @@ export function getProgressiveState(state, channel, arch, revision) {
   if (release && release.progressive && release.progressive.key) {
     progressive = release.progressive;
 
+    // TODO: Confirm that this is true when multiple progressive
+    // releases have occured.
     if (allReleases[releaseIndex + 1]) {
       progressive.from = allReleases[releaseIndex + 1].revision;
     }

--- a/static/js/publisher/release/selectors/index.js
+++ b/static/js/publisher/release/selectors/index.js
@@ -176,14 +176,12 @@ export function getArchitectures(state) {
 export function getTracks(state) {
   let tracks = [];
 
-  state.releases
-    .map(t => t.track)
-    .forEach(track => {
-      // if we haven't saved it yet
-      if (tracks.indexOf(track) === -1) {
-        tracks.push(track);
-      }
-    });
+  state.releases.map(t => t.track).forEach(track => {
+    // if we haven't saved it yet
+    if (tracks.indexOf(track) === -1) {
+      tracks.push(track);
+    }
+  });
 
   return sortAlphaNum(tracks, "latest");
 }
@@ -264,6 +262,7 @@ export function getRevisionsFromBuild(state, buildId) {
   );
 }
 
+// return the progressive release status based on channel, arch and optional revision
 export function getProgressiveState(state, channel, arch, revision) {
   const { releases } = state;
   const release = releases.filter(item => {

--- a/static/js/publisher/release/selectors/selectors.test.js
+++ b/static/js/publisher/release/selectors/selectors.test.js
@@ -21,7 +21,8 @@ import {
   getBranches,
   hasBuildRequestId,
   getLaunchpadRevisions,
-  getRevisionsFromBuild
+  getRevisionsFromBuild,
+  getProgressiveState
 } from "./index";
 
 import reducers from "../reducers";
@@ -803,5 +804,53 @@ describe("getRevisionsFromBuild", () => {
       stateWithLauchpadBuilds.revisions[3],
       stateWithLauchpadBuilds.revisions[4]
     );
+  });
+});
+
+describe("getProgressiveState", () => {
+  it("should return the progressive release state of a channel and arch", () => {
+    const state = {
+      releases: [
+        {
+          architecture: "arch1",
+          branch: null,
+          track: "latest",
+          risk: "stable",
+          revision: "1",
+          phasing: null
+        },
+        {
+          architecture: "arch2",
+          branch: null,
+          track: "latest",
+          risk: "stable",
+          revision: "3",
+          phasing: {
+            key: "test",
+            percentage: 60,
+            paused: false
+          }
+        },
+        {
+          architecture: "arch2",
+          branch: null,
+          track: "latest",
+          risk: "stable",
+          revision: "2",
+          phasing: {
+            key: "test",
+            percentage: 50,
+            paused: false
+          }
+        }
+      ]
+    };
+
+    expect(getProgressiveState(state, "latest/stable", "arch2")).toEqual({
+      from: "2",
+      key: "test",
+      paused: false,
+      percentage: 60
+    });
   });
 });

--- a/static/js/publisher/release/selectors/selectors.test.js
+++ b/static/js/publisher/release/selectors/selectors.test.js
@@ -846,11 +846,17 @@ describe("getProgressiveState", () => {
       ]
     };
 
-    expect(getProgressiveState(state, "latest/stable", "arch2")).toEqual({
+    expect(getProgressiveState(state, "latest/stable", "arch2", "3")).toEqual({
       from: "2",
       key: "test",
       paused: false,
       percentage: 60
+    });
+
+    expect(getProgressiveState(state, "latest/stable", "arch2", "2")).toEqual({
+      key: "test",
+      paused: false,
+      percentage: 50
     });
   });
 });

--- a/static/js/publisher/release/selectors/selectors.test.js
+++ b/static/js/publisher/release/selectors/selectors.test.js
@@ -817,7 +817,7 @@ describe("getProgressiveState", () => {
           track: "latest",
           risk: "stable",
           revision: "1",
-          phasing: null
+          progressive: null
         },
         {
           architecture: "arch2",
@@ -825,7 +825,7 @@ describe("getProgressiveState", () => {
           track: "latest",
           risk: "stable",
           revision: "3",
-          phasing: {
+          progressive: {
             key: "test",
             percentage: 60,
             paused: false
@@ -837,7 +837,7 @@ describe("getProgressiveState", () => {
           track: "latest",
           risk: "stable",
           revision: "2",
-          phasing: {
+          progressive: {
             key: "test",
             percentage: 50,
             paused: false

--- a/static/sass/_snapcraft_p-progressive-bar.scss
+++ b/static/sass/_snapcraft_p-progressive-bar.scss
@@ -1,0 +1,74 @@
+@mixin snapcraft-p-progressive-bar {
+  $inactive: scale-color($color-link, $lightness: 90%);
+  $active: $color-link;
+  $target: scale-color($color-link, $lightness: -20%);
+
+  .progressive-bar {
+    background: $inactive;
+    border-radius: 9px;
+    height: 9px;
+    margin-top: 7px;
+    position: relative;
+  }
+
+  .progressive-bar.is-interactive {
+    cursor: col-resize;
+    user-select: none;
+  }
+
+  .progressive-bar__current {
+    background: $active;
+    border-radius: 9px 0 0 9px;
+    border-right: 1px solid $color-x-light;
+    height: 9px;
+    left: 0;
+    pointer-events: none;
+    position: absolute;
+    top: 0;
+  }
+
+  .progressive-bar__target-value {
+    @include vf-animation(opacity, snap, in);
+    opacity: 0;
+    pointer-events: none;
+    position: absolute;
+    transform: translate(-50%, 1rem);
+  }
+
+  .progressive-bar:hover .progressive-bar__target-value,
+  .progressive-bar.is-scrubbing .progressive-bar__target-value {
+    opacity: 1;
+  }
+
+  .progressive-bar__target {
+    background: $target;
+    border-radius: 9px 0 0 9px;
+    border-right: 1px solid $color-x-light;
+    height: 9px;
+    left: 0;
+    pointer-events: none;
+    position: absolute;
+    top: 0;
+  }
+
+  .progressive-bar__target-adjust {
+    @include vf-animation(all, snap, in);
+    background: $color-x-dark;
+    border-radius: 3px;
+    bottom: 0;
+    display: block;
+    position: absolute;
+    right: 0;
+    top: 0;
+    width: 1px;
+    z-index: 1;
+  }
+
+  .progressive-bar:hover .progressive-bar__target-adjust,
+  .progressive-bar.is-scrubbing .progressive-bar__target-adjust {
+    bottom: -4px;
+    top: -4px;
+    transform: translateX(1px);
+    width: 3px;
+  }
+}

--- a/static/sass/_snapcraft_release.scss
+++ b/static/sass/_snapcraft_release.scss
@@ -312,6 +312,22 @@
     font-size: .8rem;
   }
 
+  .p-release__progressive-percentage {
+    @include vf-animation (#{transform}, fast, in);
+    background: $snapcraft-green;
+    border-radius: 0 4px 4px 0;
+    bottom: -2px;
+    height: 4px;
+    left: 0;
+    position: absolute;
+    transform: scaleX(1);
+    transform-origin: left;
+  }
+
+  .p-releases-table__cell.is-active .p-release__progressive-percentage {
+    transform: scaleX(0);
+  }
+
   // REVISIONS LIST
 
   .p-revisions-list {

--- a/static/sass/_snapcraft_release.scss
+++ b/static/sass/_snapcraft_release.scss
@@ -316,8 +316,8 @@
     @include vf-animation (#{transform}, fast, in);
     background: $color-link;
     border-radius: 0 4px 4px 0;
-    bottom: -2px;
-    height: 4px;
+    bottom: 0;
+    height: 3px;
     left: 0;
     position: absolute;
     transform: scaleX(1);

--- a/static/sass/_snapcraft_release.scss
+++ b/static/sass/_snapcraft_release.scss
@@ -314,7 +314,7 @@
 
   .p-release__progressive-percentage {
     @include vf-animation (#{transform}, fast, in);
-    background: $snapcraft-green;
+    background: $color-link;
     border-radius: 0 4px 4px 0;
     bottom: -2px;
     height: 4px;

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -7,6 +7,8 @@ $color-navigation-selected: #9c9c9c;
 
 $breakpoint-navigation-threshold: 800px;
 
+$snapcraft-green: #82bfa1;
+
 // vanilla patterns
 @import 'vanilla-framework/scss/vanilla';
 

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -229,3 +229,6 @@ $color-social-icon-foreground: $color-light;
 
 @import 'snapcraft_tour';
 @include snapcraft-tour;
+
+@import 'snapcraft_p-progressive-bar';
+@include snapcraft-p-progressive-bar;

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -7,8 +7,6 @@ $color-navigation-selected: #9c9c9c;
 
 $breakpoint-navigation-threshold: 800px;
 
-$snapcraft-green: #82bfa1;
-
 // vanilla patterns
 @import 'vanilla-framework/scss/vanilla';
 


### PR DESCRIPTION
Supersedes(partially) https://github.com/canonical-web-and-design/snapcraft.io/pull/2259
Fixes https://github.com/canonical-web-and-design/snapcraft.io/issues/2240

## QA
- Pull the branch
- `./run`
- Visit http://0.0.0.0:8004/snap/releases for a snap with a progressive release
- Click around and make sure things look ok.

This is just the viewing of a progressive release.

Cell, history closed
![Screenshot_2019-10-15  Releases and revision history for lukewh-test ](https://user-images.githubusercontent.com/479384/66851267-57365700-ef72-11e9-808e-54790dcaf25c.png)

History open
![Screenshot_2019-10-15  Releases and revision history for lukewh-test (1)](https://user-images.githubusercontent.com/479384/66851268-57ceed80-ef72-11e9-9eaf-b2d4ff1854ed.png)
