### PR TITLE
Consistent publisher headers.

### DIFF
--- a/templates/publisher/_header.html
+++ b/templates/publisher/_header.html
@@ -11,7 +11,9 @@
   {% endif %}
   <div class="u-fixed-width">
     <a href="/snaps">&lsaquo; My snaps</a>
-    <h1 class="p-heading--three">{% if snap_title %}{{ snap_title }}{% else %}{{ snap_name }}{% endif %}</h1>
+    <h1 class="p-heading--three">
+      {% if snap_title %}{{ snap_title }}{% else %}{{ snap_name }}{% endif %}
+      {% if publisher_name and publisher_name != user_name %} <small>by {{publisher_name}}</small>{% endif %}</h1>
     <nav class="p-tabs">
       <ul class="p-tabs__list u-float-right u-no-margin--bottom" role="tablist">
         <li class="p-tabs__item" role="presentation">

--- a/tests/publisher/snaps/tests_get_metrics.py
+++ b/tests/publisher/snaps/tests_get_metrics.py
@@ -45,6 +45,7 @@ class GetMetricsPostMetrics(BaseTestCases.EndpointLoggedInErrorHandling):
             "categories": {
                 "items": [{"name": "test", "since": "2018-01-01T00:00:00"}]
             },
+            "publisher": {"display-name": "test"},
         }
 
         responses.add(responses.GET, self.info_url, json=payload, status=200)

--- a/tests/publisher/snaps/tests_post_settings.py
+++ b/tests/publisher/snaps/tests_post_settings.py
@@ -102,6 +102,7 @@ class PostMetadataSettingsPage(BaseTestCases.EndpointLoggedIn):
             "store": "stotore",
             "keywords": [],
             "status": "published",
+            "publisher": {"display-name": "test"},
         }
 
         responses.add(responses.GET, info_url, json=payload, status=200)
@@ -163,6 +164,7 @@ class PostMetadataSettingsPage(BaseTestCases.EndpointLoggedIn):
             "store": "stotore",
             "keywords": [],
             "status": "published",
+            "publisher": {"display-name": "test"},
         }
 
         responses.add(responses.GET, info_url, json=payload, status=200)

--- a/tests/publisher/snaps/tests_publicise.py
+++ b/tests/publisher/snaps/tests_publicise.py
@@ -48,6 +48,7 @@ class GetPublicisePage(BaseTestCases.EndpointLoggedInErrorHandling):
             "private": False,
             "snap_name": snap_name,
             "keywords": [],
+            "publisher": {"display-name": "test"},
         }
 
         responses.add(responses.GET, self.api_url, json=payload, status=200)
@@ -73,6 +74,7 @@ class GetPublicisePage(BaseTestCases.EndpointLoggedInErrorHandling):
             "private": True,
             "snap_name": snap_name,
             "keywords": [],
+            "publisher": {"display-name": "test"},
         }
 
         responses.add(responses.GET, self.api_url, json=payload, status=200)

--- a/tests/publisher/snaps/tests_publicise_badges.py
+++ b/tests/publisher/snaps/tests_publicise_badges.py
@@ -82,6 +82,7 @@ class GetPubliciseBadgesPage(BaseTestCases.EndpointLoggedInErrorHandling):
             "snap_name": snap_name,
             "keywords": [],
             "media": [],
+            "publisher": {"display-name": "test"},
         }
 
         responses.add(responses.GET, self.api_url, json=payload, status=200)

--- a/tests/publisher/snaps/tests_publicise_cards.py
+++ b/tests/publisher/snaps/tests_publicise_cards.py
@@ -49,6 +49,7 @@ class GetPubliciseCardsPage(BaseTestCases.EndpointLoggedInErrorHandling):
             "snap_name": snap_name,
             "keywords": [],
             "media": [],
+            "publisher": {"display-name": "test"},
         }
 
         responses.add(responses.GET, self.api_url, json=payload, status=200)
@@ -76,6 +77,7 @@ class GetPubliciseCardsPage(BaseTestCases.EndpointLoggedInErrorHandling):
             "snap_name": snap_name,
             "keywords": [],
             "media": [{"url": "this is a url", "type": "screenshot"}],
+            "publisher": {"display-name": "test"},
         }
 
         responses.add(responses.GET, self.api_url, json=payload, status=200)

--- a/tests/publisher/snaps/tests_revision.py
+++ b/tests/publisher/snaps/tests_revision.py
@@ -54,7 +54,11 @@ class GetRevisionHistory(BaseTestCases.EndpointLoggedInErrorHandling):
         info_url = "https://dashboard.snapcraft.io/dev/api/snaps/info/{}"
         self.info_url = info_url.format(self.snap_name)
 
-        payload = {"snap_id": "id", "title": "Test Snap"}
+        payload = {
+            "snap_id": "id",
+            "title": "Test Snap",
+            "publisher": {"display-name": "test"},
+        }
 
         responses.add(responses.GET, self.info_url, json=payload, status=200)
 

--- a/tests/publisher/snaps/tests_settings.py
+++ b/tests/publisher/snaps/tests_settings.py
@@ -52,6 +52,7 @@ class GetSettingsPage(BaseTestCases.EndpointLoggedInErrorHandling):
             "store": "stotore",
             "keywords": [],
             "status": "published",
+            "publisher": {"display-name": "test"},
         }
 
         responses.add(responses.GET, self.api_url, json=payload, status=200)

--- a/webapp/publisher/snaps/views.py
+++ b/webapp/publisher/snaps/views.py
@@ -268,6 +268,7 @@ def publisher_snap_metrics(snap_name):
         # Data direct from details API
         "snap_name": snap_name,
         "snap_title": details["title"],
+        "publisher_name": details["publisher"]["display-name"],
         "metric_period": metric_requested["period"],
         "active_device_metric": installed_base_metric,
         "default_track": default_track,
@@ -527,7 +528,6 @@ def post_listing_snap(snap_name):
                 "snap_name": snap_details["snap_name"],
                 "snap_categories": snap_categories,
                 "icon_url": icon_urls[0] if icon_urls else None,
-                "publisher_name": snap_details["publisher"]["display-name"],
                 "username": snap_details["publisher"]["username"],
                 "screenshot_urls": screenshot_urls,
                 "banner_urls": banner_urls,
@@ -571,6 +571,7 @@ def post_listing_snap(snap_name):
                 "licenses": licenses,
                 "is_on_stable": is_on_stable,
                 "categories": categories,
+                "publisher_name": snap_details["publisher"]["display-name"],
                 # errors
                 "error_list": error_list,
                 "field_errors": field_errors,
@@ -620,6 +621,8 @@ def get_release_history(snap_name):
 
     context = {
         "snap_name": snap_name,
+        "snap_title": info["title"],
+        "publisher_name": info["publisher"]["display-name"],
         "release_history": release_history,
         "private": info.get("private"),
         "channel_maps_list": info.get("channel_maps_list"),
@@ -1029,6 +1032,7 @@ def get_settings(snap_name):
         "snap_name": snap_details["snap_name"],
         "snap_title": snap_details["title"],
         "snap_id": snap_details["snap_id"],
+        "publisher_name": snap_details["publisher"]["display-name"],
         "license": license,
         "private": snap_details["private"],
         "unlisted": snap_details["unlisted"],
@@ -1115,6 +1119,7 @@ def post_settings(snap_name):
                 # read-only values from details API
                 "snap_name": snap_details["snap_name"],
                 "snap_title": snap_details["title"],
+                "publisher_name": snap_details["publisher"]["display-name"],
                 "snap_id": snap_details["snap_id"],
                 "private": snap_details["private"],
                 "unlisted": snap_details["unlisted"],
@@ -1190,6 +1195,7 @@ def get_publicise(snap_name):
         "private": snap_details["private"],
         "snap_name": snap_details["snap_name"],
         "snap_title": snap_details["title"],
+        "publisher_name": snap_details["publisher"]["display-name"],
         "snap_id": snap_details["snap_id"],
         "available": available_languages,
         "download_version": "v1.3",
@@ -1226,6 +1232,7 @@ def get_publicise_badges(snap_name):
     context = {
         "snap_name": snap_details["snap_name"],
         "snap_title": snap_details["title"],
+        "publisher_name": snap_details["publisher"]["display-name"],
         "snap_id": snap_details["snap_id"],
         "trending": snap_public_details["snap"]["trending"],
     }
@@ -1258,6 +1265,7 @@ def get_publicise_cards(snap_name):
         "has_screenshot": has_screenshot,
         "snap_name": snap_details["snap_name"],
         "snap_title": snap_details["title"],
+        "publisher_name": snap_details["publisher"]["display-name"],
         "snap_id": snap_details["snap_id"],
     }
 


### PR DESCRIPTION
## Done

Ensure the header for different publisher snap pages show's the snap title, not the snap name.
Also if you're a collaborator include who owns the snap.

## Issue / Card

Fixes #2538 

## QA

- Pull the branch
- Run the site using the command `./run`
- View the site locally in your web browser at: http://0.0.0.0:8004/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Login, view some snaps - see that the name is consistent.
- Look at some snaps you're a collaborator for and see the different names

## Screenshots
![Screenshot_2020-02-19  Publicise Android Studio ](https://user-images.githubusercontent.com/479384/74848818-f1971480-532f-11ea-9a5e-15530a002adb.png)
