### PR TITLE
Make sure to test for bool

### DIFF
--- a/static/js/publisher/tour.js
+++ b/static/js/publisher/tour.js
@@ -63,7 +63,7 @@ export function initListingTour({ snapName, container, steps, formFields }) {
 
   const isFormCompleted = isCompleted(completedFields);
   const isTourFinished = !!(
-    window.localStorage && window.localStorage.getItem(storageKey)
+    window.localStorage && window.localStorage.getItem(storageKey) === "true"
   );
 
   // start the tour automatically if form is not completed


### PR DESCRIPTION
## Done

- Improved the type when checking if tour has already been closed

Turns out this should already be working

## Issue / Card

Fixes #2495

## QA

- Pull the branch
- Run the site using the command `./run`
- View the site locally in your web browser at: http://0.0.0.0:8004/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Go to a snap listing page that doesn't have over 50% of the fields completed
- The tour should appear
- Skip the tour
- Go back to that pages
- The tour should not appear