### PR TITLE
Progressive release apply

### DIFF
--- a/static/js/publisher/release/actions/pendingReleases.js
+++ b/static/js/publisher/release/actions/pendingReleases.js
@@ -1,6 +1,8 @@
 export const RELEASE_REVISION = "RELEASE_REVISION";
 export const UNDO_RELEASE = "UNDO_RELEASE";
 export const CANCEL_PENDING_RELEASES = "CANCEL_PENDING_RELEASES";
+export const SET_PROGRESSIVE_RELEASE_PERCENTAGE =
+  "SET_PROGRESSIVE_RELEASE_PERCENTAGE";
 
 export function releaseRevision(revision, channel) {
   return {
@@ -10,6 +12,16 @@ export function releaseRevision(revision, channel) {
 }
 
 import { getPendingChannelMap } from "../selectors";
+
+export function setProgressiveReleasePercentage(key, percentage) {
+  return {
+    type: SET_PROGRESSIVE_RELEASE_PERCENTAGE,
+    payload: {
+      key,
+      percentage
+    }
+  };
+}
 
 export function promoteRevision(revision, channel) {
   return (dispatch, getState) => {

--- a/static/js/publisher/release/actions/pendingReleases.test.js
+++ b/static/js/publisher/release/actions/pendingReleases.test.js
@@ -9,11 +9,13 @@ import {
   RELEASE_REVISION,
   UNDO_RELEASE,
   CANCEL_PENDING_RELEASES,
+  SET_PROGRESSIVE_RELEASE_PERCENTAGE,
   releaseRevision,
   promoteRevision,
   promoteChannel,
   undoRelease,
-  cancelPendingReleases
+  cancelPendingReleases,
+  setProgressiveReleasePercentage
 } from "./pendingReleases";
 
 describe("pendingReleases actions", () => {
@@ -143,6 +145,29 @@ describe("pendingReleases actions", () => {
       expect(cancelPendingReleases(revision, channel).type).toBe(
         CANCEL_PENDING_RELEASES
       );
+    });
+  });
+
+  describe("setProgressiveReleasePercentage", () => {
+    const key = "progressive-test";
+    const percentage = 42;
+
+    it("should create an action to set release progressive percentage", () => {
+      expect(setProgressiveReleasePercentage(key, percentage).type).toBe(
+        SET_PROGRESSIVE_RELEASE_PERCENTAGE
+      );
+    });
+
+    it("should supply a payload with key", () => {
+      expect(
+        setProgressiveReleasePercentage(key, percentage).payload.key
+      ).toEqual(key);
+    });
+
+    it("should supply a payload with percentage", () => {
+      expect(
+        setProgressiveReleasePercentage(key, percentage).payload.percentage
+      ).toEqual(percentage);
     });
   });
 });

--- a/static/js/publisher/release/components/progressiveConfirm.js
+++ b/static/js/publisher/release/components/progressiveConfirm.js
@@ -22,7 +22,7 @@ const ProgressiveConfirm = ({ percentage, onChange }) => {
 };
 
 ProgressiveConfirm.propTypes = {
-  percentage: PropTypes.number,
+  percentage: PropTypes.string,
   onChange: PropTypes.func
 };
 

--- a/static/js/publisher/release/components/progressiveConfirm.js
+++ b/static/js/publisher/release/components/progressiveConfirm.js
@@ -1,0 +1,29 @@
+import React from "react";
+import PropTypes from "prop-types";
+
+const ProgressiveConfirm = ({ percentage, onChange }) => {
+  return (
+    <div className="p-releases-confirm__rollout">
+      <label htmlFor="rollout">
+        Release to{" "}
+        <input
+          className="p-releases-confirm__rollout-percentage"
+          type="number"
+          max="100"
+          min="1"
+          name="rollout-percentage"
+          value={percentage}
+          onChange={onChange}
+        />
+        % of devices
+      </label>
+    </div>
+  );
+};
+
+ProgressiveConfirm.propTypes = {
+  percentage: PropTypes.number,
+  onChange: PropTypes.func
+};
+
+export default ProgressiveConfirm;

--- a/static/js/publisher/release/components/releasesConfirm.js
+++ b/static/js/publisher/release/components/releasesConfirm.js
@@ -7,6 +7,7 @@ import {
   setProgressiveReleasePercentage
 } from "../actions/pendingReleases";
 import { releaseRevisions } from "../actions/releases";
+import { isProgressiveReleaseEnabled } from "../selectors";
 
 import ProgressiveConfirm from "./progressiveConfirm";
 
@@ -58,7 +59,11 @@ class ReleasesConfirm extends Component {
 
   render() {
     const { isLoading } = this.state;
-    const { pendingReleases, pendingCloses } = this.props;
+    const {
+      pendingReleases,
+      pendingCloses,
+      isProgressiveReleaseEnabled
+    } = this.props;
     const releasesCount = Object.keys(pendingReleases).length;
     const closesCount = pendingCloses.length;
 
@@ -109,10 +114,12 @@ class ReleasesConfirm extends Component {
               </Fragment>
             )}
           </div>
-          <ProgressiveConfirm
-            percentage={this.state.percentage}
-            onChange={this.onPercentageChange.bind(this)}
-          />
+          {isProgressiveReleaseEnabled && (
+            <ProgressiveConfirm
+              percentage={this.state.percentage}
+              onChange={this.onPercentageChange.bind(this)}
+            />
+          )}
           <div className="p-releases-confirm__buttons">
             <button
               className="p-button--positive is-inline u-no-margin--bottom"
@@ -138,6 +145,7 @@ class ReleasesConfirm extends Component {
 ReleasesConfirm.propTypes = {
   pendingReleases: PropTypes.object.isRequired,
   pendingCloses: PropTypes.array.isRequired,
+  isProgressiveReleaseEnabled: PropTypes.bool.isRequired,
 
   releaseRevisions: PropTypes.func.isRequired,
   cancelPendingReleases: PropTypes.func.isRequired,
@@ -147,7 +155,8 @@ ReleasesConfirm.propTypes = {
 const mapStateToProps = state => {
   return {
     pendingCloses: state.pendingCloses,
-    pendingReleases: state.pendingReleases
+    pendingReleases: state.pendingReleases,
+    isProgressiveReleaseEnabled: isProgressiveReleaseEnabled(state)
   };
 };
 

--- a/static/js/publisher/release/components/releasesConfirm.js
+++ b/static/js/publisher/release/components/releasesConfirm.js
@@ -2,7 +2,10 @@ import React, { Component, Fragment } from "react";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
 
-import { cancelPendingReleases } from "../actions/pendingReleases";
+import {
+  cancelPendingReleases,
+  setProgressiveReleasePercentage
+} from "../actions/pendingReleases";
 import { releaseRevisions } from "../actions/releases";
 
 import ProgressiveConfirm from "./progressiveConfirm";
@@ -11,9 +14,12 @@ class ReleasesConfirm extends Component {
   constructor(props) {
     super(props);
 
+    const timestamp = new Date().getTime();
+
     this.state = {
       isLoading: false,
-      percentage: 100
+      percentage: 100,
+      progressiveKey: `progressive-release-${timestamp}`
     };
   }
 
@@ -33,10 +39,22 @@ class ReleasesConfirm extends Component {
   }
 
   onPercentageChange(event) {
-    this.setState({
-      percentage: +event.target.value
-    });
+    this.setState(
+      {
+        percentage: +event.target.value
+      },
+      () => {
+        this.props.setProgressiveReleasePercentage(
+          this.state.progressiveKey,
+          this.state.percentage
+        );
+      }
+    );
   }
+
+  // TODO:
+  // - only affects revisions that are released over something else
+  // - show which revisions will be affected by %
 
   render() {
     const { isLoading } = this.state;
@@ -122,7 +140,8 @@ ReleasesConfirm.propTypes = {
   pendingCloses: PropTypes.array.isRequired,
 
   releaseRevisions: PropTypes.func.isRequired,
-  cancelPendingReleases: PropTypes.func.isRequired
+  cancelPendingReleases: PropTypes.func.isRequired,
+  setProgressiveReleasePercentage: PropTypes.func.isRequired
 };
 
 const mapStateToProps = state => {
@@ -135,7 +154,9 @@ const mapStateToProps = state => {
 const mapDispatchToProps = dispatch => {
   return {
     releaseRevisions: () => dispatch(releaseRevisions()),
-    cancelPendingReleases: () => dispatch(cancelPendingReleases())
+    cancelPendingReleases: () => dispatch(cancelPendingReleases()),
+    setProgressiveReleasePercentage: (key, percentage) =>
+      dispatch(setProgressiveReleasePercentage(key, percentage))
   };
 };
 

--- a/static/js/publisher/release/components/releasesConfirm.js
+++ b/static/js/publisher/release/components/releasesConfirm.js
@@ -5,12 +5,15 @@ import { connect } from "react-redux";
 import { cancelPendingReleases } from "../actions/pendingReleases";
 import { releaseRevisions } from "../actions/releases";
 
+import ProgressiveConfirm from "./progressiveConfirm";
+
 class ReleasesConfirm extends Component {
   constructor(props) {
     super(props);
 
     this.state = {
-      isLoading: false
+      isLoading: false,
+      percentage: 100
     };
   }
 
@@ -29,6 +32,12 @@ class ReleasesConfirm extends Component {
     });
   }
 
+  onPercentageChange(event) {
+    this.setState({
+      percentage: +event.target.value
+    });
+  }
+
   render() {
     const { isLoading } = this.state;
     const { pendingReleases, pendingCloses } = this.props;
@@ -38,48 +47,54 @@ class ReleasesConfirm extends Component {
     return (
       (releasesCount > 0 || closesCount > 0) && (
         <div className="p-releases-confirm">
-          {releasesCount > 0 && (
-            <Fragment>
-              <span className="p-tooltip">
-                <span className="p-help">
-                  {releasesCount} revision
-                  {releasesCount > 1 ? "s" : ""}
-                </span>
-                <span className="p-tooltip__message" role="tooltip">
-                  Release revisions:
-                  <br />
-                  {Object.keys(pendingReleases).map(revId => {
-                    const release = pendingReleases[revId];
+          <div>
+            {releasesCount > 0 && (
+              <Fragment>
+                <span className="p-tooltip">
+                  <span className="p-help">
+                    {releasesCount} revision
+                    {releasesCount > 1 ? "s" : ""}
+                  </span>
+                  <span className="p-tooltip__message" role="tooltip">
+                    Release revisions:
+                    <br />
+                    {Object.keys(pendingReleases).map(revId => {
+                      const release = pendingReleases[revId];
 
-                    return (
-                      <span key={revId}>
-                        <b>{release.revision.revision}</b> (
-                        {release.revision.version}){" "}
-                        {release.revision.architectures.join(", ")} to{" "}
-                        {release.channels.join(", ")}
-                        {"\n"}
-                      </span>
-                    );
-                  })}
-                </span>
-              </span>{" "}
-              to release.
-            </Fragment>
-          )}{" "}
-          {closesCount > 0 && (
-            <Fragment>
-              <span className="p-tooltip">
-                <span className="p-help">
-                  {closesCount} channel
-                  {closesCount > 1 ? "s" : ""}
-                </span>
-                <span className="p-tooltip__message" role="tooltip">
-                  Close channels: {pendingCloses.join(", ")}
-                </span>
-              </span>{" "}
-              to close.
-            </Fragment>
-          )}{" "}
+                      return (
+                        <span key={revId}>
+                          <b>{release.revision.revision}</b> (
+                          {release.revision.version}){" "}
+                          {release.revision.architectures.join(", ")} to{" "}
+                          {release.channels.join(", ")}
+                          {"\n"}
+                        </span>
+                      );
+                    })}
+                  </span>
+                </span>{" "}
+                to release.
+              </Fragment>
+            )}{" "}
+            {closesCount > 0 && (
+              <Fragment>
+                <span className="p-tooltip">
+                  <span className="p-help">
+                    {closesCount} channel
+                    {closesCount > 1 ? "s" : ""}
+                  </span>
+                  <span className="p-tooltip__message" role="tooltip">
+                    Close channels: {pendingCloses.join(", ")}
+                  </span>
+                </span>{" "}
+                to close.
+              </Fragment>
+            )}
+          </div>
+          <ProgressiveConfirm
+            percentage={this.state.percentage}
+            onChange={this.onPercentageChange.bind(this)}
+          />
           <div className="p-releases-confirm__buttons">
             <button
               className="p-button--positive is-inline u-no-margin--bottom"

--- a/static/js/publisher/release/reducers/pendingReleases.js
+++ b/static/js/publisher/release/reducers/pendingReleases.js
@@ -1,7 +1,8 @@
 import {
   RELEASE_REVISION,
   UNDO_RELEASE,
-  CANCEL_PENDING_RELEASES
+  CANCEL_PENDING_RELEASES,
+  SET_PROGRESSIVE_RELEASE_PERCENTAGE
 } from "../actions/pendingReleases";
 import { CLOSE_CHANNEL } from "../actions/pendingCloses";
 
@@ -70,6 +71,21 @@ function closeChannel(state, channel) {
 
   return state;
 }
+
+function updateProgressiveRelease(state, progressive) {
+  const nextState = JSON.parse(JSON.stringify(state));
+
+  Object.values(nextState).forEach(pendingRelease => {
+    if (!pendingRelease.progressive) {
+      pendingRelease.progressive = { ...progressive };
+    } else if (pendingRelease.progressive.key === progressive.key) {
+      pendingRelease.progressive.percentage = progressive.percentage;
+    }
+  });
+
+  return nextState;
+}
+
 // revisions to be released:
 // key is the id of revision to release
 // value is object containing release object and channels to release to
@@ -99,6 +115,8 @@ export default function pendingReleases(state = {}, action) {
       return {};
     case CLOSE_CHANNEL:
       return closeChannel(state, action.payload.channel);
+    case SET_PROGRESSIVE_RELEASE_PERCENTAGE:
+      return updateProgressiveRelease(state, action.payload);
     default:
       return state;
   }

--- a/static/js/publisher/release/reducers/pendingReleases.js
+++ b/static/js/publisher/release/reducers/pendingReleases.js
@@ -77,7 +77,7 @@ function updateProgressiveRelease(state, progressive) {
 
   Object.values(nextState).forEach(pendingRelease => {
     if (!pendingRelease.progressive) {
-      pendingRelease.progressive = { ...progressive };
+      pendingRelease.progressive = { paused: false, ...progressive };
     } else if (pendingRelease.progressive.key === progressive.key) {
       pendingRelease.progressive.percentage = progressive.percentage;
     }

--- a/static/js/publisher/release/reducers/pendingReleases.test.js
+++ b/static/js/publisher/release/reducers/pendingReleases.test.js
@@ -359,7 +359,10 @@ describe("pendingReleases", () => {
           ...stateWithPendingRevision,
           1: {
             ...stateWithPendingRevision[1],
-            progressive: setProgressiveAction.payload
+            progressive: {
+              ...setProgressiveAction.payload,
+              paused: false
+            }
           }
         });
       });
@@ -372,7 +375,8 @@ describe("pendingReleases", () => {
           channels: ["test/edge"],
           progressive: {
             key: "progressive-test",
-            percentage: 20
+            percentage: 20,
+            paused: false
           }
         },
         2: {
@@ -380,7 +384,8 @@ describe("pendingReleases", () => {
           channels: ["test/edge"],
           progressive: {
             key: "progressive-other",
-            percentage: 20
+            percentage: 20,
+            paused: true
           }
         }
       };
@@ -393,7 +398,10 @@ describe("pendingReleases", () => {
 
         expect(result[1]).toEqual({
           ...stateWithProgressiveReleases[1],
-          progressive: setProgressiveAction.payload
+          progressive: {
+            ...stateWithProgressiveReleases[1].progressive,
+            ...setProgressiveAction.payload
+          }
         });
       });
 

--- a/static/sass/_snapcraft_release.scss
+++ b/static/sass/_snapcraft_release.scss
@@ -7,15 +7,34 @@
 
   .p-releases-confirm {
     background: $color-light;
+    display: flex;
+    justify-content: space-between;
     margin-bottom: 1em;
     padding: 1em;
     position: relative;
   }
 
   .p-releases-confirm__buttons {
-    position: absolute;
-    right: 1em;
-    top: 10px;
+    justify-self: end;
+  }
+
+  .p-releases-confirm__rollout {
+    display: flex;
+    flex-grow: 1;
+    justify-content: flex-end;
+    margin-right: 1rem;
+
+    label {
+      margin: 0;
+      padding: 0;
+    }
+
+    &-percentage {
+      margin-bottom: 0;
+      margin-right: .5rem;
+      min-width: 4rem;
+      width: 4rem;
+    }
   }
 
   // RELEASES TABLE


### PR DESCRIPTION
Fixes #2239 

### QA

- ./run or https://snapcraft-io-canonical-web-and-design-pr-2327.run.demo.haus/
- go to releases page of any snap you own
- prepare release of any revisions on top of other revisions
- next to apply button there should be a component allowing to change the % of affected devices
- if 100% is chosen standard full release should happen when "Apply" is clicked
- if % smaller than 100% is chosen a progressive release should happen when "Apply" is clicked
- if invalid number is entered "Apply" should not be disabled
- when there is no pending releases (only pending closes) the % input should not show up
- when release to some % is made or canceled, next time release is pending % input should reset to 100%

<img width="1146" alt="Screenshot 2019-10-28 at 15 10 37" src="https://user-images.githubusercontent.com/83575/67685300-1f2d0c00-f995-11e9-9c30-f7dbfbd62931.png">
