### PR TITLE
Show pending progressive updates

### DIFF
--- a/static/js/publisher/release/components/releasesTable/cellViews.js
+++ b/static/js/publisher/release/components/releasesTable/cellViews.js
@@ -47,13 +47,66 @@ EmptyInfo.propTypes = {
   trackingChannel: PropTypes.string
 };
 
+const ProgressiveState = ({
+  revision,
+  previousRevision,
+  progressiveState,
+  pendingProgressiveState
+}) => {
+  let previousRevisionInfo = "";
+  let revisionInfo = "";
+  if (progressiveState) {
+    previousRevisionInfo = ` (${100 - progressiveState.percentage}%`;
+    revisionInfo = ` (${progressiveState.percentage}%`;
+    if (pendingProgressiveState) {
+      previousRevisionInfo = `${previousRevisionInfo} → ${100 -
+        pendingProgressiveState.percentage}%`;
+      revisionInfo = `${revisionInfo} → ${pendingProgressiveState.percentage}%`;
+    }
+    previousRevisionInfo = `${previousRevisionInfo} of devices)`;
+    revisionInfo = `${revisionInfo} of devices)`;
+  }
+
+  const previousRevisionState = (
+    <Fragment>
+      Revision: <b>{previousRevision}</b>
+      {previousRevisionInfo}
+    </Fragment>
+  );
+
+  const revisionState = (
+    <Fragment>
+      Revision: <b>{revision}</b>
+      {revisionInfo}
+    </Fragment>
+  );
+
+  return (
+    <Fragment>
+      <b>Progressive release of revision {revision} in progress</b>
+      <br />
+      {previousRevisionState}
+      <br />
+      {revisionState}
+    </Fragment>
+  );
+};
+
+ProgressiveState.propTypes = {
+  revision: PropTypes.number,
+  previousRevision: PropTypes.number,
+  progressiveState: PropTypes.object,
+  pendingProgressiveState: PropTypes.object
+};
+
 // contents of a cell with a revision
 export const RevisionInfo = ({
   revision,
   isPending,
   showVersion,
   progressiveState,
-  previousRevision
+  previousRevision,
+  pendingProgressiveState
 }) => {
   let buildIcon = null;
 
@@ -106,19 +159,12 @@ export const RevisionInfo = ({
           )}
           <br />
           {previousRevision && (
-            <Fragment>
-              <b>
-                Progressive release of revision {revision.revision} in progress
-              </b>
-              <br />
-              Revision: <b>{previousRevision}</b>
-              {progressiveState
-                ? ` (${100 - progressiveState.percentage}% of devices)`
-                : ""}
-              <br />
-              Revision: <b>{revision.revision}</b> (
-              {progressiveState.percentage}% of devices)
-            </Fragment>
+            <ProgressiveState
+              revision={revision.revision}
+              previousRevision={previousRevision}
+              progressiveState={progressiveState}
+              pendingProgressiveState={pendingProgressiveState}
+            />
           )}
         </div>
 
@@ -139,7 +185,8 @@ RevisionInfo.propTypes = {
   isPending: PropTypes.bool,
   showVersion: PropTypes.bool,
   progressiveState: PropTypes.object,
-  previousRevision: PropTypes.number
+  previousRevision: PropTypes.number,
+  pendingProgressiveState: PropTypes.object
 };
 
 // generic draggable view of releases table cell

--- a/static/js/publisher/release/components/releasesTable/cellViews.js
+++ b/static/js/publisher/release/components/releasesTable/cellViews.js
@@ -47,7 +47,7 @@ EmptyInfo.propTypes = {
   trackingChannel: PropTypes.string
 };
 
-const ProgressiveState = ({
+const ProgressiveTooltip = ({
   revision,
   previousRevision,
   progressiveState,
@@ -92,7 +92,7 @@ const ProgressiveState = ({
   );
 };
 
-ProgressiveState.propTypes = {
+ProgressiveTooltip.propTypes = {
   revision: PropTypes.number,
   previousRevision: PropTypes.number,
   progressiveState: PropTypes.object,
@@ -159,7 +159,7 @@ export const RevisionInfo = ({
           )}
           <br />
           {previousRevision && (
-            <ProgressiveState
+            <ProgressiveTooltip
               revision={revision.revision}
               previousRevision={previousRevision}
               progressiveState={progressiveState}

--- a/static/js/publisher/release/components/releasesTable/releaseCell.js
+++ b/static/js/publisher/release/components/releasesTable/releaseCell.js
@@ -135,6 +135,7 @@ const ReleasesTableReleaseCell = props => {
         showVersion={showVersion}
         progressiveState={progressiveState}
         previousRevision={previousRevision ? previousRevision.revision : null}
+        pendingProgressiveState={pendingProgressiveState}
       />
     );
   } else if (isUnassigned) {

--- a/static/js/publisher/release/components/releasesTable/releaseCell.js
+++ b/static/js/publisher/release/components/releasesTable/releaseCell.js
@@ -15,9 +15,9 @@ import { undoRelease } from "../../actions/pendingReleases";
 import {
   getPendingChannelMap,
   getFilteredAvailableRevisionsForArch,
-  hasPendingRelease,
   getRevisionsFromBuild,
-  getProgressiveState
+  getProgressiveState,
+  getPendingRelease
 } from "../../selectors";
 
 import {
@@ -42,7 +42,7 @@ const ReleasesTableReleaseCell = props => {
     isOverParent,
     showVersion,
     getAvailableCount,
-    hasPendingRelease,
+    getPendingRelease,
     undoRelease,
     toggleHistoryPanel,
     getProgressiveState
@@ -57,12 +57,14 @@ const ReleasesTableReleaseCell = props => {
     pendingChannelMap[channel] && pendingChannelMap[channel][arch];
 
   // check if there is a pending release in this cell
-  const isPendingRelease = hasPendingRelease(channel, arch);
+  const pendingRelease = getPendingRelease(channel, arch);
+
+  console.log(pendingRelease);
 
   let progressiveState;
   let previousRevision;
 
-  if (!isPendingRelease && currentRevision) {
+  if (!pendingRelease && currentRevision) {
     [progressiveState, previousRevision] = getProgressiveState(
       channel,
       arch,
@@ -71,7 +73,7 @@ const ReleasesTableReleaseCell = props => {
   }
 
   const isChannelPendingClose = pendingCloses.includes(channel);
-  const isPending = isPendingRelease || isChannelPendingClose;
+  const isPending = pendingRelease || isChannelPendingClose;
   const isUnassigned = risk === AVAILABLE;
   const isActive =
     filters &&
@@ -107,7 +109,7 @@ const ReleasesTableReleaseCell = props => {
     isOverParent ? "is-over" : ""
   ].join(" ");
 
-  const actionsNode = isPendingRelease ? (
+  const actionsNode = pendingRelease ? (
     <div className="p-release-buttons">
       <button
         className="p-action-button p-tooltip p-tooltip--btm-center"
@@ -129,7 +131,7 @@ const ReleasesTableReleaseCell = props => {
     cellInfoNode = (
       <RevisionInfo
         revision={currentRevision}
-        isPending={isPendingRelease}
+        isPending={pendingRelease ? true : false}
         showVersion={showVersion}
         progressiveState={progressiveState}
         previousRevision={previousRevision ? previousRevision.revision : null}
@@ -182,7 +184,7 @@ ReleasesTableReleaseCell.propTypes = {
   pendingChannelMap: PropTypes.object,
   // compute state
   getAvailableCount: PropTypes.func,
-  hasPendingRelease: PropTypes.func,
+  getPendingRelease: PropTypes.func,
   getRevisionsFromBuild: PropTypes.func,
   getProgressiveState: PropTypes.func,
   // actions
@@ -207,11 +209,11 @@ const mapStateToProps = state => {
     pendingChannelMap: getPendingChannelMap(state),
     getAvailableCount: arch =>
       getFilteredAvailableRevisionsForArch(state, arch).length,
-    hasPendingRelease: (channel, arch) =>
-      hasPendingRelease(state, channel, arch),
     getRevisionsFromBuild: buildId => getRevisionsFromBuild(state, buildId),
     getProgressiveState: (channel, arch, revision) =>
-      getProgressiveState(state, channel, arch, revision)
+      getProgressiveState(state, channel, arch, revision),
+    getPendingRelease: (arch, channel) =>
+      getPendingRelease(state, arch, channel)
   };
 };
 

--- a/static/sass/_snapcraft_release.scss
+++ b/static/sass/_snapcraft_release.scss
@@ -362,6 +362,11 @@
     background: scale-color($color-link, $lightness: -20%);
   }
 
+  .p-release__progressive-pending-percentage + .p-release__progressive-percentage {
+    border-radius: 0;
+    border-right: 1px solid $color-x-light;
+  }
+
   .p-releases-table__cell.is-active {
     .p-release__progressive-percentage,
     .p-release__progressive-pending-percentage {

--- a/static/sass/_snapcraft_release.scss
+++ b/static/sass/_snapcraft_release.scss
@@ -335,9 +335,9 @@
     font-size: .8rem;
   }
 
-  .p-release__progressive-percentage {
+  .p-release__progressive-percentage,
+  .p-release__progressive-pending-percentage {
     @include vf-animation (#{transform}, fast, in);
-    background: $color-link;
     border-radius: 0 4px 4px 0;
     bottom: 0;
     height: 3px;
@@ -347,8 +347,26 @@
     transform-origin: left;
   }
 
-  .p-releases-table__cell.is-active .p-release__progressive-percentage {
-    transform: scaleX(0);
+  .is-highlighted {
+    .p-release__progressive-percentage,
+    .p-release__progressive-pending-percentage {
+      height: 5px;
+    }
+  }
+
+  .p-release__progressive-percentage {
+    background: $color-link;
+  }
+
+  .p-release__progressive-pending-percentage {
+    background: scale-color($color-link, $lightness: -20%);
+  }
+
+  .p-releases-table__cell.is-active {
+    .p-release__progressive-percentage,
+    .p-release__progressive-pending-percentage {
+      transform: scaleX(0);
+    }
   }
 
   // REVISIONS LIST


### PR DESCRIPTION
Fixes https://github.com/canonical-web-and-design/snapcraft.io/issues/2350

## QA
- Pull the branch
- `./run`
- Visit http://0.0.0.0:8004/snap_name/releases
- Progressively release a revision (if one does not already exist)
- Save
- Update the progressive release:
  - any action should cause the cell to be highlighted
  - updating the percentage should show the target percentage when history is closed