### PR TITLE
Add noindex to unlisted snaps pages

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ canonicalwebteam.blog==4.0.2
 canonicalwebteam.search==0.1.0
 canonicalwebteam.yaml-responses==1.1.1
 canonicalwebteam.image-template==1.0.0
-canonicalwebteam.store-api==1.0.1
+canonicalwebteam.store-api==1.0.4
 django-openid-auth==0.15
 Flask==1.0.2
 Flask-OpenID-Stateless==1.2.6

--- a/templates/_layout-brandstore.html
+++ b/templates/_layout-brandstore.html
@@ -57,6 +57,8 @@
       <meta property="twitter:url" content="https://snapcraft.io{{ self.meta_path() }}" />
     {% endblock %}
 
+    {% block extra_meta %}{% endblock %}
+
     <link rel="icon" type="image/png" href="https://assets.ubuntu.com/v1/fdc99abe-ico_16px.png" sizes="16x16" />
     <link rel="icon" type="image/png" href="https://assets.ubuntu.com/v1/0f3c662c-ico_32px.png" sizes="32x32" />
   </head>

--- a/templates/store/snap-details.html
+++ b/templates/store/snap-details.html
@@ -12,6 +12,12 @@
   {% endblock %}
 {% endif %}
 
+{% block extra_meta %}
+  {% if unlisted %}
+    <meta name="robots" content="noindex" />
+  {% endif %}
+{% endblock %}
+
 {% block meta_schema %}
   <script type="application/ld+json">
     {

--- a/tests/store/tests_details.py
+++ b/tests/store/tests_details.py
@@ -34,6 +34,7 @@ class GetDetailsPageTest(TestCase):
                                 "confinement",
                                 "categories",
                                 "trending",
+                                "unlisted",
                             ]
                         )
                     }
@@ -117,6 +118,7 @@ class GetDetailsPageTest(TestCase):
                 },
                 "categories": [{"name": "test"}],
                 "trending": False,
+                "unlisted": False,
             },
         }
 
@@ -150,6 +152,7 @@ class GetDetailsPageTest(TestCase):
                 },
                 "categories": [{"name": "test"}],
                 "trending": False,
+                "unlisted": False,
             },
             "channel-map": [
                 {
@@ -213,6 +216,7 @@ class GetDetailsPageTest(TestCase):
                 },
                 "categories": [{"name": "test"}],
                 "trending": False,
+                "unlisted": False,
             },
             "channel-map": [
                 {
@@ -268,6 +272,7 @@ class GetDetailsPageTest(TestCase):
                 },
                 "categories": [{"name": "test"}],
                 "trending": False,
+                "unlisted": False,
             },
             "channel-map": [
                 {

--- a/tests/store/tests_distro_page.py
+++ b/tests/store/tests_distro_page.py
@@ -25,6 +25,7 @@ class GetDistroPageTest(TestCase):
             },
             "categories": [{"name": "test"}],
             "trending": False,
+            "unlisted": False,
         },
         "channel-map": [
             {
@@ -69,6 +70,7 @@ class GetDistroPageTest(TestCase):
                                 "confinement",
                                 "categories",
                                 "trending",
+                                "unlisted",
                             ]
                         )
                     }

--- a/tests/store/tests_embedded_card.py
+++ b/tests/store/tests_embedded_card.py
@@ -25,6 +25,7 @@ class GetEmbeddedCardTest(TestCase):
             },
             "categories": [{"name": "test"}],
             "trending": False,
+            "unlisted": False,
         },
         "channel-map": [
             {
@@ -69,6 +70,7 @@ class GetEmbeddedCardTest(TestCase):
                                 "confinement",
                                 "categories",
                                 "trending",
+                                "unlisted",
                             ]
                         )
                     }

--- a/tests/store/tests_github_badge.py
+++ b/tests/store/tests_github_badge.py
@@ -25,6 +25,7 @@ class GetGitHubBadgeTest(TestCase):
             },
             "categories": [{"name": "test"}],
             "trending": False,
+            "unlisted": False,
         },
         "channel-map": [
             {
@@ -81,6 +82,7 @@ class GetGitHubBadgeTest(TestCase):
                                 "confinement",
                                 "categories",
                                 "trending",
+                                "unlisted",
                             ]
                         )
                     }

--- a/webapp/store/snap_details_views.py
+++ b/webapp/store/snap_details_views.py
@@ -176,6 +176,7 @@ def snap_details_views(store, api, handle_errors):
             "last_updated": logic.convert_date(last_updated),
             "last_updated_raw": last_updated,
             "is_users_snap": is_users_snap,
+            "unlisted": details["snap"]["unlisted"],
         }
 
         return context


### PR DESCRIPTION
## Done

Add noindex to unlisted snaps pages

## Issue / Card

Fixes #2396 

## QA

- Pull the branch
- Run the site using the command `./run`
- View the site locally in your web browser at: http://0.0.0.0:8004/core
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Inspect the page make make sure there is no `<meta name="robots" content="noindex" />` in the metadata
- Visit the details page for a snap that is `unlisted` and inspect the page. See that `<meta name="robots" content="noindex" />` is in the metadata.
