### PR TITLE
Don't show progressive percentage on pending channel close

### DIFF
--- a/static/js/publisher/release/components/releasesTable/releaseCell.js
+++ b/static/js/publisher/release/components/releasesTable/releaseCell.js
@@ -162,7 +162,8 @@ const ReleasesTableReleaseCell = props => {
           branchName
         )}
       />
-      {progressiveState &&
+      {!isChannelPendingClose &&
+        progressiveState &&
         progressiveState.percentage && (
           <span
             className="p-release__progressive-percentage"


### PR DESCRIPTION
Fixes #2348

Hides bar with progressive percentage in releases table when channel has pending close

### QA
- ./run or demo
- go to releases page of snap with progressive releases
- mark channel with progressive release in progress as closed
- bar with percentage on the bottom of the cell should not be visible when channel has pending close

<img width="1151" alt="Screenshot 2019-11-13 at 14 15 36" src="https://user-images.githubusercontent.com/83575/68767157-84812e00-0620-11ea-962b-ddd6dabdeda8.png">
