### PR TITLE
Ensure global errors are visible on form submission

### DIFF
--- a/static/js/publisher/form.js
+++ b/static/js/publisher/form.js
@@ -54,7 +54,10 @@ function initForm(config, initialState, errors) {
       errorInput.focus();
 
       if (errorInput.scrollIntoView) {
+        const stickyHeight = document.querySelector(".snapcraft-p-sticky")
+          .scrollHeight;
         errorInput.scrollIntoView();
+        window.scrollBy(0, -(stickyHeight + 16));
       }
     }
   }


### PR DESCRIPTION
## Done

- If there's a global error offset the scroll by the height of the sticky header

## Issue / Card

Fixes #2436 

## QA

- Pull the branch
- Run the site using the command `./run`
- View the site locally in your web browser at: http://0.0.0.0:8004/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Visit http://0.0.0.0:8004/snap_name/listing try and upload the gif referenced in the connected issue.
- Clicking Save should show an error above the form, but below the sticky header

## Screenshots

![Screenshot_2020-01-16  Listing details for Lukotron testing ](https://user-images.githubusercontent.com/479384/72522450-a2a02000-3855-11ea-9261-858c215f8dae.png)
