### PR TITLE
Fix markdown issue with URLs

### DIFF
--- a/webapp/markdown.py
+++ b/webapp/markdown.py
@@ -75,6 +75,15 @@ class DescriptionInlineGrammar(InlineGrammar):
         # https://github.com/CanonicalLtd/snap-squad/issues/936
         self.code = re.compile(r"^(`)([ \S]*?[^`])\1(?!`)")
 
+        # Rewrite to support parentheses inside URLs:
+        # https://github.com/canonical-web-and-design/snapcraft.io/issues/2424
+        self.url = re.compile(
+            r"""^([(])?(https?:\/\/[^\s<]+[^<.,:;"'\]\s])(?(1)([)]))"""
+        )
+        self.text = re.compile(
+            r"^[\s\S]+?(?=[\\<!\[_*`~]|\(?https?://| {2,}\n|$)"
+        )
+
 
 class DescriptionInline(InlineLexer):
     grammar_class = DescriptionInlineGrammar
@@ -104,6 +113,18 @@ class DescriptionInline(InlineLexer):
         "strikethrough",
         "text",
     ]
+
+    def output_url(self, m):
+        output = []
+        output.append(m.group(1) or "")
+
+        if self._in_link:
+            output.append(self.renderer.text(m.group(2)))
+        else:
+            output.append(self.renderer.autolink(m.group(2), False))
+
+        output.append(m.group(3) or "")
+        return "".join(output)
 
 
 renderer = Renderer()


### PR DESCRIPTION
## Done

Add support for parenthesis inside URLs when we are parsing markdown.

## Issue / Card

Fixes #2424

* The [issue is present in the markdown library we are using](https://github.com/lepture/mistune/issues/46)

## QA

- Pull the branch
- Run the site using the command `./run`
- View the site locally in your web browser at: http://0.0.0.0:8004/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check that all the links are displayed correctly here: http://0.0.0.0:8004/toto-fran
