### PR TITLE
Add GitHub Webhook endpoint

### DIFF
--- a/webapp/api/launchpad.py
+++ b/webapp/api/launchpad.py
@@ -40,9 +40,17 @@ class Launchpad:
 
         return collection.get("entries", [])
 
+    def get_snap(self, name):
+        """
+        Return a Snap from the Launchpad API by name
+        """
+        snap = self._request("GET", f"~{self.username}/+snap/{name}")
+
+        return snap
+
     def get_snap_by_store_name(self, snap_name):
         """
-        Return an Snap from the Launchpad API by store_name
+        Return a Snap from the Launchpad API by store_name
         """
         snaps = self.get_collection_entries(
             "+snaps",

--- a/webapp/publisher/snaps/views.py
+++ b/webapp/publisher/snaps/views.py
@@ -34,6 +34,7 @@ from webapp.publisher.snaps.build_views import (
     get_snap_builds,
     get_snap_builds_json,
     get_validate_repo,
+    post_github_webhook,
     post_snap_builds,
     post_trigger_build,
 )
@@ -113,6 +114,17 @@ publisher_snaps.add_url_rule(
 publisher_snaps.add_url_rule(
     "/<snap_name>/builds/trigger-build",
     view_func=post_trigger_build,
+    methods=["POST"],
+)
+publisher_snaps.add_url_rule(
+    "/<snap_name>/webhook/notify",
+    view_func=post_github_webhook,
+    methods=["POST"],
+)
+# This route is to support previous webhooks from build.snapcraft.io
+publisher_snaps.add_url_rule(
+    "/<github_owner>/<github_repo>/webhook/notify",
+    view_func=post_github_webhook,
     methods=["POST"],
 )
 


### PR DESCRIPTION
## Done

Create an endpoint for GitHub webhooks

## Issue / Card

Fixes #2522 

## QA

- Pull the branch
- Run the site using the command `./run`
- View the site locally in your web browser at: http://0.0.0.0:8004/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Ask me for the needed environment variables
- Run:
```
curl -H "Content-Type: application/json" -H "X-Hub-Signature: sha1=27a4e453d0dc47fadc33efdf1d8b8fa7942f5f49" -X POST -d '{"repository":{"url": "https://github.com/jkfran/test-snap-fran", "name": "test-snap-fran", "owner": {"login": "jkfran"}}}' http://0.0.0.0:8004/test-snap-fran/webhook/notify
```
- That should trigger builds for that snap:
http://0.0.0.0:8004/test-snap-fran/builds/
