### PR TITLE
Make distro list expandable on snap details page

### DIFF
--- a/static/js/public/public.js
+++ b/static/js/public/public.js
@@ -14,6 +14,7 @@ import nps from "./nps";
 import { newsletter } from "./newsletter";
 import { formValidation } from "./formValidation";
 import initExpandableSnapDetails from "./expandable-details";
+import initExpandableDistroChart from "./snap-details/exapandable-distr-chart";
 import triggerEventWhenVisible from "./ga-scroll-event";
 import { initLinkScroll } from "./scroll-to";
 
@@ -28,6 +29,7 @@ export {
   initAccordion,
   initAccordionButtons,
   initEmbeddedCardModal,
+  initExpandableDistroChart,
   initExpandableSnapDetails,
   initFSFLanguageSelect,
   initReportSnap,

--- a/static/js/public/snap-details/exapandable-distr-chart.js
+++ b/static/js/public/snap-details/exapandable-distr-chart.js
@@ -1,0 +1,18 @@
+export default function initExpandableDistroChart() {
+  const moreEl = document.querySelector(".snapcraft-distro-chart__more");
+  const detailsEl = document.querySelector(".snapcraft-distro-chart");
+
+  if (moreEl && detailsEl) {
+    moreEl.classList.remove("u-hide");
+    detailsEl.classList.add("is-collapsed");
+
+    document
+      .querySelector(".js-show-more-description")
+      .addEventListener("click", function(event) {
+        event.preventDefault();
+
+        moreEl.classList.add("u-hide");
+        detailsEl.classList.remove("is-collapsed");
+      });
+  }
+}

--- a/static/js/public/snap-details/exapandable-distr-chart.js
+++ b/static/js/public/snap-details/exapandable-distr-chart.js
@@ -1,18 +1,27 @@
 export default function initExpandableDistroChart() {
   const moreEl = document.querySelector(".snapcraft-distro-chart__more");
+  const lessEl = document.querySelector(".snapcraft-distro-chart__less");
   const detailsEl = document.querySelector(".snapcraft-distro-chart");
 
-  if (moreEl && detailsEl) {
-    moreEl.classList.remove("u-hide");
-    detailsEl.classList.add("is-collapsed");
-
-    document
-      .querySelector(".js-show-more-description")
+  if (moreEl && lessEl && detailsEl) {
+    moreEl
+      .querySelector("[data-js='js-show-more-description']")
       .addEventListener("click", function(event) {
         event.preventDefault();
 
-        moreEl.classList.add("u-hide");
+        moreEl.classList.toggle("u-show--small");
+        lessEl.classList.toggle("u-show--small");
         detailsEl.classList.remove("is-collapsed");
+      });
+
+    lessEl
+      .querySelector("[data-js='js-show-less-description']")
+      .addEventListener("click", function(event) {
+        event.preventDefault();
+
+        moreEl.classList.toggle("u-show--small");
+        lessEl.classList.toggle("u-show--small");
+        detailsEl.classList.add("is-collapsed");
       });
   }
 }

--- a/static/sass/_snapcraft_distro-chart.scss
+++ b/static/sass/_snapcraft_distro-chart.scss
@@ -1,13 +1,26 @@
 @mixin snapcraft-distro-chart {
 
   $bar-color: #084081;
+  $color-transparent-white: rgba(255, 255, 255, 0);
 
   .snapcraft-distro-chart {
+    &.is-collapsed {
+      max-height: 290px;
+      overflow: hidden;
 
-    @media screen and (min-width: $breakpoint-medium) {
-      max-height: 80vh;
-      overflow: auto;
+      @media screen and (max-width: $breakpoint-large) {
+        max-height: 170px;
+      }
+
+      @media screen and (min-width: $breakpoint-x-large) {
+        max-height: 380px;
+      }
     }
+
+    &-container {
+      position: relative;
+    }
+
 
     &__names,
     &__bars {
@@ -43,6 +56,19 @@
       float: left;
       height: 1px;
       margin: .53125rem 0 .46875rem;
+    }
+
+    &__more {
+      background: linear-gradient($color-transparent-white, $color-x-light 80%);
+      bottom: 2rem;
+      height: 180px;
+      padding-top: 10rem;
+      position: absolute;
+      width: 100%;
+
+      @media screen and (max-width: $breakpoint-medium) {
+        bottom: 0;
+      }
     }
   }
 }

--- a/static/sass/_snapcraft_distro-chart.scss
+++ b/static/sass/_snapcraft_distro-chart.scss
@@ -4,21 +4,26 @@
   $color-transparent-white: rgba(255, 255, 255, 0);
 
   .snapcraft-distro-chart {
-    &.is-collapsed {
-      max-height: 290px;
-      overflow: hidden;
-
-      @media screen and (max-width: $breakpoint-large) {
-        max-height: 170px;
-      }
-
-      @media screen and (min-width: $breakpoint-x-large) {
-        max-height: 380px;
-      }
-    }
-
     &-container {
       position: relative;
+    }
+
+    &.is-collapsed {
+      max-height: 375px;
+      overflow: auto;
+
+      @media screen and (min-width: $breakpoint-x-large) {
+        max-height: 420px;
+      }
+
+      @media screen and (min-width: $breakpoint-medium) and (max-width: $breakpoint-large) {
+        max-height: 255px;
+      }
+
+      @media screen and (max-width: $breakpoint-medium) {
+        max-height: 190px;
+        overflow: hidden;
+      }
     }
 
 
@@ -60,15 +65,11 @@
 
     &__more {
       background: linear-gradient($color-transparent-white, $color-x-light 80%);
-      bottom: 2rem;
-      height: 180px;
-      padding-top: 10rem;
+      bottom: 0;
+      height: 68px;
+      padding-top: 3rem;
       position: absolute;
       width: 100%;
-
-      @media screen and (max-width: $breakpoint-medium) {
-        bottom: 0;
-      }
     }
   }
 }

--- a/templates/store/snap-details.html
+++ b/templates/store/snap-details.html
@@ -207,7 +207,7 @@
           {% if normalized_os %}
             <div class="col-4 js-snap-distro-chart-holder snapcraft-distro-chart-container" data-live="weekly_installed_base_by_operating_system_normalized">
               <h4>Users by distribution (log)</h4>
-              <div class="snapcraft-distro-chart">
+              <div class="snapcraft-distro-chart is-collapsed">
                 <div class="snapcraft-distro-chart__names">
                   {% for distro in normalized_os %}
                   <div class="snapcraft-distro-chart__name" title="{{ distro.name }}">{{ distro.name }}</div>
@@ -222,9 +222,14 @@
                   {% endfor %}
                 </div>
               </div>
-              <div class="snapcraft-distro-chart__more u-hide">
-                <a href="/{{ package_name }}" class="js-show-more-description">Show more</a>
+              {% if normalized_os|length > 10 %}
+              <div class="snapcraft-distro-chart__more u-hide u-show--small">
+                <a href="/{{ package_name }}" data-js="js-show-more-description">Show more</a>
               </div>
+              <div class="snapcraft-distro-chart__less u-hide">
+                <a href="/{{ package_name }}" data-js="js-show-less-description">Show less</a>
+              </div>
+              {% endif %}
             </div>
           {% endif %}
         </div>

--- a/templates/store/snap-details.html
+++ b/templates/store/snap-details.html
@@ -205,7 +205,7 @@
             </div>
           {% endif %}
           {% if normalized_os %}
-            <div class="col-4 js-snap-distro-chart-holder" data-live="weekly_installed_base_by_operating_system_normalized">
+            <div class="col-4 js-snap-distro-chart-holder snapcraft-distro-chart-container" data-live="weekly_installed_base_by_operating_system_normalized">
               <h4>Users by distribution (log)</h4>
               <div class="snapcraft-distro-chart">
                 <div class="snapcraft-distro-chart__names">
@@ -221,6 +221,9 @@
                     ></div>
                   {% endfor %}
                 </div>
+              </div>
+              <div class="snapcraft-distro-chart__more u-hide">
+                <a href="/{{ package_name }}" class="js-show-more-description">Show more</a>
               </div>
             </div>
           {% endif %}
@@ -335,6 +338,12 @@
   <script>
     window.addEventListener("DOMContentLoaded", function() {
       Raven.context(function () {
+        try {
+          snapcraft.public.initExpandableDistroChart();
+        } catch (e) {
+          Raven.captureException(e);
+        }
+
         {% if not is_preview %}
         try {
           snapcraft.public.screenshots('#js-snap-screenshots');


### PR DESCRIPTION
## Done

- Make distro list expandable on `snap details` page

## Issue / Card

Fixes #2000 

## QA

- Pull the branch
- Run the site using the command `./run`
- View the site locally in your web browser at: http://0.0.0.0:8004/spotify or any other snap
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Scroll down to the distro list and click the `Show more` button
- See the list is expanded
- For design check compare to [this comment](https://github.com/canonical-web-and-design/snapcraft.io/issues/2000#event-2950599628)