### PR TITLE
Ensure revision can be dragged after progressive release is can…

### DIFF
--- a/static/js/publisher/release/components/revisionsListRowProgressive.js
+++ b/static/js/publisher/release/components/revisionsListRowProgressive.js
@@ -65,6 +65,7 @@ const RevisionsListRowProgressive = ({
 
   const handleCancelProgressiveRelease = () => {
     releaseRevision(previousRevision, channel, null);
+    setDraggable(true);
   };
 
   const handleProgressiveChange = percentage => {

--- a/static/sass/_snapcraft_release.scss
+++ b/static/sass/_snapcraft_release.scss
@@ -389,6 +389,7 @@
       }
 
       .p-revisions-list__revision-progressive {
+        cursor: default;
         display: flex;
         flex-direction: row;
 


### PR DESCRIPTION
Fixes https://github.com/canonical-web-and-design/snapcraft.io/issues/2349

## QA
- Pull the branch
- `./run`
- Visit http://0.0.0.0:8004/snap_name/releases
- Create a progressive release
- Save
- Cancel the progressive release - the row should be draggable in history
- Revert the changes - the row should be draggable in history
