### PR TITLE
Add GA event tracking to release-ui

### DIFF
--- a/static/js/base/ga.js
+++ b/static/js/base/ga.js
@@ -32,6 +32,18 @@ function triggerEvent(category, from, to, label) {
   }
 }
 
+function triggerEventReleaseUI(action, label) {
+  if (dataLayer) {
+    dataLayer.push({
+      event: "GAEvent",
+      eventCategory: `Release UI`,
+      eventAction: action,
+      eventLabel: label,
+      eventValue: undefined
+    });
+  }
+}
+
 function triggerCopyEvent(category, clipboardTarget) {
   const clipboardTargetEl = document.querySelector(clipboardTarget);
 
@@ -116,4 +128,4 @@ if (typeof dataLayer !== "undefined") {
   });
 }
 
-export { triggerEvent };
+export { triggerEvent, triggerEventReleaseUI };

--- a/static/js/publisher/release/actions/gaEventTracking.js
+++ b/static/js/publisher/release/actions/gaEventTracking.js
@@ -1,0 +1,22 @@
+import { triggerEventReleaseUI } from "../../../base/ga";
+
+export function triggerGAEvent() {
+  const eventLabelItems = [...arguments];
+  const eventAction = eventLabelItems.shift();
+  let eventLabel = "";
+
+  return (dispatch, getState) => {
+    const currentState = getState();
+
+    if (eventLabelItems.length > 1) {
+      eventLabel = `from:${currentState.options.snapName}/
+      ${eventLabelItems[0]} to:${currentState.options.snapName}/
+      ${eventLabelItems[1]}`;
+    } else if (eventLabelItems.length === 1) {
+      eventLabel = `${currentState.options.snapName}/${eventLabelItems[0]}`;
+    } else {
+      eventLabel = currentState.options.snapName;
+    }
+    triggerEventReleaseUI(eventAction, eventLabel);
+  };
+}

--- a/static/js/publisher/release/actions/gaEventTracking.js
+++ b/static/js/publisher/release/actions/gaEventTracking.js
@@ -18,5 +18,6 @@ export function triggerGAEvent() {
       eventLabel = currentState.options.snapName;
     }
     triggerEventReleaseUI(eventAction, eventLabel);
+    return { type: "GA_EVENT_SENT" };
   };
 }

--- a/static/js/publisher/release/actions/gaEventTracking.test.js
+++ b/static/js/publisher/release/actions/gaEventTracking.test.js
@@ -1,0 +1,49 @@
+/* global global, jest */
+
+import configureMockStore from "redux-mock-store";
+import thunk from "redux-thunk";
+
+const mockStore = configureMockStore([thunk]);
+
+import { triggerGAEvent } from "./gaEventTracking";
+
+describe("triggerGAEvent", () => {
+  beforeEach(() => {
+    global.dataLayer = { push: jest.fn() };
+  });
+
+  afterEach(() => {
+    global.dataLayer = undefined;
+  });
+
+  it("should call the dataLayer.push function", () => {
+    const store = mockStore({ options: { snapName: "testSnap" } });
+    store.dispatch(triggerGAEvent("test", "test"));
+
+    expect(global.dataLayer.push).toHaveBeenCalled();
+  });
+
+  it("checks should call the dataLayer.push function once", () => {
+    const store = mockStore({ options: { snapName: "testSnap" } });
+    store.dispatch(triggerGAEvent("test", "test"));
+
+    expect(global.dataLayer.push.mock.calls.length).toEqual(1);
+  });
+
+  it("should return an array of arrays containing an object", () => {
+    const store = mockStore({ options: { snapName: "testSnap" } });
+    store.dispatch(triggerGAEvent("test", "test"));
+
+    expect(global.dataLayer.push.mock.calls).toEqual([
+      [
+        {
+          event: "GAEvent",
+          eventAction: "test",
+          eventCategory: "Release UI",
+          eventLabel: "testSnap/test",
+          eventValue: undefined
+        }
+      ]
+    ]);
+  });
+});

--- a/static/js/publisher/release/actions/history.js
+++ b/static/js/publisher/release/actions/history.js
@@ -30,20 +30,24 @@ export function toggleHistory(filters) {
           filters.risk === history.filters.risk &&
           filters.branch === history.filters.branch))
     ) {
-      dispatch(
-        triggerGAEvent(
-          `click-close-history`,
-          `${filters.track}/${filters.risk}/${filters.branch}/${filters.arch}`
-        )
-      );
+      if (filters) {
+        dispatch(
+          triggerGAEvent(
+            `click-close-history`,
+            `${filters.track}/${filters.risk}/${filters.branch}/${filters.arch}`
+          )
+        );
+      }
       dispatch(closeHistory());
     } else {
-      dispatch(
-        triggerGAEvent(
-          `click-open-history`,
-          `${filters.track}/${filters.risk}/${filters.branch}/${filters.arch}`
-        )
-      );
+      if (filters) {
+        dispatch(
+          triggerGAEvent(
+            `click-open-history`,
+            `${filters.track}/${filters.risk}/${filters.branch}/${filters.arch}`
+          )
+        );
+      }
       dispatch(openHistory(filters));
     }
   };

--- a/static/js/publisher/release/actions/history.js
+++ b/static/js/publisher/release/actions/history.js
@@ -20,13 +20,6 @@ export function toggleHistory(filters) {
   return (dispatch, getState) => {
     const { history } = getState();
 
-    dispatch(
-      triggerGAEvent(
-        `click-${history.isOpen ? "close" : "open"}-history`,
-        `${filters.track}/${filters.risk}/${filters.branch}/${filters.arch}`
-      )
-    );
-
     if (
       history.isOpen &&
       (history.filters == filters ||
@@ -37,8 +30,20 @@ export function toggleHistory(filters) {
           filters.risk === history.filters.risk &&
           filters.branch === history.filters.branch))
     ) {
+      dispatch(
+        triggerGAEvent(
+          `click-close-history`,
+          `${filters.track}/${filters.risk}/${filters.branch}/${filters.arch}`
+        )
+      );
       dispatch(closeHistory());
     } else {
+      dispatch(
+        triggerGAEvent(
+          `click-open-history`,
+          `${filters.track}/${filters.risk}/${filters.branch}/${filters.arch}`
+        )
+      );
       dispatch(openHistory(filters));
     }
   };

--- a/static/js/publisher/release/actions/history.js
+++ b/static/js/publisher/release/actions/history.js
@@ -1,6 +1,8 @@
 export const OPEN_HISTORY = "OPEN_HISTORY";
 export const CLOSE_HISTORY = "CLOSE_HISTORY";
 
+import { triggerGAEvent } from "../actions/gaEventTracking";
+
 export function openHistory(filters) {
   return {
     type: OPEN_HISTORY,
@@ -17,6 +19,13 @@ export function closeHistory() {
 export function toggleHistory(filters) {
   return (dispatch, getState) => {
     const { history } = getState();
+
+    dispatch(
+      triggerGAEvent(
+        `click-${history.isOpen ? "close" : "open"}-history`,
+        `${filters.track}/${filters.risk}/${filters.branch}/${filters.arch}`
+      )
+    );
 
     if (
       history.isOpen &&

--- a/static/js/publisher/release/actions/history.test.js
+++ b/static/js/publisher/release/actions/history.test.js
@@ -1,3 +1,5 @@
+/* global global, jest */
+
 import configureMockStore from "redux-mock-store";
 import thunk from "redux-thunk";
 
@@ -18,6 +20,14 @@ describe("history actions", () => {
     risk: "stable",
     branch: null
   };
+
+  beforeEach(() => {
+    global.dataLayer = { push: jest.fn() };
+  });
+
+  afterEach(() => {
+    global.dataLayer = undefined;
+  });
 
   describe("openHistory", () => {
     it("should create an action to open history panel", () => {
@@ -82,6 +92,9 @@ describe("history actions", () => {
     describe("when history with different filters is open", () => {
       it("should dispatch action to open history panel with new filters", () => {
         const store = mockStore({
+          options: {
+            snapName: "test"
+          },
           history: {
             isOpen: true,
             filters: {
@@ -104,6 +117,9 @@ describe("history actions", () => {
     describe("when history is closed", () => {
       it("should dispatch action to open history panel", () => {
         const store = mockStore({
+          options: {
+            snapName: "test"
+          },
           history: {
             isOpen: false,
             filters: null

--- a/static/js/publisher/release/actions/history.test.js
+++ b/static/js/publisher/release/actions/history.test.js
@@ -15,7 +15,8 @@ describe("history actions", () => {
   const dummyFilters = {
     arch: "abc42",
     track: "latest",
-    risk: "stable"
+    risk: "stable",
+    branch: null
   };
 
   describe("openHistory", () => {
@@ -42,6 +43,9 @@ describe("history actions", () => {
     describe("when history with same filters is open", () => {
       it("should dispatch action to close history panel", () => {
         const store = mockStore({
+          options: {
+            snapName: "test"
+          },
           history: {
             isOpen: true,
             filters: {

--- a/static/js/publisher/release/actions/pendingReleases.js
+++ b/static/js/publisher/release/actions/pendingReleases.js
@@ -13,6 +13,8 @@ export const REMOVE_TEMP_PROGRESSIVE_KEYS = "REMOVE_TEMP_PROGRESSIVE_KEYS";
 
 import { getPendingChannelMap, getReleases } from "../selectors";
 
+import { triggerGAEvent } from "../actions/gaEventTracking";
+
 export function releaseRevision(revision, channel, progressive) {
   return (dispatch, getState) => {
     const state = getState();
@@ -143,14 +145,24 @@ export function promoteChannel(channel, targetChannel) {
 }
 
 export function undoRelease(revision, channel) {
-  return {
-    type: UNDO_RELEASE,
-    payload: { revision, channel }
+  return dispatch => {
+    dispatch(
+      triggerGAEvent(
+        "click-cancel-promotion",
+        `${channel}/${revision.architectures[0]}`
+      )
+    );
+    return dispatch({
+      type: UNDO_RELEASE,
+      payload: { revision, channel }
+    });
   };
 }
 
 export function cancelPendingReleases() {
-  return {
-    type: CANCEL_PENDING_RELEASES
+  return dispatch => {
+    return dispatch({
+      type: CANCEL_PENDING_RELEASES
+    });
   };
 }

--- a/static/js/publisher/release/actions/pendingReleases.js
+++ b/static/js/publisher/release/actions/pendingReleases.js
@@ -160,9 +160,7 @@ export function undoRelease(revision, channel) {
 }
 
 export function cancelPendingReleases() {
-  return dispatch => {
-    return dispatch({
-      type: CANCEL_PENDING_RELEASES
-    });
+  return {
+    type: CANCEL_PENDING_RELEASES
   };
 }

--- a/static/js/publisher/release/actions/pendingReleases.test.js
+++ b/static/js/publisher/release/actions/pendingReleases.test.js
@@ -1,3 +1,5 @@
+/* global global, jest */
+
 import configureMockStore from "redux-mock-store";
 import thunk from "redux-thunk";
 
@@ -49,6 +51,14 @@ describe("pendingReleases actions", () => {
       [revision2.revision]: revision2
     }
   };
+
+  beforeEach(() => {
+    global.dataLayer = { push: jest.fn() };
+  });
+
+  afterEach(() => {
+    global.dataLayer = undefined;
+  });
 
   describe("releaseRevision", () => {
     const store = mockStore(stateWithRevisions);
@@ -260,16 +270,23 @@ describe("pendingReleases actions", () => {
   });
 
   describe("undoRelease", () => {
+    const store = mockStore(stateWithRevisions);
     it("should create an action to undo release of revision", () => {
-      expect(undoRelease(revision, channel).type).toBe(UNDO_RELEASE);
+      expect(store.dispatch(undoRelease(revision, channel)).type).toBe(
+        UNDO_RELEASE
+      );
     });
 
     it("should supply a payload with revision", () => {
-      expect(undoRelease(revision, channel).payload.revision).toEqual(revision);
+      expect(
+        store.dispatch(undoRelease(revision, channel)).payload.revision
+      ).toEqual(revision);
     });
 
     it("should supply a payload with channel", () => {
-      expect(undoRelease(revision, channel).payload.channel).toEqual(channel);
+      expect(
+        store.dispatch(undoRelease(revision, channel)).payload.channel
+      ).toEqual(channel);
     });
   });
 

--- a/static/js/publisher/release/components/channelMenu.js
+++ b/static/js/publisher/release/components/channelMenu.js
@@ -10,6 +10,8 @@ export default class ChannelMenu extends Component {
   }
 
   promoteToChannelClick(targetChannel, event) {
+    this.props.gaEvent(targetChannel, "promote");
+
     this.props.promoteToChannel(targetChannel);
 
     if (this.menu) {
@@ -60,6 +62,8 @@ export default class ChannelMenu extends Component {
   }
 
   closeChannelClick(channel, event) {
+    this.props.gaEvent(channel, "close");
+
     this.props.closeChannel(channel);
 
     if (this.menu) {
@@ -125,5 +129,6 @@ ChannelMenu.propTypes = {
   targetChannels: PropTypes.array.isRequired,
   tooltip: PropTypes.string,
   promoteToChannel: PropTypes.func.isRequired,
-  closeChannel: PropTypes.func
+  closeChannel: PropTypes.func,
+  gaEvent: PropTypes.func.isRequired
 };

--- a/static/js/publisher/release/components/releasesConfirm.js
+++ b/static/js/publisher/release/components/releasesConfirm.js
@@ -63,7 +63,7 @@ class ReleasesConfirm extends Component {
 
   toggleDetails() {
     this.props.triggerGAEvent(
-      `click-${this.state.showDetails ? "hide" : "show"}Details`
+      `click-${this.state.showDetails ? "hide" : "show"}-details`
     );
     this.setState({
       showDetails: !this.state.showDetails

--- a/static/js/publisher/release/components/releasesConfirm.js
+++ b/static/js/publisher/release/components/releasesConfirm.js
@@ -10,6 +10,7 @@ import {
   setProgressiveReleasePercentage
 } from "../actions/pendingReleases";
 import { releaseRevisions } from "../actions/releases";
+import { triggerGAEvent } from "../actions/gaEventTracking";
 import { getSeparatePendingReleases } from "../selectors";
 
 class ReleasesConfirm extends Component {
@@ -23,6 +24,7 @@ class ReleasesConfirm extends Component {
   }
 
   onRevertClick() {
+    this.props.triggerGAEvent("click-revert");
     this.props.cancelPendingReleases();
     this.setState({
       showDetails: false
@@ -30,6 +32,8 @@ class ReleasesConfirm extends Component {
   }
 
   onApplyClick() {
+    this.props.triggerGAEvent("click-save");
+
     this.setState({
       isLoading: true
     });
@@ -58,6 +62,9 @@ class ReleasesConfirm extends Component {
   }
 
   toggleDetails() {
+    this.props.triggerGAEvent(
+      `click-${this.state.showDetails ? "hide" : "show"}Details`
+    );
     this.setState({
       showDetails: !this.state.showDetails
     });
@@ -128,7 +135,8 @@ ReleasesConfirm.propTypes = {
 
   releaseRevisions: PropTypes.func.isRequired,
   cancelPendingReleases: PropTypes.func.isRequired,
-  setProgressiveReleasePercentage: PropTypes.func.isRequired
+  setProgressiveReleasePercentage: PropTypes.func.isRequired,
+  triggerGAEvent: PropTypes.func.isRequired
 };
 
 const mapStateToProps = state => {
@@ -145,7 +153,8 @@ const mapDispatchToProps = dispatch => {
     releaseRevisions: () => dispatch(releaseRevisions()),
     cancelPendingReleases: () => dispatch(cancelPendingReleases()),
     setProgressiveReleasePercentage: (key, percentage) =>
-      dispatch(setProgressiveReleasePercentage(key, percentage))
+      dispatch(setProgressiveReleasePercentage(key, percentage)),
+    triggerGAEvent: (...eventProps) => dispatch(triggerGAEvent(...eventProps))
   };
 };
 

--- a/static/js/publisher/release/components/releasesTable/channelHeading.js
+++ b/static/js/publisher/release/components/releasesTable/channelHeading.js
@@ -18,6 +18,8 @@ import { closeChannel } from "../../actions/pendingCloses";
 
 import { toggleBranches } from "../../actions/branches";
 
+import { triggerGAEvent } from "../../actions/gaEventTracking";
+
 import {
   RISKS_WITH_AVAILABLE as RISKS,
   AVAILABLE,
@@ -299,6 +301,14 @@ const ReleasesTableChannelHeading = props => {
     );
   };
 
+  const triggerGAEvents = (targetChannel, actionType) => {
+    if (actionType === "close") {
+      props.triggerGAEvent("click-close-channel", targetChannel);
+    } else {
+      props.triggerGAEvent("click-promote", channel, targetChannel);
+    }
+  };
+
   return (
     <div
       ref={drag}
@@ -329,6 +339,7 @@ const ReleasesTableChannelHeading = props => {
             promoteToChannel={promoteRevisions}
             channel={channel}
             closeChannel={canBeClosed ? props.closeChannel : null}
+            gaEvent={triggerGAEvents}
           />
         )}
       </span>
@@ -379,7 +390,8 @@ ReleasesTableChannelHeading.propTypes = {
   // actions
   closeChannel: PropTypes.func.isRequired,
   promoteRevision: PropTypes.func.isRequired,
-  toggleBranches: PropTypes.func.isRequired
+  toggleBranches: PropTypes.func.isRequired,
+  triggerGAEvent: PropTypes.func.isRequired
 };
 
 const mapStateToProps = (state, props) => {
@@ -408,7 +420,8 @@ const mapDispatchToProps = dispatch => {
     promoteRevision: (revision, targetChannel) =>
       dispatch(promoteRevision(revision, targetChannel)),
     closeChannel: channel => dispatch(closeChannel(channel)),
-    toggleBranches: channel => dispatch(toggleBranches(channel))
+    toggleBranches: channel => dispatch(toggleBranches(channel)),
+    triggerGAEvent: (...eventProps) => dispatch(triggerGAEvent(...eventProps))
   };
 };
 

--- a/static/js/publisher/release/components/releasesTable/channelHeading.js
+++ b/static/js/publisher/release/components/releasesTable/channelHeading.js
@@ -301,7 +301,7 @@ const ReleasesTableChannelHeading = props => {
     );
   };
 
-  const triggerGAEvents = (targetChannel, actionType) => {
+  const triggerGAEvent = (targetChannel, actionType) => {
     if (actionType === "close") {
       props.triggerGAEvent("click-close-channel", targetChannel);
     } else {
@@ -339,7 +339,7 @@ const ReleasesTableChannelHeading = props => {
             promoteToChannel={promoteRevisions}
             channel={channel}
             closeChannel={canBeClosed ? props.closeChannel : null}
-            gaEvent={triggerGAEvents}
+            gaEvent={triggerGAEvent}
           />
         )}
       </span>

--- a/static/js/publisher/release/components/releasesTable/releaseCell.js
+++ b/static/js/publisher/release/components/releasesTable/releaseCell.js
@@ -11,6 +11,7 @@ import { DND_ITEM_REVISIONS } from "../dnd";
 
 import { toggleHistory } from "../../actions/history";
 import { undoRelease } from "../../actions/pendingReleases";
+import { triggerGAEvent } from "../../actions/gaEventTracking";
 
 import {
   getPendingChannelMap,
@@ -45,7 +46,8 @@ const ReleasesTableReleaseCell = props => {
     hasPendingRelease,
     undoRelease,
     toggleHistoryPanel,
-    getProgressiveState
+    getProgressiveState,
+    triggerGAEvent
   } = props;
 
   const branchName = branch ? branch.branch : null;
@@ -93,11 +95,16 @@ const ReleasesTableReleaseCell = props => {
   };
 
   function handleHistoryIconClick(arch, risk, track, branchName) {
+    triggerGAEvent("click-history", `${track}/${risk}/${branchName}/${arch}`);
     toggleHistoryPanel({ arch, risk, track, branch: branchName });
   }
 
   function undoClick(revision, channel, event) {
     event.stopPropagation();
+    triggerGAEvent(
+      "click-cancel-promotion",
+      `${channel}/${revision.architectures[0]}`
+    );
     undoRelease(revision, channel);
   }
 
@@ -201,6 +208,7 @@ ReleasesTableReleaseCell.propTypes = {
   // actions
   toggleHistoryPanel: PropTypes.func.isRequired,
   undoRelease: PropTypes.func.isRequired,
+  triggerGAEvent: PropTypes.func.isRequired,
   // props
   track: PropTypes.string,
   risk: PropTypes.string,
@@ -231,7 +239,9 @@ const mapStateToProps = state => {
 const mapDispatchToProps = dispatch => {
   return {
     toggleHistoryPanel: filters => dispatch(toggleHistory(filters)),
-    undoRelease: (revision, channel) => dispatch(undoRelease(revision, channel))
+    undoRelease: (revision, channel) =>
+      dispatch(undoRelease(revision, channel)),
+    triggerGAEvent: (...eventProps) => dispatch(triggerGAEvent(...eventProps))
   };
 };
 

--- a/static/js/publisher/release/components/releasesTable/releaseCell.js
+++ b/static/js/publisher/release/components/releasesTable/releaseCell.js
@@ -11,7 +11,6 @@ import { DND_ITEM_REVISIONS } from "../dnd";
 
 import { toggleHistory } from "../../actions/history";
 import { undoRelease } from "../../actions/pendingReleases";
-import { triggerGAEvent } from "../../actions/gaEventTracking";
 
 import {
   getPendingChannelMap,
@@ -46,8 +45,7 @@ const ReleasesTableReleaseCell = props => {
     hasPendingRelease,
     undoRelease,
     toggleHistoryPanel,
-    getProgressiveState,
-    triggerGAEvent
+    getProgressiveState
   } = props;
 
   const branchName = branch ? branch.branch : null;
@@ -95,16 +93,11 @@ const ReleasesTableReleaseCell = props => {
   };
 
   function handleHistoryIconClick(arch, risk, track, branchName) {
-    triggerGAEvent("click-history", `${track}/${risk}/${branchName}/${arch}`);
     toggleHistoryPanel({ arch, risk, track, branch: branchName });
   }
 
   function undoClick(revision, channel, event) {
     event.stopPropagation();
-    triggerGAEvent(
-      "click-cancel-promotion",
-      `${channel}/${revision.architectures[0]}`
-    );
     undoRelease(revision, channel);
   }
 
@@ -208,7 +201,6 @@ ReleasesTableReleaseCell.propTypes = {
   // actions
   toggleHistoryPanel: PropTypes.func.isRequired,
   undoRelease: PropTypes.func.isRequired,
-  triggerGAEvent: PropTypes.func.isRequired,
   // props
   track: PropTypes.string,
   risk: PropTypes.string,
@@ -239,9 +231,7 @@ const mapStateToProps = state => {
 const mapDispatchToProps = dispatch => {
   return {
     toggleHistoryPanel: filters => dispatch(toggleHistory(filters)),
-    undoRelease: (revision, channel) =>
-      dispatch(undoRelease(revision, channel)),
-    triggerGAEvent: (...eventProps) => dispatch(triggerGAEvent(...eventProps))
+    undoRelease: (revision, channel) => dispatch(undoRelease(revision, channel))
   };
 };
 

--- a/static/sass/_snapcraft-publisher.scss
+++ b/static/sass/_snapcraft-publisher.scss
@@ -6,12 +6,12 @@
 
 
   .snap-installs-placeholder {
-    width: 100%;
     height: 100%;
+    width: 100%;
 
     .p-icon--spinner {
-      width: $sp-x-large;
       height: $sp-x-large;
+      width: $sp-x-large;
     }
   }
 }

--- a/static/sass/_snapcraft_p-docs.scss
+++ b/static/sass/_snapcraft_p-docs.scss
@@ -93,8 +93,8 @@
 
     .p-search-box__input {
       flex-grow: 1;
-      margin-right: 2rem;
       margin-bottom: 0;
+      margin-right: 2rem;
     }
 
     button {


### PR DESCRIPTION
## Done

- Add GA event tracking to release-ui

## Issue / Card

Fixes https://github.com/canonical-web-and-design/snap-squad/issues/1225

## QA

- Pull the branch
- Run the site using the command `./run`
- View the site locally in your web browser at: http://0.0.0.0:8004/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare to [events scheme](https://github.com/canonical-web-and-design/snap-squad/issues/1224)

- I think the best way to test what info is sent to Google is to run the branch locally and edit `ga.js` by adding a `console.log("EventAction: " + action + "\nEventLabel:" + label);` on line 36

