### PR TITLE
Use the correct last page link

### DIFF
--- a/tests/store/tests_search.py
+++ b/tests/store/tests_search.py
@@ -221,7 +221,7 @@ class GetSearchViewTest(TestCase):
             snap_list.append({"package_name": "toto" + str(i), "icon_url": ""})
 
         payload = {
-            "_embedded": {"clickindex:package": snap_list[:47]},
+            "_embedded": {"clickindex:package": snap_list[:44]},
             "total": 144,
             "_links": {
                 "last": {"href": "http://url.c?q=snap&size=1&page=1"},
@@ -231,7 +231,7 @@ class GetSearchViewTest(TestCase):
         }
 
         search_api_formated = self.search_snap_api_url.format(
-            snap_name="snap", page="1", size="47"
+            snap_name="snap", page="1", size="44"
         )
         responses.add(
             responses.Response(
@@ -248,9 +248,9 @@ class GetSearchViewTest(TestCase):
         self.assert_context("category", "toto")
         self.assert_context("category_display", "Toto")
         self.assert_context(
-            "featured_snaps", [snap_list[1], snap_list[0]] + snap_list[2:19]
+            "featured_snaps", [snap_list[1], snap_list[0]] + snap_list[2:16]
         )
-        self.assert_context("searched_snaps", snap_list[19:47])
+        self.assert_context("searched_snaps", snap_list[16:44])
         self.assert_context("page", 1)
         self.assert_context("total", 144)
         self.assert_context(

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -145,15 +145,11 @@ def store_blueprint(store_query=None, testing=False):
         if not snap_searched and not snap_category:
             return flask.redirect(flask.url_for(".homepage"))
 
-        # The default size should be 44 (rows of 4)
-        # it's important that this is smaller than the category page 1 size
-        # below otherwise snaps can be missed out of results
-        size = 44
+        # The default size is 44
+        # (11 rows of 4) - on search results pages
+        # or (1 + 5 rows of 3 + 7 rows of 4) - on category page 1
 
-        # Page 1 has a snap at the top, and a few rows of 3, followed by rows
-        # of 4 - so we need to offset to ensure there's no hanging snap
-        if snap_category and page == 1:
-            size = 47
+        size = 44
 
         error_info = {}
         searched_results = []
@@ -209,7 +205,7 @@ def store_blueprint(store_query=None, testing=False):
 
         # These are the hand-selected "featured snaps" in each category.
         # We don't have this information on the API, so it's hardcoded.
-        number_of_featured_snaps = 19
+        number_of_featured_snaps = 16
 
         if snap_category_display and page == 1:
             if snaps_results and snaps_results[0]:


### PR DESCRIPTION
## Done

- "Last >>" button link fixed to take you to the last page if you are on the first page 

## Issue / Card

Fixes #2453 

## QA

- Pull the branch
- Run the site using the command `./run`
- View the site locally in your web browser at: http://0.0.0.0:8004/search?category=games&page=1
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Click on the "Last >>" link and see that you are taken to page 6
