### PR TITLE
RHEL distro page

### DIFF
--- a/static/sass/_snapcraft_p-code-copyable.scss
+++ b/static/sass/_snapcraft_p-code-copyable.scss
@@ -33,5 +33,6 @@
   code.p-code-copyable__input { //sass-lint:disable-line no-qualifying-elements
     background: $color-x-light;
     box-shadow: none;
+    white-space: pre-line;
   }
 }

--- a/templates/partials/_code-snippet-multi.html
+++ b/templates/partials/_code-snippet-multi.html
@@ -1,4 +1,4 @@
 <div class="p-code-copyable">
-  <textarea class="p-code-copyable__input" id="snippet-{{ snippet_id }}" readonly="readonly" rows="{{ snippet_value.count('\n') }}">{{ snippet_value }}</textarea>
+  <code class="p-code-copyable__input" id="snippet-{{ snippet_id }}">{{ snippet_value }}</code>
   <button class="p-code-copyable__action js-clipboard-copy" data-clipboard-target="#snippet-{{ snippet_id }}">Copy to clipboard</button>
 </div>

--- a/templates/store/snap-details/_distro-instructions-for-snap-support.html
+++ b/templates/store/snap-details/_distro-instructions-for-snap-support.html
@@ -110,6 +110,16 @@
       </a>
     </div>
     <div class="col-3 col-medium-3">
+      <a class="p-media-object" href="/install/{{package_name}}/rhel">
+        <span class="p-media-object__image">
+          <img src="https://assets.ubuntu.com/v1/be89e41a-red-hat-2019-primary-stacked.svg" alt="">
+        </span>
+        <span class="p-media-object__details">
+          <h4 class="p-media-object__title p-heading--five u-no-margin--bottom">Red Hat Enterprise Linux</h4>
+        </span>
+      </a>
+    </div>
+    <div class="col-3 col-medium-3">
       <a class="p-media-object" href="/install/{{package_name}}/ubuntu">
         <span class="p-media-object__image">
           <img src="https://assets.ubuntu.com/v1/100386fb-Distro_Logo_Ubuntu.svg" alt="">

--- a/webapp/store/content/distros/rhel.yaml
+++ b/webapp/store/content/distros/rhel.yaml
@@ -1,7 +1,7 @@
 name: Red Hat Enterprise Linux
 color-1: "#ee0000"
 color-2: "#820000"
-logo: https://assets.ubuntu.com/v1/eb20b7c6-red-hat-mono.svg # TODO
+logo: https://assets.ubuntu.com/v1/be89e41a-red-hat-2019-primary-stacked.svg
 logo-mono: https://assets.ubuntu.com/v1/eb20b7c6-red-hat-mono.svg
 install:
   - action: |

--- a/webapp/store/content/distros/rhel.yaml
+++ b/webapp/store/content/distros/rhel.yaml
@@ -1,0 +1,33 @@
+name: Red Hat Enterprise Linux
+color-1: "#ee0000"
+color-2: "#820000"
+logo: https://assets.ubuntu.com/v1/eb20b7c6-red-hat-mono.svg # TODO
+logo-mono: https://assets.ubuntu.com/v1/eb20b7c6-red-hat-mono.svg
+install:
+  - action: |
+      Snap is available for <a href="https://www.redhat.com/" class="p-link--external">Red Hat Enterprise Linux (RHEL) 7</a>, from the 7.6 release onward, from the <a href="https://fedoraproject.org/wiki/EPEL" class="p-link--external">Extra Packages for Enterprise Linux (EPEL)</a> repository.
+  - action: |
+      It is not yet available in the EPEL 8 repository, and consequently, not yet available for <a href="https://www.redhat.com/en/enterprise-linux-8" class="p-link--external">RHEL 8</a> unless you <a href="https://snapcraft.io/docs/building-snap-rpms-on-rhel">build the RPM yourself</a>.
+  - action: |
+      The EPEL repository can be added to your system with the following command:
+    command: |
+      sudo rpm -ivh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+  - action: |
+      Adding the <i>optional</i> and <i>extras</i> repositories is also recommended:
+    command: |
+      sudo subscription-manager repos --enable "rhel-*-optional-rpms" --enable "rhel-*-extras-rpms"
+      sudo yum update
+  - action: |
+      Snap can now be installed as follows:
+    command: |
+      sudo yum install snapd
+  - action: |
+      Once installed, the <i>systemd</i> unit that manages the main snap communication socket needs to be enabled:
+    command: |
+      sudo systemctl enable --now snapd.socket
+  - action: |
+      To enable <i>classic</i> snap support, enter the following to create a symbolic link between <code>/var/lib/snapd/snap</code> and <code>/snap</code>:
+    command: |
+      sudo ln -s /var/lib/snapd/snap /snap
+  - action: |
+      Either log out and back in again or restart your system to ensure snap’s paths are updated correctly.


### PR DESCRIPTION
Fixes https://github.com/canonical-web-and-design/snap-squad/issues/1133

Adds Red Hat Enterprise Linux distro page.

### QA

- ./run or https://snapcraft-io-canonical-web-and-design-pr-2314.run.demo.haus/
- go to /install/SNAP/rhel of any snap https://snapcraft-io-canonical-web-and-design-pr-2314.run.demo.haus/install/lxd/rhel
- try different snaps
- check if everything renders well
- check if install instructions are correct (https://snapcraft.io/docs/installing-snap-on-red-hat)
- go to any snap details page, check in distros list in the bottom includes Red Hat
- click on a link, make sure it goes to RHEL distro page

<img width="1206" alt="Screenshot 2019-10-17 at 13 45 13" src="https://user-images.githubusercontent.com/83575/67006038-6210f900-f0e4-11e9-9710-42e66ea4f46b.png">


<img width="1168" alt="Screenshot 2019-10-18 at 09 27 26" src="https://user-images.githubusercontent.com/83575/67074493-8672e100-f189-11e9-8979-fbd082b70ea4.png">
