### PR TITLE
Add spam validation for blog whitepapers

### DIFF
--- a/static/js/public/formValidation.js
+++ b/static/js/public/formValidation.js
@@ -1,0 +1,27 @@
+function formValidation() {
+  const form = document.querySelector(".marketo-form");
+  // If the form doesn't exist silently pass over this functionality.
+  if (!form) {
+    return;
+  }
+
+  const startTime = Date.now();
+  let delta = null;
+
+  const spamCheck = document.createElement("input");
+  spamCheck.id = "grecaptcharesponse";
+  spamCheck.type = "hidden";
+
+  const timer = setInterval(function() {
+    delta = Date.now() - startTime; // milliseconds elapsed since start
+    // if the form is submitted after more than 3 seconds, it means it was not a bot
+    if (delta / 1000 > 3) {
+      spamCheck.value = "noBot";
+      clearInterval(timer);
+    }
+  }, 100); // update about every 100 miliseconds
+
+  form.appendChild(spamCheck);
+}
+
+export { formValidation };

--- a/static/js/public/public.js
+++ b/static/js/public/public.js
@@ -12,6 +12,7 @@ import { initFSFLanguageSelect } from "./fsf-language-select";
 import firstSnapFlow from "./first-snap-flow";
 import nps from "./nps";
 import { newsletter } from "./newsletter";
+import { formValidation } from "./formValidation";
 import initExpandableSnapDetails from "./expandable-details";
 import triggerEventWhenVisible from "./ga-scroll-event";
 import { initLinkScroll } from "./scroll-to";
@@ -35,5 +36,6 @@ export {
   initLinkScroll,
   videos,
   nps,
-  newsletter
+  newsletter,
+  formValidation
 };

--- a/templates/blog/article.html
+++ b/templates/blog/article.html
@@ -119,6 +119,7 @@
         {% endif %}
 
         snapcraft.public.newsletter();
+        snapcraft.public.formValidation();
       });
     });
   </script>


### PR DESCRIPTION
## Done

Add bot verification to articles on /blog

## Issue / Card

Fixes #2336 

## QA

- Pull the branch
- Run the site using the command `./run`
- View the site locally in your web browser at: http://0.0.0.0:8004/blog/management-of-snaps-in-a-controlled-enterprise-environment
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Inspect the form and find the `<input id="grecaptcharesponse" type="hidden" value="noBot">` and notice there is no `value` filed at the begining and it is added after some time (3 seconds)
