### PR TITLE
Check if snapcraft.yaml is present

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,6 +25,7 @@ responses==0.9.0
 ruamel.yaml==0.15.72
 talisker[flask,gunicorn,raven,prometheus]==0.15.0
 gevent==1.4.0
+vcrpy-unittest==0.1.7
 
 # Temporary fix to SSO redirect issue
 Werkzeug==0.14.1

--- a/tests/api/cassettes/GitHubAPITest.test_get_user_repositories.yaml
+++ b/tests/api/cassettes/GitHubAPITest.test_get_user_repositories.yaml
@@ -1,0 +1,163 @@
+interactions:
+- request:
+    body: '{"query": "{\n              viewer {\n                repositories(\n                    first:
+      100,\n                    privacy: PUBLIC,\n                    ownerAffiliations:\n                        [OWNER,
+      ORGANIZATION_MEMBER],\n                \n                ) {\n              edges
+      {\n                node {\n                  nameWithOwner\n                  yamlLocation1:\n                    object(expression:
+      \"master:snapcraft.yaml\")\n                    { id }\n                  yamlLocation2:\n                    object(expression:
+      \"master:.snapcraft.yaml\")\n                    { id }\n                  yamlLocation3:\n                    object(expression:
+      \"master:snap/snapcraft.yaml\")\n                    { id }\n                  yamlLocation4:\n                    object(expression:
+      \"master:build-aux/snap/snapcraft.yaml\")\n                    { id }\n                }\n              }\n              pageInfo
+      {\n                hasNextPage\n                endCursor\n              }\n            }\n          }\n        }"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1065'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - storefront (a85017b3bae1b0f4530624eb0909c64e855c8a6a;devel)
+    method: POST
+    uri: https://api.github.com/graphql
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7WUUW+bMBDHv4ufEy0BMmmR+pDOGyOb7TE5RWbagwdOsLEBBVIKEd99tvbUppGq
+        tXs46e4vnX0//08+g5x3HKzP4F6KXhxddhRN3cquPkrRulrkB5f8PIOqzoVTKm5EIruC9JVrAb9P
+        UufztuMHWR3mbcWb7Mj33VzW7zrRdkswAwM3+lud8U7W1dKdIXPbiGD8PjYP90xFI4GfVkjtVpjW
+        vc1HpsoRqc3AaGRjMxJ68BktexxGfqpuC0xZjwwb2IhWWG0LMD2+xQPr6qT1Y9F/Tgz+itM0+2dE
+        7xLx8nI70VVu5iNYDyj8odOQBRjuvFTlJYE2wniBVRYwE/UpRT1LIo8k24KZXZ/CeHzK/b8Q/Rci
+        XnLbia5yZwOmTUmS2CfwViKIC6wKVy8J3C1SqksbOjVoTGm8tD7bN9kapLR5yv0GLgavQbzkthNd
+        5w6QajSCbo9zw+hWoXC3TMPUYGW9NyxAtPQQzDxC7yRJPmtk/ba7vwDTaxZ19eaIjnuafs1Aww8i
+        qva1oy54i8VD991KYL3nuhUzIKr84+nY1u7HYP7dkHkfBlKxgTRfCFRfo3Fzc+PgpukP4k+8cJYE
+        AAA=
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type
+      Cache-Control:
+      - no-cache
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 04 Feb 2020 12:01:38 GMT
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Server:
+      - GitHub.com
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Accepted-OAuth-Scopes:
+      - repo
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-GitHub-Media-Type:
+      - github.v4
+      X-GitHub-Request-Id:
+      - BE32:2BEC7:11F91D3:1527136:5E395D21
+      X-OAuth-Client-Id:
+      - cdeb3a60fecee4208395
+      X-OAuth-Scopes:
+      - repo
+      X-RateLimit-Limit:
+      - '5000'
+      X-RateLimit-Remaining:
+      - '4993'
+      X-RateLimit-Reset:
+      - '1580817914'
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"query": "{\n              viewer {\n                repositories(\n                    first:
+      100,\n                    privacy: PUBLIC,\n                    ownerAffiliations:\n                        [OWNER,
+      ORGANIZATION_MEMBER],\n                \n                ) {\n              edges
+      {\n                node {\n                  nameWithOwner\n                  yamlLocation1:\n                    object(expression:
+      \"master:snapcraft.yaml\")\n                    { id }\n                  yamlLocation2:\n                    object(expression:
+      \"master:.snapcraft.yaml\")\n                    { id }\n                  yamlLocation3:\n                    object(expression:
+      \"master:snap/snapcraft.yaml\")\n                    { id }\n                  yamlLocation4:\n                    object(expression:
+      \"master:build-aux/snap/snapcraft.yaml\")\n                    { id }\n                }\n              }\n              pageInfo
+      {\n                hasNextPage\n                endCursor\n              }\n            }\n          }\n        }"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1065'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - storefront (a85017b3bae1b0f4530624eb0909c64e855c8a6a;devel)
+    method: POST
+    uri: https://api.github.com/graphql
+  response:
+    body:
+      string: '{"message":"Bad credentials","documentation_url":"https://developer.github.com/v4"}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type
+      Content-Length:
+      - '83'
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 04 Feb 2020 12:01:38 GMT
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Server:
+      - GitHub.com
+      Status:
+      - 401 Unauthorized
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-GitHub-Media-Type:
+      - github.v4
+      X-GitHub-Request-Id:
+      - BE32:2BEC7:11F92B4:152723F:5E395D22
+      X-RateLimit-Limit:
+      - '0'
+      X-RateLimit-Remaining:
+      - '0'
+      X-RateLimit-Reset:
+      - '1580821298'
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 401
+      message: Unauthorized
+version: 1

--- a/tests/api/cassettes/GitHubAPITest.test_get_username.yaml
+++ b/tests/api/cassettes/GitHubAPITest.test_get_username.yaml
@@ -1,0 +1,140 @@
+interactions:
+- request:
+    body: '{"query": "{ viewer { login } }"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '33'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - storefront (a85017b3bae1b0f4530624eb0909c64e855c8a6a;devel)
+    method: POST
+    uri: https://api.github.com/graphql
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6tWSkksSVSyqlYqy0wtTy0CsXLy0zPzlKyUkkozc1J0i0sSgdx03eK8xILkosS0
+        Et3MfKXa2loA1+bv3DoAAAA=
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type
+      Cache-Control:
+      - no-cache
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 04 Feb 2020 11:21:42 GMT
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Server:
+      - GitHub.com
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Accepted-OAuth-Scopes:
+      - repo
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-GitHub-Media-Type:
+      - github.v4
+      X-GitHub-Request-Id:
+      - DBAA:2415D:5C9ED4:6BF4CF:5E3953C6
+      X-OAuth-Client-Id:
+      - cdeb3a60fecee4208395
+      X-OAuth-Scopes:
+      - repo
+      X-RateLimit-Limit:
+      - '5000'
+      X-RateLimit-Remaining:
+      - '4996'
+      X-RateLimit-Reset:
+      - '1580817914'
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"query": "{ viewer { login } }"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '33'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - storefront (a85017b3bae1b0f4530624eb0909c64e855c8a6a;devel)
+    method: POST
+    uri: https://api.github.com/graphql
+  response:
+    body:
+      string: '{"message":"Bad credentials","documentation_url":"https://developer.github.com/v4"}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type
+      Content-Length:
+      - '83'
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 04 Feb 2020 11:21:42 GMT
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Server:
+      - GitHub.com
+      Status:
+      - 401 Unauthorized
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-GitHub-Media-Type:
+      - github.v4
+      X-GitHub-Request-Id:
+      - DBAA:2415D:5C9EF3:6BF4F4:5E3953C6
+      X-RateLimit-Limit:
+      - '0'
+      X-RateLimit-Remaining:
+      - '0'
+      X-RateLimit-Reset:
+      - '1580818902'
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 401
+      message: Unauthorized
+version: 1

--- a/tests/api/cassettes/GitHubAPITest.test_is_snapcraft_yaml_present.yaml
+++ b/tests/api/cassettes/GitHubAPITest.test_is_snapcraft_yaml_present.yaml
@@ -1,0 +1,934 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - storefront (a85017b3bae1b0f4530624eb0909c64e855c8a6a;devel)
+    method: GET
+    uri: https://api.github.com/repos/build-staging-snapcraft-io/test1/contents/snapcraft.yaml
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA72SXU/CMBSG/8uuhY5OkZEYA34QJMoFBpCQkNOu2wpdu6ydE4z/3Q6IAaIhfsTL
+        np6+z3tO31dHQsKcpqMlpDSD0FSXkAjnxEnBxJ/VdQy27DZqHvE97GLAGFzPb5yD756S89CFs7qL
+        Q0w9v47BCmm+sgDfO3HyTNinsTGpbiIEKa9G3MQ5qVKVoIylSiOScxFUtIGIy6jyYarCFTJMmxqi
+        ShomjUb7hi8zFl4koA3LLDI2iZjt03ZIRxlEKII2YgcYq22FDqR/NojVQSVIo2/sMlCFFAqCAwcZ
+        FNtV5ppl2xWtt3p01q/GNMu0jEXIBbNDbyVtgSS3ZvKooqAzXAXXN70gGS4pFs9krqK7VSu/H9Ae
+        9YaGjG6XzPYNy75WupiMH+ZTSRNRBJ1N9/ameBrfuXSlet2rtmGD2vrcj1TUvWpFtPNSm2CR93k7
+        n0oYFb2ptHaYpCqwASn9gGb1U1ubCS4X2mm+OpqJ8H9yZv/w16Af5aAM+A75j8L99vYO9MPjBg8E
+        AAA=
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type
+      Cache-Control:
+      - public, max-age=60, s-maxage=60
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 04 Feb 2020 12:09:57 GMT
+      ETag:
+      - W/"0813b93202a22a03987a904b7f0a5602f2c3962a"
+      Last-Modified:
+      - Tue, 04 Feb 2020 11:46:53 GMT
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Server:
+      - GitHub.com
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-GitHub-Media-Type:
+      - github.v3
+      X-GitHub-Request-Id:
+      - 91DE:2656B:18066B7:1C47513:5E395F15
+      X-RateLimit-Limit:
+      - '60'
+      X-RateLimit-Remaining:
+      - '59'
+      X-RateLimit-Reset:
+      - '1580821797'
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - storefront (a85017b3bae1b0f4530624eb0909c64e855c8a6a;devel)
+    method: GET
+    uri: https://api.github.com/repos/build-staging-snapcraft-io/test2/contents/snapcraft.yaml
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAzXLMQ6AIAxA0auYuiod3DyAo1cwCg2YACW0uBjvrovjz8u/IZHI7glmWFm7hVt2
+        MIBj2xJl3fXkvLUaPw+qRWZERxdFLlSNPzW0w1hOeE1YqbCg5azfKNh70vEveF733EQragAAAA==
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 04 Feb 2020 12:09:57 GMT
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Server:
+      - GitHub.com
+      Status:
+      - 404 Not Found
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-GitHub-Media-Type:
+      - github.v3
+      X-GitHub-Request-Id:
+      - 91DE:2656B:1806724:1C47572:5E395F15
+      X-RateLimit-Limit:
+      - '60'
+      X-RateLimit-Remaining:
+      - '58'
+      X-RateLimit-Reset:
+      - '1580821797'
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 404
+      message: Not Found
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - storefront (a85017b3bae1b0f4530624eb0909c64e855c8a6a;devel)
+    method: GET
+    uri: https://api.github.com/repos/build-staging-snapcraft-io/test2/contents/.snapcraft.yaml
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA72SXWvCMBSG/0uu1dSPVSeMoQ5Fy+aFQ50Ikq+20TQpTbpOxf++VGU42ZC5MehN
+        Tk7f5z0n7xZIFDHQBCUtUUwS5JvSGkUCFECMTPjlhQ6RrVccyqjfqN24fp027Edrbr2BscOqDsLu
+        LUaYObRWtUqabyzitloAaSLsr6ExsW5CiGJeCrgJU1wiKoIJi5WGOOWCFrVBAZdB8cNVkStomDYV
+        SJQ0TBoNzyzfJ8y/i5A2LLHM0ERi8Rl3groIwUJheBA751hxq3Smfd0oVgfmJA1/sE2qMikUomcO
+        EpQdl5lqlhyXtN/rxWG/ndOs4zwbPhfMTn3UtAUcdc3sWQW0N97Qh75Ho/GaVMQrXqpgsGmljyPi
+        kerY4El3zWzfOO9rxavZ9Gk5lyQSGe0duo832ct04JCN8vqdtmGj8v48DFTQ77QC0nsrzyoiHfJ2
+        Opdoknlzae0wSRS1Gcn9IM3cmq0tBJcrDZpboJnw/ylq9hV/TboqCXnGT8h/le/d7h1IaVmYFgQA
+        AA==
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type
+      Cache-Control:
+      - public, max-age=60, s-maxage=60
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 04 Feb 2020 12:09:57 GMT
+      ETag:
+      - W/"20dedf8456f7d87d8d4678bb0e30ab69babe0d43"
+      Last-Modified:
+      - Tue, 04 Feb 2020 11:47:58 GMT
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Server:
+      - GitHub.com
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-GitHub-Media-Type:
+      - github.v3
+      X-GitHub-Request-Id:
+      - 91DE:2656B:18067C6:1C47601:5E395F15
+      X-RateLimit-Limit:
+      - '60'
+      X-RateLimit-Remaining:
+      - '57'
+      X-RateLimit-Reset:
+      - '1580821797'
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - storefront (a85017b3bae1b0f4530624eb0909c64e855c8a6a;devel)
+    method: GET
+    uri: https://api.github.com/repos/build-staging-snapcraft-io/test3/contents/snapcraft.yaml
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAzXLMQ6AIAxA0auYuiod3DyAo1cwCg2YACW0uBjvrovjz8u/IZHI7glmWFm7hVt2
+        MIBj2xJl3fXkvLUaPw+qRWZERxdFLlSNPzW0w1hOeE1YqbCg5azfKNh70vEveF733EQragAAAA==
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 04 Feb 2020 12:09:58 GMT
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Server:
+      - GitHub.com
+      Status:
+      - 404 Not Found
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-GitHub-Media-Type:
+      - github.v3
+      X-GitHub-Request-Id:
+      - 91DE:2656B:1806829:1C476A4:5E395F15
+      X-RateLimit-Limit:
+      - '60'
+      X-RateLimit-Remaining:
+      - '56'
+      X-RateLimit-Reset:
+      - '1580821796'
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 404
+      message: Not Found
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - storefront (a85017b3bae1b0f4530624eb0909c64e855c8a6a;devel)
+    method: GET
+    uri: https://api.github.com/repos/build-staging-snapcraft-io/test3/contents/.snapcraft.yaml
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAzXLMQ6AIAxA0auYuiod3DyAo1cwCg2YACW0uBjvrovjz8u/IZHI7glmWFm7hVt2
+        MIBj2xJl3fXkvLUaPw+qRWZERxdFLlSNPzW0w1hOeE1YqbCg5azfKNh70vEveF733EQragAAAA==
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 04 Feb 2020 12:09:58 GMT
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Server:
+      - GitHub.com
+      Status:
+      - 404 Not Found
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-GitHub-Media-Type:
+      - github.v3
+      X-GitHub-Request-Id:
+      - 91DE:2656B:1806881:1C47712:5E395F16
+      X-RateLimit-Limit:
+      - '60'
+      X-RateLimit-Remaining:
+      - '55'
+      X-RateLimit-Reset:
+      - '1580821797'
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 404
+      message: Not Found
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - storefront (a85017b3bae1b0f4530624eb0909c64e855c8a6a;devel)
+    method: GET
+    uri: https://api.github.com/repos/build-staging-snapcraft-io/test3/contents/snap/snapcraft.yaml
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA72SX0+DMBTFv0uf3Tphm7DEmKlxmUR90KAuS0xpL1BXWkKLOJZ9d8skRqfR+Ce+
+        wb2X8zv3clZIkgzQCGlJclqQ2HSXJBNoB+XEpG0dv2vqlNge89me14t6Lhl69nngDfrgM/Ahpi70
+        B0OHeU7s+LFV07y2FN/dQWUh7KepMbkeYUxy3k24ScuoS1WGC8iVxlHJBetoQxIuk84LvMMVNqCN
+        i6mSBqTRG2Nb7g4KiPczog0UlpuaTNy9Rb7CfQmKhIrws9hHLAuwalv6P1vJ6uCGpvE3rspUJYUi
+        bMtBQar2qKWGoj3W5r5fLvzprmaZN1GJuQC7eatrC1F2YmZXKmGTsGbHZwHLwiV1xEN0r5LTelye
+        XdKAuqGJrk+WYOfCZm6cL2Y35/dzSTNRscnzdNupbm9Oe7RWwfTo0MDl7ub9IlHJ9Gic0Mnj7swR
+        5QU/LOeSXFfBXFo7IKliNi+NH6Jh2Le1O8HlQqPRCmkQ8T/Gzv7NX9N+lIgm76/If5n19foJTg+G
+        OC0EAAA=
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type
+      Cache-Control:
+      - public, max-age=60, s-maxage=60
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 04 Feb 2020 12:09:58 GMT
+      ETag:
+      - W/"d9d780b03a68d9d5854e9de9efc3e4562d82f29f"
+      Last-Modified:
+      - Tue, 04 Feb 2020 11:49:00 GMT
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Server:
+      - GitHub.com
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-GitHub-Media-Type:
+      - github.v3
+      X-GitHub-Request-Id:
+      - 91DE:2656B:18068D4:1C4777F:5E395F16
+      X-RateLimit-Limit:
+      - '60'
+      X-RateLimit-Remaining:
+      - '54'
+      X-RateLimit-Reset:
+      - '1580821797'
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - storefront (a85017b3bae1b0f4530624eb0909c64e855c8a6a;devel)
+    method: GET
+    uri: https://api.github.com/repos/build-staging-snapcraft-io/test4/contents/snapcraft.yaml
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAzXLMQ6AIAxA0auYuiod3DyAo1cwCg2YACW0uBjvrovjz8u/IZHI7glmWFm7hVt2
+        MIBj2xJl3fXkvLUaPw+qRWZERxdFLlSNPzW0w1hOeE1YqbCg5azfKNh70vEveF733EQragAAAA==
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 04 Feb 2020 12:09:58 GMT
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Server:
+      - GitHub.com
+      Status:
+      - 404 Not Found
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-GitHub-Media-Type:
+      - github.v3
+      X-GitHub-Request-Id:
+      - 91DE:2656B:1806936:1C477F5:5E395F16
+      X-RateLimit-Limit:
+      - '60'
+      X-RateLimit-Remaining:
+      - '53'
+      X-RateLimit-Reset:
+      - '1580821797'
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 404
+      message: Not Found
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - storefront (a85017b3bae1b0f4530624eb0909c64e855c8a6a;devel)
+    method: GET
+    uri: https://api.github.com/repos/build-staging-snapcraft-io/test4/contents/.snapcraft.yaml
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAzXLMQ6AIAxA0auYuiod3DyAo1cwCg2YACW0uBjvrovjz8u/IZHI7glmWFm7hVt2
+        MIBj2xJl3fXkvLUaPw+qRWZERxdFLlSNPzW0w1hOeE1YqbCg5azfKNh70vEveF733EQragAAAA==
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 04 Feb 2020 12:09:58 GMT
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Server:
+      - GitHub.com
+      Status:
+      - 404 Not Found
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-GitHub-Media-Type:
+      - github.v3
+      X-GitHub-Request-Id:
+      - 91DE:2656B:18069AF:1C4786D:5E395F16
+      X-RateLimit-Limit:
+      - '60'
+      X-RateLimit-Remaining:
+      - '52'
+      X-RateLimit-Reset:
+      - '1580821796'
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 404
+      message: Not Found
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - storefront (a85017b3bae1b0f4530624eb0909c64e855c8a6a;devel)
+    method: GET
+    uri: https://api.github.com/repos/build-staging-snapcraft-io/test4/contents/snap/snapcraft.yaml
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAzXLMQ6AIAxA0auYuiod3DyAo1cwCg2YACW0uBjvrovjz8u/IZHI7glmWFm7hVt2
+        MIBj2xJl3fXkvLUaPw+qRWZERxdFLlSNPzW0w1hOeE1YqbCg5azfKNh70vEveF733EQragAAAA==
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 04 Feb 2020 12:09:59 GMT
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Server:
+      - GitHub.com
+      Status:
+      - 404 Not Found
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-GitHub-Media-Type:
+      - github.v3
+      X-GitHub-Request-Id:
+      - 91DE:2656B:1806A15:1C47900:5E395F16
+      X-RateLimit-Limit:
+      - '60'
+      X-RateLimit-Remaining:
+      - '51'
+      X-RateLimit-Reset:
+      - '1580821797'
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 404
+      message: Not Found
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - storefront (a85017b3bae1b0f4530624eb0909c64e855c8a6a;devel)
+    method: GET
+    uri: https://api.github.com/repos/build-staging-snapcraft-io/test4/contents/build-aux/snap/snapcraft.yaml
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA8WTbUvDMBSF/0s/u6WbW3UDkak4dKiIss0xGLfJTRtNk9Kk1k323023KiqM+YL4
+        pdD29D7nnp48ewoS9LqeUZDSDLitzyGR3o6Xgo3d8zAXktUgfyKlYnX5IDMxOBX6PrT3ODSpj23G
+        edAOON9vdAJ/L+i0ww5gE/1W2HJzjVg4Xmd3x8sz6T6NrU1NlxBIRT0SNs7DOtUJyTDVhqzpxkIk
+        VFR7g9eEJhaNbRGqlUVlX5UbfB5myA8SMBYz5yC2iZx9hL8Db0WGUodkPazyt4HqUG7uJ9LP1nRz
+        SMk15BtJM10oqYF9cpBBUQWdG8yqAFeZb139i1vbeVpWiguJLoOKUHYpObWTWx2x/nDBTq4HLBnO
+        aVM+hvc6Ol/08osbOqC7QxuOTufodMNS10sfJuPL+6miiSxYf62u3hR343OfLvTg7PjI4k1jdX8V
+        6ejsuBfR/lNj0pT5lTjKpwpGxWCqnB1UVDPXptIPGAzKTs6kUA/G6z57BiX/l1K6P/xr7o9aUp6G
+        d+S/OQnL5QsPMfxnaQQAAA==
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type
+      Cache-Control:
+      - public, max-age=60, s-maxage=60
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 04 Feb 2020 12:09:59 GMT
+      ETag:
+      - W/"e00a57fa2c0e5dff656ff819607695b9ae2e04b4"
+      Last-Modified:
+      - Tue, 04 Feb 2020 11:49:37 GMT
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Server:
+      - GitHub.com
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-GitHub-Media-Type:
+      - github.v3
+      X-GitHub-Request-Id:
+      - 91DE:2656B:1806A77:1C4797E:5E395F17
+      X-RateLimit-Limit:
+      - '60'
+      X-RateLimit-Remaining:
+      - '50'
+      X-RateLimit-Reset:
+      - '1580821797'
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - storefront (a85017b3bae1b0f4530624eb0909c64e855c8a6a;devel)
+    method: GET
+    uri: https://api.github.com/repos/build-staging-snapcraft-io/test5/contents/snapcraft.yaml
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAzWMwQrDIBAFfyVsr6l76C3f0XtJzaJCdMV9BkLpv1cKOQ7MzIeymK1BaKFnTDY1
+        qWoJ2s5pkOSK09FMm/qepWBF0vLqbR9+BKotzJscsmuV5kJC7G/nNfPx4P+KvRaM0PgWBPeL6PsD
+        6KWPXHoAAAA=
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 04 Feb 2020 12:09:59 GMT
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Server:
+      - GitHub.com
+      Status:
+      - 404 Not Found
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-GitHub-Media-Type:
+      - github.v3
+      X-GitHub-Request-Id:
+      - 91DE:2656B:1806AD6:1C479E6:5E395F17
+      X-RateLimit-Limit:
+      - '60'
+      X-RateLimit-Remaining:
+      - '49'
+      X-RateLimit-Reset:
+      - '1580821797'
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 404
+      message: Not Found
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - storefront (a85017b3bae1b0f4530624eb0909c64e855c8a6a;devel)
+    method: GET
+    uri: https://api.github.com/repos/build-staging-snapcraft-io/test5/contents/.snapcraft.yaml
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAzWMwQrDIBAFfyVsr6l76C3f0XtJzaJCdMV9BkLpv1cKOQ7MzIeymK1BaKFnTDY1
+        qWoJ2s5pkOSK09FMm/qepWBF0vLqbR9+BKotzJscsmuV5kJC7G/nNfPx4P+KvRaM0PgWBPeL6PsD
+        6KWPXHoAAAA=
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 04 Feb 2020 12:09:59 GMT
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Server:
+      - GitHub.com
+      Status:
+      - 404 Not Found
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-GitHub-Media-Type:
+      - github.v3
+      X-GitHub-Request-Id:
+      - 91DE:2656B:1806B2E:1C47A51:5E395F17
+      X-RateLimit-Limit:
+      - '60'
+      X-RateLimit-Remaining:
+      - '48'
+      X-RateLimit-Reset:
+      - '1580821797'
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 404
+      message: Not Found
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - storefront (a85017b3bae1b0f4530624eb0909c64e855c8a6a;devel)
+    method: GET
+    uri: https://api.github.com/repos/build-staging-snapcraft-io/test5/contents/snap/snapcraft.yaml
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAzWMwQrDIBAFfyVsr6l76C3f0XtJzaJCdMV9BkLpv1cKOQ7MzIeymK1BaKFnTDY1
+        qWoJ2s5pkOSK09FMm/qepWBF0vLqbR9+BKotzJscsmuV5kJC7G/nNfPx4P+KvRaM0PgWBPeL6PsD
+        6KWPXHoAAAA=
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 04 Feb 2020 12:09:59 GMT
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Server:
+      - GitHub.com
+      Status:
+      - 404 Not Found
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-GitHub-Media-Type:
+      - github.v3
+      X-GitHub-Request-Id:
+      - 91DE:2656B:1806B8B:1C47AAE:5E395F17
+      X-RateLimit-Limit:
+      - '60'
+      X-RateLimit-Remaining:
+      - '47'
+      X-RateLimit-Reset:
+      - '1580821797'
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 404
+      message: Not Found
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - storefront (a85017b3bae1b0f4530624eb0909c64e855c8a6a;devel)
+    method: GET
+    uri: https://api.github.com/repos/build-staging-snapcraft-io/test5/contents/build-aux/snap/snapcraft.yaml
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAzWMwQrDIBAFfyVsr6l76C3f0XtJzaJCdMV9BkLpv1cKOQ7MzIeymK1BaKFnTDY1
+        qWoJ2s5pkOSK09FMm/qepWBF0vLqbR9+BKotzJscsmuV5kJC7G/nNfPx4P+KvRaM0PgWBPeL6PsD
+        6KWPXHoAAAA=
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 04 Feb 2020 12:09:59 GMT
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Server:
+      - GitHub.com
+      Status:
+      - 404 Not Found
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-GitHub-Media-Type:
+      - github.v3
+      X-GitHub-Request-Id:
+      - 91DE:2656B:1806BE7:1C47B1B:5E395F17
+      X-RateLimit-Limit:
+      - '60'
+      X-RateLimit-Remaining:
+      - '46'
+      X-RateLimit-Reset:
+      - '1580821796'
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 404
+      message: Not Found
+version: 1

--- a/tests/api/test_github.py
+++ b/tests/api/test_github.py
@@ -1,0 +1,65 @@
+from os import getenv
+from vcr_unittest import VCRTestCase
+from webapp.api.github import GitHubAPI
+from werkzeug.exceptions import Unauthorized
+
+
+class GitHubAPITest(VCRTestCase):
+    def _get_vcr_kwargs(self):
+        """
+        This removes the authorization header
+        from VCR so we don't record auth parameters
+        """
+        return {"filter_headers": ["Authorization"]}
+
+    def setUp(self):
+        self.client = GitHubAPI(getenv("GITHUB_TEST_USER_TOKEN", "secret"))
+        return super(GitHubAPITest, self).setUp()
+
+    def test_get_username(self):
+        username = self.client.get_username()
+        self.assertEqual("build-staging-snapcraft-io", username)
+
+        # Test Unauthorized exception when using bad credentials
+        self.client.access_token = "bad-token"
+        self.assertRaises(Unauthorized, self.client.get_username)
+
+    def test_get_user_repositories(self):
+        repos = self.client.get_user_repositories()
+        [self.assertIn("name", repo) for repo in repos]
+        [self.assertIn("snapcraft_yaml", repo) for repo in repos]
+
+        # Test Unauthorized exception when using bad credentials
+        self.client.access_token = "bad-token"
+        self.assertRaises(Unauthorized, self.client.get_user_repositories)
+
+    def test_is_snapcraft_yaml_present(self):
+        # /snapcraft.yaml is present
+        case1 = self.client.is_snapcraft_yaml_present(
+            "build-staging-snapcraft-io", "test1"
+        )
+        self.assertEqual(True, case1)
+
+        # /.snapcraft.yaml is present
+        case2 = self.client.is_snapcraft_yaml_present(
+            "build-staging-snapcraft-io", "test2"
+        )
+        self.assertEqual(True, case2)
+
+        # /snap/snapcraft.yaml is present
+        case3 = self.client.is_snapcraft_yaml_present(
+            "build-staging-snapcraft-io", "test3"
+        )
+        self.assertEqual(True, case3)
+
+        # /build-aux/snap/snapcraft.yaml is present
+        case4 = self.client.is_snapcraft_yaml_present(
+            "build-staging-snapcraft-io", "test4"
+        )
+        self.assertEqual(True, case4)
+
+        # The repo doesn't contain a valid yaml file
+        case5 = self.client.is_snapcraft_yaml_present(
+            "build-staging-snapcraft-io", "test5"
+        )
+        self.assertEqual(False, case5)

--- a/webapp/authentication.py
+++ b/webapp/authentication.py
@@ -39,6 +39,7 @@ def empty_session(session):
     session.pop("macaroon_discharge", None)
     session.pop("openid", None)
     session.pop("user_shared_snaps", None)
+    session.pop("github_auth_secret", None)
 
 
 def get_caveat_id(root):

--- a/webapp/login/views.py
+++ b/webapp/login/views.py
@@ -99,9 +99,7 @@ def after_login(resp):
 @login.route("/logout")
 def logout():
     no_redirect = flask.request.args.get("no_redirect", default="false")
-
-    if authentication.is_authenticated(flask.session):
-        authentication.empty_session(flask.session)
+    authentication.empty_session(flask.session)
 
     if no_redirect == "true":
         return flask.redirect("/")

--- a/webapp/publisher/github/views.py
+++ b/webapp/publisher/github/views.py
@@ -1,0 +1,23 @@
+import flask
+from webapp.api.github import GitHubAPI
+from webapp.decorators import login_required
+
+publisher_github = flask.Blueprint(
+    "github", __name__, template_folder="/templates", static_folder="/static"
+)
+
+
+@publisher_github.route("/publisher/github/get-repos", methods=["GET"])
+@login_required
+def get_repos():
+    github = GitHubAPI(flask.session.get("github_auth_secret"))
+    repos = github.get_user_repositories()
+    return flask.jsonify(repos)
+
+
+@publisher_github.route("/publisher/github/get-orgs", methods=["GET"])
+@login_required
+def get_orgs():
+    github = GitHubAPI(flask.session.get("github_auth_secret"))
+    orgs = github.get_orgs()
+    return flask.jsonify(orgs)

--- a/webapp/publisher/snaps/views.py
+++ b/webapp/publisher/snaps/views.py
@@ -43,6 +43,7 @@ from webapp.publisher.snaps.builds import (
     build_link,
     map_build_and_upload_states,
 )
+from werkzeug.exceptions import Unauthorized
 
 
 publisher_snaps = flask.Blueprint(
@@ -1356,11 +1357,24 @@ def get_snap_builds(snap_name):
     }
 
     # Get built snap in launchpad with this store name
+    github = GitHubAPI(flask.session.get("github_auth_secret"))
     lp_snap = launchpad.get_snap_by_store_name(details["snap_name"])
 
     if lp_snap:
         # Git repository without GitHub hostname
         context["github_repository"] = lp_snap["git_repository_url"][19:]
+        github_owner, github_repo = context["github_repository"].split("/")
+
+        # Check if this repo has a snapcraft.yaml
+        yaml_file_exist = github.is_snapcraft_yaml_present(
+            github_owner, github_repo
+        )
+
+        if not yaml_file_exist:
+            flask.flash(
+                "This repository doesn't contain a snapcraft.yaml", "negative"
+            )
+
         bsi_url = flask.current_app.config["BSI_URL"]
 
         builds = launchpad.get_collection_entries(
@@ -1390,11 +1404,16 @@ def get_snap_builds(snap_name):
                 }
             )
     else:
-        github = GitHubAPI(flask.session.get("github_auth_secret"))
-        context["github_user"] = github.get_user()
-
-        if context["github_user"]:
-            context["github_repositories"] = github.get_user_repositories()
+        try:
+            context["github_user"] = github.get_username()
+            # Get snapcraft repositories sorted by snapcraft_yaml
+            context["github_repositories"] = sorted(
+                github.get_user_repositories(),
+                key=lambda k: k["snapcraft_yaml"],
+                reverse=True,
+            )
+        except Unauthorized:
+            context["github_user"] = None
 
     return flask.render_template("publisher/builds.html", **context)
 

--- a/webapp/publisher/snaps/views.py
+++ b/webapp/publisher/snaps/views.py
@@ -1360,19 +1360,24 @@ def get_snap_builds(snap_name):
     github = GitHubAPI(flask.session.get("github_auth_secret"))
     lp_snap = launchpad.get_snap_by_store_name(details["snap_name"])
 
+    try:
+        context["github_user"] = github.get_username()
+    except Unauthorized:
+        context["github_user"] = None
+
     if lp_snap:
         # Git repository without GitHub hostname
         context["github_repository"] = lp_snap["git_repository_url"][19:]
         github_owner, github_repo = context["github_repository"].split("/")
 
         # Check if this repo has a snapcraft.yaml
-        yaml_file_exist = github.is_snapcraft_yaml_present(
+        context["yaml_file_exist"] = github.is_snapcraft_yaml_present(
             github_owner, github_repo
         )
 
-        if not yaml_file_exist:
+        if not context["yaml_file_exist"]:
             flask.flash(
-                "This repository doesn't contain a snapcraft.yaml", "negative"
+                "This repository doesn't contain a snapcraft.yaml", "negative",
             )
 
         bsi_url = flask.current_app.config["BSI_URL"]
@@ -1403,17 +1408,13 @@ def get_snap_builds(snap_name):
                     "title": build["title"],
                 }
             )
-    else:
-        try:
-            context["github_user"] = github.get_username()
-            # Get snapcraft repositories sorted by snapcraft_yaml
-            context["github_repositories"] = sorted(
-                github.get_user_repositories(),
-                key=lambda k: k["snapcraft_yaml"],
-                reverse=True,
-            )
-        except Unauthorized:
-            context["github_user"] = None
+    elif context["github_user"]:
+        # Get snapcraft repositories sorted by snapcraft_yaml
+        context["github_repositories"] = sorted(
+            github.get_user_repositories(),
+            key=lambda k: k["snapcraft_yaml"],
+            reverse=True,
+        )
 
     return flask.render_template("publisher/builds.html", **context)
 

--- a/webapp/publisher/snaps/views.py
+++ b/webapp/publisher/snaps/views.py
@@ -1371,11 +1371,11 @@ def get_snap_builds(snap_name):
         github_owner, github_repo = context["github_repository"].split("/")
 
         # Check if this repo has a snapcraft.yaml
-        context["yaml_file_exist"] = github.is_snapcraft_yaml_present(
+        context["yaml_file_exists"] = github.is_snapcraft_yaml_present(
             github_owner, github_repo
         )
 
-        if not context["yaml_file_exist"]:
+        if not context["yaml_file_exists"]:
             flask.flash(
                 "This repository doesn't contain a snapcraft.yaml", "negative",
             )


### PR DESCRIPTION
## Done

In this PR we are using the GitHub GraphQL API to:

- List all the user repositories and mark the ones with a snapcraft.yaml present:
![github-graphql1](https://user-images.githubusercontent.com/6353928/73292414-ee5dac80-41f9-11ea-9998-682ccaedc31a.png)


- Show an error on the builds page when the selected repo for the snap doesnt contain a snapcraft.yaml:
![github-graphql2](https://user-images.githubusercontent.com/6353928/73292597-38df2900-41fa-11ea-9265-cf2035f6c331.png)


## Issue / Card

Fixes #2449

## QA

- Pull the branch
- Run the site using the command `./run`
- View the site locally in your web browser at: http://0.0.0.0:8004/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Login as a publisher
- Go to http://0.0.0.0:8004/<your_snap>/builds and check to you can:
- Login with GitHub
- Try to link you snap with a github repo and check that the repos contains a mark when snapcraft.yaml is present
- Check if a snap with a github repo without snapcraft.yaml get the error
