### PR TITLE
Add progressive releases to API calls

### DIFF
--- a/static/js/publisher/release/actions/releases.js
+++ b/static/js/publisher/release/actions/releases.js
@@ -121,11 +121,16 @@ export function releaseRevisions() {
     const { pendingReleases, pendingCloses, revisions, options } = getState();
     const { csrfToken, snapName, defaultTrack } = options;
     const releases = Object.keys(pendingReleases).map(id => {
-      return {
+      const pendingRelease = pendingReleases[id];
+
+      const release = {
         id,
-        revision: pendingReleases[id].revision,
-        channels: pendingReleases[id].channels
+        revision: pendingRelease.revision,
+        channels: pendingRelease.channels,
+        progressive: pendingRelease.progressive
       };
+
+      return release;
     });
 
     const _handleReleaseResponse = (json, release) => {

--- a/static/js/publisher/release/actions/releases.test.js
+++ b/static/js/publisher/release/actions/releases.test.js
@@ -154,6 +154,7 @@ describe("releases actions", () => {
         architectures: ["amd64"],
         revision: 3
       };
+
       const release = {
         architecture: "amd64",
         branch: null,
@@ -170,7 +171,12 @@ describe("releases actions", () => {
         pendingReleases: {
           "3": {
             revision: revision,
-            channels: ["latest/edge"]
+            channels: ["latest/edge"],
+            progressive: {
+              key: "test",
+              percentage: 50,
+              paused: false
+            }
           }
         },
         pendingCloses: ["latest/edge"],

--- a/static/js/publisher/release/api/releases.js
+++ b/static/js/publisher/release/api/releases.js
@@ -12,7 +12,8 @@ export function fetchReleases(onComplete, releases, csrfToken, snapName) {
         csrfToken,
         snapName,
         release.id,
-        release.channels
+        release.channels,
+        release.progressive
       ).then(json => onComplete(json, release));
     }));
   });
@@ -39,7 +40,23 @@ export function fetchReleasesHistory(csrfToken, snapName) {
     });
 }
 
-export function fetchRelease(csrfToken, snapName, revision, channels) {
+export function fetchRelease(
+  csrfToken,
+  snapName,
+  revision,
+  channels,
+  progressive
+) {
+  const body = {
+    name: snapName,
+    revision,
+    channels
+  };
+
+  if (progressive) {
+    body.progressive = progressive;
+  }
+
   return fetch(`/${snapName}/releases`, {
     method: "POST",
     mode: "cors",
@@ -51,7 +68,7 @@ export function fetchRelease(csrfToken, snapName, revision, channels) {
     },
     redirect: "follow",
     referrer: "no-referrer",
-    body: JSON.stringify({ revision, channels, name: snapName })
+    body
   })
     .then(response => response.json())
     .catch(() => {


### PR DESCRIPTION
Add progressive info to releases API calls

### QA

- it's not used anywhere, so just code review needed if it applies to current API