### PR TITLE
Upgrade to latest version of discourse docs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # App dependencies
 bleach==3.1.0
-canonicalwebteam.discourse-docs==0.6.4
+canonicalwebteam.discourse-docs==0.11.0
 canonicalwebteam.blog==4.0.2
 canonicalwebteam.search==0.1.0
 canonicalwebteam.yaml-responses==1.1.1

--- a/webapp/docs/views.py
+++ b/webapp/docs/views.py
@@ -10,11 +10,11 @@ def init_docs(app, url_prefix):
     discourse_parser = DocParser(
         api=DiscourseAPI(base_url="https://forum.snapcraft.io/"),
         index_topic_id=11127,
+        category_id=15,
         url_prefix=url_prefix,
     )
     discourse_docs = DiscourseDocs(
         parser=discourse_parser,
-        category_id=15,
         document_template="docs/document.html",
         url_prefix=url_prefix,
     )


### PR DESCRIPTION
## Done

Upgrade to latest version of discourse docs module


## QA

- Pull the branch
- Run the site using the command `./run`
- View the site locally in your web browser at: http://0.0.0.0:8004/docs
-  plya around with docs and make sure it workiworks