### PR TITLE
Don't resize banners - they should look good

### DIFF
--- a/templates/store/_category-partial.html
+++ b/templates/store/_category-partial.html
@@ -12,9 +12,9 @@
             image(
               url=snap.banner_url,
               alt=snap.title,
-              width="1104",
-              height="368",
-              hi_def=True,
+              width="1920",
+              height="640",
+              hi_def=False,
             ) | safe
           }}
         </a>


### PR DESCRIPTION
Fixes https://github.com/canonical-web-and-design/snapcraft.io/issues/2382

This will increase the page size slightly, but it's worth it for quality looking images, imo. We ask publishers to upload higher res images, then we compress them!

## QA
- Pull the branch
- `./run`
- Visit http://0.0.0.0:8004/store
- At 1x dpi ensure the 0ad banner under the "Games" heading is nice and sharp