### PR TITLE
Change `canBeProgressive` into `previousRevisions`

### DIFF
--- a/static/js/publisher/release/reducers/pendingReleases.js
+++ b/static/js/publisher/release/reducers/pendingReleases.js
@@ -30,7 +30,7 @@ function releaseRevision(
   revision,
   channel,
   progressive,
-  canBeProgressive
+  previousRevisions
 ) {
   state = { ...state };
 
@@ -61,8 +61,8 @@ function releaseRevision(
     channel
   };
 
-  if (canBeProgressive) {
-    state[revision.revision][channel].canBeProgressive = true;
+  if (previousRevisions) {
+    state[revision.revision][channel].previousRevisions = previousRevisions;
   }
 
   if (progressive) {
@@ -91,8 +91,12 @@ function setProgressiveRelease(state, progressive) {
 
   Object.values(nextState).forEach(pendingRelease => {
     Object.values(pendingRelease).forEach(channel => {
+      const hasPreviousRevisions =
+        channel.previousRevisions &&
+        Object.keys(channel.previousRevisions).length > 0;
+
       if (
-        channel.canBeProgressive &&
+        hasPreviousRevisions &&
         !channel.progressive &&
         progressive.percentage < 100
       ) {
@@ -159,7 +163,9 @@ function resumeProgressiveRelease(state, key) {
 //       revision: { revision: <revisionId>, version, ... },
 //       channel: <channel>,
 //       progressive: { key, percentage, paused },
-//       canBeProgressive: bool
+//       previousRevisions: {
+//         <arch>: { revision: <revisionId>, version, ... }
+//       }
 //     }
 //   }
 // }
@@ -173,7 +179,7 @@ export default function pendingReleases(state = {}, action) {
         action.payload.revision,
         action.payload.channel,
         action.payload.progressive,
-        action.payload.canBeProgressive
+        action.payload.previousRevisions
       );
     case UNDO_RELEASE:
       return removePendingRelease(

--- a/static/js/publisher/release/reducers/pendingReleases.test.js
+++ b/static/js/publisher/release/reducers/pendingReleases.test.js
@@ -155,21 +155,23 @@ describe("pendingReleases", () => {
       });
     });
 
-    describe("when canBeProgressive is passed", () => {
-      let releaseRevisionCanBeProgressiveAction = {
+    describe("when previousRevisions are passed", () => {
+      let releaseRevisionPreviousRevisionsAction = {
         type: RELEASE_REVISION,
         payload: {
           revision: { revision: 1, architectures: ["abc42", "test64"] },
           channel: "test/edge",
-          canBeProgressive: true
+          previousRevisions: {
+            abc42: { revision: 0, architectures: ["abc42"] }
+          }
         }
       };
 
-      it("should set a release to allow progressive releaes", () => {
+      it("should save previous revisions in release object", () => {
         const state = {
           "1": {
             "test/edge": {
-              revision: releaseRevisionCanBeProgressiveAction.payload.revision,
+              revision: releaseRevisionPreviousRevisionsAction.payload.revision,
               channel: "test/edge"
             }
           }
@@ -177,15 +179,17 @@ describe("pendingReleases", () => {
 
         const result = pendingReleases(
           state,
-          releaseRevisionCanBeProgressiveAction
+          releaseRevisionPreviousRevisionsAction
         );
 
         expect(result).toEqual({
           "1": {
             "test/edge": {
-              revision: releaseRevisionCanBeProgressiveAction.payload.revision,
+              revision: releaseRevisionPreviousRevisionsAction.payload.revision,
               channel: "test/edge",
-              canBeProgressive: true
+              previousRevisions: {
+                abc42: { revision: 0, architectures: ["abc42"] }
+              }
             }
           }
         });
@@ -625,7 +629,9 @@ describe("pendingReleases", () => {
           "test/edge": {
             revision: { revision: 1, architectures: ["abc42", "test64"] },
             channel: "test/edge",
-            canBeProgressive: true
+            previousRevisions: {
+              abc42: { revision: 0, architectures: ["abc42"] }
+            }
           }
         }
       };
@@ -738,7 +744,9 @@ describe("pendingReleases", () => {
               percentage: 20,
               paused: true
             },
-            canBeProgressive: true
+            previousRevisions: {
+              abc42: { revision: 0, architectures: ["abc42"] }
+            }
           }
         }
       };


### PR DESCRIPTION
Fixes #2346 

### QA
- make sure everything works as before (around releasing progressive releases and not allowing progressive releases when there is no revision already released)