### PR TITLE
1776 save/revert are not disabled for snap with categories

### DIFF
--- a/static/js/libs/arrays.js
+++ b/static/js/libs/arrays.js
@@ -18,8 +18,8 @@ function arraysEqual(oldArray, newArray) {
     return false;
   }
 
-  const _oldArray = oldArray.splice(0);
-  const _newArray = newArray.splice(0);
+  const _oldArray = [...oldArray];
+  const _newArray = [...newArray];
 
   _oldArray.sort();
   _newArray.sort();

--- a/static/js/libs/arrays.test.js
+++ b/static/js/libs/arrays.test.js
@@ -10,7 +10,7 @@ describe("arraysEqual", () => {
   });
 
   it("should return arrays of strings as equal", () => {
-    expect(arraysEqual(["test"], ["test"])).toEqual(true);
+    expect(arraysEqual(["a", "b", "c"], ["a", "b", "c"])).toEqual(true);
   });
 
   it("should return arrays of numbers as equal", () => {
@@ -35,7 +35,7 @@ describe("arraysEqual", () => {
   });
 
   it("should fail if an array of strings differ", () => {
-    expect(arraysEqual(["a"], ["b"])).toEqual(false);
+    expect(arraysEqual(["a", "b", "c"], ["a", "d", "c"])).toEqual(false);
   });
 
   it("should fail if an array of numbers differ", () => {
@@ -44,6 +44,18 @@ describe("arraysEqual", () => {
 
   it("should fail if an array of objects differ", () => {
     expect(arraysEqual([{ test: "test" }], [{ test: "test2" }])).toEqual(false);
+  });
+
+  it("should fail if an array is modified", () => {
+    let arr1 = ["test1", 1];
+    let arr1Copy = [...arr1];
+    let arr2 = ["test2", 2];
+    let arr2Copy = [...arr2];
+    arraysEqual(arr1, arr2);
+    expect(
+      JSON.stringify(arr1) === JSON.stringify(arr1Copy) &&
+        JSON.stringify(arr2) === JSON.stringify(arr2Copy)
+    ).toEqual(true);
   });
 });
 

--- a/templates/publisher/listing.html
+++ b/templates/publisher/listing.html
@@ -127,7 +127,7 @@ Listing details for {% if display_title %}{{ display_title }}{% else %}{{ snap_t
             <select
               name="primary_category"
               {% if snap_categories.categories[0] %}
-              value="{{ snap_categories.categories[0].name }}"
+              value="{{ snap_categories.categories[0] }}"
               {% endif %}
               {% if snap_categories.locked %} disabled="disabled"{% endif %}
               >
@@ -135,7 +135,7 @@ Listing details for {% if display_title %}{{ display_title }}{% else %}{{ snap_t
               {% for category in categories %}
               <option
                 value="{{ category.slug }}"
-                {% if snap_categories.categories[0] and (snap_categories.categories[0].name == category.slug) %}
+                {% if snap_categories.categories[0] and (snap_categories.categories[0] == category.slug) %}
                 selected="selected"
                 {% endif %}
                 >{{ category.name }}</option>
@@ -171,7 +171,7 @@ Listing details for {% if display_title %}{{ display_title }}{% else %}{{ snap_t
               <select
                 name="secondary_category"
                 {% if snap_categories.categories[1] %}
-                value="{{ snap_categories.categories[1].name }}"
+                value="{{ snap_categories.categories[1] }}"
                 {% endif %}
                 {% if snap_categories.locked %} disabled="disabled"{% endif %}
                 >
@@ -179,10 +179,10 @@ Listing details for {% if display_title %}{{ display_title }}{% else %}{{ snap_t
                 {% for category in categories %}
                 <option
                   value="{{ category.slug }}"
-                  {% if snap_categories.categories[1] and (snap_categories.categories[1].name == category.slug) %}
+                  {% if snap_categories.categories[1] and (snap_categories.categories[1] == category.slug) %}
                   selected="selected"
                   {% endif %}
-                  {% if snap_categories.categories[0] and category.slug == snap_categories.categories[0].name %}
+                  {% if snap_categories.categories[0] and category.slug == snap_categories.categories[0] %}
                   disabled="disabled"
                   {% endif %}
                   >{{ category.name }}</option>

--- a/webapp/publisher/snaps/views.py
+++ b/webapp/publisher/snaps/views.py
@@ -342,6 +342,10 @@ def get_listing_snap(snap_name):
 
     snap_categories = logic.filter_categories(snap_categories)
 
+    snap_categories["categories"] = [
+        category["name"] for category in snap_categories["categories"]
+    ]
+
     filename = f"publisher/content/listing_tour.yaml"
     tour_steps = helpers.get_yaml(filename, typ="rt")
 


### PR DESCRIPTION
Fixes #1776 

## QA
- Pull the branch
- `./run`
- Visit http://0.0.0.0:8004/snap_name/listing (the snap should have at least one category set)
- Change anything on listing page (add something to title)
- Save/Revert button should get enabled
- Without saving anything remove the change done before (change the title back)
- Save/Revert button should get disabled (there are no changes to save)