### PR TITLE
Make year in the footer dynamic

### DIFF
--- a/templates/_footer.html
+++ b/templates/_footer.html
@@ -5,7 +5,7 @@
         <a class="p-link--soft" href="#">Back to top<i class="p-icon--top"></i></a>
       </p>
       <p>
-        &copy; 2019 Canonical Ltd. <br/>
+        &copy; {{ now.year }} Canonical Ltd. <br/>
         Ubuntu and Canonical are registered trademarks of Canonical Ltd.
         <br/>
         Powered by <a href="https://www.ubuntu.com/kubernetes">Charmed Kubernetes</a>

--- a/webapp/handlers.py
+++ b/webapp/handlers.py
@@ -8,6 +8,8 @@ import prometheus_client
 import webapp.template_utils as template_utils
 from webapp import authentication
 
+from datetime import datetime
+
 badge_counter = prometheus_client.Counter(
     "badge_counter", "A counter of badges requests"
 )
@@ -53,6 +55,7 @@ def set_handlers(app):
             "webapp_config": app.config["WEBAPP_CONFIG"],
             "BSI_URL": app.config["BSI_URL"],
             "IS_BRAND_STORE": is_brand_store,
+            "now": datetime.now(),
             # Functions
             "contains": template_utils.contains,
             "join": template_utils.join,


### PR DESCRIPTION
## Done

Make year in the footer dynamic

## Issue / Card

Fixes #2474 

## QA

- Pull the branch
- Run the site using the command `./run`
- View the site locally in your web browser at: http://0.0.0.0:8004/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See the year in the footer is 2020
