### PR TITLE
Add &rel=0 to youtube embed code

### DIFF
--- a/templates/partials/_video.html
+++ b/templates/partials/_video.html
@@ -1,6 +1,6 @@
 {% if video.type == "youtube" %}
   <iframe id="ytplayer" type="text/html" width="818" height="460"
-          src="{{ video.url }}?autoplay=1&mute=1&modestbranding=1" frameborder="0"></iframe>
+          src="{{ video.url }}?autoplay=1&mute=1&modestbranding=1&rel=0" frameborder="0"></iframe>
 {% elif video.type == "vimeo" %}
   <iframe id="vimeoplayer" width="818" height="460" frameborder="0"
           webkitallowfullscreen mozallowfullscreen allowfullscreen


### PR DESCRIPTION
## Done

 * Changed youtube embed code to specify ?rel=0 - to only show videos from the same publisher

## Issue / Card

Fixes #2553 

## QA

- Pull the branch
- Run the site using the command `./run`
- View the site locally in your web browser at: http://0.0.0.0:8004/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- [List additional steps to QA the new features or prove the bug has been resolved]

## Screenshots

[if relevant, include a screenshot]