### PR TITLE
Drops redundant placeholder from search field

### DIFF
--- a/templates/partials/search-bar.html
+++ b/templates/partials/search-bar.html
@@ -16,7 +16,7 @@
       <div class="p-form__group">
         <label for="search-input" class="u-off-screen">Search</label>
         <div class="p-form__control u-clearfix">
-          <input class="u-no-margin--bottom" id="search-input" type="search" name="q" placeholder="{% if not IS_BRAND_STORE %}Search thousands of snaps{% else %}Search available snaps{% endif %}" value="{{ query }}" />
+          <input class="u-no-margin--bottom" id="search-input" type="search" name="q" value="{{ query }}" />
         </div>
       </div>
       <button type="submit" alt="search" class="p-button--positive">Search</button>


### PR DESCRIPTION
## Done

Drops the placeholder text from the Snap Store search field.

Text field placeholders have many problems with visibitility, interaction, and accessibility: see [Adam Silver’s list](https://adamsilver.io/articles/placeholders-are-problematic/) for example.

In this case the placeholder is gratuitously unnecessary: It says “Search thousands of snaps” when those exact words are already printed in 35.65px font immediately above. And there’s a “Search” button alongside to boot.

![image](https://user-images.githubusercontent.com/19801137/75110516-07a21f00-5627-11ea-93d5-00e65ebb689a.png)

(In a brand store, the field apparently says “Search available snaps” instead … as opposed to what? Searching unavailable ones? If it’s important to explain that some snaps won’t be findable, then spell it out separately.)

## Issue / Card

None

## QA

- Pull the branch
- Run the site using the command `./run`
- View the page locally at: http://0.0.0.0:8004/store

## Screenshots

![image](https://user-images.githubusercontent.com/19801137/75110536-3b7d4480-5627-11ea-80b8-9c8c93df570d.png)
