### PR TITLE
Show a message if no snaps are returned on store

### DIFF
--- a/templates/store/_category-partial.html
+++ b/templates/store/_category-partial.html
@@ -1,12 +1,17 @@
 <div id="js-snap-{{ category }}">
   <div class="u-fixed-width">
-    {% if has_featured %}
-      {% if snaps[0].banner_url %}
-        <a class="p-featured-snap--banner" href="/{{ snaps[0].package_name }}">     
+    {% if snaps %}
+      {% set snap = snaps[0] %}
+    {% else %}
+      {% set snap = None %}
+    {% endif %}
+    {% if snap and has_featured %}
+      {% if snap and snap.banner_url %}
+        <a class="p-featured-snap--banner" href="/{{ snap.package_name }}">
           {{
             image(
-              url=snaps[0].banner_url,
-              alt=snaps[0].title,
+              url=snap.banner_url,
+              alt=snap.title,
               width="1104",
               height="368",
               hi_def=True,
@@ -14,26 +19,29 @@
           }}
         </a>
       {% else %}
-        {% if snaps[0]["icon_url"] != "" %}
-            {% set snap = snaps[0] %}
-            {% include "store/_generated-featured-snap-partial.html" %}
+        {% if snap["icon_url"] != "" %}
+          {% include "store/_generated-featured-snap-partial.html" %}
         {% endif %}
       {% endif %}
     {% endif %}
   </div>
   <div class="row">
-      {% set show_summary = True %}
-      {% for snap in snaps %}
-          {% if loop.index != 1 or snap["icon_url"] == "" %}
-              {% if has_featured %}
-                  {% set icon_size = "large" %}
-                  <div class="col-4 col-medium-3">
-              {% else %}
-                  <div class="col-3">
-              {% endif %}
-              {% include "store/_media-object-snap-partial.html" %}
-              </div>
+     {% set show_summary = True %}
+     {% if snaps %}
+       {% for snap in snaps %}
+         {% if loop.index != 1 or snap["icon_url"] == "" %}
+           {% if has_featured %}
+             {% set icon_size = "large" %}
+             <div class="col-4 col-medium-3">
+            {% else %}
+              <div class="col-3">
+            {% endif %}
+            {% include "store/_media-object-snap-partial.html" %}
+            </div>
           {% endif %}
-      {% endfor %}
+        {% endfor %}
+      {% else %}
+        <p>Sorry we're having difficulty getting a list of snaps. Please try again later.</p>
+      {% endif %}
   </div>
 </div>

--- a/templates/store/_category-partial.html
+++ b/templates/store/_category-partial.html
@@ -40,8 +40,6 @@
             </div>
           {% endif %}
         {% endfor %}
-      {% else %}
-        <p>Sorry we're having difficulty getting a list of snaps. Please try again later.</p>
       {% endif %}
   </div>
 </div>

--- a/tests/store/tests_get_store_view.py
+++ b/tests/store/tests_get_store_view.py
@@ -30,7 +30,17 @@ class GetStoreViewTest(TestCase):
     @responses.activate
     def test_get_store_view(self):
         payload_categories = {}
-        payload_featured_snaps = {}
+        payload_featured_snaps = {
+            "_embedded": {
+                "clickindex:package": [
+                    {
+                        "media": [{"type": "icon", "url": "test.png"}],
+                        "package_name": "featured_test",
+                    }
+                ]
+            },
+            "total": 1,
+        }
 
         responses.add(
             responses.Response(
@@ -52,8 +62,8 @@ class GetStoreViewTest(TestCase):
 
         response = self.client.get(self.endpoint_url)
 
-        assert len(responses.calls) == 2
-        assert response.status_code == 200
+        self.assertEqual(len(responses.calls), 2)
+        self.assertEqual(response.status_code, 200)
 
         self.assert_template_used("store/store.html")
 
@@ -92,15 +102,25 @@ class GetStoreViewTest(TestCase):
 
         response = self.client.get(self.endpoint_url)
 
-        assert len(responses.calls) == 2
-        assert response.status_code == 200
+        self.assertEqual(len(responses.calls), 2)
+        self.assertEqual(response.status_code, 200)
 
         self.assert_template_used("store/store.html")
 
     @responses.activate
     def test_get_store_view_fail_categories(self):
         payload_categories = {}
-        payload_featured_snaps = {}
+        payload_featured_snaps = {
+            "_embedded": {
+                "clickindex:package": [
+                    {
+                        "media": [{"type": "icon", "url": "test.png"}],
+                        "package_name": "featured_test",
+                    }
+                ]
+            },
+            "total": 1,
+        }
 
         responses.add(
             responses.Response(
@@ -122,8 +142,8 @@ class GetStoreViewTest(TestCase):
 
         response = self.client.get(self.endpoint_url)
 
-        assert len(responses.calls) == 2
-        assert response.status_code == 502
+        self.assertEqual(len(responses.calls), 2)
+        self.assertEqual(response.status_code, 200)
 
         self.assert_template_used("store/store.html")
 
@@ -152,8 +172,7 @@ class GetStoreViewTest(TestCase):
 
         response = self.client.get(self.endpoint_url)
 
-        assert len(responses.calls) == 2
-        assert response.status_code == 200
+        self.assertEqual(len(responses.calls), 2)
+        self.assertEqual(response.status_code, 502)
 
-        self.assert_template_used("store/store.html")
-        self.assert_context("featured_snaps", [])
+        self.assert_template_used("50X.html")

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -62,9 +62,8 @@ def store_blueprint(store_query=None, testing=False):
 
         try:
             categories_results = api.get_categories()
-        except ApiError as api_error:
+        except ApiError:
             categories_results = []
-            status_code, error_info = _handle_errors(api_error)
 
         categories = logic.get_categories(categories_results)
 
@@ -72,8 +71,10 @@ def store_blueprint(store_query=None, testing=False):
             featured_snaps_results = api.get_searched_snaps(
                 snap_searched="", category="featured", size=10, page=1
             )
-        except ApiError:
+        except ApiError as api_error:
             featured_snaps_results = []
+            status_code, error_info = _handle_errors(api_error)
+            flask.abort(status_code)
 
         featured_snaps = logic.get_searched_snaps(featured_snaps_results)
 

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -72,11 +72,13 @@ def store_blueprint(store_query=None, testing=False):
                 snap_searched="", category="featured", size=10, page=1
             )
         except ApiError as api_error:
-            featured_snaps_results = []
             status_code, error_info = _handle_errors(api_error)
-            flask.abort(status_code)
+            return flask.abort(status_code)
 
         featured_snaps = logic.get_searched_snaps(featured_snaps_results)
+
+        if not featured_snaps:
+            return flask.abort(503)
 
         # if the first snap (banner snap) doesn't have an icon, remove the last
         # snap from the list to avoid a hanging snap (grid of 9)


### PR DESCRIPTION
Fixes https://github.com/canonical-web-and-design/snapcraft.io/issues/2334

## QA
- Pull the branch
- Add `featured_snaps = []` to `webapp/store/views.py:79`
- `./run`
- Visit http://0.0.0.0:8004/store - you should receive an error page

![Screenshot_2019-11-04 Maintenance mode enabled](https://user-images.githubusercontent.com/479384/68114693-8fd0ad00-feee-11e9-844d-ecfb7df9b53e.png)
