### PR TITLE
Always get total active devices from most recent 24 hours

### DIFF
--- a/tests/publisher/snaps/tests_get_metrics.py
+++ b/tests/publisher/snaps/tests_get_metrics.py
@@ -83,7 +83,7 @@ class GetMetricsPostMetrics(BaseTestCases.EndpointLoggedInErrorHandling):
 
         response = self.client.get(self.endpoint_url)
 
-        self.assertEqual(2, len(responses.calls))
+        self.assertEqual(3, len(responses.calls))
         called = responses.calls[0]
         self.assertEqual(self.info_url, called.request.url)
         self.assertEqual(
@@ -133,7 +133,7 @@ class GetMetricsPostMetrics(BaseTestCases.EndpointLoggedInErrorHandling):
 
         response = self.client.get(self.endpoint_url + "?period=1y")
 
-        self.assertEqual(2, len(responses.calls))
+        self.assertEqual(3, len(responses.calls))
         called = responses.calls[0]
         self.assertEqual(self.info_url, called.request.url)
         self.assertEqual(
@@ -183,7 +183,7 @@ class GetMetricsPostMetrics(BaseTestCases.EndpointLoggedInErrorHandling):
 
         response = self.client.get(self.endpoint_url + "?period=30d")
 
-        self.assertEqual(2, len(responses.calls))
+        self.assertEqual(3, len(responses.calls))
         called = responses.calls[0]
         self.assertEqual(self.info_url, called.request.url)
         self.assertEqual(
@@ -233,7 +233,7 @@ class GetMetricsPostMetrics(BaseTestCases.EndpointLoggedInErrorHandling):
 
         response = self.client.get(self.endpoint_url + "?period=7d")
 
-        self.assertEqual(2, len(responses.calls))
+        self.assertEqual(3, len(responses.calls))
         called = responses.calls[0]
         self.assertEqual(self.info_url, called.request.url)
         self.assertEqual(
@@ -287,7 +287,7 @@ class GetMetricsPostMetrics(BaseTestCases.EndpointLoggedInErrorHandling):
 
         response = self.client.get(self.endpoint_url + "?period=3m")
 
-        self.assertEqual(2, len(responses.calls))
+        self.assertEqual(3, len(responses.calls))
         called = responses.calls[0]
         self.assertEqual(self.info_url, called.request.url)
         self.assertEqual(
@@ -339,7 +339,7 @@ class GetMetricsPostMetrics(BaseTestCases.EndpointLoggedInErrorHandling):
             self.endpoint_url + "?period=7d&active-devices=os"
         )
 
-        self.assertEqual(2, len(responses.calls))
+        self.assertEqual(3, len(responses.calls))
         called = responses.calls[0]
         self.assertEqual(self.info_url, called.request.url)
         self.assertEqual(
@@ -391,7 +391,7 @@ class GetMetricsPostMetrics(BaseTestCases.EndpointLoggedInErrorHandling):
             self.endpoint_url + "?period=1y&active-devices=os"
         )
 
-        self.assertEqual(2, len(responses.calls))
+        self.assertEqual(3, len(responses.calls))
         called = responses.calls[0]
         self.assertEqual(self.info_url, called.request.url)
         self.assertEqual(
@@ -443,7 +443,7 @@ class GetMetricsPostMetrics(BaseTestCases.EndpointLoggedInErrorHandling):
             self.endpoint_url + "?period=30d&active-devices=os"
         )
 
-        self.assertEqual(2, len(responses.calls))
+        self.assertEqual(3, len(responses.calls))
         called = responses.calls[0]
         self.assertEqual(self.info_url, called.request.url)
         self.assertEqual(
@@ -499,7 +499,7 @@ class GetMetricsPostMetrics(BaseTestCases.EndpointLoggedInErrorHandling):
             self.endpoint_url + "?period=3m&active-devices=os"
         )
 
-        self.assertEqual(2, len(responses.calls))
+        self.assertEqual(3, len(responses.calls))
         called = responses.calls[0]
         self.assertEqual(self.info_url, called.request.url)
         self.assertEqual(


### PR DESCRIPTION
## Done

- Get latest days metrics to display as the Weekly active devices total

## Issue / Card

Fixes #2506

## QA

- Pull the branch
- Run the site using the command `./run`
- View the site locally in your web browser at: http://0.0.0.0:8004/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Visit the metrics page for a snap
  - View last 7 days and 2 years
  - The number in the heading above the graph should be the same

## Screenshots

![Screenshot_2020-02-19  Publisher metrics for OBS Studio ](https://user-images.githubusercontent.com/479384/74857959-6a03d280-533c-11ea-86f6-3109690f0681.png)
![Screenshot_2020-02-19  Publisher metrics for OBS Studio (1)](https://user-images.githubusercontent.com/479384/74857960-6a03d280-533c-11ea-9715-73538b67b6db.png)
