### PR TITLE
Move confirm buttons to own component

### DIFF
--- a/static/js/publisher/release/components/releasesConfirm.js
+++ b/static/js/publisher/release/components/releasesConfirm.js
@@ -3,6 +3,7 @@ import PropTypes from "prop-types";
 import { connect } from "react-redux";
 
 import ReleasesConfirmDetails from "./releasesConfirmDetails/";
+import ReleasesConfirmActions from "./releasesConfirmActions";
 
 import {
   cancelPendingReleases,
@@ -107,22 +108,13 @@ class ReleasesConfirm extends Component {
                   </p>
                 </div>
               )}
-              <div className="p-releases-confirm__buttons">
-                <button
-                  className="p-button--neutral u-no-margin--bottom"
-                  disabled={!isCancelEnabled}
-                  onClick={this.onRevertClick.bind(this)}
-                >
-                  Revert
-                </button>
-                <button
-                  className="p-button--positive is-inline u-no-margin--bottom u-no-margin--right"
-                  disabled={!isApplyEnabled}
-                  onClick={this.onApplyClick.bind(this)}
-                >
-                  {isLoading ? "Loading..." : "Save"}
-                </button>
-              </div>
+              <ReleasesConfirmActions
+                isCancelEnabled={isCancelEnabled}
+                cancelPendingReleases={this.onRevertClick.bind(this)}
+                isApplyEnabled={isApplyEnabled}
+                applyPendingReleases={this.onApplyClick.bind(this)}
+                isLoading={isLoading}
+              />
             </div>
           </div>
         </div>

--- a/static/js/publisher/release/components/releasesConfirmActions.js
+++ b/static/js/publisher/release/components/releasesConfirmActions.js
@@ -28,7 +28,7 @@ const ReleasesConfirmActions = ({
 
 ReleasesConfirmActions.propTypes = {
   isCancelEnabled: PropTypes.bool,
-  cancelPendingRelease: PropTypes.func,
+  cancelPendingReleases: PropTypes.func,
   isApplyEnabled: PropTypes.bool,
   applyPendingReleases: PropTypes.func,
   isLoading: PropTypes.bool

--- a/static/js/publisher/release/components/releasesConfirmActions.js
+++ b/static/js/publisher/release/components/releasesConfirmActions.js
@@ -1,0 +1,37 @@
+import React from "react";
+import PropTypes from "prop-types";
+
+const ReleasesConfirmActions = ({
+  isCancelEnabled,
+  cancelPendingReleases,
+  isApplyEnabled,
+  applyPendingReleases,
+  isLoading
+}) => (
+  <div className="p-releases-confirm__buttons">
+    <button
+      className="p-button--neutral u-no-margin--bottom"
+      disabled={!isCancelEnabled}
+      onClick={cancelPendingReleases}
+    >
+      Revert
+    </button>
+    <button
+      className="p-button--positive is-inline u-no-margin--bottom u-no-margin--right"
+      disabled={!isApplyEnabled}
+      onClick={applyPendingReleases}
+    >
+      {isLoading ? "Loading..." : "Save"}
+    </button>
+  </div>
+);
+
+ReleasesConfirmActions.propTypes = {
+  isCancelEnabled: PropTypes.bool,
+  cancelPendingRelease: PropTypes.func,
+  isApplyEnabled: PropTypes.bool,
+  applyPendingReleases: PropTypes.func,
+  isLoading: PropTypes.bool
+};
+
+export default ReleasesConfirmActions;


### PR DESCRIPTION
## Done

- Moved revert and save buttons to own component

## Issue / Card

Fixes https://github.com/canonical-web-and-design/snapcraft.io/issues/2386

## QA

- Pull the branch
- Run the site using the command `./run`
- View the site locally in your web browser at: http://0.0.0.0:8004/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Visit http://0.0.0.0:8004/snap_name/releases
- Use the release UI and make sure the revert and save buttons work as expected:
 - disabled when no changes
 - active when changes
 - revert resets the releases state
 - save saves the new releases state