### PR TITLE
Fix overflowing long version names

### DIFF
--- a/templates/publisher/account-snaps.html
+++ b/templates/publisher/account-snaps.html
@@ -115,7 +115,7 @@ My published snaps — Linux software in the Snap Store
   {% endfor %}
   {% endif %}
   <div class="u-fixed-width">
-    <table class="p-table--vertical-middle">
+    <table class="p-table--vertical-middle u-text-wrap">
       <thead>
         <tr>
           <th width="30%">Name</th>


### PR DESCRIPTION
## Done

Fix overflowing for long version names on snap dashboard

## Issue / Card

Fixes #1761 

## QA

- Pull the branch
- Run the site using the command `./run`
- View the site locally in your web browser at: http://0.0.0.0:8004/snaps
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Resize the screen and see the version name (or other fields) don't overflow
- The mobile version still looks bad, but will be updated with [mobile friendly table](https://docs.vanillaframework.io/examples/patterns/tables/table-mobile-card/) once we upgrade to vanilla 2.5.0

## Screenshots

![image](https://user-images.githubusercontent.com/40214246/72610969-bfedf080-3920-11ea-82fa-e126e85fb29a.png)
