### PR TITLE
remove legacy banner whitelisting

### DIFF
--- a/static/js/publisher/market/restrictions.js
+++ b/static/js/publisher/market/restrictions.js
@@ -1,3 +1,13 @@
+/**
+   These configs can contain a whitelist array of objects at the top level
+   containing: {
+     dimensions: [width, height],
+     fileName: "string",
+     accept: ["file/format", "file/format"]
+   }
+   This was previously used for legacy banners
+*/
+
 const MEDIA_RESTRICTIONS = {
   accept: ["image/png", "image/gif", "image/jpeg"],
   width: {
@@ -26,19 +36,7 @@ const MEDIA_RESTRICTIONS = {
       min: 0,
       max: 40
     }
-  },
-  whitelist: [
-    {
-      dimensions: [1218, 240],
-      fileName: "banner",
-      accept: ["image/png", "image/jpeg"]
-    },
-    {
-      dimensions: [240, 240],
-      fileName: "banner-icon",
-      accept: ["image/png", "image/jpeg"]
-    }
-  ]
+  }
 };
 
 const ICON_RESTRICTIONS = {


### PR DESCRIPTION
## Done

- Remove whitelist in media restrictions

## QA

- Pull the branch
- Run the site using the command `./run`
- View the site locally in your web browser at: http://0.0.0.0:8004/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Adding an image to the media section that is called "banner.jpg" that is exactly 1218 x 240 you should receive an error from the client (before submitting the form).