### PR TITLE
Trending GitHub badge

### DIFF
--- a/tests/store/tests_details.py
+++ b/tests/store/tests_details.py
@@ -15,7 +15,7 @@ class GetDetailsPageTest(TestCase):
                 self.snap_name,
                 "?fields=title,summary,description,license,contact,website,",
                 "publisher,prices,media,download,version,created-at,"
-                "confinement,categories",
+                "confinement,categories,trending",
             ]
         )
         self.endpoint_url = "/" + self.snap_name
@@ -94,6 +94,7 @@ class GetDetailsPageTest(TestCase):
                     "validation": True,
                 },
                 "categories": [{"name": "test"}],
+                "trending": False,
             },
         }
 
@@ -126,6 +127,7 @@ class GetDetailsPageTest(TestCase):
                     "validation": True,
                 },
                 "categories": [{"name": "test"}],
+                "trending": False,
             },
             "channel-map": [
                 {
@@ -188,6 +190,7 @@ class GetDetailsPageTest(TestCase):
                     "validation": True,
                 },
                 "categories": [{"name": "test"}],
+                "trending": False,
             },
             "channel-map": [
                 {
@@ -242,6 +245,7 @@ class GetDetailsPageTest(TestCase):
                     "validation": True,
                 },
                 "categories": [{"name": "test"}],
+                "trending": False,
             },
             "channel-map": [
                 {

--- a/tests/store/tests_distro_page.py
+++ b/tests/store/tests_distro_page.py
@@ -23,6 +23,7 @@ class GetDistroPageTest(TestCase):
                 "validation": True,
             },
             "categories": [{"name": "test"}],
+            "trending": False,
         },
         "channel-map": [
             {
@@ -49,7 +50,7 @@ class GetDistroPageTest(TestCase):
                 self.snap_name,
                 "?fields=title,summary,description,license,contact,website,",
                 "publisher,prices,media,download,version,created-at,"
-                "confinement,categories",
+                "confinement,categories,trending",
             ]
         )
         self.featured_snaps_api_url = "".join(

--- a/tests/store/tests_embedded_card.py
+++ b/tests/store/tests_embedded_card.py
@@ -23,6 +23,7 @@ class GetEmbeddedCardTest(TestCase):
                 "validation": True,
             },
             "categories": [{"name": "test"}],
+            "trending": False,
         },
         "channel-map": [
             {
@@ -49,7 +50,7 @@ class GetEmbeddedCardTest(TestCase):
                 self.snap_name,
                 "?fields=title,summary,description,license,contact,website,",
                 "publisher,prices,media,download,version,created-at,"
-                "confinement,categories",
+                "confinement,categories,trending",
             ]
         )
         self.endpoint_url = "/" + self.snap_name + "/embedded"

--- a/tests/store/tests_github_badge.py
+++ b/tests/store/tests_github_badge.py
@@ -23,6 +23,7 @@ class GetGitHubBadgeTest(TestCase):
                 "validation": True,
             },
             "categories": [{"name": "test"}],
+            "trending": False,
         },
         "channel-map": [
             {
@@ -61,7 +62,7 @@ class GetGitHubBadgeTest(TestCase):
                 self.snap_name,
                 "?fields=title,summary,description,license,contact,website,",
                 "publisher,prices,media,download,version,created-at,"
-                "confinement,categories",
+                "confinement,categories,trending",
             ]
         )
         self.endpoint_url = "/" + self.snap_name + "/badge.svg"

--- a/webapp/api/store.py
+++ b/webapp/api/store.py
@@ -20,7 +20,8 @@ SNAP_INFO_URL = "".join(
         SNAPCRAFT_IO_API_V2,
         "snaps/info/{snap_name}",
         "?fields=title,summary,description,license,contact,website,publisher,",
-        "prices,media,download,version,created-at,confinement,categories",
+        "prices,media,download,version,created-at,confinement,categories,",
+        "trending",
     ]
 )
 


### PR DESCRIPTION
Fixes #2323 

### QA

- ./run or demo
- check if GH badge is working as before: https://snapcraft-io-canonical-web-and-design-pr-2331.run.demo.haus/toto/badge.svg
- check if name can be removed from a badge: https://snapcraft-io-canonical-web-and-design-pr-2331.run.demo.haus/speed-test/badge.svg?name=0
- check if trending badge works for trending snap: https://snapcraft-io-canonical-web-and-design-pr-2331.run.demo.haus/kdenlive/trending.svg
- check if trending badge works without the name: https://snapcraft-io-canonical-web-and-design-pr-2331.run.demo.haus/kdenlive/trending.svg?name=0
- check if trending barge is empty image when snap is not trending
https://snapcraft-io-canonical-web-and-design-pr-2331.run.demo.haus/toto/trending.svg

Examples:

/badge.svg
![](https://snapcraft-io-canonical-web-and-design-pr-2331.run.demo.haus/speed-test/badge.svg)

/badge.svg?name=0
![](https://snapcraft-io-canonical-web-and-design-pr-2331.run.demo.haus/speed-test/badge.svg?name=0)

/trending.svg (not trending)
![](https://snapcraft-io-canonical-web-and-design-pr-2331.run.demo.haus/speed-test/trending.svg)

/trending.svg
![](https://snapcraft-io-canonical-web-and-design-pr-2331.run.demo.haus/kdenlive/trending.svg)

/trending.svg?name=0
![](https://snapcraft-io-canonical-web-and-design-pr-2331.run.demo.haus/kdenlive/trending.svg?name=0)