### PR TITLE
FSF - Remove clone step

### DIFF
--- a/static/sass/_patterns_annotated_code.scss
+++ b/static/sass/_patterns_annotated_code.scss
@@ -13,7 +13,7 @@
     code {
       background: none;
       box-shadow: none;
-      white-space: pre;
+      white-space: pre-wrap;
     }
 
     code b {

--- a/templates/first-snap/build.html
+++ b/templates/first-snap/build.html
@@ -45,11 +45,11 @@
   </a>
 
   {% if os and os.startswith('macos') %}
-    <a class="p-button--positive u-float-right" href="/first-snap/{{ language }}/{{ os }}/test">
+    <a class="p-button--positive u-float-right u-no-margin--right" href="/first-snap/{{ language }}/{{ os }}/test">
       Next: Test snap &rsaquo;
     </a>
   {% else %}
-    <a class="p-button--positive u-float-right" href="/first-snap/{{ language }}/{{ os }}/push">
+    <a class="p-button--positive u-float-right u-no-margin--right" href="/first-snap/{{ language }}/{{ os }}/push">
       Next: Publish to store &rsaquo;
     </a>
   {% endif %}

--- a/templates/first-snap/install-snapcraft.html
+++ b/templates/first-snap/install-snapcraft.html
@@ -43,7 +43,7 @@
     &lsaquo; Previous: Select language
   </a>
 
-  <a class="p-button--positive is--disabled u-float-right" id="js-pagination-next">
+  <a class="p-button--positive is--disabled u-float-right u-no-margin--right" id="js-pagination-next">
     Next: Package snap &rsaquo;
   </a>
 {% endblock %}

--- a/templates/first-snap/package.html
+++ b/templates/first-snap/package.html
@@ -33,38 +33,17 @@
           </section>
         </li>
         <li class="p-accordion__group">
-          <button {% if has_user_chosen_name %}aria-expanded="true"{% else %}aria-expanded="false"{% endif %} type="button" class="p-accordion__tab" id="tab2" role="tab" aria-controls="#tab2-section" >
+          <button {% if has_user_chosen_name %}aria-expanded="true"{% else %}aria-expanded="false"{% endif %} type="button" class="p-accordion__tab" id="tab2" role="tab" aria-controls="#tab2-section">
             <h4 class="u-no-margin--bottom">
-              Step 2: Download an example app
-              <i class="p-icon--success u-hide"></i>
+              Step 2: Download your snapcraft.yaml
             </h4>
           </button>
           <section class="p-accordion__panel" id="tab2-section" role="tabpanel" {% if has_user_chosen_name %}aria-hidden="false"{% else %}aria-hidden="true"{% endif %} aria-labelledby="tab2-section">
             <div class="p-strip is-shallow">
               <div class="row">
-                <div class="col-8">
-                  <p>Clone the following application to use for the purpose of this tutorial:</p>
-                  {% set snippet_value = steps.download %}
-                  {% set snippet_id = "download" %}
-                  {% include "/partials/_code-snippet.html" %}
-                  <button id="js-clone-continue-button" class="p-button--positive">Continue</button>
-                </div>
-              </div>
-            </div>
-          </section>
-        </li>
-        <li class="p-accordion__group">
-          <button aria-expanded="false" type="button" class="p-accordion__tab" id="tab3" role="tab" aria-controls="#tab3-section" >
-            <h4 class="u-no-margin--bottom">
-              Step 3: Download your snapcraft.yaml
-            </h4>
-          </button>
-          <section class="p-accordion__panel" id="tab3-section" role="tabpanel" aria-hidden="true" aria-labelledby="tab3-section">
-            <div class="p-strip is-shallow">
-              <div class="row">
                 <div class="col-9">
                   <p>A <a href="/docs/snapcraft-format">snapcraft.yaml file</a> holds the basic meta data for the snap.</p>
-                  <p>You can edit the meta data later on. For now we have generated an example snapcraft.yaml for you using the snap name you have chosen.</p>
+                  <p>We have generated an example snapcraft.yaml for you using the snap name you have chosen, don’t worry you can edit this at any point later on.</p>
                   <p>To discover more about the <code>snapcraft.yaml</code>, mouse over each piece of metadata in the interactive <code>.yaml</code> viewer below:</p>
                   <div class="p-annotated-code">
                     <div class="p-annotated-code__filename">snapcraft.yaml</div>
@@ -75,25 +54,13 @@
                       </div>
                     {% endfor %}
                   </div>
-                  <p>In order for your snap to build using the name you have chosen you'll need to replace the example application's <code>snapcraft.yaml</code> file.</p>
-                  <p>First download new <code>snapcraft.yaml</code> file that contains your chosen name:</p>
                   <p><a class="p-button--positive" href="/first-snap/{{ language }}/snapcraft.yaml" download>Download snapcraft.yaml file</a>
-                  <p>Next move or copy it to project folder making sure to override the old file.</p>
                 </div>
               </div>
             </div>
           </section>
         </li>
       </ol>
-    </div>
-  </div>
-  <div class="row">
-    <p>Now we'll take a real world app, and package it as a snap</p>
-  </div>
-
-  <div class="row">
-    <div class="col-8">
-
     </div>
   </div>
 {% endblock %}
@@ -103,7 +70,7 @@
     &lsaquo; Previous: Install Snapcraft
   </a>
 
-  <a class="p-button--positive u-float-right" href="/first-snap/{{ language }}/{{ os }}/build">
+  <a class="p-button--positive u-float-right u-no-margin--right" href="/first-snap/{{ language }}/{{ os }}/build">
     Next: Build snap &rsaquo;
   </a>
 {% endblock %}
@@ -117,9 +84,6 @@
            "{{language}}"
         );
         snapcraft.public.initAccordion('.p-accordion__list');
-        snapcraft.public.initAccordionButtons(
-          document.getElementById("js-clone-continue-button")
-        );
       });
     });
   </script>

--- a/templates/first-snap/push.html
+++ b/templates/first-snap/push.html
@@ -133,7 +133,7 @@
       &lsaquo; Build snap
     </a>
   {% endif %}
-  <a class="p-button--positive is-disabled u-float-right"
+  <a class="p-button--positive is-disabled u-float-right u-no-margin--right"
     id="js-pagination-next" aria-label="Next: Go to listing">
     Go to listing &rsaquo;
   </a>

--- a/webapp/first_snap/content/c/build.yaml
+++ b/webapp/first_snap/content/c/build.yaml
@@ -1,7 +1,9 @@
 name: test-dosbox-{name}
 linux:
   auto:
-    - action: "Return to the root directory of the project containing your snapcraft.yaml and run snapcraft:"
+    - action: "Create a directory, move the downloaded snapcraft.yaml file into the new directory and navigate there:"
+      command: mkdir ~/${name} && mv ~/Downloads/snapcraft.yaml ~/${name} && cd  ~/${name}
+    - action: "Run snapcraft:"
       command: snapcraft
     - action: "Install the snap:"
       command: sudo snap install --devmode --dangerous *.snap
@@ -24,7 +26,9 @@ linux:
         Make sure the name matches what has been used previously (i.e <code>${name}</code>)
 macos:
   auto:
-    - action: "Return to the root directory of the project containing your snapcraft.yaml and run snapcraft:"
+    - action: "Create a directory, move the downloaded snapcraft.yaml file into the new directory and navigate there:"
+      command: mkdir ~/${name} && mv ~/Downloads/snapcraft.yaml ~/${name} && cd  ~/${name}
+    - action: "Run snapcraft:"
       command: snapcraft
   manual:
     - action: "Return to the root directory of the project containing your snapcraft.yaml and run the snapcraft Docker image:"

--- a/webapp/first_snap/content/golang/build.yaml
+++ b/webapp/first_snap/content/golang/build.yaml
@@ -1,7 +1,9 @@
 name: test-httplab-{name}
 linux:
   auto:
-    - action: "Return to the root directory of the project containing your snapcraft.yaml and run snapcraft:"
+    - action: "Create a directory, move the downloaded snapcraft.yaml file into the new directory and navigate there:"
+      command: mkdir ~/${name} && mv ~/Downloads/snapcraft.yaml ~/${name} && cd  ~/${name}
+    - action: "Run snapcraft:"
       command: snapcraft
     - action: "Install the snap:"
       command: sudo snap install --devmode --dangerous *.snap
@@ -24,7 +26,9 @@ linux:
         Make sure the name matches what has been used previously (i.e <code>${name}</code>)
 macos:
   auto:
-    - action: "Return to the root directory of the project containing your snapcraft.yaml and run snapcraft:"
+    - action: "Create a directory, move the downloaded snapcraft.yaml file into the new directory and navigate there:"
+      command: mkdir ~/${name} && mv ~/Downloads/snapcraft.yaml ~/${name} && cd  ~/${name}
+    - action: "Run snapcraft:"
       command: snapcraft
   manual:
     - action: "Return to the root directory of the project containing your snapcraft.yaml and run the snapcraft Docker image:"

--- a/webapp/first_snap/content/golang/snapcraft.yaml
+++ b/webapp/first_snap/content/golang/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: ${name}
-version: git
+version: '1.0'
 summary: An interactive web server.
 description: |
   HTTPLab let you inspect HTTP requests and forge responses.

--- a/webapp/first_snap/content/java/build.yaml
+++ b/webapp/first_snap/content/java/build.yaml
@@ -5,28 +5,28 @@ linux:
       command: mkdir ~/${name} && mv ~/Downloads/snapcraft.yaml ~/${name} && cd  ~/${name}
     - action: "Run snapcraft:"
       command: snapcraft
-    - action: "Install the snap"
+    - action: "Install the snap:"
       command: sudo snap install --devmode --dangerous *.snap
-    - action: "List your installed snaps to confirm"
+    - action: "List your installed snaps to confirm:"
       command: snap list
-    - action: "Run the snap"
+    - action: "Run the snap:"
       command: ${name} -h
     - warning: |
         Make sure the name matches what has been used previously (i.e <code>${name}</code>)
   manual:
-    - action: "Return to the root directory of the project containing your snapcraft.yaml and run the snapcraft Docker image"
+    - action: Return to the root directory of the project containing your snapcraft.yaml and run the snapcraft Docker image
       command: docker run -v $PWD:$PWD -w $PWD snapcore/snapcraft snapcraft
-    - action: "Install the snap"
+    - action: Install the snap
       command: sudo snap install --devmode --dangerous *.snap
-    - action: "List your installed snaps to confirm"
+    - action: List your installed snaps to confirm
       command: snap list
-    - action: "Run the snap"
+    - action: Run the snap
       command: ${name} -h
     - warning: |
         Make sure the name matches what has been used previously (i.e <code>${name}</code>)
 macos:
   auto:
-   - action: "Create a directory, move the downloaded snapcraft.yaml file into the new directory and navigate there:"
+    - action: "Create a directory, move the downloaded snapcraft.yaml file into the new directory and navigate there:"
       command: mkdir ~/${name} && mv ~/Downloads/snapcraft.yaml ~/${name} && cd  ~/${name}
     - action: "Run snapcraft:"
       command: snapcraft

--- a/webapp/first_snap/content/java/build.yaml
+++ b/webapp/first_snap/content/java/build.yaml
@@ -1,30 +1,34 @@
 name: test-freeplane-{name}
 linux:
   auto:
-    - action: Return to the root directory of the project containing your snapcraft.yaml and run snapcraft
+    - action: "Create a directory, move the downloaded snapcraft.yaml file into the new directory and navigate there:"
+      command: mkdir ~/${name} && mv ~/Downloads/snapcraft.yaml ~/${name} && cd  ~/${name}
+    - action: "Run snapcraft:"
       command: snapcraft
-    - action: Install the snap
+    - action: "Install the snap"
       command: sudo snap install --devmode --dangerous *.snap
-    - action: List your installed snaps to confirm
+    - action: "List your installed snaps to confirm"
       command: snap list
-    - action: Run the snap
+    - action: "Run the snap"
       command: ${name} -h
     - warning: |
         Make sure the name matches what has been used previously (i.e <code>${name}</code>)
   manual:
-    - action: Return to the root directory of the project containing your snapcraft.yaml and run the snapcraft Docker image
+    - action: "Return to the root directory of the project containing your snapcraft.yaml and run the snapcraft Docker image"
       command: docker run -v $PWD:$PWD -w $PWD snapcore/snapcraft snapcraft
-    - action: Install the snap
+    - action: "Install the snap"
       command: sudo snap install --devmode --dangerous *.snap
-    - action: List your installed snaps to confirm
+    - action: "List your installed snaps to confirm"
       command: snap list
-    - action: Run the snap
+    - action: "Run the snap"
       command: ${name} -h
     - warning: |
         Make sure the name matches what has been used previously (i.e <code>${name}</code>)
 macos:
   auto:
-    - action: "Return to the root directory of the project containing your snapcraft.yaml and run snapcraft:"
+   - action: "Create a directory, move the downloaded snapcraft.yaml file into the new directory and navigate there:"
+      command: mkdir ~/${name} && mv ~/Downloads/snapcraft.yaml ~/${name} && cd  ~/${name}
+    - action: "Run snapcraft:"
       command: snapcraft
   manual:
     - action: "Return to the root directory of the project containing your snapcraft.yaml and run the snapcraft Docker image:"

--- a/webapp/first_snap/content/moos/build.yaml
+++ b/webapp/first_snap/content/moos/build.yaml
@@ -1,7 +1,9 @@
 name: test-moos-{name}
 linux:
   auto:
-    - action: "Return to the root directory of the project containing your snapcraft.yaml and run snapcraft:"
+    - action: "Create a directory, move the downloaded snapcraft.yaml file into the new directory and navigate there:"
+      command: mkdir ~/${name} && mv ~/Downloads/snapcraft.yaml ~/${name} && cd  ~/${name}
+    - action: "Run snapcraft:"
       command: snapcraft
     - action: "Install the snap:"
       command: sudo snap install --devmode --dangerous *.snap
@@ -24,7 +26,9 @@ linux:
         Make sure the name matches what has been used previously (i.e <code>test-moos-{name}</code>)
 macos:
   auto:
-    - action: "Return to the root directory of the project containing your snapcraft.yaml and run snapcraft:"
+    - action: "Create a directory, move the downloaded snapcraft.yaml file into the new directory and navigate there:"
+      command: mkdir ~/${name} && mv ~/Downloads/snapcraft.yaml ~/${name} && cd  ~/${name}
+    - action: "Run snapcraft:"
       command: snapcraft
   manual:
     - action: "Return to the root directory of the project containing your snapcraft.yaml and run the snapcraft Docker image:"

--- a/webapp/first_snap/content/node/build.yaml
+++ b/webapp/first_snap/content/node/build.yaml
@@ -1,7 +1,9 @@
 name: test-wethr-{name}
 linux:
   auto:
-    - action: "Return to the root directory of the project containing your snapcraft.yaml and run snapcraft:"
+    - action: "Create a directory, move the downloaded snapcraft.yaml file into the new directory and navigate there:"
+      command: mkdir ~/${name} && mv ~/Downloads/snapcraft.yaml ~/${name} && cd  ~/${name}
+    - action: "Run snapcraft:"
       command: snapcraft
     - action: "Install the snap:"
       command: sudo snap install --devmode --dangerous *.snap
@@ -24,7 +26,9 @@ linux:
         Make sure the name matches what has been used previously (i.e <code>${name}</code>)
 macos:
   auto:
-    - action: "Return to the root directory of the project containing your snapcraft.yaml and run snapcraft:"
+    - action: "Create a directory, move the downloaded snapcraft.yaml file into the new directory and navigate there:"
+      command: mkdir ~/${name} && mv ~/Downloads/snapcraft.yaml ~/${name} && cd  ~/${name}
+    - action: "Run snapcraft:"
       command: snapcraft
   manual:
     - action: "Return to the root directory of the project containing your snapcraft.yaml and run the snapcraft Docker image:"

--- a/webapp/first_snap/content/node/snapcraft.yaml
+++ b/webapp/first_snap/content/node/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: ${name}
-version: git
+version: '1.0'
 summary: Command line weather tool.
 description: |
   Get current weather:-

--- a/webapp/first_snap/content/pre-built/build.yaml
+++ b/webapp/first_snap/content/pre-built/build.yaml
@@ -1,7 +1,9 @@
 name: test-geekbench4-{name}
 linux:
   auto:
-    - action: "Return to the root directory of the project containing your snapcraft.yaml and run snapcraft:"
+    - action: "Create a directory, move the downloaded snapcraft.yaml file into the new directory and navigate there:"
+      command: mkdir ~/${name} && mv ~/Downloads/snapcraft.yaml ~/${name} && cd  ~/${name}
+    - action: "Run snapcraft:"
       command: snapcraft
     - action: "Install the snap:"
       command: sudo snap install --devmode --dangerous *.snap
@@ -24,7 +26,9 @@ linux:
         Make sure the name matches what has been used previously (i.e <code>${name}</code>)
 macos:
   auto:
-    - action: "Return to the root directory of the project containing your snapcraft.yaml and run snapcraft:"
+    - action: "Create a directory, move the downloaded snapcraft.yaml file into the new directory and navigate there:"
+      command: mkdir ~/${name} && mv ~/Downloads/snapcraft.yaml ~/${name} && cd  ~/${name}
+    - action: "Run snapcraft:"
       command: snapcraft
   manual:
     - action: "Return to the root directory of the project containing your snapcraft.yaml and run the snapcraft Docker image:"

--- a/webapp/first_snap/content/python/build.yaml
+++ b/webapp/first_snap/content/python/build.yaml
@@ -1,7 +1,9 @@
 name: test-offlineimap-{name}
 linux:
   auto:
-    - action: "Return to the root directory of the project containing your snapcraft.yaml and run snapcraft:"
+    - action: "Create a directory, move the downloaded snapcraft.yaml file into the new directory and navigate there:"
+      command: mkdir ~/${name} && mv ~/Downloads/snapcraft.yaml ~/${name} && cd  ~/${name}
+    - action: "Run snapcraft:"
       command: snapcraft
     - action: "Install the snap:"
       command: sudo snap install --devmode --dangerous *.snap
@@ -24,7 +26,9 @@ linux:
         Make sure the name matches what has been used previously (i.e <code>${name}</code>)
 macos:
   auto:
-    - action: "Return to the root directory of the project containing your snapcraft.yaml and run snapcraft:"
+    - action: "Create a directory, move the downloaded snapcraft.yaml file into the new directory and navigate there:"
+      command: mkdir ~/${name} && mv ~/Downloads/snapcraft.yaml ~/${name} && cd  ~/${name}
+    - action: "Run snapcraft:"
       command: snapcraft
   manual:
     - action: "Return to the root directory of the project containing your snapcraft.yaml and run the snapcraft Docker image:"

--- a/webapp/first_snap/content/python/snapcraft.yaml
+++ b/webapp/first_snap/content/python/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: ${name}
-version: git
+version: '1.0'
 summary: OfflineIMAP
 description: |
   OfflineIMAP is software that downloads your email mailbox(es) as local

--- a/webapp/first_snap/content/ros/build.yaml
+++ b/webapp/first_snap/content/ros/build.yaml
@@ -1,7 +1,9 @@
 name: test-ros-talker-listener-{name}
 linux:
   auto:
-    - action: "Return to the root directory of the project containing your snapcraft.yaml and run snapcraft:"
+    - action: "Create a directory, move the downloaded snapcraft.yaml file into the new directory and navigate there:"
+      command: mkdir ~/${name} && mv ~/Downloads/snapcraft.yaml ~/${name} && cd  ~/${name}
+    - action: "Run snapcraft:"
       command: snapcraft
     - action: "Install the snap:"
       command: sudo snap install --devmode --dangerous *.snap
@@ -24,7 +26,9 @@ linux:
         Make sure the name matches what has been used previously (i.e <code>${name}</code>)
 macos:
   auto:
-    - action: "Return to the root directory of the project containing your snapcraft.yaml and run snapcraft:"
+    - action: "Create a directory, move the downloaded snapcraft.yaml file into the new directory and navigate there:"
+      command: mkdir ~/${name} && mv ~/Downloads/snapcraft.yaml ~/${name} && cd  ~/${name}
+    - action: "Run snapcraft:"
       command: snapcraft
   manual:
     - action: "Return to the root directory of the project containing your snapcraft.yaml and run the snapcraft Docker image:"

--- a/webapp/first_snap/content/ros2/build.yaml
+++ b/webapp/first_snap/content/ros2/build.yaml
@@ -1,7 +1,9 @@
 name: test-ros2-talker-listener-{name}
 linux:
   auto:
-    - action: "Return to the root directory of the project containing your snapcraft.yaml and run snapcraft:"
+    - action: "Create a directory, move the downloaded snapcraft.yaml file into the new directory and navigate there:"
+      command: mkdir ~/${name} && mv ~/Downloads/snapcraft.yaml ~/${name} && cd  ~/${name}
+    - action: "Run snapcraft:"
       command: snapcraft
     - action: "Install the snap:"
       command: sudo snap install --devmode --dangerous *.snap
@@ -24,7 +26,9 @@ linux:
         Make sure the name matches what has been used previously (i.e <code>${name}</code>)
 macos:
   auto:
-    - action: "Return to the root directory of the project containing your snapcraft.yaml and run snapcraft:"
+    - action: "Create a directory, move the downloaded snapcraft.yaml file into the new directory and navigate there:"
+      command: mkdir ~/${name} && mv ~/Downloads/snapcraft.yaml ~/${name} && cd  ~/${name}
+    - action: "Run snapcraft:"
       command: snapcraft
   manual:
     - action: "Return to the root directory of the project containing your snapcraft.yaml and run the snapcraft Docker image:"

--- a/webapp/first_snap/content/ruby/build.yaml
+++ b/webapp/first_snap/content/ruby/build.yaml
@@ -1,7 +1,9 @@
 name: test-mdl-{name}
 linux:
   auto:
-    - action: "Return to the root directory of the project containing your snapcraft.yaml and run snapcraft:"
+    - action: "Create a directory, move the downloaded snapcraft.yaml file into the new directory and navigate there:"
+      command: mkdir ~/${name} && mv ~/Downloads/snapcraft.yaml ~/${name} && cd  ~/${name}
+    - action: "Run snapcraft:"
       command: snapcraft
     - action: "Install the snap:"
       command: sudo snap install --devmode --dangerous *.snap
@@ -24,7 +26,9 @@ linux:
         Make sure the name matches what has been used previously (i.e <code>${name}</code>)
 macos:
   auto:
-    - action: "Return to the root directory of the project containing your snapcraft.yaml and run snapcraft:"
+    - action: "Create a directory, move the downloaded snapcraft.yaml file into the new directory and navigate there:"
+      command: mkdir ~/${name} && mv ~/Downloads/snapcraft.yaml ~/${name} && cd  ~/${name}
+    - action: "Run snapcraft:"
       command: snapcraft
   manual:
     - action: "Return to the root directory of the project containing your snapcraft.yaml and run the snapcraft Docker image:"

--- a/webapp/first_snap/content/rust/build.yaml
+++ b/webapp/first_snap/content/rust/build.yaml
@@ -1,7 +1,9 @@
 name: test-xsv-{name}
 linux:
   auto:
-    - action: "Return to the root directory of the project containing your snapcraft.yaml and run snapcraft:"
+    - action: "Create a directory, move the downloaded snapcraft.yaml file into the new directory and navigate there:"
+      command: mkdir ~/${name} && mv ~/Downloads/snapcraft.yaml ~/${name} && cd  ~/${name}
+    - action: "Run snapcraft:"
       command: snapcraft
     - action: "Install the snap:"
       command: sudo snap install --devmode --dangerous *.snap
@@ -24,7 +26,9 @@ linux:
         Make sure the name matches what has been used previously (i.e <code>${name}</code>)
 macos:
   auto:
-    - action: "Return to the root directory of the project containing your snapcraft.yaml and run snapcraft:"
+    - action: "Create a directory, move the downloaded snapcraft.yaml file into the new directory and navigate there:"
+      command: mkdir ~/${name} && mv ~/Downloads/snapcraft.yaml ~/${name} && cd  ~/${name}
+    - action: "Run snapcraft:"
       command: snapcraft
   manual:
     - action: "Return to the root directory of the project containing your snapcraft.yaml and run the snapcraft Docker image:"

--- a/webapp/first_snap/content/rust/snapcraft.yaml
+++ b/webapp/first_snap/content/rust/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: ${name}
-version: git
+version: '1.0'
 summary: A fast CSV command line toolkit written in Rust
 description: |
   xsv is a command line program for indexing,


### PR DESCRIPTION
## Done

- Remove `clone` step from `Package snap`
- Update `Build snap` steps
- Fix `Next step` buttons to be centred on mobile
- Add `version: 1.0` to the yaml files that had `version: git`

## Issue / Card

Fixes https://github.com/canonical-web-and-design/snap-squad/issues/1039

## QA

- Pull the branch
- Run the site using the command `./run`
- View the site locally in your web browser at: http://0.0.0.0:8004/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Go to http://0.0.0.0:8004/first-snap/python/macos/package and compare to [design](https://app.zeplin.io/project/5ca61ca69972713e007a03c2/screen/5d124e3089704a716c8fba9b)
- Go to http://0.0.0.0:8004/first-snap/golang/linux/build and compare to [design](https://app.zeplin.io/project/5ca61ca69972713e007a03c2/screen/5d124e3100deaf70afe81302)
- Repeat the two steps above for various languages and os
