### PR TITLE
Improve screenshot sizes on snap details

### DIFF
--- a/static/sass/_patterns_carousel.scss
+++ b/static/sass/_patterns_carousel.scss
@@ -30,6 +30,7 @@
         margin-bottom: 0;
         max-height: 460px;
         max-width: 100%;
+        width: auto;
       }
     }
 

--- a/templates/partials/_snap-screenshot.html
+++ b/templates/partials/_snap-screenshot.html
@@ -10,8 +10,8 @@
     {% if screenshot.width and screenshot.height and not disable_lazy %}
       {% set ratio = screenshot.width / screenshot.height %}
       {% set is_hidef = screenshot.width > 819 %}
-      {% set width = "819" if is_hidef else screenshot.width %}
-      {% set height = screenshot.width / ratio %}
+      {% set width = 819 if is_hidef else screenshot.width %}
+      {% set height = width / ratio %}
       {{
         image(
           url=screenshot.url,


### PR DESCRIPTION
Fixes https://github.com/canonical-web-and-design/snapcraft.io/issues/2333

## QA
- Pull the branch
- `./run`
- Visit http://0.0.0.0:8004/remarkable
- Compare the screenshot sizing with https://snapcraft.io/remarkable