### PR TITLE
Fix branch cells widths

### DIFF
--- a/static/sass/_snapcraft_release.scss
+++ b/static/sass/_snapcraft_release.scss
@@ -37,9 +37,9 @@
 
   .p-releases-table__row--branch {
     height: 4rem;
-    margin-left: 2rem;
 
     .p-releases-channel {
+      margin-left: 2rem;
       width: calc(280px - 2rem);
     }
   }


### PR DESCRIPTION
Fix width of releases cells in branch rows.

### QA
- ./run or https://snapcraft-io-canonical-web-and-design-pr-2337.run.demo.haus/
- go to releases page of snap with branches (and not many architectures)
- open branches
- cells should align
- try different screen widths

<img width="1306" alt="Screenshot 2019-11-06 at 12 59 30" src="https://user-images.githubusercontent.com/83575/68296683-76b63080-0095-11ea-928f-c83951e4967b.png">
