### PR TITLE
Make channel map window width adapt to font size on large screens

### DIFF
--- a/static/sass/_snapcraft_details_heading.scss
+++ b/static/sass/_snapcraft_details_heading.scss
@@ -89,7 +89,7 @@
   .p-channel-map {
     background: $color-x-light;
     box-shadow: 0 1px 5px 1px transparentize($color-x-dark, .8);
-    max-width: 700px;
+    max-width: 45rem;
     overflow: hidden;
     position: absolute;
     right: 0;


### PR DESCRIPTION
Fixes #2338

Updates the width of channel map popover to make sure it adapts to increased font size on largest screens

### QA
- ./run or https://snapcraft-io-canonical-web-and-design-pr-2340.run.demo.haus/
- go to /gnome-chess on large screen
- open channel map
- date should fit without truncating
- open channel map on smaller screens as well to see if everything fits

<img width="1322" alt="Screenshot 2019-11-07 at 12 26 05" src="https://user-images.githubusercontent.com/83575/68385337-d249f200-0159-11ea-834f-bb6a49539b45.png">
