### PR TITLE
Release UI - hide launchpad

### DIFF
--- a/static/js/publisher/release/components/availableRevisionsMenu.js
+++ b/static/js/publisher/release/components/availableRevisionsMenu.js
@@ -8,7 +8,6 @@ import { selectAvailableRevisions } from "../actions/availableRevisionsSelect";
 import { getAvailableRevisionsBySelection } from "../selectors";
 
 import {
-  AVAILABLE_REVISIONS_SELECT_LAUNCHPAD,
   AVAILABLE_REVISIONS_SELECT_UNRELEASED,
   AVAILABLE_REVISIONS_SELECT_RECENT,
   AVAILABLE_REVISIONS_SELECT_ALL
@@ -23,10 +22,6 @@ const menuLabels = {
   [AVAILABLE_REVISIONS_SELECT_UNRELEASED]: {
     label: "Unreleased",
     description: "Revisions not released to any channel"
-  },
-  [AVAILABLE_REVISIONS_SELECT_LAUNCHPAD]: {
-    label: "Launchpad",
-    description: "Revisions built on Launchpad"
   },
   [AVAILABLE_REVISIONS_SELECT_ALL]: {
     label: "All revisions"
@@ -90,18 +85,6 @@ export class AvailableRevisionsMenu extends Component {
 
   renderItems() {
     let items = Object.keys(menuLabels);
-
-    items = items.filter(item => {
-      // remove Launchpad menu option if there are no LP builds
-      if (
-        item === AVAILABLE_REVISIONS_SELECT_LAUNCHPAD &&
-        this.props.getFilteredCount(AVAILABLE_REVISIONS_SELECT_LAUNCHPAD) === 0
-      ) {
-        return false;
-      }
-
-      return true;
-    });
 
     return (
       <span className="p-contextual-menu__group">

--- a/static/js/publisher/release/components/releasesTable/index.js
+++ b/static/js/publisher/release/components/releasesTable/index.js
@@ -191,25 +191,6 @@ class ReleasesTable extends Component {
       this.props.isHistoryOpen && this.props.filters ? "has-active" : ""
     }`;
 
-    const lpRevisions = this.props.launchpadRevisions;
-
-    const builds = lpRevisions
-      .map(getBuildId)
-      .filter((item, i, ar) => ar.indexOf(item) === i)
-      .map(buildId => {
-        const revs = this.props.getRevisionsFromBuild(buildId);
-
-        const revsMap = {};
-
-        revs.forEach(r => {
-          r.architectures.forEach(arch => {
-            revsMap[arch] = r;
-          });
-        });
-
-        return revsMap;
-      });
-
     return (
       <div className="row">
         <div className={className}>
@@ -227,9 +208,6 @@ class ReleasesTable extends Component {
             ))}
           </div>
           {this.renderRows()}
-
-          {!!builds.length && <h4>Revisions built on Launchpad</h4>}
-          {builds.map(revisions => this.renderBuildRow(revisions))}
         </div>
       </div>
     );

--- a/static/js/publisher/release/components/revisionsListRow.js
+++ b/static/js/publisher/release/components/revisionsListRow.js
@@ -7,7 +7,7 @@ import format from "date-fns/format";
 
 import { useDragging, DND_ITEM_REVISIONS, Handle } from "./dnd";
 import { toggleRevision } from "../actions/channelMap";
-import { getSelectedRevisions, hasBuildRequestId } from "../selectors";
+import { getSelectedRevisions } from "../selectors";
 
 import DevmodeRevision from "./devmodeRevision";
 
@@ -122,10 +122,10 @@ RevisionsListRow.propTypes = {
   showChannels: PropTypes.bool,
   isPending: PropTypes.bool,
   isActive: PropTypes.bool,
+  showBuildRequest: PropTypes.bool.isRequired,
 
   // computed state (selectors)
   selectedRevisions: PropTypes.array.isRequired,
-  showBuildRequest: PropTypes.bool.isRequired,
 
   // actions
   toggleRevision: PropTypes.func.isRequired
@@ -133,8 +133,7 @@ RevisionsListRow.propTypes = {
 
 const mapStateToProps = state => {
   return {
-    selectedRevisions: getSelectedRevisions(state),
-    showBuildRequest: hasBuildRequestId(state)
+    selectedRevisions: getSelectedRevisions(state)
   };
 };
 


### PR DESCRIPTION
Hides Launchpad related UI from Release page, so we can merge the feature branch without enabling it yet.

Build request id is going to be shown in revision tooltips and history (when available).

This PR is agains feature branch (for easier code review), but is meant as means to make feature branch tested and merged to master.

### QA
- ./run or demo
- go to releases page of snap with launchpad builds
- make sure Launchpad is not available in "Available" dropdown
- click around, see if everything works
- if history of any release cell doesn't have revisions with build id, "Build request" column should not be shown