### PR TITLE
Ensure progressive releases are hidden when flag is disabled

### DIFF
--- a/static/js/publisher/release/components/releasesConfirmDetails/index.js
+++ b/static/js/publisher/release/components/releasesConfirmDetails/index.js
@@ -99,6 +99,7 @@ const ReleasesConfirmDetails = ({
               revisionInfo={revisionInfo}
               channel={channel}
               key={`${revisionInfo.revision}-{${channel}`}
+              showBar={showProgressiveReleases}
             />
           );
         })}

--- a/static/js/publisher/release/components/releasesConfirmDetails/releaseRow.js
+++ b/static/js/publisher/release/components/releasesConfirmDetails/releaseRow.js
@@ -3,7 +3,14 @@ import PropTypes from "prop-types";
 
 import { ProgressiveBar } from "../progressiveBar";
 
-const ReleaseRow = ({ type, revisionInfo, channel, progress, notes }) => (
+const ReleaseRow = ({
+  type,
+  revisionInfo,
+  channel,
+  progress,
+  notes,
+  showProgressiveReleases
+}) => (
   <div className="p-release-details-row">
     <span className="p-release-details-row__type">{type}</span>
     <span className="p-release-details-row__info">
@@ -21,18 +28,19 @@ const ReleaseRow = ({ type, revisionInfo, channel, progress, notes }) => (
         <span className="p-release-details-row__progress">{progress}</span>
       </Fragment>
     )}
-    {!progress && (
-      <Fragment>
-        <span className="p-release-details-row__join">to</span>
-        <span className="p-release-details-row__progress">
-          <ProgressiveBar percentage={100} disabled={true} />
-          <span>100% of devices</span>
-        </span>
-        <span className="p-release-details-row__notes">
-          Cannot progressively release to an empty channel
-        </span>
-      </Fragment>
-    )}
+    {!progress &&
+      showProgressiveReleases && (
+        <Fragment>
+          <span className="p-release-details-row__join">to</span>
+          <span className="p-release-details-row__progress">
+            <ProgressiveBar percentage={100} disabled={true} />
+            <span>100% of devices</span>
+          </span>
+          <span className="p-release-details-row__notes">
+            Cannot progressively release to an empty channel
+          </span>
+        </Fragment>
+      )}
     {notes && (
       <span className="p-release-details-row__notes">
         <small>{notes}</small>
@@ -46,7 +54,8 @@ ReleaseRow.propTypes = {
   revisionInfo: PropTypes.object,
   channel: PropTypes.node,
   progress: PropTypes.node,
-  notes: PropTypes.node
+  notes: PropTypes.node,
+  showProgressiveReleases: PropTypes.bool
 };
 
 export default ReleaseRow;

--- a/templates/publisher/release-history.html
+++ b/templates/publisher/release-history.html
@@ -45,7 +45,7 @@ Releases and revision history for {% if snap_title %}{{ snap_title }}{% else %}{
               defaultTrack: {% if default_track %}{{ default_track|tojson }}{% else %}"latest"{% endif %},
               csrfToken: {{ csrf_token()|tojson }},
               flags: {
-                isProgressiveReleaseEnabled: true
+                isProgressiveReleaseEnabled: {{ user_is_canonical|tojson }}
               }
             }
           );

--- a/webapp/handlers.py
+++ b/webapp/handlers.py
@@ -29,7 +29,9 @@ def set_handlers(app):
 
         if authentication.is_authenticated(flask.session):
             user_name = flask.session["openid"]["fullname"]
-            user_is_canonical = flask.session["openid"]["is_canonical"]
+            user_is_canonical = flask.session["openid"].get(
+                "is_canonical", False
+            )
         else:
             user_name = None
             user_is_canonical = False

--- a/webapp/handlers.py
+++ b/webapp/handlers.py
@@ -29,8 +29,10 @@ def set_handlers(app):
 
         if authentication.is_authenticated(flask.session):
             user_name = flask.session["openid"]["fullname"]
+            user_is_canonical = flask.session["openid"]["is_canonical"]
         else:
             user_name = None
+            user_is_canonical = False
 
         page_slug = template_utils.generate_slug(flask.request.path)
 
@@ -53,6 +55,7 @@ def set_handlers(app):
             "webapp_config": app.config["WEBAPP_CONFIG"],
             "BSI_URL": app.config["BSI_URL"],
             "IS_BRAND_STORE": is_brand_store,
+            "user_is_canonical": user_is_canonical,
             # Functions
             "contains": template_utils.contains,
             "join": template_utils.join,


### PR DESCRIPTION
## Done

- Ensure the new details section doesn't reference progressive releases when flag is disabled
- Pass through whether the user is a memeber of canonical on login

## Issue / Card

Fixes #2450

## QA

- Pull the branch
- Run the site using the command `./run`
- View the site locally in your web browser at: http://0.0.0.0:8004/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Visit http://0.0.0.0:8004/snap_name/releases
- If you're part of the canonical group on launchpad you should be able to see progressive releases
- If not, you can't
- You can manually disable the flag in the `releases-history.html` template