### PR TITLE
Make the table on /snaps mobile friendly

### DIFF
--- a/static/sass/_snapcraft_p-table-mobile-card.scss
+++ b/static/sass/_snapcraft_p-table-mobile-card.scss
@@ -1,0 +1,7 @@
+@mixin snapcraft-p-table-mobile-card {
+  .p-table--mobile-card {
+    .p-table--mobile-card__header {
+      padding-left: 0;
+    }
+  }
+}

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -25,6 +25,7 @@ $color-social-icon-foreground: $color-light;
 @include vf-p-strip;
 @include vf-p-media-object;
 @include vf-p-modal;
+@include vf-p-table-mobile-card;
 @include vf-p-muted-heading;
 @include vf-p-navigation;
 @include vf-p-notification;
@@ -226,3 +227,7 @@ $color-social-icon-foreground: $color-light;
 
 @import 'snapcraft_tour';
 @include snapcraft-tour;
+
+// Convert first row of a card to a header
+@import 'snapcraft_p-table-mobile-card';
+@include snapcraft-p-table-mobile-card;

--- a/templates/publisher/account-snaps.html
+++ b/templates/publisher/account-snaps.html
@@ -115,9 +115,9 @@ My published snaps — Linux software in the Snap Store
   {% endfor %}
   {% endif %}
   <div class="u-fixed-width">
-    <table class="p-table--vertical-middle u-text-wrap">
+    <table class="p-table--mobile-card" role="grid">
       <thead>
-        <tr>
+        <tr role="row">
           <th width="30%">Name</th>
           <th width="10%">Visibility</th>
           <th width="20%">Owner</th>
@@ -134,8 +134,8 @@ My published snaps — Linux software in the Snap Store
         {% else %}
         {% set published = False %}
         {% endif %}
-        <tr>
-          <td>
+        <tr role="row">
+          <td role="rowheader" class="p-table--mobile-card__header">
             <a href="/{{snap}}/listing" class="p-heading-icon--small">
               <span class="p-heading-icon__header">
                 {% if snaps[snap].icon_url %}
@@ -156,14 +156,14 @@ My published snaps — Linux software in the Snap Store
               </span>
             </a>
           </td>
-          <td>
+          <td role="gridcell" aria-label="Visibility">
             {% if snaps[snap].private %}
             Private
             {% else %}
             Public
             {% endif %}
           </td>
-          <td>
+          <td role="gridcell" aria-label="Owner">
             {% if snaps[snap].publisher.username == current_user %}
             You
             {% else %}
@@ -171,15 +171,15 @@ My published snaps — Linux software in the Snap Store
             {% endif %}
           </td>
           {% if published %}
-          <td>{{ snaps[snap].latest_release.channels[0] }}</td>
-          <td>
+          <td role="gridcell" aria-label="Latest release">{{ snaps[snap].latest_release.channels[0] }}</td>
+          <td role="gridcell" aria-label="Version">
             <a href="/{{snap}}/releases">
               {{ snaps[snap].latest_release.version }}
             </a>
           </td>
           {% else %}
-          <td><a href="/{{snap}}/releases">Not released</a></td>
-          <td></td>
+          <td role="gridcell" aria-label="Latest release"><a href="/{{snap}}/releases">Not released</a></td>
+          <td role="gridcell" aria-label="Version"></td>
           {% endif %}
         </tr>
         {% endwith %}


### PR DESCRIPTION
## Done

- Make the table on `/snaps` mobile friendly

## Issue / Card

Fixes #2458

## QA

- Pull the branch
- Run the site using the command `./run`
- View the site locally in your web browser at: http://0.0.0.0:8004/snaps
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Change the view to mobile and see the table looks better

## Screenshots

[if relevant, include a screenshot]
![image](https://user-images.githubusercontent.com/40214246/72813732-c7ccce00-3c5b-11ea-8364-34b03139bddd.png)
