### PR TITLE
Reduce docker image size

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,11 +1,22 @@
 # Don't include caches, logs and documentation
-cache.sqlite
 *.log
+.circleci
+.codecov
+.git
+.github
+.gitignore
+.vscode
+cache.sqlite
 README.md
 HACKING.md
 
 # The run script isn't needed
 run
+.docker-project
+
+# Environemnt
+.env
+.env.local
 
 # Node is only needed for building, not running
 package.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,15 +5,14 @@ ENV LANG C.UTF-8
 WORKDIR /srv
 
 # System dependencies
-RUN apt-get update && apt-get install --yes python3-pip libsodium-dev
+RUN apt-get update && apt-get install --no-install-recommends --yes python3 python3-setuptools python3-pip libsodium-dev
 
 # Import code, install code dependencies
 ADD . .
-RUN pip3 install -r requirements.txt
+RUN python3 -m pip install --no-cache-dir -r requirements.txt
 
 # Set git commit ID
 ARG COMMIT_ID
-RUN test -n "${COMMIT_ID}"
 RUN echo "${COMMIT_ID}" > version-info.txt
 ENV COMMIT_ID "${COMMIT_ID}"
 


### PR DESCRIPTION
## Done
Tweak the dockerfile in order to reduce the size of the built image.

## QA
- `docker build -t snapcraft .`
- Run `docker image` and check the size of `snapcraft` (currently around `600Mb`)
- `docker run -ti -p 8004:80 snapcraft`
- Browse `localhost:8004` and make sure all features work.
