### PR TITLE
Clone helper

### DIFF
--- a/static/js/publisher/release/helpers.js
+++ b/static/js/publisher/release/helpers.js
@@ -62,3 +62,7 @@ export function isSameVersion(revisions) {
 
   return hasSameVersion;
 }
+
+export function jsonClone(obj) {
+  return JSON.parse(JSON.stringify(obj));
+}

--- a/static/js/publisher/release/helpers.test.js
+++ b/static/js/publisher/release/helpers.test.js
@@ -3,7 +3,8 @@ import {
   getChannelName,
   isRevisionBuiltOnLauchpad,
   getRevisionsArchitectures,
-  isSameVersion
+  isSameVersion,
+  jsonClone
 } from "./helpers";
 
 describe("getChannelName", () => {
@@ -83,5 +84,30 @@ describe("isSameVersion", () => {
       { version: "test2" }
     ];
     expect(isSameVersion(revisions)).toBe(false);
+  });
+});
+
+describe("jsonClone", () => {
+  it("should make a copy of a JS Object Literal", () => {
+    const testJson = {
+      string: "string",
+      number: 12,
+      boolean: true,
+      array: ["string", 12, true]
+    };
+    const result = jsonClone(testJson);
+    expect(result).toEqual(testJson);
+    expect(result).not.toBe(testJson);
+  });
+
+  it("should remove methods", () => {
+    const testJson = {
+      string: "string",
+      function: function() {
+        return "test";
+      }
+    };
+
+    expect(jsonClone(testJson)).toEqual({ string: "string" });
   });
 });

--- a/static/js/publisher/release/reducers/pendingReleases.js
+++ b/static/js/publisher/release/reducers/pendingReleases.js
@@ -14,9 +14,10 @@ import {
 import { CLOSE_CHANNEL } from "../actions/pendingCloses";
 
 import { TEMP_KEY } from "../constants";
+import { jsonClone } from "../helpers";
 
 function removePendingRelease(state, revision, channel) {
-  const newState = JSON.parse(JSON.stringify(state));
+  const newState = jsonClone(state);
   if (newState[revision.revision]) {
     if (newState[revision.revision][channel]) {
       delete newState[revision.revision][channel];
@@ -96,7 +97,7 @@ function closeChannel(state, channel) {
 }
 
 function setProgressiveRelease(state, progressive) {
-  const nextState = JSON.parse(JSON.stringify(state));
+  const nextState = jsonClone(state);
 
   Object.values(nextState).forEach(pendingRelease => {
     Object.values(pendingRelease).forEach(channel => {
@@ -118,7 +119,7 @@ function setProgressiveRelease(state, progressive) {
 }
 
 function updateProgressiveRelease(state, progressive) {
-  const nextState = JSON.parse(JSON.stringify(state));
+  const nextState = jsonClone(state);
 
   Object.values(nextState).forEach(pendingRelease => {
     Object.values(pendingRelease).forEach(channel => {
@@ -132,7 +133,7 @@ function updateProgressiveRelease(state, progressive) {
 }
 
 function pauseProgressiveRelease(state, key) {
-  const nextState = JSON.parse(JSON.stringify(state));
+  const nextState = jsonClone(state);
 
   Object.values(nextState).forEach(pendingRelease => {
     Object.values(pendingRelease).forEach(channel => {
@@ -146,7 +147,7 @@ function pauseProgressiveRelease(state, key) {
 }
 
 function resumeProgressiveRelease(state, key) {
-  const nextState = JSON.parse(JSON.stringify(state));
+  const nextState = jsonClone(state);
 
   Object.values(nextState).forEach(pendingRelease => {
     Object.values(pendingRelease).forEach(channel => {
@@ -164,7 +165,7 @@ function resumeProgressiveRelease(state, key) {
 // That means the progressive.key is ignored and other releases with the
 // same key are not affected.
 function cancelProgressiveRelease(state, key, previousRevision) {
-  let nextState = JSON.parse(JSON.stringify(state));
+  let nextState = jsonClone(state);
 
   Object.keys(nextState).forEach(revision => {
     const pendingReleaseChannels = nextState[revision];
@@ -185,7 +186,7 @@ function cancelProgressiveRelease(state, key, previousRevision) {
 }
 
 function setTempProgressiveKeys(state) {
-  const nextState = JSON.parse(JSON.stringify(state));
+  const nextState = jsonClone(state);
 
   let index = 0;
   Object.keys(nextState).forEach(revision => {
@@ -207,7 +208,7 @@ function setTempProgressiveKeys(state) {
 }
 
 function removeTempProgressiveKeys(state) {
-  const nextState = JSON.parse(JSON.stringify(state));
+  const nextState = jsonClone(state);
 
   Object.keys(nextState).forEach(revision => {
     const pendingReleaseChannels = nextState[revision];

--- a/static/js/publisher/release/selectors/index.js
+++ b/static/js/publisher/release/selectors/index.js
@@ -5,7 +5,12 @@ import {
   AVAILABLE_REVISIONS_SELECT_RECENT,
   AVAILABLE_REVISIONS_SELECT_LAUNCHPAD
 } from "../constants";
-import { isInDevmode, getBuildId, isRevisionBuiltOnLauchpad } from "../helpers";
+import {
+  isInDevmode,
+  getBuildId,
+  isRevisionBuiltOnLauchpad,
+  jsonClone
+} from "../helpers";
 import { sortAlphaNum, getChannelString } from "../../../libs/channels";
 
 // returns true if isProgressiveReleaseEnabled feature flag is enabled
@@ -96,7 +101,7 @@ export function hasDevmodeRevisions(state) {
 // get channel map data updated with any pending releases
 export function getPendingChannelMap(state) {
   const { channelMap, pendingReleases } = state;
-  const pendingChannelMap = JSON.parse(JSON.stringify(channelMap));
+  const pendingChannelMap = jsonClone(channelMap);
 
   // for each release
   Object.keys(pendingReleases).forEach(releasedRevision => {
@@ -299,7 +304,7 @@ export function getProgressiveState(state, channel, arch, isPending) {
       release.progressive &&
       release.progressive.key
     ) {
-      progressiveStatus = JSON.parse(JSON.stringify(release.progressive));
+      progressiveStatus = jsonClone(release.progressive);
 
       previousRevision = allReleases[1];
 
@@ -362,7 +367,7 @@ export function getSeparatePendingReleases(state) {
   Object.keys(pendingReleases).forEach(revId => {
     Object.keys(pendingReleases[revId]).forEach(channel => {
       const pendingRelease = pendingReleases[revId][channel];
-      const releaseCopy = JSON.parse(JSON.stringify(pendingRelease));
+      const releaseCopy = jsonClone(pendingRelease);
 
       if (isProgressiveEnabled && pendingRelease.replaces) {
         const oldRelease = pendingRelease.replaces;


### PR DESCRIPTION
## Done

- Moved `JSON.parse(JSON.stringify(arg))` to helper called `jsonClone`

## Issue / Card

Fixes #2400 

## QA

- Pull the branch
- Run the site using the command `./run`
- View the site locally in your web browser at: http://0.0.0.0:8004/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Ensure tests pass and release UI works as before