### PR TITLE
Get GitHub repos filtered by org

### DIFF
--- a/templates/publisher/builds.html
+++ b/templates/publisher/builds.html
@@ -42,7 +42,7 @@ Builds for
           <li class="p-inline-list__item">
             {% if github_user %}
             <a href="https://github.com/{{ github_user['login'] }}" class="p-link--soft u-float-right">
-              <img src="{{ github_user['avatar_url'] }}" alt="@{{ github_user['login'] }}"
+              <img src="{{ github_user['avatarUrl'] }}" alt="@{{ github_user['login'] }}"
                 class="p-build__avatar">
               {{ github_user["login"] }}
             </a>
@@ -111,6 +111,20 @@ Builds for
       </div>
     {% else %}
       <div class="row p-form__group">
+        <div class="col-2" data-tour="listing-category">
+          <label class="p-form__label">Select a organization:</label>
+        </div>
+        <div class="col-4">
+          <div class="p-form__control" data-tour="listing-category">
+            <select name="github_org">
+              <option value="">{{ github_user["login"] }}</option>
+              {% for org in github_orgs %}
+              <option value="{{ org.login }}">{{ org.name }}</option>
+              {% endfor %}
+            </select>
+          </div>
+        </div>
+
         <div class="col-2" data-tour="listing-category">
           <label class="p-form__label">Select a repository:</label>
         </div>

--- a/tests/api/cassettes/GitHubAPITest.test_get_org_repositories.yaml
+++ b/tests/api/cassettes/GitHubAPITest.test_get_org_repositories.yaml
@@ -1,0 +1,274 @@
+interactions:
+- request:
+    body: '{"query": "{\n              viewer {\n              organization(login:
+      \"canonical-web-and-design\") {\n                    repositories(\n                        first:
+      100,\n                        privacy: PUBLIC\n                    \n                )
+      {\n              edges {\n                node {\n                  nameWithOwner\n                  yamlLocation1:\n                    object(expression:
+      \"master:snapcraft.yaml\")\n                    { id }\n                  yamlLocation2:\n                    object(expression:
+      \"master:.snapcraft.yaml\")\n                    { id }\n                  yamlLocation3:\n                    object(expression:
+      \"master:snap/snapcraft.yaml\")\n                    { id }\n                  yamlLocation4:\n                    object(expression:
+      \"master:build-aux/snap/snapcraft.yaml\")\n                    { id }\n                }\n                }\n                pageInfo
+      {\n                  hasNextPage\n                  endCursor\n                }\n              }\n            }\n          }\n        }"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1079'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - storefront (7104187423b5359d0e2cc3fe52d2c408b1df98eb;devel)
+    method: POST
+    uri: https://api.github.com/graphql
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA81bS2/jNhD+LzqHbmwnRRtgD9112gao5GZhryEXPdAULVHiCxRpWQr2v3doO96m
+        zqFodovJyVKCZDLPb2a+eUoK6mly95TsBO+4i5+MK6kWA/XC6PjsuDWt8MYJ3sZnXpTxwx9PiTYF
+        j280VXwlfDXvdPwVCaPaaMGoJB3fEKoLUvBWlPq7rutG52+OmFHJVdJTJX8z7PDnxsmdDlK+fDl5
+        7eX0tZc3x5efP1/9B9nCJmgfkAlVcWeaQDZByMJS1hDb+8po0oG2yWZwiPR3kLH13CKSqaipLg3Z
+        yMCtE9ojEu0cBhAinlM12nHXQgjwgrQegoEhkvWkxqNcxBnjyVboAmIdT/jStuW+HaGMYkU1Lbkb
+        YZYRkglpe43K7QxruHtOeRvackT+ZqnzUO2QetzB04ii1qIK0lOuI9aZmjN/rGuoJNwB9JGSkq0D
+        TNMZ1yByuWCloQU5ZpG3yPWUiAJgWjp7/P5R7Xd5ne7TOr9Nh6af1z/dpAqeF2mXrh7G2S/3k2xW
+        qXRYduu6hJ9rbvMhHzK13OcqU9mM3eZ1/i75/LIUvAmKKUrbkTBv+RcvYeSbJGIaZ2UpTAPwsODg
+        GT0RCqoMsTKUQiPSnQZx9mRrXEddQbwh1jhMSKxlxvIWYE2Q3HtMNaYUkMOFcwZKM3c7wTAJV4c6
+        EAYmbRH5mqRBs8pCltyEEh9ItY4ygPbQPuMBzkyaUBChhceVcmuLNOUee8oth07N0xKRJQvDWqgF
+        ClPhlHTDJSZ3ByXFpqJwAPMQ2U7ClKxl1HISrYhIsGNDTVglNCUAiAvreNsSX3GFqRodB4wEM3wv
+        pdnASFTTHSLzRm9DmmcNC4rrOAuDgedhuvi2TvGi68lv0sV9P58tr+fqYZoP6W06+6SyoZBZXTV5
+        3UzTCXRBs4dhvsjH69V9lw+fVLp67NKB9dnk8et2Pc+RZhy6JFDwHZeAkh1OV2l9Lzkpg4AsgCi2
+        Dj47ajW1zNEtMnhlYY2Azs98iGsmKpGmpFN1Oc+GcAHm6Ghx3+aNkY3A1GHzPVUWIrTGFJ1HxIAz
+        oT3DmGhO2JJaCFXtMSnvVKsqiNYBqjM2NMiMrgOU0WBxhegBbWEV7oVcp409omr6EuEjzcGR4PBl
+        BYlPiSWHnRWFIguTu2eOBjjlF6CNyOCvyXpaICGS8m/W9rThBtb4hDpol3eo2uM4GjqjK0Tqu6jC
+        +GIG4sPzFhOeehG7JHjx2oTtot1thnSRX2f18mauPlbrei2zVRbb3H0+3N+sF2WXT5b9evFRzBc/
+        qzUs/tLhfb2epeO8Xo7Xi8t2939iZjFjGgGLLSMF61H5rjL49jIXxKISmABxWo0JPx43lnG8A/hW
+        b0WJSTikHTsLrTeKwPgV+oGWk4pTmIhhUhwk88Ybiy+Fb6QpcXZ6z+sIjmkofDFFB6eDxSWi1Bta
+        pIQME6fUhFqBKS5Lx7muTGg5rnYY1uGccQsEdDzr8AE0FTZkA2RrSBowQQCC/Nv2Dl+ZihS02ArY
+        PXNFhSSew2QNJESkwa2kbUNgW6CBZYbHsJp70JTGFQGb0OOsSxEDAdyAGRrkMkRWvEC3lfeoLg7i
+        hA8pgFRBemGBPjpyARNBUAkGVy4/IKN8AvHuwLqDpScqKmohgLAYHDQAirqmMJ0m2qAqACVsO+Hi
+        AbSnvevxEVLPi3bbY2PbnDPHqbzD8kdhQpJ1ZGZTTAXhORwiKMJ0j3RRqOKd47l5x2TTL9SzjTOs
+        gr3ZCE7luNMUE0Hu2ChvhURF8biw8ulULl7TYrLxhZxxIoIZ1h1vGRB2Nz42NwzmIQCO/6UCLybx
+        99NsVo7TxWOfLUyfqUc4qXnfZLN8uq6X1+nqHohpcIIzPIzTWTPOF5lIZ+U0XaXXaV1O1ouq+ee5
+        zTc4h6ZAJGn4t8KJf14lFq5VHvTWxAvyirYZ3/vf4VVy513gVwnXxQeAOaDluySffurZ5Md+rvN+
+        bn+df9C/ClG+A/7d4esvAsARR8Y+AAA=
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type
+      Cache-Control:
+      - no-cache
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 07 Feb 2020 17:08:31 GMT
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Server:
+      - GitHub.com
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Accepted-OAuth-Scopes:
+      - repo
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-GitHub-Media-Type:
+      - github.v4
+      X-GitHub-Request-Id:
+      - 9E06:2C0B4:148B579:18B4486:5E3D998A
+      X-OAuth-Client-Id:
+      - cdeb3a60fecee4208395
+      X-OAuth-Scopes:
+      - read:org, repo
+      X-RateLimit-Limit:
+      - '5000'
+      X-RateLimit-Remaining:
+      - '4983'
+      X-RateLimit-Reset:
+      - '1581097620'
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"query": "{\n              viewer {\n              organization(login:
+      \"canonical-web-and-design\") {\n                    repositories(\n                        first:
+      100,\n                        privacy: PUBLIC\n                    after: \"Y3Vyc29yOnYyOpHOCnHiig==\"\n                )
+      {\n              edges {\n                node {\n                  nameWithOwner\n                  yamlLocation1:\n                    object(expression:
+      \"master:snapcraft.yaml\")\n                    { id }\n                  yamlLocation2:\n                    object(expression:
+      \"master:.snapcraft.yaml\")\n                    { id }\n                  yamlLocation3:\n                    object(expression:
+      \"master:snap/snapcraft.yaml\")\n                    { id }\n                  yamlLocation4:\n                    object(expression:
+      \"master:build-aux/snap/snapcraft.yaml\")\n                    { id }\n                }\n                }\n                pageInfo
+      {\n                  hasNextPage\n                  endCursor\n                }\n              }\n            }\n          }\n        }"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1114'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - storefront (7104187423b5359d0e2cc3fe52d2c408b1df98eb;devel)
+    method: POST
+    uri: https://api.github.com/graphql
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA82X32/TMBDH/xc/16HrOiQm7QHRiR+iDUUdI0U8XOxr4zb2BdtZ+kP937GLBkzb
+        Ex2S8+SclOQT++77vdszCR7Y5Z7dKezQxhXZJRi1A6/IxHuLDTnlySp08R7lMi6+7ZkhiTFiQOOt
+        8lXemfgKJsCQUQJq3mHJwUgu0amleSFJuGzVrlpRgdUuE6RZj21B1x9JHD94xi5NW9cPg4OngudP
+        BYe/godD7x/ofmMHao+gM6mcoNY65BE8IVKLNYJDl0nUlFXQpgT31+k33KLzXICoMKHtk+Rta04B
+        2jMlQ6KPR9OXU725K1bXw8nu9dl4Nu1PRtTN9XQ4GVxvJrfTQbFbn+ezD1X+9mYzn4mL+e30Yr76
+        rIvVcjjeibMiPJPPRJ8dHib986byoga35mVImlN++3FpnkaJ1qtFEIpY+Vlbtsa3qWpCYlwawPFW
+        pXSY96J/r54edVODx4UyMthCOjq/bktc1NRxg11qHuSjXkbHDAJvT5KoZ67VpfK8I7t2FTUJneUj
+        z3Zh30SVEKFFEMECSTdk0PiUnHoVRUSCq0oCKxPaM/mjVh4zRQkxoRfpQWklLDkPYp2d2NE8s1zE
+        Jj9TSSV7IPqT7Lyx5Mlvm5T6oeCcYdBCXpKq0R7NM6ECOM5sKDk5nVgz9NgEwrSKHJqU+iMwJW24
+        qKmV/0/YvvdYA0t8bxYUB/MK3AQ3/lMIscsF1A57DI18E2ZaioN6cf5lKwavtrkptnnzLh8VX/vQ
+        XV2xw/H6CaltDIUeEAAA
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type
+      Cache-Control:
+      - no-cache
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 07 Feb 2020 17:08:33 GMT
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Server:
+      - GitHub.com
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Accepted-OAuth-Scopes:
+      - repo
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-GitHub-Media-Type:
+      - github.v4
+      X-GitHub-Request-Id:
+      - 9E06:2C0B4:148BA2D:18B4A34:5E3D998F
+      X-OAuth-Client-Id:
+      - cdeb3a60fecee4208395
+      X-OAuth-Scopes:
+      - read:org, repo
+      X-RateLimit-Limit:
+      - '5000'
+      X-RateLimit-Remaining:
+      - '4982'
+      X-RateLimit-Reset:
+      - '1581097620'
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"query": "{\n              viewer {\n                repositories(\n                    first:
+      100,\n                    privacy: PUBLIC,\n                    ownerAffiliations:
+      [OWNER],\n                \n                ) {\n              edges {\n                node
+      {\n                  nameWithOwner\n                  yamlLocation1:\n                    object(expression:
+      \"master:snapcraft.yaml\")\n                    { id }\n                  yamlLocation2:\n                    object(expression:
+      \"master:.snapcraft.yaml\")\n                    { id }\n                  yamlLocation3:\n                    object(expression:
+      \"master:snap/snapcraft.yaml\")\n                    { id }\n                  yamlLocation4:\n                    object(expression:
+      \"master:build-aux/snap/snapcraft.yaml\")\n                    { id }\n                }\n              }\n              pageInfo
+      {\n                hasNextPage\n                endCursor\n              }\n            }\n          }\n        }"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1019'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - storefront (7104187423b5359d0e2cc3fe52d2c408b1df98eb;devel)
+    method: POST
+    uri: https://api.github.com/graphql
+  response:
+    body:
+      string: '{"message":"Bad credentials","documentation_url":"https://developer.github.com/v4"}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type
+      Content-Length:
+      - '83'
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 07 Feb 2020 17:08:33 GMT
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Server:
+      - GitHub.com
+      Status:
+      - 401 Unauthorized
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-GitHub-Media-Type:
+      - github.v4
+      X-GitHub-Request-Id:
+      - 9E06:2C0B4:148BBAD:18B4C14:5E3D9991
+      X-RateLimit-Limit:
+      - '0'
+      X-RateLimit-Remaining:
+      - '0'
+      X-RateLimit-Reset:
+      - '1581098913'
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 401
+      message: Unauthorized
+version: 1

--- a/tests/api/cassettes/GitHubAPITest.test_get_orgs.yaml
+++ b/tests/api/cassettes/GitHubAPITest.test_get_orgs.yaml
@@ -1,0 +1,82 @@
+interactions:
+- request:
+    body: '{"query": "\n            {\n              viewer {\n                organizations(first:
+      100,) {\n                  edges {\n                    node {\n                      login\n                      name\n                    }\n                  }\n                  pageInfo
+      {\n                    hasNextPage\n                    endCursor\n                  }\n                }\n              }\n            }\n        "}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '430'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - storefront (7104187423b5359d0e2cc3fe52d2c408b1df98eb;devel)
+    method: POST
+    uri: https://api.github.com/graphql
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA22PMQvCQAyF/0rJ3C46WXCQLhbEOokiDrGXngdtTnqnZy3+d3OIOGimx5f3HskI
+        Cj1CPsLNUKA+KttrZPNAbyy7CEhpEnEYga2iSFqrDUMOBbJlU2O78gpSYOxk/aVJxM9n+husP8Es
+        0ClDVpkiZzT/KxFHIo7k7Ug8YSelxxQuqKnkxsaLzujWdPcbQZA32DpKgVgV195Z+Qr20+1QT2ZD
+        xfuhuiyrRbkLRZjPpUnmBU2gXucHAQAA
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type
+      Cache-Control:
+      - no-cache
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 07 Feb 2020 17:13:34 GMT
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Server:
+      - GitHub.com
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Accepted-OAuth-Scopes:
+      - repo
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-GitHub-Media-Type:
+      - github.v4
+      X-GitHub-Request-Id:
+      - A1F4:015D:2694259:2EB5576:5E3D9ABE
+      X-OAuth-Client-Id:
+      - cdeb3a60fecee4208395
+      X-OAuth-Scopes:
+      - read:org, repo
+      X-RateLimit-Limit:
+      - '5000'
+      X-RateLimit-Remaining:
+      - '4980'
+      X-RateLimit-Reset:
+      - '1581097620'
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/api/cassettes/GitHubAPITest.test_get_user.yaml
+++ b/tests/api/cassettes/GitHubAPITest.test_get_user.yaml
@@ -1,6 +1,7 @@
 interactions:
 - request:
-    body: '{"query": "{ viewer { login } }"}'
+    body: '{"query": "\n        {\n          viewer {\n            login\n            name\n            avatarUrl(size:
+      100)\n          }\n        }\n        "}'
     headers:
       Accept:
       - application/json
@@ -9,18 +10,19 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '33'
+      - '149'
       Content-Type:
       - application/json
       User-Agent:
-      - storefront (a85017b3bae1b0f4530624eb0909c64e855c8a6a;devel)
+      - storefront (7104187423b5359d0e2cc3fe52d2c408b1df98eb;devel)
     method: POST
     uri: https://api.github.com/graphql
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA6tWSkksSVSyqlYqy0wtTy0CsXLy0zPzlKyUkkozc1J0i0sSgdx03eK8xILkosS0
-        Et3MfKXa2loA1+bv3DoAAAA=
+        H4sIAAAAAAAAAzWMQQrCMBREryJ/IQq2iaGgDRQPIR7gt41poE1K8hMXJXc3ou5m3jxmgxEJQW6Q
+        jHop/0mz08aChD6aeawCYam6ChbXweOTKuPgBBYXVZz7n+4OP/FYRkzl1D/8XIyJaA2SsS8LotaG
+        ptjHoPzgLClL9eAWFploLlzwa3sL3ZnzfeoayDm/AbHk/8ShAAAA
     headers:
       Access-Control-Allow-Origin:
       - '*'
@@ -37,7 +39,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 04 Feb 2020 11:21:42 GMT
+      - Fri, 07 Feb 2020 17:00:36 GMT
       Referrer-Policy:
       - origin-when-cross-origin, strict-origin-when-cross-origin
       Server:
@@ -59,24 +61,25 @@ interactions:
       X-GitHub-Media-Type:
       - github.v4
       X-GitHub-Request-Id:
-      - DBAA:2415D:5C9ED4:6BF4CF:5E3953C6
+      - 979E:3CC0D:1DDC74E:2418E80:5E3D97B4
       X-OAuth-Client-Id:
       - cdeb3a60fecee4208395
       X-OAuth-Scopes:
-      - repo
+      - read:org, repo
       X-RateLimit-Limit:
       - '5000'
       X-RateLimit-Remaining:
-      - '4996'
+      - '4993'
       X-RateLimit-Reset:
-      - '1580817914'
+      - '1581098000'
       X-XSS-Protection:
       - 1; mode=block
     status:
       code: 200
       message: OK
 - request:
-    body: '{"query": "{ viewer { login } }"}'
+    body: '{"query": "\n        {\n          viewer {\n            login\n            name\n            avatarUrl(size:
+      100)\n          }\n        }\n        "}'
     headers:
       Accept:
       - application/json
@@ -85,11 +88,11 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '33'
+      - '149'
       Content-Type:
       - application/json
       User-Agent:
-      - storefront (a85017b3bae1b0f4530624eb0909c64e855c8a6a;devel)
+      - storefront (7104187423b5359d0e2cc3fe52d2c408b1df98eb;devel)
     method: POST
     uri: https://api.github.com/graphql
   response:
@@ -109,7 +112,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 04 Feb 2020 11:21:42 GMT
+      - Fri, 07 Feb 2020 17:00:36 GMT
       Referrer-Policy:
       - origin-when-cross-origin, strict-origin-when-cross-origin
       Server:
@@ -125,13 +128,13 @@ interactions:
       X-GitHub-Media-Type:
       - github.v4
       X-GitHub-Request-Id:
-      - DBAA:2415D:5C9EF3:6BF4F4:5E3953C6
+      - 979E:3CC0D:1DDC800:2418F3E:5E3D97B4
       X-RateLimit-Limit:
       - '0'
       X-RateLimit-Remaining:
       - '0'
       X-RateLimit-Reset:
-      - '1580818902'
+      - '1581098436'
       X-XSS-Protection:
       - 1; mode=block
     status:

--- a/tests/api/cassettes/GitHubAPITest.test_get_user_repositories.yaml
+++ b/tests/api/cassettes/GitHubAPITest.test_get_user_repositories.yaml
@@ -1,9 +1,9 @@
 interactions:
 - request:
     body: '{"query": "{\n              viewer {\n                repositories(\n                    first:
-      100,\n                    privacy: PUBLIC,\n                    ownerAffiliations:\n                        [OWNER,
-      ORGANIZATION_MEMBER],\n                \n                ) {\n              edges
-      {\n                node {\n                  nameWithOwner\n                  yamlLocation1:\n                    object(expression:
+      100,\n                    privacy: PUBLIC,\n                    ownerAffiliations:
+      [OWNER],\n                \n                ) {\n              edges {\n                node
+      {\n                  nameWithOwner\n                  yamlLocation1:\n                    object(expression:
       \"master:snapcraft.yaml\")\n                    { id }\n                  yamlLocation2:\n                    object(expression:
       \"master:.snapcraft.yaml\")\n                    { id }\n                  yamlLocation3:\n                    object(expression:
       \"master:snap/snapcraft.yaml\")\n                    { id }\n                  yamlLocation4:\n                    object(expression:
@@ -17,11 +17,11 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '1065'
+      - '1019'
       Content-Type:
       - application/json
       User-Agent:
-      - storefront (a85017b3bae1b0f4530624eb0909c64e855c8a6a;devel)
+      - storefront (7104187423b5359d0e2cc3fe52d2c408b1df98eb;devel)
     method: POST
     uri: https://api.github.com/graphql
   response:
@@ -52,7 +52,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 04 Feb 2020 12:01:38 GMT
+      - Fri, 07 Feb 2020 17:00:37 GMT
       Referrer-Policy:
       - origin-when-cross-origin, strict-origin-when-cross-origin
       Server:
@@ -74,17 +74,17 @@ interactions:
       X-GitHub-Media-Type:
       - github.v4
       X-GitHub-Request-Id:
-      - BE32:2BEC7:11F91D3:1527136:5E395D21
+      - 97A2:3128F:4DE783:5CC42E:5E3D97B4
       X-OAuth-Client-Id:
       - cdeb3a60fecee4208395
       X-OAuth-Scopes:
-      - repo
+      - read:org, repo
       X-RateLimit-Limit:
       - '5000'
       X-RateLimit-Remaining:
-      - '4993'
+      - '4992'
       X-RateLimit-Reset:
-      - '1580817914'
+      - '1581097999'
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -92,9 +92,9 @@ interactions:
       message: OK
 - request:
     body: '{"query": "{\n              viewer {\n                repositories(\n                    first:
-      100,\n                    privacy: PUBLIC,\n                    ownerAffiliations:\n                        [OWNER,
-      ORGANIZATION_MEMBER],\n                \n                ) {\n              edges
-      {\n                node {\n                  nameWithOwner\n                  yamlLocation1:\n                    object(expression:
+      100,\n                    privacy: PUBLIC,\n                    ownerAffiliations:
+      [OWNER],\n                \n                ) {\n              edges {\n                node
+      {\n                  nameWithOwner\n                  yamlLocation1:\n                    object(expression:
       \"master:snapcraft.yaml\")\n                    { id }\n                  yamlLocation2:\n                    object(expression:
       \"master:.snapcraft.yaml\")\n                    { id }\n                  yamlLocation3:\n                    object(expression:
       \"master:snap/snapcraft.yaml\")\n                    { id }\n                  yamlLocation4:\n                    object(expression:
@@ -108,11 +108,11 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '1065'
+      - '1019'
       Content-Type:
       - application/json
       User-Agent:
-      - storefront (a85017b3bae1b0f4530624eb0909c64e855c8a6a;devel)
+      - storefront (7104187423b5359d0e2cc3fe52d2c408b1df98eb;devel)
     method: POST
     uri: https://api.github.com/graphql
   response:
@@ -132,7 +132,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 04 Feb 2020 12:01:38 GMT
+      - Fri, 07 Feb 2020 17:00:37 GMT
       Referrer-Policy:
       - origin-when-cross-origin, strict-origin-when-cross-origin
       Server:
@@ -148,13 +148,13 @@ interactions:
       X-GitHub-Media-Type:
       - github.v4
       X-GitHub-Request-Id:
-      - BE32:2BEC7:11F92B4:152723F:5E395D22
+      - 97A2:3128F:4DE7C5:5CC46F:5E3D97B5
       X-RateLimit-Limit:
       - '0'
       X-RateLimit-Remaining:
       - '0'
       X-RateLimit-Reset:
-      - '1580821298'
+      - '1581098437'
       X-XSS-Protection:
       - 1; mode=block
     status:

--- a/tests/api/cassettes/GitHubAPITest.test_is_snapcraft_yaml_present.yaml
+++ b/tests/api/cassettes/GitHubAPITest.test_is_snapcraft_yaml_present.yaml
@@ -9,7 +9,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - storefront (a85017b3bae1b0f4530624eb0909c64e855c8a6a;devel)
+      - storefront (7104187423b5359d0e2cc3fe52d2c408b1df98eb;devel)
     method: GET
     uri: https://api.github.com/repos/build-staging-snapcraft-io/test1/contents/snapcraft.yaml
   response:
@@ -39,7 +39,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 04 Feb 2020 12:09:57 GMT
+      - Fri, 07 Feb 2020 17:00:38 GMT
       ETag:
       - W/"0813b93202a22a03987a904b7f0a5602f2c3962a"
       Last-Modified:
@@ -64,13 +64,13 @@ interactions:
       X-GitHub-Media-Type:
       - github.v3
       X-GitHub-Request-Id:
-      - 91DE:2656B:18066B7:1C47513:5E395F15
+      - 97A6:31293:25FA793:2E06BFB:5E3D97B5
       X-RateLimit-Limit:
       - '60'
       X-RateLimit-Remaining:
-      - '59'
+      - '31'
       X-RateLimit-Reset:
-      - '1580821797'
+      - '1581097806'
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -86,7 +86,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - storefront (a85017b3bae1b0f4530624eb0909c64e855c8a6a;devel)
+      - storefront (7104187423b5359d0e2cc3fe52d2c408b1df98eb;devel)
     method: GET
     uri: https://api.github.com/repos/build-staging-snapcraft-io/test2/contents/snapcraft.yaml
   response:
@@ -108,7 +108,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 04 Feb 2020 12:09:57 GMT
+      - Fri, 07 Feb 2020 17:00:38 GMT
       Referrer-Policy:
       - origin-when-cross-origin, strict-origin-when-cross-origin
       Server:
@@ -126,13 +126,13 @@ interactions:
       X-GitHub-Media-Type:
       - github.v3
       X-GitHub-Request-Id:
-      - 91DE:2656B:1806724:1C47572:5E395F15
+      - 97A6:31293:25FA7F0:2E06C58:5E3D97B6
       X-RateLimit-Limit:
       - '60'
       X-RateLimit-Remaining:
-      - '58'
+      - '30'
       X-RateLimit-Reset:
-      - '1580821797'
+      - '1581097806'
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -148,7 +148,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - storefront (a85017b3bae1b0f4530624eb0909c64e855c8a6a;devel)
+      - storefront (7104187423b5359d0e2cc3fe52d2c408b1df98eb;devel)
     method: GET
     uri: https://api.github.com/repos/build-staging-snapcraft-io/test2/contents/.snapcraft.yaml
   response:
@@ -178,7 +178,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 04 Feb 2020 12:09:57 GMT
+      - Fri, 07 Feb 2020 17:00:38 GMT
       ETag:
       - W/"20dedf8456f7d87d8d4678bb0e30ab69babe0d43"
       Last-Modified:
@@ -203,13 +203,13 @@ interactions:
       X-GitHub-Media-Type:
       - github.v3
       X-GitHub-Request-Id:
-      - 91DE:2656B:18067C6:1C47601:5E395F15
+      - 97A6:31293:25FA868:2E06CB9:5E3D97B6
       X-RateLimit-Limit:
       - '60'
       X-RateLimit-Remaining:
-      - '57'
+      - '29'
       X-RateLimit-Reset:
-      - '1580821797'
+      - '1581097805'
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -225,7 +225,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - storefront (a85017b3bae1b0f4530624eb0909c64e855c8a6a;devel)
+      - storefront (7104187423b5359d0e2cc3fe52d2c408b1df98eb;devel)
     method: GET
     uri: https://api.github.com/repos/build-staging-snapcraft-io/test3/contents/snapcraft.yaml
   response:
@@ -247,7 +247,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 04 Feb 2020 12:09:58 GMT
+      - Fri, 07 Feb 2020 17:00:38 GMT
       Referrer-Policy:
       - origin-when-cross-origin, strict-origin-when-cross-origin
       Server:
@@ -265,13 +265,13 @@ interactions:
       X-GitHub-Media-Type:
       - github.v3
       X-GitHub-Request-Id:
-      - 91DE:2656B:1806829:1C476A4:5E395F15
+      - 97A6:31293:25FA91D:2E06DB4:5E3D97B6
       X-RateLimit-Limit:
       - '60'
       X-RateLimit-Remaining:
-      - '56'
+      - '28'
       X-RateLimit-Reset:
-      - '1580821796'
+      - '1581097805'
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -287,7 +287,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - storefront (a85017b3bae1b0f4530624eb0909c64e855c8a6a;devel)
+      - storefront (7104187423b5359d0e2cc3fe52d2c408b1df98eb;devel)
     method: GET
     uri: https://api.github.com/repos/build-staging-snapcraft-io/test3/contents/.snapcraft.yaml
   response:
@@ -309,7 +309,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 04 Feb 2020 12:09:58 GMT
+      - Fri, 07 Feb 2020 17:00:39 GMT
       Referrer-Policy:
       - origin-when-cross-origin, strict-origin-when-cross-origin
       Server:
@@ -327,13 +327,13 @@ interactions:
       X-GitHub-Media-Type:
       - github.v3
       X-GitHub-Request-Id:
-      - 91DE:2656B:1806881:1C47712:5E395F16
+      - 97A6:31293:25FA962:2E06E18:5E3D97B6
       X-RateLimit-Limit:
       - '60'
       X-RateLimit-Remaining:
-      - '55'
+      - '27'
       X-RateLimit-Reset:
-      - '1580821797'
+      - '1581097806'
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -349,7 +349,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - storefront (a85017b3bae1b0f4530624eb0909c64e855c8a6a;devel)
+      - storefront (7104187423b5359d0e2cc3fe52d2c408b1df98eb;devel)
     method: GET
     uri: https://api.github.com/repos/build-staging-snapcraft-io/test3/contents/snap/snapcraft.yaml
   response:
@@ -379,7 +379,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 04 Feb 2020 12:09:58 GMT
+      - Fri, 07 Feb 2020 17:00:39 GMT
       ETag:
       - W/"d9d780b03a68d9d5854e9de9efc3e4562d82f29f"
       Last-Modified:
@@ -404,13 +404,13 @@ interactions:
       X-GitHub-Media-Type:
       - github.v3
       X-GitHub-Request-Id:
-      - 91DE:2656B:18068D4:1C4777F:5E395F16
+      - 97A6:31293:25FA9BD:2E06E76:5E3D97B7
       X-RateLimit-Limit:
       - '60'
       X-RateLimit-Remaining:
-      - '54'
+      - '26'
       X-RateLimit-Reset:
-      - '1580821797'
+      - '1581097805'
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -426,7 +426,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - storefront (a85017b3bae1b0f4530624eb0909c64e855c8a6a;devel)
+      - storefront (7104187423b5359d0e2cc3fe52d2c408b1df98eb;devel)
     method: GET
     uri: https://api.github.com/repos/build-staging-snapcraft-io/test4/contents/snapcraft.yaml
   response:
@@ -448,7 +448,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 04 Feb 2020 12:09:58 GMT
+      - Fri, 07 Feb 2020 17:00:39 GMT
       Referrer-Policy:
       - origin-when-cross-origin, strict-origin-when-cross-origin
       Server:
@@ -466,13 +466,13 @@ interactions:
       X-GitHub-Media-Type:
       - github.v3
       X-GitHub-Request-Id:
-      - 91DE:2656B:1806936:1C477F5:5E395F16
+      - 97A6:31293:25FAA1A:2E06EEA:5E3D97B7
       X-RateLimit-Limit:
       - '60'
       X-RateLimit-Remaining:
-      - '53'
+      - '25'
       X-RateLimit-Reset:
-      - '1580821797'
+      - '1581097805'
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -488,7 +488,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - storefront (a85017b3bae1b0f4530624eb0909c64e855c8a6a;devel)
+      - storefront (7104187423b5359d0e2cc3fe52d2c408b1df98eb;devel)
     method: GET
     uri: https://api.github.com/repos/build-staging-snapcraft-io/test4/contents/.snapcraft.yaml
   response:
@@ -510,7 +510,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 04 Feb 2020 12:09:58 GMT
+      - Fri, 07 Feb 2020 17:00:39 GMT
       Referrer-Policy:
       - origin-when-cross-origin, strict-origin-when-cross-origin
       Server:
@@ -528,13 +528,13 @@ interactions:
       X-GitHub-Media-Type:
       - github.v3
       X-GitHub-Request-Id:
-      - 91DE:2656B:18069AF:1C4786D:5E395F16
+      - 97A6:31293:25FAA69:2E06F56:5E3D97B7
       X-RateLimit-Limit:
       - '60'
       X-RateLimit-Remaining:
-      - '52'
+      - '24'
       X-RateLimit-Reset:
-      - '1580821796'
+      - '1581097805'
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -550,7 +550,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - storefront (a85017b3bae1b0f4530624eb0909c64e855c8a6a;devel)
+      - storefront (7104187423b5359d0e2cc3fe52d2c408b1df98eb;devel)
     method: GET
     uri: https://api.github.com/repos/build-staging-snapcraft-io/test4/contents/snap/snapcraft.yaml
   response:
@@ -572,7 +572,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 04 Feb 2020 12:09:59 GMT
+      - Fri, 07 Feb 2020 17:00:39 GMT
       Referrer-Policy:
       - origin-when-cross-origin, strict-origin-when-cross-origin
       Server:
@@ -590,13 +590,13 @@ interactions:
       X-GitHub-Media-Type:
       - github.v3
       X-GitHub-Request-Id:
-      - 91DE:2656B:1806A15:1C47900:5E395F16
+      - 97A6:31293:25FAAD7:2E06FBE:5E3D97B7
       X-RateLimit-Limit:
       - '60'
       X-RateLimit-Remaining:
-      - '51'
+      - '23'
       X-RateLimit-Reset:
-      - '1580821797'
+      - '1581097805'
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -612,7 +612,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - storefront (a85017b3bae1b0f4530624eb0909c64e855c8a6a;devel)
+      - storefront (7104187423b5359d0e2cc3fe52d2c408b1df98eb;devel)
     method: GET
     uri: https://api.github.com/repos/build-staging-snapcraft-io/test4/contents/build-aux/snap/snapcraft.yaml
   response:
@@ -642,7 +642,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 04 Feb 2020 12:09:59 GMT
+      - Fri, 07 Feb 2020 17:00:40 GMT
       ETag:
       - W/"e00a57fa2c0e5dff656ff819607695b9ae2e04b4"
       Last-Modified:
@@ -667,13 +667,13 @@ interactions:
       X-GitHub-Media-Type:
       - github.v3
       X-GitHub-Request-Id:
-      - 91DE:2656B:1806A77:1C4797E:5E395F17
+      - 97A6:31293:25FAB1C:2E07025:5E3D97B7
       X-RateLimit-Limit:
       - '60'
       X-RateLimit-Remaining:
-      - '50'
+      - '22'
       X-RateLimit-Reset:
-      - '1580821797'
+      - '1581097806'
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -689,7 +689,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - storefront (a85017b3bae1b0f4530624eb0909c64e855c8a6a;devel)
+      - storefront (7104187423b5359d0e2cc3fe52d2c408b1df98eb;devel)
     method: GET
     uri: https://api.github.com/repos/build-staging-snapcraft-io/test5/contents/snapcraft.yaml
   response:
@@ -712,7 +712,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 04 Feb 2020 12:09:59 GMT
+      - Fri, 07 Feb 2020 17:00:40 GMT
       Referrer-Policy:
       - origin-when-cross-origin, strict-origin-when-cross-origin
       Server:
@@ -730,13 +730,13 @@ interactions:
       X-GitHub-Media-Type:
       - github.v3
       X-GitHub-Request-Id:
-      - 91DE:2656B:1806AD6:1C479E6:5E395F17
+      - 97A6:31293:25FAB7D:2E07085:5E3D97B8
       X-RateLimit-Limit:
       - '60'
       X-RateLimit-Remaining:
-      - '49'
+      - '21'
       X-RateLimit-Reset:
-      - '1580821797'
+      - '1581097805'
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -752,7 +752,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - storefront (a85017b3bae1b0f4530624eb0909c64e855c8a6a;devel)
+      - storefront (7104187423b5359d0e2cc3fe52d2c408b1df98eb;devel)
     method: GET
     uri: https://api.github.com/repos/build-staging-snapcraft-io/test5/contents/.snapcraft.yaml
   response:
@@ -775,7 +775,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 04 Feb 2020 12:09:59 GMT
+      - Fri, 07 Feb 2020 17:00:40 GMT
       Referrer-Policy:
       - origin-when-cross-origin, strict-origin-when-cross-origin
       Server:
@@ -793,13 +793,13 @@ interactions:
       X-GitHub-Media-Type:
       - github.v3
       X-GitHub-Request-Id:
-      - 91DE:2656B:1806B2E:1C47A51:5E395F17
+      - 97A6:31293:25FABE9:2E07104:5E3D97B8
       X-RateLimit-Limit:
       - '60'
       X-RateLimit-Remaining:
-      - '48'
+      - '20'
       X-RateLimit-Reset:
-      - '1580821797'
+      - '1581097805'
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -815,7 +815,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - storefront (a85017b3bae1b0f4530624eb0909c64e855c8a6a;devel)
+      - storefront (7104187423b5359d0e2cc3fe52d2c408b1df98eb;devel)
     method: GET
     uri: https://api.github.com/repos/build-staging-snapcraft-io/test5/contents/snap/snapcraft.yaml
   response:
@@ -838,7 +838,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 04 Feb 2020 12:09:59 GMT
+      - Fri, 07 Feb 2020 17:00:40 GMT
       Referrer-Policy:
       - origin-when-cross-origin, strict-origin-when-cross-origin
       Server:
@@ -856,13 +856,13 @@ interactions:
       X-GitHub-Media-Type:
       - github.v3
       X-GitHub-Request-Id:
-      - 91DE:2656B:1806B8B:1C47AAE:5E395F17
+      - 97A6:31293:25FAC56:2E07189:5E3D97B8
       X-RateLimit-Limit:
       - '60'
       X-RateLimit-Remaining:
-      - '47'
+      - '19'
       X-RateLimit-Reset:
-      - '1580821797'
+      - '1581097805'
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -878,7 +878,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - storefront (a85017b3bae1b0f4530624eb0909c64e855c8a6a;devel)
+      - storefront (7104187423b5359d0e2cc3fe52d2c408b1df98eb;devel)
     method: GET
     uri: https://api.github.com/repos/build-staging-snapcraft-io/test5/contents/build-aux/snap/snapcraft.yaml
   response:
@@ -901,7 +901,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 04 Feb 2020 12:09:59 GMT
+      - Fri, 07 Feb 2020 17:00:41 GMT
       Referrer-Policy:
       - origin-when-cross-origin, strict-origin-when-cross-origin
       Server:
@@ -919,13 +919,13 @@ interactions:
       X-GitHub-Media-Type:
       - github.v3
       X-GitHub-Request-Id:
-      - 91DE:2656B:1806BE7:1C47B1B:5E395F17
+      - 97A6:31293:25FACB5:2E07208:5E3D97B8
       X-RateLimit-Limit:
       - '60'
       X-RateLimit-Remaining:
-      - '46'
+      - '18'
       X-RateLimit-Reset:
-      - '1580821796'
+      - '1581097806'
       X-XSS-Protection:
       - 1; mode=block
     status:

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -27,6 +27,7 @@ from webapp.handlers import set_handlers
 from webapp.login.views import login
 from webapp.login.oauth_views import oauth
 from webapp.publisher.snaps.views import publisher_snaps
+from webapp.publisher.github.views import publisher_github
 from webapp.publisher.views import account
 from webapp.snapcraft.views import snapcraft_blueprint
 from webapp.store.views import store_blueprint
@@ -83,6 +84,7 @@ def init_snapcraft(app, testing=False):
     app.register_blueprint(store_blueprint(testing=testing))
     app.register_blueprint(account, url_prefix="/account")
     app.register_blueprint(publisher_snaps)
+    app.register_blueprint(publisher_github)
     init_docs(app, "/docs")
     init_blog(app, "/blog")
 

--- a/webapp/login/oauth_views.py
+++ b/webapp/login/oauth_views.py
@@ -27,7 +27,7 @@ def github_auth():
 
     params = {
         "client_id": os.getenv("GITHUB_CLIENT_ID"),
-        "scope": "repo",
+        "scope": "repo read:org",
         "state": flask.session["csrf_token"],
     }
 

--- a/webapp/publisher/github/views.py
+++ b/webapp/publisher/github/views.py
@@ -11,13 +11,11 @@ publisher_github = flask.Blueprint(
 @login_required
 def get_repos():
     github = GitHubAPI(flask.session.get("github_auth_secret"))
-    repos = github.get_user_repositories()
+    org = flask.request.args.get("org")
+
+    if org:
+        repos = github.get_org_repositories(org)
+    else:
+        repos = github.get_user_repositories()
+
     return flask.jsonify(repos)
-
-
-@publisher_github.route("/publisher/github/get-orgs", methods=["GET"])
-@login_required
-def get_orgs():
-    github = GitHubAPI(flask.session.get("github_auth_secret"))
-    orgs = github.get_orgs()
-    return flask.jsonify(orgs)

--- a/webapp/publisher/snaps/views.py
+++ b/webapp/publisher/snaps/views.py
@@ -1404,17 +1404,12 @@ def get_snap_builds(snap_name):
             )
     else:
         try:
-            context["github_user"] = github.get_username()
+            context["github_user"] = github.get_user()
         except Unauthorized:
             context["github_user"] = None
 
         if context["github_user"]:
-            # Get snapcraft repositories sorted by snapcraft_yaml
-            context["github_repositories"] = sorted(
-                github.get_user_repositories(),
-                key=lambda k: k["snapcraft_yaml"],
-                reverse=True,
-            )
+            context["github_orgs"] = github.get_orgs()
 
     return flask.render_template("publisher/builds.html", **context)
 


### PR DESCRIPTION
## Done

- Added route "/publisher/github/get-repos" that return a json
- List of GitHub Orgs passed to the template

## Issue / Card

Fixes #2486 

## QA

- Pull the branch
- Run the site using the command `./run`
- View the site locally in your web browser at: http://0.0.0.0:8004/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Go to /<snap_name>/builds and login with github
- Now you should be able to see an HTML select with all your GitHub organizations
- Check that http://0.0.0.0:8004/publisher/github/get-repos return a JSON with all your repos
- Check that http://0.0.0.0:8004/publisher/github/get-repos?org=canonical-web-and-design return a JSON with the Canonical repos.
