### PR TITLE
Register GitHub repo with Snap via the Launchpad API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,5 @@ webapp/licenses.json
 coverage/
 .webcache/
 .webcache_blog/
+.coverage
+

--- a/webapp/api/github.py
+++ b/webapp/api/github.py
@@ -10,9 +10,7 @@ class GitHubAPI:
 
     BASE_URL = "https://api.github.com/"
 
-    def __init__(
-        self, access_token=None, session=api.requests.Session(),
-    ):
+    def __init__(self, access_token=None, session=api.requests.Session()):
         self.access_token = access_token
         self.session = session
         self.session.headers["Accept"] = "application/json"
@@ -34,7 +32,7 @@ class GitHubAPI:
         """
         params = {"per_page": per_page, "page": page}
 
-        return self._request(method="GET", url_path=url_path, params=params,)
+        return self._request(method="GET", url_path=url_path, params=params)
 
     def get_user(self):
         """

--- a/webapp/api/launchpad.py
+++ b/webapp/api/launchpad.py
@@ -1,6 +1,88 @@
-from launchpadlib.launchpad import Launchpad
+from hashlib import md5
+from webapp.api.requests import Session
 
 
-launchpad = Launchpad.login_anonymously(
-    "storefront", "production", version="devel"
-)
+class Launchpad:
+    """
+    Provides authentication for Launchpad.
+    """
+
+    BASE_URL = "https://api.launchpad.net"
+
+    def __init__(self, username, token, signature, session=Session()):
+        self.username = username
+        self.session = session
+        self.session.headers["Accept"] = "application/json"
+        self.session.headers["Authorization"] = (
+            f'OAuth oauth_version="1.0", '
+            f'oauth_signature_method="PLAINTEXT", '
+            f"oauth_consumer_key={username}, "
+            f'oauth_token="{token}", '
+            f'oauth_signature="&{signature}"'
+        )
+
+    def _request(self, method="GET", url=None, params={}, data={}):
+        """
+        Makes a raw HTTP request and returns the response.
+        """
+        url = f"{self.BASE_URL}/devel/{url}"
+
+        response = self.session.request(method, url, params=params, data=data)
+        response.raise_for_status()
+
+        return response.json() if response.content else None
+
+    def get_collection_entries(self, resource, params=None):
+        """
+        Return collection items from the API
+        """
+        collection = self._request(url=resource, params=params)
+
+        return collection.get("entries", [])
+
+    def get_snap_by_store_name(self, snap_name):
+        """
+        Return an Snap from the Launchpad API by store_name
+        """
+        snaps = self.get_collection_entries(
+            "+snaps",
+            {
+                "ws.op": "findByStoreName",
+                "owner": "/~build.snapcraft.io",
+                "store_name": snap_name,
+            },
+        )
+
+        # The Launchpad API only allow to perform a find by store_name
+        # but we are only interested in exactly this one
+        if snaps and snaps[0]["store_name"] == snap_name:
+            return snaps[0]
+
+        return None
+
+    def new_snap(self, snap_name, git_url):
+        """
+        Create an ISnap in Launchpad
+        """
+        data = {
+            "ws.op": "new",
+            "owner": f"/~{self.username}",
+            "name": md5(git_url.encode("UTF-8")).hexdigest(),
+            "store_name": snap_name,
+            "git_repository_url": git_url,
+            "git_path": "HEAD",
+            "auto_build": "false",
+            "auto_build_archive": "/ubuntu/+archive/primary",
+            "auto_build_pocket": "Updates",
+            "processors": [
+                "/+processors/amd64",
+                "/+processors/arm64",
+                "/+processors/armhf",
+                "/+processors/i386",
+                "/+processors/ppc64el",
+                "/+processors/s390x",
+            ],
+            "store_series": "/+snappy-series/16",
+        }
+
+        return self._request("POST", "+snaps", data=data)

--- a/webapp/login/oauth_views.py
+++ b/webapp/login/oauth_views.py
@@ -8,7 +8,7 @@ from werkzeug.exceptions import BadRequest
 
 
 oauth = flask.Blueprint(
-    "oauth", __name__, template_folder="/templates", static_folder="/static",
+    "oauth", __name__, template_folder="/templates", static_folder="/static"
 )
 
 

--- a/webapp/publisher/snaps/builds.py
+++ b/webapp/publisher/snaps/builds.py
@@ -38,10 +38,10 @@ class LaunchpadStoreUploadState(Enum):
 def build_link(bsi_url, snap, build):
     """ Builds the link to the build page
     """
-    build_id = build.self_link.split("/")[-1]
+    build_id = build["self_link"].split("/")[-1]
 
     # Remove GitHub hostname & split owner/repo
-    owner, repo = snap.git_repository_url[19:].split("/")
+    owner, repo = snap["git_repository_url"][19:].split("/")
 
     return f"{bsi_url}/user/{owner}/{repo}/{build_id}"
 

--- a/webapp/publisher/snaps/views.py
+++ b/webapp/publisher/snaps/views.py
@@ -1414,19 +1414,25 @@ def post_snap_builds(snap_name):
 
     # Get built snap in launchpad with this store name
     lp_snap = launchpad.get_snap_by_store_name(details["snap_name"])
+    github_repo = flask.request.form.get("github_repository")
+    git_url = f"https://github.com/{github_repo}"
 
-    if lp_snap:
-        flask.flash(
-            "It is not possible to change the git repository for this snap.",
-            "negative",
+    if not lp_snap:
+        result = launchpad.new_snap(snap_name, git_url)
+
+        if result:
+            flask.flash(
+                "The GitHub repository was linked correctly.", "positive"
+            )
+        else:
+            flask.flash(
+                "An error occurred linking the GitHub repository.", "negative"
+            )
+    elif lp_snap["git_repository_url"] != git_url:
+        # In the future, create a new record, delete the old one
+        raise AttributeError(
+            f"Snap {snap_name} already has a build repository associated"
         )
-    else:
-        github_repo = flask.request.form.get("github_repository")
-        git_url = f"https://github.com/{github_repo}"
-
-        launchpad.new_snap(snap_name, git_url)
-
-        flask.flash("The GitHub repository was linked correctly.", "positive")
 
     return flask.redirect(
         flask.url_for(".get_snap_builds", snap_name=snap_name)

--- a/webapp/publisher/snaps/views.py
+++ b/webapp/publisher/snaps/views.py
@@ -1,3 +1,4 @@
+import os
 from json import loads
 
 import flask
@@ -28,7 +29,7 @@ from canonicalwebteam.store_api.exceptions import (
     StoreApiCircuitBreaker,
 )
 from webapp.api.github import GitHubAPI
-from webapp.api.launchpad import launchpad
+from webapp.api.launchpad import Launchpad
 from webapp.store.logic import (
     get_categories,
     filter_screenshots,
@@ -52,6 +53,11 @@ publisher_snaps = flask.Blueprint(
 )
 
 store_api = SnapcraftStoreApi(talisker.requests.get_session(requests.Session))
+launchpad = Launchpad(
+    username=os.getenv("LP_API_USERNAME"),
+    token=os.getenv("LP_API_TOKEN"),
+    signature=os.getenv("LP_API_TOKEN_SECRET"),
+)
 
 
 def refresh_redirect(path):
@@ -1345,42 +1351,83 @@ def get_snap_builds(snap_name):
         "snap_id": details["snap_id"],
         "snap_name": details["snap_name"],
         "snap_title": details["title"],
+        "snap_builds_enabled": False,
+        "snap_builds": [],
     }
 
-    lp_snaps = launchpad.snaps.findByStoreName(
-        owner="https://api.launchpad.net/devel/~build.snapcraft.io",
-        store_name=details["snap_name"],
-    )
+    # Get built snap in launchpad with this store name
+    lp_snap = launchpad.get_snap_by_store_name(details["snap_name"])
 
-    github = GitHubAPI(flask.session.get("github_auth_secret"))
-    context["github_user"] = github.get_user()
-
-    if context["github_user"]:
-        context["github_repositories"] = github.get_user_repositories()
-
-    context["snap_builds_enabled"] = len(lp_snaps) >= 1
-    if context["snap_builds_enabled"]:
-        context["snap_builds"] = []
+    if lp_snap:
+        # Git repository without GitHub hostname
+        context["github_repository"] = lp_snap["git_repository_url"][19:]
         bsi_url = flask.current_app.config["BSI_URL"]
 
-        for build in lp_snaps[0].builds:
-            link = build_link(bsi_url, lp_snaps[0], build)
+        builds = launchpad.get_collection_entries(
+            # Remove first part of the URL
+            lp_snap["builds_collection_link"][32:]
+        )
+
+        context["snap_builds_enabled"] = bool(builds)
+
+        for build in builds:
+            link = build_link(bsi_url, lp_snap, build)
             status = map_build_and_upload_states(
-                build.buildstate, build.store_upload_status
+                build["buildstate"], build["store_upload_status"]
             )
 
             context["snap_builds"].append(
                 {
-                    "id": build.self_link.split("/")[-1],
-                    "arch_tag": build.arch_tag,
-                    "datebuilt": build.datebuilt,
-                    "duration": build.duration,
+                    "id": build["self_link"].split("/")[-1],
+                    "arch_tag": build["arch_tag"],
+                    "datebuilt": build["datebuilt"],
+                    "duration": build["duration"],
                     "link": link,
-                    "logs": build.build_log_url,
-                    "revision_id": build.revision_id,
+                    "logs": build["build_log_url"],
+                    "revision_id": build["revision_id"],
                     "status": status,
-                    "title": build.title,
+                    "title": build["title"],
                 }
             )
+    else:
+        github = GitHubAPI(flask.session.get("github_auth_secret"))
+        context["github_user"] = github.get_user()
+
+        if context["github_user"]:
+            context["github_repositories"] = github.get_user_repositories()
 
     return flask.render_template("publisher/builds.html", **context)
+
+
+@publisher_snaps.route("/<snap_name>/builds", methods=["POST"])
+@login_required
+def post_snap_builds(snap_name):
+    try:
+        details = api.get_snap_info(snap_name, flask.session)
+    except ApiResponseErrorList as api_response_error_list:
+        if api_response_error_list.status_code == 404:
+            return flask.abort(404, "No snap named {}".format(snap_name))
+        else:
+            return _handle_error_list(api_response_error_list.errors)
+    except ApiError as api_error:
+        return _handle_errors(api_error)
+
+    # Get built snap in launchpad with this store name
+    lp_snap = launchpad.get_snap_by_store_name(details["snap_name"])
+
+    if lp_snap:
+        flask.flash(
+            "It is not possible to change the git repository for this snap.",
+            "negative",
+        )
+    else:
+        github_repo = flask.request.form.get("github_repository")
+        git_url = f"https://github.com/{github_repo}"
+
+        launchpad.new_snap(snap_name, git_url)
+
+        flask.flash("The GitHub repository was linked correctly.", "positive")
+
+    return flask.redirect(
+        flask.url_for(".get_snap_builds", snap_name=snap_name)
+    )

--- a/webapp/publisher/snaps/views.py
+++ b/webapp/publisher/snaps/views.py
@@ -1418,16 +1418,8 @@ def post_snap_builds(snap_name):
     git_url = f"https://github.com/{github_repo}"
 
     if not lp_snap:
-        result = launchpad.new_snap(snap_name, git_url)
-
-        if result:
-            flask.flash(
-                "The GitHub repository was linked correctly.", "positive"
-            )
-        else:
-            flask.flash(
-                "An error occurred linking the GitHub repository.", "negative"
-            )
+        launchpad.new_snap(snap_name, git_url)
+        flask.flash("The GitHub repository was linked correctly.", "positive")
     elif lp_snap["git_repository_url"] != git_url:
         # In the future, create a new record, delete the old one
         raise AttributeError(

--- a/yarn.lock
+++ b/yarn.lock
@@ -7770,6 +7770,11 @@ validate-npm-package-license@^3.0.1:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
 
+vanilla-framework@2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-2.4.1.tgz#36ef374e90b8457a07e55cf33be1bcfd07092c84"
+  integrity sha512-St8LdmoMpWSFWvFRDBNjFcdfWo/nOMwrkRPJN+dR0vOHP/Jb1UqOSxw+wDxkiGrpeRb0VPFwCuz/2u0RWb0xuQ==
+
 vanilla-framework@^2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-2.5.0.tgz#b7f689d7583f4a215cde39b726091ffc2ec4f62a"


### PR DESCRIPTION
## Done

- Replace launchpadlib
- Launchpad API request to create a new Snap

## Issue / Card

Fixes https://github.com/canonical-web-and-design/snapcraft.io/issues/2421

## QA

**Ask @jkfran for the needed environment variables**

- Pull the branch
- Run the site using the command `./run`
- View the site locally in your web browser at: http://0.0.0.0:8004/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Login as a publisher
- Go to http://0.0.0.0:8004/<your_snap>/builds and check to you can:
- Login with GitHub, select and save
- Check that the repo is now always displayed in the GitHub configuration section
