### PR TITLE
Update to image-template v1.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
-# App dependencies
+f# App dependencies
 bleach==3.1.0
 canonicalwebteam.discourse-docs==0.6.4
 canonicalwebteam.blog==4.0.0
 canonicalwebteam.search==0.1.0
 canonicalwebteam.yaml-responses==1.1.1
-canonicalwebteam.image-template==0.3.1
+canonicalwebteam.image-template==1.0.0
 Flask==1.0.2
 Flask-OpenID-Stateless==1.2.6
 Flask-WTF==0.14.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-f# App dependencies
+# App dependencies
 bleach==3.1.0
 canonicalwebteam.discourse-docs==0.6.4
 canonicalwebteam.blog==4.0.0

--- a/templates/_layout.html
+++ b/templates/_layout.html
@@ -36,7 +36,7 @@
 
     <script src="{{ static_url('js/dist/base.js') }}" defer></script>
     {% block scripts_includes %}{% endblock %}
-    <script src="https://assets.ubuntu.com/v1/842d27d3-lazysizes.min.js" async></script>
+    <script src="https://assets.ubuntu.com/v1/703e23c9-lazysizes+noscript+native-loading.5.1.2.min.js" defer></script>
 
     <meta name="description" content="{% block meta_description %}Snaps are containerised software packages that are simple to create and install. They auto-update and are safe to run. And because they bundle their dependencies, they work on all major Linux systems without modification.{% endblock %}">
     <meta name="copydoc" content="{% block meta_copydoc %}https://drive.google.com/drive/folders/1q9ia7iDuWQlCaJ7nfKVeQ5G-FPyJbP-H{% endblock %}">

--- a/templates/index.html
+++ b/templates/index.html
@@ -58,7 +58,7 @@
             width="146",
             height="145",
             hi_def=True,
-            lazy=False
+            loading="eager"
           ) | safe
         }}
       </a>
@@ -72,7 +72,7 @@
               width="146",
               height="145",
               hi_def=True,
-              lazy=False
+              loading="eager"
             ) | safe
           }}
          </a>
@@ -86,7 +86,7 @@
               width="146",
               height="145",
               hi_def=True,
-              lazy=False
+              loading="eager"
             ) | safe
           }}
         </a>
@@ -100,7 +100,7 @@
               width="146",
               height="145",
               hi_def=True,
-              lazy=False
+              loading="eager"
             ) | safe
           }}
         </a>
@@ -114,7 +114,7 @@
               width="146",
               height="145",
               hi_def=True,
-              lazy=False
+              loading="eager"
             ) | safe
           }}
         </a>
@@ -128,7 +128,7 @@
               width="146",
               height="145",
               hi_def=True,
-              lazy=False
+              loading="eager"
             ) | safe
           }}
         </a>

--- a/templates/partials/_snap-screenshot.html
+++ b/templates/partials/_snap-screenshot.html
@@ -1,16 +1,36 @@
 <div class="p-carousel__item--screenshot swiper-slide">
-  {% if screenshot.endswith('.gif') %}
-  <video autoplay loop muted playsinline data-original="{{ screenshot }}">
-    <source src="https://res.cloudinary.com/canonical/image/fetch/f_webm/{{ screenshot }}" type="video/webm">
-    <source src="https://res.cloudinary.com/canonical/image/fetch/f_mp4/{{ screenshot }}" type="video/mp4">
-    <img src="https://res.cloudinary.com/canonical/image/fetch/f_jpg,q_auto,f_auto,w_430/{{ screenshot }}" />
-  </video>
+  {% if screenshot.url.endswith('.gif') %}
+    <video autoplay loop muted playsinline data-original="{{ screenshot.url }}">
+      <source src="https://res.cloudinary.com/canonical/image/fetch/f_webm/{{ screenshot.url }}" type="video/webm">
+      <source src="https://res.cloudinary.com/canonical/image/fetch/f_mp4/{{ screenshot.url }}" type="video/mp4">
+      <img src="https://res.cloudinary.com/canonical/image/fetch/f_jpg,q_auto,f_auto,w_430/{{ screenshot.url }}" />
+    </video>
   {% else %}
-  <img src="https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,w_430/{{ screenshot }}"
-       srcset="https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,w_430/{{ screenshot }} 215w,
-                          https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,w_860/{{ screenshot }} 430w"
-       sizes="(min-width: 1031px) 430px,
+    {# if the screenshot was uploaded recently - we can use the information provided #}
+    {% if screenshot.width and screenshot.height and not disable_lazy %}
+      {% set ratio = screenshot.width / screenshot.height %}
+      {% set is_hidef = screenshot.width > 819 %}
+      {% set width = "819" if is_hidef else screenshot.width %}
+      {% set height = screenshot.width / ratio %}
+      {{
+        image(
+          url=screenshot.url,
+          alt="",
+          width=width|int,
+          height=height|int,
+          hi_def=is_hidef,
+          loading="eager",
+          attrs={"data-original": screenshot.url}
+        ) | safe
+      }}
+    {# otherwise fall back to the faithful #}
+    {% else %}
+      <img src="https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,w_430/{{ screenshot.url }}"
+           srcset="https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,w_430/{{ screenshot.url }} 215w,
+                          https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,w_860/{{ screenshot.url }} 430w"
+           sizes="(min-width: 1031px) 430px,
                           (max-width: 1030px) and (min-width: 876px) 430px,
-                          (max-width: 760px) 215px" data-original="https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,w_1170/{{ screenshot }}" alt="">
+                          (max-width: 760px) 215px" data-original="https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,w_1170/{{ screenshot.url }}" alt="">
+    {% endif %}
   {% endif %}
 </div>

--- a/templates/store/_generated-featured-snap-partial.html
+++ b/templates/store/_generated-featured-snap-partial.html
@@ -20,8 +20,8 @@
         width="147",
         height="147",
         hi_def=False,
-        lazy=False,
-        crossOrigin="anonymous"
+        loading="eager",
+        attrs={"crossOrigin": "anonymous"}
       ) | safe
       }}
     </div>

--- a/templates/store/_media-object-snap-partial.html
+++ b/templates/store/_media-object-snap-partial.html
@@ -20,8 +20,7 @@
       width=size,
       height=size,
       hi_def=True,
-      extra_classes="p-media-object__image",
-      style=style
+      attrs={"class": "p-media-object__image", style: style}
     ) | safe
   }}
   <div class="p-media-object__details">

--- a/templates/store/snap-details/_snap_heading_data.html
+++ b/templates/store/snap-details/_snap_heading_data.html
@@ -1,5 +1,15 @@
 {% if icon_url %}
-  <img class="p-snap-heading__icon" src="{{ icon_url }}" alt="{{ snap_title }} snap" data-live="icon" />
+  {{
+    image(
+      url=icon_url,
+      alt=snap_title,
+      width=60,
+      height=60,
+      hi_def=True,
+      loading="eager",
+      attrs={"class": "p-snap-heading__icon", "data-live": "icon"}
+    ) | safe
+  }}
 {% else %}
   <img class="p-snap-heading__icon" src="https://assets.ubuntu.com/v1/be6eb412-snapcraft-missing-icon.svg" alt="" data-live="icon" />
 {% endif %}

--- a/templates/store/snap-distro-install.html
+++ b/templates/store/snap-distro-install.html
@@ -80,8 +80,8 @@
               width="126",
               height="126",
               hi_def=True,
-              lazy=False,
-              extra_classes="distro-banner__logo u-vertically-center"
+              loading="eager",
+              attrs={"class": "distro-banner__logo u-vertically-center"}
             ) | safe
           }}
        </div>

--- a/templates/store/snap-embedded-card.html
+++ b/templates/store/snap-embedded-card.html
@@ -38,7 +38,8 @@
 {% if show_screenshot and screenshots[0] %}
 <div class="p-strip is-shallow">
   <div class="row">
-  {% set screenshot = screenshots[0] %}
+    {% set screenshot = screenshots[0] %}
+    {% set disable_lazy = True %}
   {% include "partials/_snap-screenshot.html" %}
   </div>
 </div>

--- a/templates/store/store.html
+++ b/templates/store/store.html
@@ -61,7 +61,7 @@
   <section class="p-strip--image is-deep is-dark p-strip--snap-store">
     <div class="row u-vertically-center">
       <div class="col-7 u-fade-left--medium">
-        <p class="u-hide--large u-hide--medium u-align--center">
+        <div class="u-hide--large u-hide--medium u-align--center">
           {{
             image(
               url="https://assets.ubuntu.com/v1/08af835e-Snap+Store+shopping+icon.svg",
@@ -69,10 +69,10 @@
               width="160",
               height="160",
               hi_def=True,
-              extra_classes="p-icon--snap-store u-fade-up"
+              attrs={"class": "p-icon--snap-store u-fade-up"}
             ) | safe
           }}
-        </p>
+        </div>
         <h1 class="p-heading--two">Access the App Store for Linux <br class="u-hide--small u-hide--medium">from your desktop</h1>
         <p class="u-no-padding--top p-heading--four">Easily find and install new applications or remove existing installed applications with the Snap Store snap.</p>
         <p>
@@ -87,7 +87,7 @@
             width="160",
             height="160",
             hi_def=True,
-            extra_classes="p-icon--snap-store u-fade-up"
+            attrs={"class": "p-icon--snap-store u-fade-up"}
           ) | safe
         }}
       </div>

--- a/webapp/store/logic.py
+++ b/webapp/store/logic.py
@@ -416,7 +416,7 @@ def filter_screenshots(media):
     banner_regex = r"/banner(\-icon)?(_.*)?\.(png|jpg)"
 
     return [
-        m["url"]
+        m
         for m in media
         if m["type"] == "screenshot" and not re.search(banner_regex, m["url"])
     ][:5]


### PR DESCRIPTION
Fixes https://github.com/canonical-web-and-design/snapcraft.io/issues/2306

This also adds conditional image-template usage on snap details pages.
Older screenshots don't have an image and width set in the store - this means we need 3 branches:
 - gif: for gifs
 - set sizes: we can infer the properties needed for the image-template
 - no sizes: we can't use the image-template as the image could be one of multiple ratios and the module requires both width and height (this can be removed when [this issue](https://bugs.launchpad.net/snapstore/+bug/1818065) is closed)

## QA
- Pull the branch
- `./run`
- Visit http://0.0.0.0:8004/skype
  - should be the same markup as before - no image template
- Visit http://0.0.0.0:8004/sayonara-player-unofficial
  - should have the image template markup
- Ensure the embeds also work as expected