### PR TITLE
Let the release date breath

### DIFF
--- a/static/js/publisher/release/components/revisionsList.js
+++ b/static/js/publisher/release/components/revisionsList.js
@@ -320,7 +320,7 @@ class RevisionsList extends Component {
               <th width="30px" />
               <th
                 className={!isReleaseHistory ? "col-checkbox-spacer" : ""}
-                width="150px"
+                width="140px"
                 scope="col"
               >
                 Revision
@@ -331,7 +331,7 @@ class RevisionsList extends Component {
                 <th scope="col">Progressive release status</th>
               )}
               {showChannels && <th scope="col">Channels</th>}
-              <th scope="col" width="130px" className="u-align--right">
+              <th scope="col" width="140px" className="u-align--right">
                 {isReleaseHistory ? "Release date" : "Submission date"}
               </th>
             </tr>


### PR DESCRIPTION
Fixes https://github.com/canonical-web-and-design/snapcraft.io/issues/2363

## QA
- Pull the branch
- `./run`
- Visit http://0.0.0.0:8004/snap_name/releases
- Do some releases, click around, make sure there is enough space for the "Release date" column of the history table.