### PR TITLE
Add build status colors and build date

### DIFF
--- a/static/js/publisher/builds/index.js
+++ b/static/js/publisher/builds/index.js
@@ -1,7 +1,116 @@
 import React from "react";
 import ReactDOM from "react-dom";
 
+import distanceInWords from "date-fns/distance_in_words_strict";
+
 import MainTable from "@canonical/react-components/dist/components/MainTable";
+
+const NEVER_BUILT = "never_built";
+const BUILDING_SOON = "building_soon";
+const WONT_RELEASE = "wont_release";
+const RELEASED = "released";
+const RELEASE_FAILED = "release_failed";
+const RELEASING_SOON = "releasing_soon";
+const IN_PROGRESS = "in_progress";
+const FAILED_TO_BUILD = "failed_to_build";
+const UNKNOWN = "unknown";
+
+// based on BSI:
+// https://github.com/canonical-web-and-design/build.snapcraft.io/blob/master/src/common/helpers/snap-builds.js
+export const BuildStatusColours = {
+  BLUE: "blue",
+  GREEN: "green",
+  YELLOW: "yellow",
+  RED: "red",
+  GREY: "grey"
+};
+
+export const BuildStatusIcons = {
+  TICK: "tick",
+  TICK_OUTLINED: "outlined_tick",
+  TICK_SOLID: "solid_tick",
+  ELLIPSES: "ellipses",
+  SPINNER: "spinner",
+  CROSS: "cross"
+};
+
+export const UserFacingStatus = {
+  // Used only when there is no build returned from LP.
+  // When build is returned from LP (scheduled) it's 'Building soon' for BSI.
+  [NEVER_BUILT]: createStatus(
+    "Never built",
+    BuildStatusColours.GREY,
+    false,
+    8,
+    "never_built"
+  ),
+  [BUILDING_SOON]: createStatus(
+    "Building soon",
+    BuildStatusColours.GREY,
+    BuildStatusIcons.ELLIPSES,
+    7,
+    "building_soon"
+  ),
+  [WONT_RELEASE]: createStatus(
+    "Built, won’t be released",
+    BuildStatusColours.GREEN,
+    BuildStatusIcons.TICK_OUTLINED,
+    6,
+    "wont_release"
+  ),
+  [RELEASED]: createStatus(
+    "Built and released",
+    BuildStatusColours.GREEN,
+    BuildStatusIcons.TICK_SOLID,
+    5,
+    "released"
+  ),
+  [RELEASE_FAILED]: createStatus(
+    "Built, failed to release",
+    BuildStatusColours.RED,
+    BuildStatusIcons.TICK,
+    4,
+    "release_failed"
+  ),
+  [RELEASING_SOON]: createStatus(
+    "Built, releasing soon",
+    BuildStatusColours.GREY,
+    BuildStatusIcons.TICK,
+    3,
+    "releasing_soon"
+  ),
+  [IN_PROGRESS]: createStatus(
+    "In progress",
+    BuildStatusColours.BLUE,
+    BuildStatusIcons.SPINNER,
+    2,
+    "in_progress"
+  ),
+  [FAILED_TO_BUILD]: createStatus(
+    "Failed to build",
+    BuildStatusColours.RED,
+    BuildStatusIcons.CROSS,
+    1,
+    "failed_to_build"
+  ),
+  [UNKNOWN]: createStatus(
+    "Unknown",
+    BuildStatusColours.GREY,
+    false,
+    8,
+    "never_built"
+  )
+};
+
+function createStatus(statusMessage, colour, icon, priority, badge) {
+  return {
+    statusMessage,
+    colour,
+    icon,
+    priority,
+    badge
+  };
+}
 
 export function initBuilds(id, snapName, builds) {
   const rows = builds.map(build => {
@@ -14,10 +123,27 @@ export function initBuilds(id, snapName, builds) {
           content: build.arch_tag
         },
         {
-          content: build.duration
+          content: build.duration,
+          className: "u-hide--small"
         },
         {
-          content: <a href={build.logs}>{build.status}</a>
+          content: (
+            <span
+              className={`u-build-status--${
+                UserFacingStatus[build.status].colour
+              }`}
+            >
+              <a href={build.logs}>
+                {UserFacingStatus[build.status].statusMessage}
+              </a>
+            </span>
+          )
+        },
+        {
+          content: distanceInWords(new Date(), build.datebuilt, {
+            addSuffix: true
+          }),
+          className: "u-align--right"
         }
       ]
     };
@@ -33,10 +159,15 @@ export function initBuilds(id, snapName, builds) {
           content: "Architecture"
         },
         {
-          content: "Duration"
+          content: "Duration",
+          className: "u-hide--small"
         },
         {
           content: "Result"
+        },
+        {
+          content: "Build date",
+          className: "u-align--right"
         }
       ]}
       rows={rows}

--- a/static/sass/_snapcraft_builds.scss
+++ b/static/sass/_snapcraft_builds.scss
@@ -1,0 +1,26 @@
+@mixin snapcraft-builds {
+  .u-build-status--blue,
+  .u-build-status--blue a {
+    color: $color-information;
+  }
+
+  .u-build-status--green,
+  .u-build-status--green a {
+    color: $color-positive;
+  }
+
+  .u-build-status--yellow,
+  .u-build-status--yellow a {
+    color: $color-caution;
+  }
+
+  .u-build-status--red,
+  .u-build-status--red a {
+    color: $color-negative;
+  }
+
+  .u-build-status--grey,
+  .u-build-status--grey a {
+    color: $color-mid-dark;
+  }
+}

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -224,3 +224,6 @@ $color-social-icon-foreground: $color-light;
 
 @import 'snapcraft_tour';
 @include snapcraft-tour;
+
+@import 'snapcraft_builds';
+@include snapcraft-builds;


### PR DESCRIPTION
Fixes #2347

### QA
- ./run or demo
- go to builds page of any snap with some builds
- status message should show with relevant color
- there should be a build date in the table

<img width="1161" alt="Screenshot 2019-11-21 at 16 18 40" src="https://user-images.githubusercontent.com/83575/69351657-f8a07f00-0c7b-11ea-8861-2340d0f6771f.png">
