### PR TITLE
Update progressiveBar target % when props change

### DIFF
--- a/static/js/publisher/release/actions/releases.js
+++ b/static/js/publisher/release/actions/releases.js
@@ -130,7 +130,11 @@ export function releaseRevisions() {
             id: pendingRelease.revision.revision,
             revision: pendingRelease.revision,
             channels: [pendingRelease.channel],
-            progressive: pendingRelease.progressive
+            progressive:
+              pendingRelease.progressive &&
+              pendingRelease.progressive.percentages < 100
+                ? pendingRelease.progressive
+                : null
           };
 
           return release;

--- a/static/js/publisher/release/actions/releases.js
+++ b/static/js/publisher/release/actions/releases.js
@@ -132,7 +132,7 @@ export function releaseRevisions() {
             channels: [pendingRelease.channel],
             progressive:
               pendingRelease.progressive &&
-              pendingRelease.progressive.percentages < 100
+              pendingRelease.progressive.percentage < 100
                 ? pendingRelease.progressive
                 : null
           };

--- a/static/js/publisher/release/actions/releases.test.js
+++ b/static/js/publisher/release/actions/releases.test.js
@@ -91,55 +91,104 @@ describe("releases actions", () => {
   });
 
   describe("handleReleaseResponse", () => {
-    it("should dispatch RELEASE_REVISION_SUCCESS", () => {
-      const store = mockStore({});
+    describe("RELEASE_REVISION_SUCCESS", () => {
+      it("should be dispatched if revision is passed", () => {
+        const store = mockStore({});
 
-      const dispatch = store.dispatch;
-      const json = {
-        success: true,
-        channel_map_tree: {
-          latest: {
-            16: {
-              amd64: [
-                {
-                  channel: "edge",
-                  info: "specific",
-                  revision: 3,
-                  version: "test"
-                }
-              ]
+        const dispatch = store.dispatch;
+        const json = {
+          success: true,
+          channel_map_tree: {
+            latest: {
+              16: {
+                amd64: [
+                  {
+                    channel: "edge",
+                    info: "specific",
+                    revision: 3,
+                    version: "test"
+                  }
+                ]
+              }
             }
           }
-        }
-      };
+        };
 
-      const release = [
-        {
-          id: 3,
+        const release = [
+          {
+            id: 3,
+            revision: 3,
+            channels: ["latest/edge"]
+          }
+        ];
+
+        const revision = {
+          architectures: ["amd64"],
+          revision: 3
+        };
+
+        const revisions = {
+          "3": revision
+        };
+
+        handleReleaseResponse(dispatch, json, release, revisions, "latest");
+
+        const actions = store.getActions();
+
+        expect(actions[0]).toEqual({
+          payload: {
+            channel: "latest/edge",
+            revision: revision
+          },
+          type: "RELEASE_REVISION_SUCCESS"
+        });
+      });
+
+      it("should be dispatched if there are no revisions", () => {
+        const store = mockStore({});
+
+        const dispatch = store.dispatch;
+        const json = {
+          success: true,
+          channel_map_tree: {
+            latest: {
+              16: {
+                amd64: [
+                  {
+                    channel: "edge",
+                    info: "specific",
+                    revision: 3,
+                    version: "test"
+                  }
+                ]
+              }
+            }
+          }
+        };
+
+        const revision = {
+          architectures: ["amd64"],
           revision: 3,
+          version: "test"
+        };
+
+        const release = {
+          id: 4,
+          revision: revision,
           channels: ["latest/edge"]
-        }
-      ];
+        };
 
-      const revision = {
-        architectures: ["amd64"],
-        revision: 3
-      };
+        handleReleaseResponse(dispatch, json, release, {}, "latest");
 
-      const revisions = {
-        "3": revision
-      };
+        const actions = store.getActions();
 
-      handleReleaseResponse(dispatch, json, release, revisions, "latest");
-
-      const actions = store.getActions();
-
-      expect(actions[0]).toEqual({
-        payload: {
-          channel: "latest/edge",
-          revision: revision
-        },
-        type: "RELEASE_REVISION_SUCCESS"
+        expect(actions[0]).toEqual({
+          payload: {
+            channel: "latest/edge",
+            revision: revision
+          },
+          type: "RELEASE_REVISION_SUCCESS"
+        });
       });
     });
   });

--- a/static/js/publisher/release/api/releases.js
+++ b/static/js/publisher/release/api/releases.js
@@ -77,7 +77,7 @@ export function fetchRelease(
 }
 
 export function fetchCloses(onComplete, csrfToken, snapName, channels) {
-  if (channels.length) {
+  if (channels && channels.length) {
     return fetchClose(csrfToken, snapName, channels).then(json => {
       onComplete(json, channels);
     });

--- a/static/js/publisher/release/components/progressiveBar.js
+++ b/static/js/publisher/release/components/progressiveBar.js
@@ -80,14 +80,23 @@ class InteractiveProgressiveBar extends React.Component {
     window.removeEventListener("mousemove", this.onMouseMoveHandler);
   }
 
-  componentDidUpdate(prevProps) {
+  componentDidUpdate(prevProps, prevState) {
+    const { disabled: prevDisabled } = prevProps;
+    const { scrubTarget } = prevState;
+    const { disabled: nextDisabled, targetPercentage } = this.props;
     // We really don't want to flood the browser with event listeners
-    if (prevProps.disabled && !this.props.disabled) {
+    if (prevDisabled && !nextDisabled) {
       window.addEventListener("mouseup", this.onMouseUpHandler);
       window.addEventListener("mousemove", this.onMouseMoveHandler);
-    } else if (!prevProps.disabled && this.props.disabled) {
+    } else if (!prevDisabled && nextDisabled) {
       window.removeEventListener("mouseup", this.onMouseUpHandler);
       window.removeEventListener("mousemove", this.onMouseMoveHandler);
+    }
+
+    if (scrubTarget !== targetPercentage) {
+      this.setState({
+        scrubTarget: targetPercentage
+      });
     }
   }
 

--- a/static/js/publisher/release/components/revisionsListRowProgressive.js
+++ b/static/js/publisher/release/components/revisionsListRowProgressive.js
@@ -15,21 +15,16 @@ import { InteractiveProgressiveBar } from "./progressiveBar";
 
 const RevisionsListRowProgressive = ({
   channel,
-  architecture,
   revision,
   setDraggable,
-  getProgressiveState,
   releaseRevision,
   updateProgressiveReleasePercentage,
   pauseProgressiveRelease,
-  resumeProgressiveRelease
+  resumeProgressiveRelease,
+  progressiveState,
+  previousRevision,
+  pendingProgressiveState
 }) => {
-  const [
-    progressiveState,
-    previousRevision,
-    pendingProgressiveState
-  ] = getProgressiveState(channel, architecture, revision.revision);
-
   let showProgressivePause = false;
   let showProgressiveResume = false;
 
@@ -117,7 +112,9 @@ const RevisionsListRowProgressive = ({
         <InteractiveProgressiveBar
           percentage={progressiveState.percentage}
           targetPercentage={
-            pendingProgressiveState ? pendingProgressiveState.percentage : null
+            pendingProgressiveState
+              ? pendingProgressiveState.percentage
+              : progressiveState.percentage
           }
           singleDirection={1}
           onChange={handleProgressiveChange}
@@ -156,17 +153,28 @@ RevisionsListRowProgressive.propTypes = {
 
   setDraggable: PropTypes.func.isRequired,
 
-  getProgressiveState: PropTypes.func.isRequired,
+  progressiveState: PropTypes.object,
+  previousRevision: PropTypes.object,
+  pendingProgressiveState: PropTypes.object,
   releaseRevision: PropTypes.func.isRequired,
   updateProgressiveReleasePercentage: PropTypes.func.isRequired,
   pauseProgressiveRelease: PropTypes.func.isRequired,
   resumeProgressiveRelease: PropTypes.func.isRequired
 };
 
-const mapStateToProps = state => ({
-  getProgressiveState: (channel, arch, revision) =>
-    getProgressiveState(state, channel, arch, revision)
-});
+const mapStateToProps = (state, { channel, architecture, revision }) => {
+  const [
+    progressiveState,
+    previousRevision,
+    pendingProgressiveState
+  ] = getProgressiveState(state, channel, architecture, revision.revision);
+
+  return {
+    progressiveState,
+    previousRevision,
+    pendingProgressiveState
+  };
+};
 
 const mapDispatchToProps = dispatch => {
   return {

--- a/static/js/publisher/release/components/revisionsListRowProgressive.js
+++ b/static/js/publisher/release/components/revisionsListRowProgressive.js
@@ -47,7 +47,9 @@ const RevisionsListRowProgressive = ({
   }
 
   const handlePauseProgressiveRelease = () => {
-    releaseRevision(revision, channel, progressiveState);
+    if (!pendingProgressiveState) {
+      releaseRevision(revision, channel, progressiveState);
+    }
     pauseProgressiveRelease(progressiveState.key);
   };
 

--- a/static/js/publisher/release/reducers/pendingReleases.js
+++ b/static/js/publisher/release/reducers/pendingReleases.js
@@ -114,11 +114,7 @@ function updateProgressiveRelease(state, progressive) {
   Object.values(nextState).forEach(pendingRelease => {
     Object.values(pendingRelease).forEach(channel => {
       if (channel.progressive && channel.progressive.key === progressive.key) {
-        if (progressive.percentage < 100) {
-          channel.progressive.percentage = progressive.percentage;
-        } else {
-          delete channel.progressive; // At 100% we just want to do a regular release
-        }
+        channel.progressive.percentage = progressive.percentage;
       }
     });
   });

--- a/static/js/publisher/release/reducers/pendingReleases.js
+++ b/static/js/publisher/release/reducers/pendingReleases.js
@@ -35,11 +35,13 @@ function releaseRevision(
   state = { ...state };
 
   // cancel any other pending release for the same channel in same architectures
+  // if it's a different revision
   revision.architectures.forEach(arch => {
     Object.keys(state).forEach(revId => {
       const pendingRelease = state[revId];
 
       if (
+        parseInt(revId) !== revision.revision &&
         pendingRelease[channel] &&
         pendingRelease[channel].revision.architectures.includes(arch)
       ) {
@@ -56,16 +58,18 @@ function releaseRevision(
     state[revision.revision] = {};
   }
 
-  state[revision.revision][channel] = {
-    revision,
-    channel
-  };
+  if (!state[revision.revision][channel]) {
+    state[revision.revision][channel] = {
+      revision,
+      channel
+    };
+  }
 
   if (previousRevisions) {
     state[revision.revision][channel].previousRevisions = previousRevisions;
   }
 
-  if (progressive) {
+  if (progressive && !state[revision.revision][channel].progressive) {
     state[revision.revision][channel].progressive = progressive;
   }
 

--- a/static/js/publisher/release/selectors/index.js
+++ b/static/js/publisher/release/selectors/index.js
@@ -372,10 +372,7 @@ export function getSeparatePendingReleases(state) {
           });
         }
 
-        if (
-          !newState.paused &&
-          newState.percentage !== previousState.percentage
-        ) {
+        if (newState.percentage !== previousState.percentage) {
           changes.push({
             key: "percentage",
             value: newState.percentage


### PR DESCRIPTION
Fixes https://github.com/canonical-web-and-design/snapcraft.io/issues/2343
Fixes https://github.com/canonical-web-and-design/snapcraft.io/issues/2362

## QA
- Pull the branch
- `./run`
- Visit http://0.0.0.0:8004/snap_name/releases
- Progressively release a revision
- Once released, slide the progressive percentage bar
- Revert the changes
- The progressive release bar should reset to its previous value