### PR TITLE
Make snap title wrap

### DIFF
--- a/static/sass/_snapcraft_details_heading.scss
+++ b/static/sass/_snapcraft_details_heading.scss
@@ -16,7 +16,6 @@
 
     &__title {
       flex-grow: 1;
-      flex-shrink: 0;
       margin: 0;
       margin-bottom: $sp-large;
 
@@ -32,8 +31,6 @@
 
     &__name {
       margin-bottom: 0;
-      overflow: hidden;
-      text-overflow: ellipsis;
     }
 
     &__publisher {

--- a/static/sass/_utilities_text-wrap.scss
+++ b/static/sass/_utilities_text-wrap.scss
@@ -1,0 +1,5 @@
+@mixin u-text-wrap {
+  .u-text-wrap {
+    overflow-wrap: break-word;
+  }
+}

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -222,5 +222,8 @@ $color-social-icon-foreground: $color-light;
 @import 'utilities_disabled';
 @include u-disabled;
 
+@import 'utilities_text-wrap';
+@include u-text-wrap;
+
 @import 'snapcraft_tour';
 @include snapcraft-tour;

--- a/templates/store/snap-details.html
+++ b/templates/store/snap-details.html
@@ -145,7 +145,7 @@
 
   <div class="p-strip is-shallow">
     <div class="row">
-      <div class="col-8">
+      <div class="col-8 u-text-wrap">
         {% if summary or is_preview %}<h4 data-live="summary">{{ summary }}</h4>{% endif %}
         <div data-live="description">{{ description | safe }}</div>
         {% if website or is_preview %}<p><a href="{{ website }}" data-live="website">Developer website</a></p>{% endif %}


### PR DESCRIPTION
## Done

- Make snap title wrap on mobile

## Issue / Card

Fixes #1999 

## QA

- Pull the branch
- Run the site using the command `./run`
- View the site locally in your web browser at: http://0.0.0.0:8004/gimp
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See the page loads correctly and the snap name is wrapped
