### PR TITLE
Add trending badge option to publicise page

### DIFF
--- a/static/js/publisher/publicise.js
+++ b/static/js/publisher/publicise.js
@@ -225,7 +225,9 @@ const getBadgesHTML = (snapName, options) => {
 };
 
 const getBadgesPreviewHTML = (snapName, options) => {
-  return getBadgesCode(snapName, options, getBadgePreview);
+  const code = getBadgesCode(snapName, options, getBadgePreview);
+
+  return code || "<em>select a badge to display</em>";
 };
 
 const getBadgesMarkdown = (snapName, options) => {

--- a/static/js/publisher/publicise.js
+++ b/static/js/publisher/publicise.js
@@ -246,9 +246,7 @@ const getBadgesHTML = (snapName, options) => {
 };
 
 const getBadgesPreviewHTML = (snapName, options) => {
-  const code = getBadgesCode(snapName, options, getBadgePreview);
-
-  return code || "<em>select a badge to display</em>";
+  return getBadgesCode(snapName, options, getBadgePreview);
 };
 
 const getBadgesMarkdown = (snapName, options) => {
@@ -262,6 +260,8 @@ function initGitHubBadgePicker(options) {
     previewElement,
     markdownElement,
     notificationElement,
+    badgeCodeElement,
+    optionsUncheckedElement,
     isTrending
   } = options;
   const optionButtons = [].slice.call(options.optionButtons);
@@ -275,6 +275,14 @@ function initGitHubBadgePicker(options) {
       notificationElement.classList.remove("u-hide");
     } else {
       notificationElement.classList.add("u-hide");
+    }
+
+    if (state["show-channel"] || state["show-trending"]) {
+      optionsUncheckedElement.classList.add("u-hide");
+      badgeCodeElement.classList.remove("u-hide");
+    } else {
+      optionsUncheckedElement.classList.remove("u-hide");
+      badgeCodeElement.classList.add("u-hide");
     }
 
     previewElement.innerHTML = getBadgesPreviewHTML(snapName, state);

--- a/static/js/publisher/publicise.js
+++ b/static/js/publisher/publicise.js
@@ -181,13 +181,34 @@ function initEmbeddedCardPicker(options) {
 
 // GITHUB BADGES
 
-const getBadgePath = (snapName, badgeName = "badge", showName = true) => {
-  return `/${snapName}/${badgeName}.svg${showName ? "" : "?name=0"}`;
+const getBadgePath = (
+  snapName,
+  badgeName = "badge",
+  showName = true,
+  isPreview = false
+) => {
+  const params = [];
+  if (!showName) {
+    params.push("name=0");
+  }
+
+  if (isPreview) {
+    params.push("preview=1");
+  }
+
+  return `/${snapName}/${badgeName}.svg${
+    params.length ? `?${params.join("&")}` : ""
+  }`;
 };
 
 const getBadgePreview = (snapName, badgeName, showName) => {
   return `<a href="/${snapName}">
-  <img alt="${snapName}" src="${getBadgePath(snapName, badgeName, showName)}" />
+  <img alt="${snapName}" src="${getBadgePath(
+    snapName,
+    badgeName,
+    showName,
+    badgeName === "trending"
+  )}" />
   </a>`;
 };
 
@@ -235,7 +256,14 @@ const getBadgesMarkdown = (snapName, options) => {
 };
 
 function initGitHubBadgePicker(options) {
-  const { snapName, htmlElement, previewElement, markdownElement } = options;
+  const {
+    snapName,
+    htmlElement,
+    previewElement,
+    markdownElement,
+    notificationElement,
+    isTrending
+  } = options;
   const optionButtons = [].slice.call(options.optionButtons);
 
   let state = {
@@ -243,6 +271,12 @@ function initGitHubBadgePicker(options) {
   };
 
   const render = state => {
+    if (state["show-trending"] && !isTrending) {
+      notificationElement.classList.remove("u-hide");
+    } else {
+      notificationElement.classList.add("u-hide");
+    }
+
     previewElement.innerHTML = getBadgesPreviewHTML(snapName, state);
     htmlElement.innerHTML = getBadgesHTML(snapName, state);
     markdownElement.innerHTML = getBadgesMarkdown(snapName, state);

--- a/static/js/publisher/publicise.js
+++ b/static/js/publisher/publicise.js
@@ -179,4 +179,92 @@ function initEmbeddedCardPicker(options) {
   return () => render(state);
 }
 
-export { initSnapButtonsPicker, initEmbeddedCardPicker };
+// GITHUB BADGES
+
+const getBadgePath = (snapName, badgeName = "badge", showName = true) => {
+  return `/${snapName}/${badgeName}.svg${showName ? "" : "?name=0"}`;
+};
+
+const getBadgePreview = (snapName, badgeName, showName) => {
+  return `<a href="/${snapName}">
+  <img alt="${snapName}" src="${getBadgePath(snapName, badgeName, showName)}" />
+  </a>`;
+};
+
+const getBadgeHTML = (snapName, badgeName, showName) => {
+  return `&lt;a href="https://snapcraft.io/${snapName}"&gt;
+  &lt;img alt="${snapName}" src="https://snapcraft.io${getBadgePath(
+    snapName,
+    badgeName,
+    showName
+  )}" /&gt;
+  &lt;/a&gt;`;
+};
+
+const getBadgeMarkdown = (snapName, badgeName, showName) => {
+  return `[![${snapName}](https://snapcraft.io/${getBadgePath(
+    snapName,
+    badgeName,
+    showName
+  )})](https://snapcraft.io/${snapName})`;
+};
+
+const getBadgesCode = (snapName, options, badgeGenerator) => {
+  const badges = [];
+  if (options["show-channel"]) {
+    badges.push(badgeGenerator(snapName));
+  }
+  if (options["show-trending"]) {
+    badges.push(badgeGenerator(snapName, "trending", badges.length === 0));
+  }
+  return badges.join("\n");
+};
+
+const getBadgesHTML = (snapName, options) => {
+  return getBadgesCode(snapName, options, getBadgeHTML);
+};
+
+const getBadgesPreviewHTML = (snapName, options) => {
+  return getBadgesCode(snapName, options, getBadgePreview);
+};
+
+const getBadgesMarkdown = (snapName, options) => {
+  return getBadgesCode(snapName, options, getBadgeMarkdown);
+};
+
+function initGitHubBadgePicker(options) {
+  const { snapName, htmlElement, previewElement, markdownElement } = options;
+  const optionButtons = [].slice.call(options.optionButtons);
+
+  let state = {
+    ...getCurrentFormState([], optionButtons)
+  };
+
+  const render = state => {
+    previewElement.innerHTML = getBadgesPreviewHTML(snapName, state);
+    htmlElement.innerHTML = getBadgesHTML(snapName, state);
+    markdownElement.innerHTML = getBadgesMarkdown(snapName, state);
+  };
+
+  const getFormState = () => {
+    return getCurrentFormState([], optionButtons);
+  };
+
+  const updateState = () => {
+    state = {
+      ...state,
+      ...getFormState()
+    };
+    render(state);
+  };
+
+  optionButtons.forEach(checkbox => {
+    checkbox.addEventListener("change", () => {
+      updateState();
+    });
+  });
+
+  render(state);
+}
+
+export { initSnapButtonsPicker, initEmbeddedCardPicker, initGitHubBadgePicker };

--- a/static/sass/_snapcraft_p-code-copyable.scss
+++ b/static/sass/_snapcraft_p-code-copyable.scss
@@ -33,6 +33,7 @@
   code.p-code-copyable__input { //sass-lint:disable-line no-qualifying-elements
     background: $color-x-light;
     box-shadow: none;
+    min-height: 1.5rem;
     white-space: pre-line;
   }
 }

--- a/templates/publisher/publicise/github_badges.html
+++ b/templates/publisher/publicise/github_badges.html
@@ -8,10 +8,27 @@
 
   <div class="row">
     <div class="col-2">
+      Display:
+    </div>
+    <div class="col-7" id="js-options">
+        <input type="checkbox" name="show-channel" id="option-show-channel" checked>
+        <label for="option-show-channel">
+          Stable channel from default track
+        </label>
+        <input type="checkbox" name="show-trending" id="option-show-trending" {% if trending %}checked{% endif %}>
+        <label for="option-show-trending">
+          Trending status
+          <span class="p-form-help-text">Badge will only display when your snap is flaged as trending</span>
+        </label>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="col-2">
       Preview:
     </div>
     <div class="col-7">
-      <p class="snapcraft-publicise__images">
+      <p class="snapcraft-publicise__images" id="snippet-badge-preview">
         <a href="https://snapcraft.io/{{ snap_name }}">
           <img alt="{{ snap_title }}" src="/{{ snap_name }}/badge.svg" />
         </a>
@@ -50,10 +67,22 @@
 <script src="{{ static_url('js/modules/clipboard.min.js') }}" defer></script>
 {% endblock %}
 
+{% block scripts_includes %}
+  <script src="{{ static_url('js/dist/publisher.js') }}" defer></script>
+{% endblock %}
+
 {% block scripts %}
 <script>
   window.addEventListener("DOMContentLoaded", function() {
     Raven.context(function () {
+      snapcraft.publisher.publicise.initGitHubBadgePicker({
+        snapName: "{{ snap_name }}",
+        previewElement: document.getElementById("snippet-badge-preview"),
+        htmlElement: document.getElementById("snippet-badge-html"),
+        markdownElement: document.getElementById("snippet-badge-markdown"),
+        optionButtons: document.querySelectorAll("#js-options input[type=checkbox]")
+      });
+
       if (typeof ClipboardJS !== 'undefined') {
         new ClipboardJS('.js-clipboard-copy');
       }

--- a/templates/publisher/publicise/github_badges.html
+++ b/templates/publisher/publicise/github_badges.html
@@ -18,7 +18,7 @@
         <input type="checkbox" name="show-trending" id="option-show-trending" {% if trending %}checked{% endif %}>
         <label for="option-show-trending">
           Trending status
-          <span class="p-form-help-text">Badge will only display when your snap is flaged as trending</span>
+          <span class="p-form-help-text">Badge will only display when your snap is flagged as trending</span>
         </label>
     </div>
   </div>
@@ -33,6 +33,12 @@
           <img alt="{{ snap_title }}" src="/{{ snap_name }}/badge.svg" />
         </a>
       </p>
+
+      <div class="p-notification--information u-hide" id="notification-trending">
+        <p class="p-notification__response">
+          <span class="p-notification__status">Trending badge:</span>Your snap is not currently flagged as trending. Only when your snap becomes trending will the trending badge appear on external sites.
+        </p>
+      </div>
     </div>
   </div>
 
@@ -77,10 +83,12 @@
     Raven.context(function () {
       snapcraft.publisher.publicise.initGitHubBadgePicker({
         snapName: "{{ snap_name }}",
+        isTrending: {{ trending|tojson }},
         previewElement: document.getElementById("snippet-badge-preview"),
         htmlElement: document.getElementById("snippet-badge-html"),
         markdownElement: document.getElementById("snippet-badge-markdown"),
-        optionButtons: document.querySelectorAll("#js-options input[type=checkbox]")
+        optionButtons: document.querySelectorAll("#js-options input[type=checkbox]"),
+        notificationElement: document.getElementById("notification-trending")
       });
 
       if (typeof ClipboardJS !== 'undefined') {

--- a/templates/publisher/publicise/github_badges.html
+++ b/templates/publisher/publicise/github_badges.html
@@ -20,50 +20,53 @@
           Trending status
           <span class="p-form-help-text">Badge will only display when your snap is flagged as trending</span>
         </label>
+        <p class="u-hide" id="options-unchecked-warning"><em>Please select at least one badge to display from the list above</em></p>
     </div>
   </div>
 
-  <div class="row">
-    <div class="col-2">
-      Preview:
-    </div>
-    <div class="col-7">
-      <p class="snapcraft-publicise__images" id="snippet-badge-preview">
-        <a href="https://snapcraft.io/{{ snap_name }}">
-          <img alt="{{ snap_title }}" src="/{{ snap_name }}/badge.svg" />
-        </a>
-      </p>
-
-      <div class="p-notification--information u-hide" id="notification-trending">
-        <p class="p-notification__response">
-          <span class="p-notification__status">Trending badge:</span>Your snap is not currently flagged as trending. Only when your snap becomes trending will the trending badge appear on external sites.
+  <div id="badge-code-wrapper">
+    <div class="row">
+      <div class="col-2">
+        Preview:
+      </div>
+      <div class="col-7">
+        <p class="snapcraft-publicise__images" id="snippet-badge-preview">
+          <a href="https://snapcraft.io/{{ snap_name }}">
+            <img alt="{{ snap_title }}" src="/{{ snap_name }}/badge.svg" />
+          </a>
         </p>
+
+        <div class="p-notification--information u-hide" id="notification-trending">
+          <p class="p-notification__response">
+            <span class="p-notification__status">Trending badge:</span>Your snap is not currently flagged as trending. Only when your snap becomes trending will the trending badge appear on external sites.
+          </p>
+        </div>
       </div>
     </div>
-  </div>
 
-  <div class="row">
-    <div class="col-2">
-      <label>HTML:</label>
-    </div>
-    <div class="col-7">
-      <div class="p-code-copyable not-cli">
-        <code class="p-code-copyable__input" id="snippet-badge-html">&lt;a href="https://snapcraft.io/{{ snap_name }}"&gt;
-  &lt;img alt="{{ snap_title }}" src="https://snapcraft.io/{{ snap_name }}/badge.svg" /&gt;
-&lt;/a&gt;</code>
-        <button class="p-code-copyable__action js-clipboard-copy" data-clipboard-target="#snippet-badge-html">Copy to clipboard</button>
+    <div class="row">
+      <div class="col-2">
+        <label>HTML:</label>
+      </div>
+      <div class="col-7">
+        <div class="p-code-copyable not-cli">
+          <code class="p-code-copyable__input" id="snippet-badge-html">&lt;a href="https://snapcraft.io/{{ snap_name }}"&gt;
+    &lt;img alt="{{ snap_title }}" src="https://snapcraft.io/{{ snap_name }}/badge.svg" /&gt;
+  &lt;/a&gt;</code>
+          <button class="p-code-copyable__action js-clipboard-copy" data-clipboard-target="#snippet-badge-html">Copy to clipboard</button>
+        </div>
       </div>
     </div>
-  </div>
 
-  <div class="row">
-    <div class="col-2">
-      <label>Markdown:</label>
-    </div>
-    <div class="col-7">
-      <div class="p-code-copyable not-cli">
-        <code class="p-code-copyable__input" id="snippet-badge-markdown">[![{{ snap_title }}](https://snapcraft.io/{{ snap_name }}/badge.svg)](https://snapcraft.io/{{ snap_name }})</code>
-        <button class="p-code-copyable__action js-clipboard-copy" data-clipboard-target="#snippet-badge-markdown">Copy to clipboard</button>
+    <div class="row">
+      <div class="col-2">
+        <label>Markdown:</label>
+      </div>
+      <div class="col-7">
+        <div class="p-code-copyable not-cli">
+          <code class="p-code-copyable__input" id="snippet-badge-markdown">[![{{ snap_title }}](https://snapcraft.io/{{ snap_name }}/badge.svg)](https://snapcraft.io/{{ snap_name }})</code>
+          <button class="p-code-copyable__action js-clipboard-copy" data-clipboard-target="#snippet-badge-markdown">Copy to clipboard</button>
+        </div>
       </div>
     </div>
   </div>
@@ -88,7 +91,9 @@
         htmlElement: document.getElementById("snippet-badge-html"),
         markdownElement: document.getElementById("snippet-badge-markdown"),
         optionButtons: document.querySelectorAll("#js-options input[type=checkbox]"),
-        notificationElement: document.getElementById("notification-trending")
+        notificationElement: document.getElementById("notification-trending"),
+        badgeCodeElement: document.getElementById("badge-code-wrapper"),
+        optionsUncheckedElement: document.getElementById("options-unchecked-warning")
       });
 
       if (typeof ClipboardJS !== 'undefined') {

--- a/tests/publisher/snaps/tests_publicise_badges.py
+++ b/tests/publisher/snaps/tests_publicise_badges.py
@@ -11,11 +11,44 @@ class PublicisePageNotAuth(BaseTestCases.EndpointLoggedOut):
 
 
 class GetPubliciseBadgesPage(BaseTestCases.EndpointLoggedInErrorHandling):
+    snap_payload = {
+        "snap-id": "id",
+        "name": "snapName",
+        "default-track": "test",
+        "snap": {
+            "title": "Snap Title",
+            "summary": "This is a summary",
+            "description": "this is a description",
+            "media": [],
+            "license": "license",
+            "prices": 0,
+            "publisher": {
+                "display-name": "Toto",
+                "username": "toto",
+                "validation": True,
+            },
+            "categories": [],
+            "trending": False,
+        },
+        "channel-map": [],
+    }
+
     def setUp(self):
         snap_name = "test-snap"
 
         api_url = "https://dashboard.snapcraft.io/dev/api/snaps/info/{}"
         api_url = api_url.format(snap_name)
+        self.public_api_url = "".join(
+            [
+                "https://api.snapcraft.io/v2/",
+                "snaps/info/",
+                snap_name,
+                "?fields=title,summary,description,license,contact,website,",
+                "publisher,prices,media,download,version,created-at,"
+                "confinement,categories,trending",
+            ]
+        )
+
         endpoint_url = "/{}/publicise/badges".format(snap_name)
 
         super().setUp(
@@ -52,6 +85,12 @@ class GetPubliciseBadgesPage(BaseTestCases.EndpointLoggedInErrorHandling):
         }
 
         responses.add(responses.GET, self.api_url, json=payload, status=200)
+        responses.add(
+            responses.GET,
+            self.public_api_url,
+            json=self.snap_payload,
+            status=200,
+        )
 
         response = self.client.get(self.endpoint_url)
 

--- a/webapp/publisher/snaps/views.py
+++ b/webapp/publisher/snaps/views.py
@@ -1206,10 +1206,16 @@ def get_publicise_badges(snap_name):
     if snap_details["private"]:
         return flask.abort(404, "No snap named {}".format(snap_name))
 
+    try:
+        snap_public_details = store_api.get_snap_details(snap_name)
+    except ApiError as api_error:
+        return _handle_errors(api_error)
+
     context = {
         "snap_name": snap_details["snap_name"],
         "snap_title": snap_details["title"],
         "snap_id": snap_details["snap_id"],
+        "trending": snap_public_details["snap"]["trending"],
     }
 
     return flask.render_template(


### PR DESCRIPTION
Fixes #2324 

Adds option to add trending badge on publicise page

### QA
- ./run or https://snapcraft-io-canonical-web-and-design-pr-2332.run.demo.haus/
- go to publicise page of any snap (not trending)
- choose GitHub badge, an option to show trending badge should be available
- click to choose trending badge
- preview should show trending badge with a warning message that this is just a preview (because snap is not trending)
- code should update to include additional trending badge
- using the code in external service should not show the trending badge (as snap is not trending)
- go to publicise page of trending snap https://snapcraft-io-canonical-web-and-design-pr-2332.run.demo.haus/kdenlive/publicise/badges
- trending badge should be checked (visible) by default (only if snap is currently trending)
- try different options on setting badges on/off

<img width="1178" alt="Screenshot 2019-11-04 at 16 55 37" src="https://user-images.githubusercontent.com/83575/68135453-f58b5c00-ff23-11e9-9322-cb33bdf7d732.png">
<img width="1167" alt="Screenshot 2019-11-04 at 16 55 28" src="https://user-images.githubusercontent.com/83575/68135454-f58b5c00-ff23-11e9-8b83-76d6f1f2657c.png">
