### PR TITLE
Hide discourse docs lightbox

### DIFF
--- a/static/sass/_snapcraft_p-docs.scss
+++ b/static/sass/_snapcraft_p-docs.scss
@@ -11,6 +11,12 @@
       max-width: 100%;
     }
 
+    .lightbox-wrapper {
+      .meta {
+        display: none;
+      }
+    }
+
     // Discourse adds "emoji" <img>s, which are huge
     // They need to be constrained
     .emoji {


### PR DESCRIPTION
Fixes https://github.com/canonical-web-and-design/snapcraft.io/issues/2384

## QA
- Pull the branch
- `./run`
- Visit http://0.0.0.0:8004/docs/remote-build
- Make sure the images look better than in the bug report