### PR TITLE
Progressive bar styling - rounded at 100% and greyscale when disabled

### DIFF
--- a/static/js/publisher/release/components/progressiveBar.js
+++ b/static/js/publisher/release/components/progressiveBar.js
@@ -16,15 +16,19 @@ const ProgressiveBar = ({
     current = targetPercentage;
   }
 
+  const classes = [
+    "progressive-bar",
+    "p-tooltip--btm-center",
+    disabled ? "is-disabled" : ""
+  ];
+
   return (
-    <div
-      className={`progressive-bar p-tooltip--btm-center ${
-        disabled ? "is-disabled" : ""
-      }`}
-    >
+    <div className={classes.join(" ")}>
       {!readonly && (
         <div
-          className="progressive-bar__target"
+          className={`progressive-bar__target ${
+            targetPercentage === 100 ? "is-full" : ""
+          }`}
           style={{ width: `${targetPercentage}%` }}
         >
           {!disabled && <div className="progressive-bar__target-adjust" />}
@@ -41,7 +45,9 @@ const ProgressiveBar = ({
         </span>
       </div>
       <div
-        className="progressive-bar__current"
+        className={`progressive-bar__current ${
+          current === 100 ? "is-full" : ""
+        }`}
         style={{ width: `${current}%` }}
       />
     </div>

--- a/static/sass/_snapcraft_p-progressive-bar.scss
+++ b/static/sass/_snapcraft_p-progressive-bar.scss
@@ -3,6 +3,16 @@
   $active: $color-link;
   $target: scale-color($color-link, $lightness: -20%);
 
+  %bar {
+    border-radius: 9px 0 0 9px;
+    border-right: 1px solid $color-x-light;
+    height: 9px;
+    left: 0;
+    pointer-events: none;
+    position: absolute;
+    top: 0;
+  }
+
   .progressive-bar {
     background: $inactive;
     border-radius: 9px;
@@ -20,19 +30,20 @@
 
   .progressive-bar.is-disabled {
     cursor: not-allowed;
-    opacity: .8;
     pointer-events: none;
+
+    .progressive-bar__current {
+      background: lighten(grayscale($active), 20);
+    }
+
+    .progressive-bar__target {
+      background: lighten(grayscale($target), 20);
+    }
   }
 
   .progressive-bar__current {
+    @extend %bar;
     background: $active;
-    border-radius: 9px 0 0 9px;
-    border-right: 1px solid $color-x-light;
-    height: 9px;
-    left: 0;
-    pointer-events: none;
-    position: absolute;
-    top: 0;
   }
 
   .progressive-bar__target-value {
@@ -49,14 +60,8 @@
   }
 
   .progressive-bar__target {
+    @extend %bar;
     background: $target;
-    border-radius: 9px 0 0 9px;
-    border-right: 1px solid $color-x-light;
-    height: 9px;
-    left: 0;
-    pointer-events: none;
-    position: absolute;
-    top: 0;
   }
 
   .progressive-bar__target-adjust {
@@ -77,5 +82,11 @@
     border-radius: 17px;
     transform: translate(7px);
     width: 17px;
+  }
+
+  .progressive-bar__current.is-full,
+  .progressive-bar__target.is-full {
+    border-radius: 9px;
+    border-right: 0;
   }
 }


### PR DESCRIPTION
## Done

- Added `is-full` state to bars when percentage is 100%
- Lighten and greyscale bars when `is-disabled`

## Issue / Card

Fixes #2393 
Fixes #2398 

## QA

- Pull the branch
- Run the site using the command `./run`
- View the site locally in your web browser at: http://0.0.0.0:8004/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Visit http://0.0.0.0:8004/snap_name/releases
- Play with the progressive releases/ normal releases - see that the progressive bars are different in the different states

## Screenshots
![Screenshot_2020-01-22  Releases and revision history for lukewh-test ](https://user-images.githubusercontent.com/479384/72906933-efd73280-3d2a-11ea-9949-123286d586f6.png)
![Screenshot_2020-01-22  Releases and revision history for lukewh-test (1)](https://user-images.githubusercontent.com/479384/72906935-f06fc900-3d2a-11ea-9914-bf31e0d26559.png)
![Screenshot_2020-01-22  Releases and revision history for lukewh-test (2)](https://user-images.githubusercontent.com/479384/72906936-f06fc900-3d2a-11ea-9c4b-e4dfd005e20d.png)
![Screenshot_2020-01-22  Releases and revision history for lukewh-test (3)](https://user-images.githubusercontent.com/479384/72907002-0f6e5b00-3d2b-11ea-8a79-e4c606c3ef4f.png)
