### PR TITLE
Add progressive release feature flag support

### DIFF
--- a/static/js/publisher/release/components/revisionsList.js
+++ b/static/js/publisher/release/components/revisionsList.js
@@ -22,7 +22,8 @@ import {
   getSelectedRevisions,
   getSelectedArchitectures,
   getFilteredAvailableRevisions,
-  getFilteredAvailableRevisionsForArch
+  getFilteredAvailableRevisionsForArch,
+  isProgressiveReleaseEnabled
 } from "../selectors";
 
 import { getPendingRelease } from "../releasesState";
@@ -97,7 +98,8 @@ class RevisionsList extends Component {
       availableRevisionsSelect,
       showChannels,
       filteredAvailableRevisions,
-      pendingChannelMap
+      pendingChannelMap,
+      isProgressiveReleaseEnabled
     } = this.props;
     let filteredRevisions = filteredAvailableRevisions;
     let title = "Latest revisions";
@@ -244,6 +246,10 @@ class RevisionsList extends Component {
     const showBuildRequest = filteredRevisions.some(revision =>
       getBuildId(revision)
     );
+
+    const showProgressiveReleases =
+      isProgressiveReleaseEnabled && !showChannels;
+
     return (
       <Fragment>
         <div className="u-clearfix">
@@ -310,7 +316,9 @@ class RevisionsList extends Component {
               </th>
               <th scope="col">Version</th>
               {showBuildRequest && <th scope="col">Build Request</th>}
-              {!showChannels && <th scope="col">Progressive release status</th>}
+              {showProgressiveReleases && (
+                <th scope="col">Progressive release status</th>
+              )}
               {showChannels && <th scope="col">Channels</th>}
               <th scope="col" width="130px" className="u-align--right">
                 {isReleaseHistory ? "Release date" : "Submission date"}
@@ -377,6 +385,7 @@ RevisionsList.propTypes = {
   getSelectedRevision: PropTypes.func.isRequired,
   getFilteredAvailableRevisionsForArch: PropTypes.func.isRequired,
   pendingChannelMap: PropTypes.object,
+  isProgressiveReleaseEnabled: PropTypes.bool,
 
   // actions
   closeHistoryPanel: PropTypes.func.isRequired,
@@ -401,7 +410,8 @@ const mapStateToProps = state => {
     selectedArchitectures: getSelectedArchitectures(state),
     filteredAvailableRevisions: getFilteredAvailableRevisions(state),
     getFilteredAvailableRevisionsForArch: arch =>
-      getFilteredAvailableRevisionsForArch(state, arch)
+      getFilteredAvailableRevisionsForArch(state, arch),
+    isProgressiveReleaseEnabled: isProgressiveReleaseEnabled(state)
   };
 };
 

--- a/static/js/publisher/release/components/revisionsListRow.js
+++ b/static/js/publisher/release/components/revisionsListRow.js
@@ -8,7 +8,11 @@ import format from "date-fns/format";
 import { getChannelString } from "../../../libs/channels.js";
 import { useDragging, DND_ITEM_REVISIONS, Handle } from "./dnd";
 import { toggleRevision } from "../actions/channelMap";
-import { getSelectedRevisions, getProgressiveState } from "../selectors";
+import {
+  getSelectedRevisions,
+  getProgressiveState,
+  isProgressiveReleaseEnabled
+} from "../selectors";
 
 import RevisionLabel from "./revisionLabel";
 import { ProgressiveBar } from "./progressiveBar";
@@ -21,7 +25,8 @@ const RevisionsListRow = props => {
     showBuildRequest,
     isPending,
     isActive,
-    getProgressiveState
+    getProgressiveState,
+    isProgressiveReleaseEnabled
   } = props;
 
   const revisionDate = revision.release
@@ -61,6 +66,8 @@ const RevisionsListRow = props => {
 
   const buildRequestId =
     revision.attributes && revision.attributes["build-request-id"];
+
+  const showProgressiveReleases = isProgressiveReleaseEnabled && !showChannels;
 
   return (
     <tr
@@ -104,7 +111,7 @@ const RevisionsListRow = props => {
           )}
         </td>
       )}
-      {!showChannels && (
+      {showProgressiveReleases && (
         <td>
           {progressiveState && (
             <ProgressiveBar
@@ -150,6 +157,7 @@ RevisionsListRow.propTypes = {
   // computed state (selectors)
   selectedRevisions: PropTypes.array.isRequired,
   getProgressiveState: PropTypes.func,
+  isProgressiveReleaseEnabled: PropTypes.bool,
 
   // actions
   toggleRevision: PropTypes.func.isRequired
@@ -159,7 +167,8 @@ const mapStateToProps = state => {
   return {
     selectedRevisions: getSelectedRevisions(state),
     getProgressiveState: (channel, arch, revision) =>
-      getProgressiveState(state, channel, arch, revision)
+      getProgressiveState(state, channel, arch, revision),
+    isProgressiveReleaseEnabled: isProgressiveReleaseEnabled(state)
   };
 };
 

--- a/static/js/publisher/release/reducers/options.js
+++ b/static/js/publisher/release/reducers/options.js
@@ -1,5 +1,5 @@
 // Currently these options are only set as initial state
 // in release.js
-export default function options(state = {}) {
+export default function options(state = { flags: {} }) {
   return state;
 }

--- a/static/js/publisher/release/selectors/index.js
+++ b/static/js/publisher/release/selectors/index.js
@@ -8,6 +8,11 @@ import {
 import { isInDevmode, getBuildId, isRevisionBuiltOnLauchpad } from "../helpers";
 import { sortAlphaNum, getChannelString } from "../../../libs/channels";
 
+// returns true if isProgressiveReleaseEnabled feature flag is enabled
+export function isProgressiveReleaseEnabled(state) {
+  return !!state.options.flags.isProgressiveReleaseEnabled;
+}
+
 // returns release history filtered by history filters
 export function getFilteredReleaseHistory(state) {
   const releases = state.releases;
@@ -264,6 +269,10 @@ export function getRevisionsFromBuild(state, buildId) {
 
 // return the progressive release status based on channel, arch
 export function getProgressiveState(state, channel, arch, revision) {
+  if (!isProgressiveReleaseEnabled(state)) {
+    return null;
+  }
+
   const { releases } = state;
   const allReleases = releases.filter(
     item => channel === getChannelString(item) && arch === item.architecture

--- a/templates/publisher/release-history.html
+++ b/templates/publisher/release-history.html
@@ -43,7 +43,10 @@ Releases and revision history for {% if snap_title %}{{ snap_title }}{% else %}{
             {{ channel_maps_list|tojson }},
             {
               defaultTrack: {% if default_track %}{{ default_track|tojson }}{% else %}"latest"{% endif %},
-              csrfToken: {{ csrf_token()|tojson }}
+              csrfToken: {{ csrf_token()|tojson }},
+              flags: {
+                isProgressiveReleaseEnabled: true
+              }
             }
           );
         });


### PR DESCRIPTION
In preparation for enabling progressive releases via feature flag this PR adds a hardcoded feature flag for the UI.

### QA
Enabled:

- ./run or demo
- go to releases page of any snap with progressive releases
- make sure progressive releases work as before (can be viewed)

Disabled: 

- locally disable feature flag (turn it to false in `release-history.html` template)
- ./run
- go to releases page of any snap with or without progressive releases
- make sure any progressive release stuff doesn't show up in the table or history