### PR TITLE
Make releases confirm always visible and consistent with other forms

### DIFF
--- a/static/js/publisher/release/components/releasesConfirm.js
+++ b/static/js/publisher/release/components/releasesConfirm.js
@@ -74,8 +74,8 @@ class ReleasesConfirm extends Component {
     const showProgressive = isProgressiveReleaseEnabled && releasesCount > 0;
 
     return (
-      <div className="p-releases-confirm u-vertically-center">
-        <div>
+      <div className="p-releases-confirm u-vertically-center row">
+        <div className="col-5">
           {releasesCount > 0 && (
             <Fragment>
               <span className="p-tooltip">
@@ -119,27 +119,29 @@ class ReleasesConfirm extends Component {
             </Fragment>
           )}
         </div>
-        {showProgressive && (
-          <ProgressiveConfirm
-            percentage={this.state.percentage}
-            onChange={this.onPercentageChange.bind(this)}
-          />
-        )}
-        <div className="p-releases-confirm__buttons">
-          <button
-            className="p-button--neutral u-no-margin--bottom"
-            disabled={!isCancelEnabled}
-            onClick={this.onRevertClick.bind(this)}
-          >
-            Revert
-          </button>
-          <button
-            className="p-button--positive is-inline u-no-margin--bottom u-no-margin--right"
-            disabled={!isApplyEnabled}
-            onClick={this.onApplyClick.bind(this)}
-          >
-            {isLoading ? "Loading..." : "Save"}
-          </button>
+        <div className="col-7 p-releasses-confirm__actions">
+          {showProgressive && (
+            <ProgressiveConfirm
+              percentage={this.state.percentage}
+              onChange={this.onPercentageChange.bind(this)}
+            />
+          )}
+          <div className="p-releases-confirm__buttons">
+            <button
+              className="p-button--neutral u-no-margin--bottom"
+              disabled={!isCancelEnabled}
+              onClick={this.onRevertClick.bind(this)}
+            >
+              Revert
+            </button>
+            <button
+              className="p-button--positive is-inline u-no-margin--bottom u-no-margin--right"
+              disabled={!isApplyEnabled}
+              onClick={this.onApplyClick.bind(this)}
+            >
+              {isLoading ? "Loading..." : "Save"}
+            </button>
+          </div>
         </div>
       </div>
     );

--- a/static/js/publisher/release/components/releasesConfirm.js
+++ b/static/js/publisher/release/components/releasesConfirm.js
@@ -64,81 +64,84 @@ class ReleasesConfirm extends Component {
     const closesCount = pendingCloses.length;
 
     const isPercentageValid = +percentage > 0 && +percentage <= 100;
-    const isApplyEnabled = !isLoading && isPercentageValid;
+
+    const isApplyEnabled =
+      (releasesCount > 0 || closesCount > 0) && !isLoading && isPercentageValid;
+
+    const isCancelEnabled =
+      (releasesCount > 0 || closesCount > 0) && !isLoading;
 
     const showProgressive = isProgressiveReleaseEnabled && releasesCount > 0;
 
     return (
-      (releasesCount > 0 || closesCount > 0) && (
-        <div className="p-releases-confirm">
-          <div>
-            {releasesCount > 0 && (
-              <Fragment>
-                <span className="p-tooltip">
-                  <span className="p-help">
-                    {releasesCount} revision
-                    {releasesCount > 1 ? "s" : ""}
-                  </span>
-                  <span className="p-tooltip__message" role="tooltip">
-                    Release revisions:
-                    <br />
-                    {Object.keys(pendingReleases).map(revId => {
-                      const release = pendingReleases[revId];
+      <div className="p-releases-confirm u-vertically-center">
+        <div>
+          {releasesCount > 0 && (
+            <Fragment>
+              <span className="p-tooltip">
+                <span className="p-help">
+                  {releasesCount} revision
+                  {releasesCount > 1 ? "s" : ""}
+                </span>
+                <span className="p-tooltip__message" role="tooltip">
+                  Release revisions:
+                  <br />
+                  {Object.keys(pendingReleases).map(revId => {
+                    const release = pendingReleases[revId];
 
-                      return (
-                        <span key={revId}>
-                          <b>{release.revision.revision}</b> (
-                          {release.revision.version}){" "}
-                          {release.revision.architectures.join(", ")} to{" "}
-                          {release.channels.join(", ")}
-                          {"\n"}
-                        </span>
-                      );
-                    })}
-                  </span>
-                </span>{" "}
-                to release.
-              </Fragment>
-            )}{" "}
-            {closesCount > 0 && (
-              <Fragment>
-                <span className="p-tooltip">
-                  <span className="p-help">
-                    {closesCount} channel
-                    {closesCount > 1 ? "s" : ""}
-                  </span>
-                  <span className="p-tooltip__message" role="tooltip">
-                    Close channels: {pendingCloses.join(", ")}
-                  </span>
-                </span>{" "}
-                to close.
-              </Fragment>
-            )}
-          </div>
-          {showProgressive && (
-            <ProgressiveConfirm
-              percentage={this.state.percentage}
-              onChange={this.onPercentageChange.bind(this)}
-            />
+                    return (
+                      <span key={revId}>
+                        <b>{release.revision.revision}</b> (
+                        {release.revision.version}){" "}
+                        {release.revision.architectures.join(", ")} to{" "}
+                        {release.channels.join(", ")}
+                        {"\n"}
+                      </span>
+                    );
+                  })}
+                </span>
+              </span>{" "}
+              to release.
+            </Fragment>
+          )}{" "}
+          {closesCount > 0 && (
+            <Fragment>
+              <span className="p-tooltip">
+                <span className="p-help">
+                  {closesCount} channel
+                  {closesCount > 1 ? "s" : ""}
+                </span>
+                <span className="p-tooltip__message" role="tooltip">
+                  Close channels: {pendingCloses.join(", ")}
+                </span>
+              </span>{" "}
+              to close.
+            </Fragment>
           )}
-          <div className="p-releases-confirm__buttons">
-            <button
-              className="p-button--positive is-inline u-no-margin--bottom"
-              disabled={!isApplyEnabled}
-              onClick={this.onApplyClick.bind(this)}
-            >
-              {isLoading ? "Loading..." : "Apply"}
-            </button>
-            <button
-              className="p-button--neutral u-no-margin--bottom u-no-margin--right"
-              disabled={isLoading}
-              onClick={this.onRevertClick.bind(this)}
-            >
-              Cancel
-            </button>
-          </div>
         </div>
-      )
+        {showProgressive && (
+          <ProgressiveConfirm
+            percentage={this.state.percentage}
+            onChange={this.onPercentageChange.bind(this)}
+          />
+        )}
+        <div className="p-releases-confirm__buttons">
+          <button
+            className="p-button--neutral u-no-margin--bottom"
+            disabled={!isCancelEnabled}
+            onClick={this.onRevertClick.bind(this)}
+          >
+            Revert
+          </button>
+          <button
+            className="p-button--positive is-inline u-no-margin--bottom u-no-margin--right"
+            disabled={!isApplyEnabled}
+            onClick={this.onApplyClick.bind(this)}
+          >
+            {isLoading ? "Loading..." : "Save"}
+          </button>
+        </div>
+      </div>
     );
   }
 }

--- a/static/js/publisher/release/releasesController.js
+++ b/static/js/publisher/release/releasesController.js
@@ -45,9 +45,9 @@ class ReleasesController extends Component {
     return (
       <Fragment>
         <div className="row">
+          <ReleasesConfirm />
           {visible && <Notification />}
           <ReleasesHeading />
-          <ReleasesConfirm />
         </div>
         <ReleasesTable />
         {showModal && <Modal />}

--- a/static/sass/_snapcraft_release.scss
+++ b/static/sass/_snapcraft_release.scss
@@ -7,8 +7,6 @@
 
   .p-releases-confirm {
     border-bottom: 1px solid $color-mid-light;
-    display: flex;
-    justify-content: space-between;
     margin-bottom: 1em;
     padding: 1em 0;
     position: relative;
@@ -16,6 +14,7 @@
 
   .p-releases-confirm__buttons {
     justify-self: end;
+    margin-left: auto;
   }
 
   .p-releases-confirm__rollout {
@@ -35,6 +34,11 @@
       min-width: 4rem;
       width: 4rem;
     }
+  }
+
+  .p-releasses-confirm__actions {
+    display: flex;
+    justify-content: space-between;
   }
 
   // RELEASES TABLE

--- a/static/sass/_snapcraft_release.scss
+++ b/static/sass/_snapcraft_release.scss
@@ -6,11 +6,11 @@
   // RELEASES CONFIRM
 
   .p-releases-confirm {
-    background: $color-light;
+    border-bottom: 1px solid $color-mid-light;
     display: flex;
     justify-content: space-between;
     margin-bottom: 1em;
-    padding: 1em;
+    padding: 1em 0;
     position: relative;
   }
 

--- a/templates/publisher/release-history.html
+++ b/templates/publisher/release-history.html
@@ -9,7 +9,7 @@ Releases and revision history for {% if snap_title %}{{ snap_title }}{% else %}{
   {% set selected_tab='release' %}
   {% include "publisher/_header.html" %}
 
-  <section class="p-strip is-shallow">
+  <section class="p-strip is-shallow u-no-padding--top">
     <div id="release-history">
       {% if release_history["error-list"] %}
         <div class="row">


### PR DESCRIPTION
As a preparation to making releases confirm sticky and possibly with an accordion with changes, this PR makes the releases confirm bar always visible and consistent with other forms in publisher pages.

### QA
- ./run or https://snapcraft-io-canonical-web-and-design-pr-2330.run.demo.haus/
- go to releases page
- Save/Revert bar should be always visible and should have styling similar to Listing/Settings page
- Button labels and order should be consistent as well (Revert+Save instead of Apply+Cancel)
- when releases or closes are pending the bar should update as before, showing a summary of changes with tooltips, making buttons enabled, etc
- it should still work (releasing/closing should work as before)

<img width="1172" alt="Screenshot 2019-10-29 at 16 47 30" src="https://user-images.githubusercontent.com/83575/67784884-bfa22f80-fa6c-11e9-8428-b07ad61bd66a.png">

