### PR TITLE
Fetch snap builds from launchpad

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ Flask==1.0.2
 Flask-OpenID-Stateless==1.2.6
 Flask-WTF==0.14.2
 humanize==0.5.1
+launchpadlib==1.10.7
 Markdown==3.0.1
 mistune==0.8.4
 pybadges==1.1.0

--- a/templates/publisher/_header.html
+++ b/templates/publisher/_header.html
@@ -30,6 +30,19 @@
         </li>
         <li class="p-tabs__item" role="presentation">
           <a
+            href="/{{ snap_name }}/builds"
+            class="p-tabs__link"
+            tabindex="0"
+            role="tab"
+            {% if selected_tab == 'builds' %}
+              aria-selected="true"
+            {% endif %}
+          >
+          Builds
+          </a>
+        </li>
+        <li class="p-tabs__item" role="presentation">
+          <a
             href="/{{ snap_name }}/releases"
             class="p-tabs__link"
             tabindex="0"

--- a/templates/publisher/build-list.html
+++ b/templates/publisher/build-list.html
@@ -1,0 +1,12 @@
+{% extends "publisher/_publisher_layout.html" %}
+
+{% block meta_title %}
+  Build details for {% if display_title %}{{ display_title }}{% else %}{{ snap_title }}{% endif %}
+{% endblock %}
+
+{% block content %}
+  <div id="main-content">
+    {% set selected_tab='builds' %}
+    {% include "publisher/_header.html" %}
+  </div>
+{% endblock %}

--- a/webapp/api/launchpad.py
+++ b/webapp/api/launchpad.py
@@ -1,0 +1,6 @@
+from launchpadlib.launchpad import Launchpad
+
+
+launchpad = Launchpad.login_anonymously(
+    "storefront", "production", version="devel"
+)

--- a/webapp/publisher/snaps/views.py
+++ b/webapp/publisher/snaps/views.py
@@ -20,6 +20,7 @@ from webapp.api.exceptions import (
     MacaroonRefreshRequired,
     MissingUsername,
 )
+from webapp.api.launchpad import launchpad
 from webapp.api.store import StoreApi
 from webapp.store.logic import (
     get_categories,
@@ -1308,3 +1309,62 @@ def post_preview(snap_name):
     context["normalized_os"] = preview_data.get_normalised_oses()
 
     return flask.render_template("store/snap-details.html", **context)
+
+
+@publisher_snaps.route("/<snap_name>/builds", methods=["GET"])
+@login_required
+def get_snap_builds(snap_name):
+    try:
+        details = api.get_snap_info(snap_name, flask.session)
+    except ApiResponseErrorList as api_response_error_list:
+        if api_response_error_list.status_code == 404:
+            return flask.abort(404, "No snap named {}".format(snap_name))
+        else:
+            return _handle_error_list(api_response_error_list.errors)
+    except ApiError as api_error:
+        return _handle_errors(api_error)
+
+    context = {
+        "snap_id": details["snap_id"],
+        "snap_name": details["snap_name"],
+        "snap_title": details["title"],
+    }
+
+    lp_snaps = launchpad.snaps.findByStoreName(
+        owner="https://api.launchpad.net/devel/~build.snapcraft.io",
+        store_name=details["snap_name"],
+    )
+
+    def build_link(snap, build):
+        build_id = build.self_link.split("/")[-1]
+        bsi_user = snap.git_repository_url.split("https://github.com/")[-1]
+        return f"https://build.snapcraft.io/user/{bsi_user}/{build_id}"
+
+    builds = []
+    if len(lp_snaps) >= 1:
+        for build in lp_snaps[0].builds:
+            builds.append(
+                {
+                    "arch_tag": build.arch_tag,
+                    "datebuilt": build.datebuilt,
+                    "duration": build.duration,
+                    "link": build_link(lp_snaps[0], build),
+                    "logs": build.build_log_url,
+                    "revision_id": build.revision_id,
+                    "status": build.buildstate,
+                    "store": {
+                        "upload_status": build.store_upload_status,
+                        "error_messages": build.store_upload_error_messages,
+                    },
+                    "title": build.title,
+                }
+            )
+
+    context = {
+        "snap_id": details["snap_id"],
+        "snap_builds": builds,
+        "snap_name": details["snap_name"],
+        "snap_title": details["title"],
+    }
+
+    return flask.render_template("publisher/build-list.html", **context)


### PR DESCRIPTION
## Done

Fetches snap builds from launchpad, based on the snap's store name.
Passes the builds to the template under `snap_builds` and the build repository under `snap_builds_git`.

## QA
TBD

Fixes #2356