### PR TITLE
Increase tour background transparency

### DIFF
--- a/static/sass/_snapcraft_tour.scss
+++ b/static/sass/_snapcraft_tour.scss
@@ -1,5 +1,5 @@
 @mixin snapcraft-tour {
-  $color-overlay: transparentize($color-dark, .15);
+  $color-overlay: transparentize($color-dark, .35);
   $triangle-height: $sp-unit;
   $triangle-spacing: 2 * $triangle-height;
 


### PR DESCRIPTION
## Done

- Increase tour background transparency

## Issue / Card

Fixes #2311 

## QA

- Pull the branch
- Run the site using the command `./run`
- View the site locally in your web browser at: http://0.0.0.0:8004/[snap_name]/listing
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Click on the tour button and note the background is not as dark anymore

## Screenshots

![image](https://user-images.githubusercontent.com/40214246/74248775-047e6900-4ce0-11ea-89ee-f15f73b5d3c1.png)
