### PR TITLE
Enable register snap name button initially

### DIFF
--- a/static/js/public/first-snap-flow.js
+++ b/static/js/public/first-snap-flow.js
@@ -225,14 +225,13 @@ function initChooseName(formEl, language) {
 }
 
 function initRegisterName(formEl, notificationEl, successEl) {
-  const initialNotificationClassName = notificationEl.className;
-  const initialNotificationHtml = notificationEl.querySelector(
-    ".p-notification__response"
-  ).innerHTML;
-
   const snapNameInput = formEl.querySelector("[name=snap-name]");
 
   snapNameInput.addEventListener("keyup", () => {
+    if (notificationEl.classList.contains("u-hide")) {
+      notificationEl.classList.remove("u-hide");
+    }
+
     const isValid = validateSnapName(snapNameInput.value);
 
     if (!isValid) {
@@ -242,12 +241,6 @@ function initRegisterName(formEl, notificationEl, successEl) {
       snapNameInput.parentNode.classList.remove("is-error");
       formEl.querySelector("button").disabled = false;
     }
-
-    updateNotification(
-      notificationEl,
-      initialNotificationClassName,
-      initialNotificationHtml
-    );
   });
 
   function showSuccess(message) {

--- a/templates/first-snap/push.html
+++ b/templates/first-snap/push.html
@@ -67,13 +67,13 @@
                         Name should only have lowercase letters, numbers, and hyphens, must have at least one letter, and cannot start or end with a hyphen.
                       </p>
                     </div>
-                    <div id="register-name-notification" class="p-notification--caution">
+                    <div id="register-name-notification" class="p-notification--caution u-hide">
                       <p class="p-notification__response">
                         <span class="p-notification__status"></span>
                         Make sure the name matches what has been used previously (i.e <code>{{ snap_name }}</code>)
                       </p>
                     </div>
-                    <button class="p-button--positive" {% if not has_user_chosen_name %}disabled{% endif %}>Register snap name</button>
+                    <button class="p-button--positive">Register snap name</button>
                   </form>
                 </div>
               </div>


### PR DESCRIPTION
## Done

- Make `Register snap name` button enabled when loading the page

## Issue / Card

Fixes #2399 

## QA

- Pull the branch
- Run the site using the command `./run`
- View the site locally in your web browser at: http://0.0.0.0:8004/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Create a new snap
- When you get to the `Publish to store` step, note the `Register snap name` button is enabled, and if you edit snap name a warning message appears
