### PR TITLE
FSF expand next accordion when clicking register snap name

### DIFF
--- a/static/js/public/first-snap-flow.js
+++ b/static/js/public/first-snap-flow.js
@@ -2,6 +2,8 @@
 
 import "whatwg-fetch";
 
+import { toggleAccordion } from "./accordion";
+
 function install(language) {
   const osPickers = Array.from(document.querySelectorAll(".js-os-select"));
   const osWrappers = Array.from(document.querySelectorAll(".js-os-wrapper"));
@@ -267,6 +269,14 @@ function initRegisterName(formEl, notificationEl, successEl) {
         } else if (json.code == "created") {
           showSuccess(`Name "${json.snap_name}" registered successfully.`);
         } else if (json.code == "already_owned") {
+          // Jump to the next accordion panel
+          const currentPanel = formEl.closest(".p-accordion__group");
+          const currentToggle = currentPanel.querySelector(".p-accordion__tab");
+          const nextPanel = currentPanel.nextElementSibling;
+          const nextToggle = nextPanel.querySelector(".p-accordion__tab");
+          toggleAccordion(currentToggle, false);
+          toggleAccordion(nextToggle, true);
+
           showSuccess(`You already own "${json.snap_name}"".`);
         }
       })

--- a/static/js/public/first-snap-flow.js
+++ b/static/js/public/first-snap-flow.js
@@ -257,6 +257,21 @@ function initRegisterName(formEl, notificationEl, successEl) {
   formEl.addEventListener("submit", event => {
     event.preventDefault();
     let formData = new FormData(formEl);
+    const submitButton = formEl.querySelector(
+      "[data-js='js-snap-name-register']"
+    );
+
+    const currentPanel = formEl.closest(".p-accordion__group");
+    const currentToggle = currentPanel.querySelector(".p-accordion__tab");
+    const nextPanel = currentPanel.nextElementSibling;
+    const nextToggle = nextPanel.querySelector(".p-accordion__tab");
+
+    // Show spinner if data fetch takes long
+    setTimeout(() => {
+      if (currentToggle.getAttribute("aria-expanded") === "true") {
+        submitButton.classList.add("has-spinner");
+      }
+    }, 400);
 
     fetch("/register-snap/json", {
       method: "POST",
@@ -267,20 +282,25 @@ function initRegisterName(formEl, notificationEl, successEl) {
         if (json.errors) {
           showError(json.errors[0].message);
         } else if (json.code == "created") {
+          // Jump to the next accordion panel
+          toggleAccordion(currentToggle, false);
+          toggleAccordion(nextToggle, true);
+
+          submitButton.classList.remove("has-spinner");
+
           showSuccess(`Name "${json.snap_name}" registered successfully.`);
         } else if (json.code == "already_owned") {
           // Jump to the next accordion panel
-          const currentPanel = formEl.closest(".p-accordion__group");
-          const currentToggle = currentPanel.querySelector(".p-accordion__tab");
-          const nextPanel = currentPanel.nextElementSibling;
-          const nextToggle = nextPanel.querySelector(".p-accordion__tab");
           toggleAccordion(currentToggle, false);
           toggleAccordion(nextToggle, true);
+
+          submitButton.classList.remove("has-spinner");
 
           showSuccess(`You already own "${json.snap_name}"".`);
         }
       })
       .catch(() => {
+        submitButton.classList.remove("has-spinner");
         errorNotification(
           notificationEl,
           "There was some problem registering name. Please try again."

--- a/templates/first-snap/push.html
+++ b/templates/first-snap/push.html
@@ -73,7 +73,12 @@
                         Make sure the name matches what has been used previously (i.e <code>{{ snap_name }}</code>)
                       </p>
                     </div>
-                    <button class="p-button--positive">Register snap name</button>
+                    <button class="p-button--positive p-button-spinner" data-js="js-snap-name-register">
+                      <span class="p-button__spinner vanilla-workaround--dark">
+                        <i class="p-icon--spinner u-animation--spin"></i>
+                      </span>
+                      <span class="p-button__text">Register snap name</span>
+                  </button>
                   </form>
                 </div>
               </div>


### PR DESCRIPTION
## Done

- Expand next accordion when clicking register snap name and no errors

## Issue / Card

Fixes https://github.com/canonical-web-and-design/snap-squad/issues/1038

## QA

- Pull the branch
- Run the site using the command `./run`
- View the site locally in your web browser at: http://0.0.0.0:8004/first-snap/python/linux/push
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Click on `Register snap name` and see the next accordion panel is expanded automatically.