### PR TITLE
Ensure progressive values align

### DIFF
--- a/static/js/publisher/release/actions/pendingReleases.js
+++ b/static/js/publisher/release/actions/pendingReleases.js
@@ -18,7 +18,7 @@ import { triggerGAEvent } from "../actions/gaEventTracking";
 export function releaseRevision(revision, channel, progressive) {
   return (dispatch, getState) => {
     const state = getState();
-    const { revisions } = state;
+    const { revisions, pendingReleases } = state;
 
     const previousRevisions = getReleases(
       state,
@@ -33,12 +33,30 @@ export function releaseRevision(revision, channel, progressive) {
     if (!progressive && previousRevisions.length > 0 && previousRevisions[0]) {
       revisionToRelease = revisions[revision.revision];
 
+      let percentage = 100;
+
+      // If there's already a "null" release in staging that is progressive
+      // assign that value to subsequent progressive releases
+      Object.keys(pendingReleases).forEach(revision => {
+        Object.keys(pendingReleases[revision]).forEach(channel => {
+          const release = pendingReleases[revision][channel];
+
+          if (
+            release.progressive &&
+            release.progressive.key === null &&
+            percentage === 100
+          ) {
+            percentage = release.progressive.percentage;
+          }
+        });
+      });
+
       // Set key to null as we want to set the same key for a group
       // of releases on release. In actions/releases.js the key is either
       // updated, or the progressive object is removed completely
       progressive = {
         key: null,
-        percentage: 100,
+        percentage: percentage,
         paused: false
       };
     }


### PR DESCRIPTION
## Done

- Set new releases that can be progressive to the percentage of the previously set release that can be progressive

## Issue / Card

Fixes #1236

## QA

- Pull the branch
- Run the site using the command `./run`
- View the site locally in your web browser at: http://0.0.0.0:8004/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Visit http://0.0.0.0:8004/snap_name/releases
- Stage a new progressive release (with a not-100% percentage)
- Stage more progressive releases
- All the table cells below should maintain the bar across the same percentage of the cell
