### PR TITLE
Fix feed issue with articles without category

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # App dependencies
 bleach==3.1.0
 canonicalwebteam.discourse-docs==0.6.4
-canonicalwebteam.blog==4.0.0
+canonicalwebteam.blog==4.0.2
 canonicalwebteam.search==0.1.0
 canonicalwebteam.yaml-responses==1.1.1
 canonicalwebteam.image-template==1.0.0


### PR DESCRIPTION
## Done

Update canonicalwebteam.blog to 4.0.2 to fix an issue with the blog feeds
https://github.com/canonical-web-and-design/canonicalwebteam.blog/pull/128

## QA

- Check out this feature branch
- Run the site using the command `./run clean && ./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8004/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Ensure that http://0.0.0.0:8004/blog/feed/ works


## Issue / Card
https://github.com/canonical-web-and-design/canonicalwebteam.blog/issues/127
