### PR TITLE
Move the release details below the button row

### DIFF
--- a/static/js/publisher/release/components/releasesConfirm.js
+++ b/static/js/publisher/release/components/releasesConfirm.js
@@ -83,7 +83,6 @@ class ReleasesConfirm extends Component {
     return (
       <Fragment>
         <div className="p-releases-confirm">
-          {showDetails && <ReleasesConfirmDetails updates={updates} />}
           <div className="row u-vertically-center">
             <div className="col-6">
               {updatesCount > 0 && (
@@ -118,6 +117,7 @@ class ReleasesConfirm extends Component {
             </div>
           </div>
         </div>
+        {showDetails && <ReleasesConfirmDetails updates={updates} />}
       </Fragment>
     );
   }

--- a/static/sass/_snapcraft_release.scss
+++ b/static/sass/_snapcraft_release.scss
@@ -7,7 +7,7 @@
 
   .p-releases-confirm {
     border-bottom: 1px solid $color-mid-light;
-    margin-bottom: 1em;
+    margin-bottom: 1rem;
     padding: .5em 0;
     position: relative;
   }
@@ -42,8 +42,10 @@
 
   .p-releases-confirm__details {
     border-bottom: 1px solid $color-mid-light;
-    margin: .5rem 0 .5rem;
+    margin: .5rem 0 1rem;
     padding-bottom: .5rem;
+    position: relative;
+    top: -1rem;
   }
 
   // RELEASES TABLE


### PR DESCRIPTION
## Done

- Open details below the button row

## Issue / Card

Fixes #2403 

## QA

- Pull the branch
- Run the site using the command `./run`
- View the site locally in your web browser at: http://0.0.0.0:8004/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Visit http://0.0.0.0:8004/snap_name/releaes
- Make some changes and see that the details opens below the buttons

## Screenshots

[if relevant, include a screenshot]