### PR TITLE
Remove "Go to listing" button

### DIFF
--- a/static/js/public/first-snap-flow.js
+++ b/static/js/public/first-snap-flow.js
@@ -22,7 +22,7 @@ function install(language) {
     if (!document.querySelector(".js-linux-manual")) {
       const paginationBtn = document.querySelector(`#js-pagination-next`);
       if (paginationBtn) {
-        paginationBtn.classList.remove("is--disabled");
+        paginationBtn.classList.remove("is-disabled");
         paginationBtn.href = `/first-snap/${language}/${selectedOs}/package`;
       }
     }
@@ -86,7 +86,7 @@ function install(language) {
 
     const paginationBtn = document.querySelector(`#js-pagination-next`);
     if (paginationBtn) {
-      paginationBtn.classList.remove("is--disabled");
+      paginationBtn.classList.remove("is-disabled");
       paginationBtn.href = `/first-snap/${language}/${type}/package`;
     }
   }
@@ -168,19 +168,20 @@ function push() {
   }
 
   getCount(snapName => {
+    // Enable "Continue" button
     const continueBtn = document.querySelector(".js-continue");
     if (continueBtn) {
       continueBtn.href = `/${snapName}/listing?from=first-snap`;
       continueBtn.classList.add("p-button--positive");
       continueBtn.classList.remove("p-button--neutral");
-      continueBtn.classList.remove("is--disabled");
+      continueBtn.classList.remove("is-disabled");
       continueBtn.innerHTML = "Continue";
     }
-
+    // Update "Go to listing" button for a published snap
     const paginationBtn = document.querySelector("#js-pagination-next");
     if (paginationBtn) {
       paginationBtn.href = `/${snapName}/listing?from=first-snap`;
-      paginationBtn.classList.remove("is--disabled");
+      paginationBtn.classList.remove("is-disabled");
     }
   });
 }
@@ -273,6 +274,17 @@ function initRegisterName(formEl, notificationEl, successEl) {
       }
     };
 
+    // Enable "Go to listing" button for an unpublished app
+    const enableGoToListingButton = () => {
+      const snapName = formEl.querySelector("[name=snap-name]").value;
+      const paginationBtn = document.querySelector("#js-pagination-next");
+      if (paginationBtn) {
+        paginationBtn.href = `/${snapName}/listing?from=first-snap-unpublished`;
+        paginationBtn.classList.remove("is-disabled");
+        ``;
+      }
+    };
+
     // Show spinner if data fetch takes long
     const timer = setTimeout(() => {
       if (currentToggle.getAttribute("aria-expanded") === "true") {
@@ -304,6 +316,7 @@ function initRegisterName(formEl, notificationEl, successEl) {
 
         enableButton();
         showSuccess(message);
+        enableGoToListingButton();
       })
       .catch(() => {
         clearTimeout(timer);

--- a/static/js/public/first-snap-flow.js
+++ b/static/js/public/first-snap-flow.js
@@ -171,7 +171,7 @@ function push() {
     // Enable "Continue" button
     const continueBtn = document.querySelector(".js-continue");
     if (continueBtn) {
-      continueBtn.href = `/${snapName}/listing?from=first-snap`;
+      continueBtn.href = `/${snapName}/releases`;
       continueBtn.classList.add("p-button--positive");
       continueBtn.classList.remove("p-button--neutral");
       continueBtn.classList.remove("is-disabled");

--- a/templates/first-snap/push.html
+++ b/templates/first-snap/push.html
@@ -110,7 +110,7 @@
                   <p>
                     Once you've pushed to the Snap store, edit your snap public presentation.
                   </p>
-                  <a class="p-button--neutral js-continue is--disabled">
+                  <a class="p-button--neutral js-continue is-disabled">
                     <i class="p-icon--spinner u-animation--spin"></i>
                     &nbsp;Waiting for push...</a>
                 </div>
@@ -133,8 +133,8 @@
       &lsaquo; Build snap
     </a>
   {% endif %}
-
-  <a class="p-button--positive is--disabled u-float-right" id="js-pagination-next" aria-label="Next: Go to listing">
+  <a class="p-button--positive is-disabled u-float-right"
+    id="js-pagination-next" aria-label="Next: Go to listing">
     Go to listing &rsaquo;
   </a>
 {% endblock %}

--- a/templates/publisher/_header.html
+++ b/templates/publisher/_header.html
@@ -1,10 +1,14 @@
 <section class="p-strip is-shallow u-no-padding--bottom">
-  {% if from == "first-snap" %}
+  {% if from in ["first-snap", "first-snap-unpublished"] %}
   <div class="row">
     <div class="p-notification--information">
       <p class="p-notification__response">
         <span class="p-notification__status">Congratulations</span>
+        {% if from == "first-snap" %}
         {{ snap_name }} is pushed to the Store. Modify its public information, include screenshots then visit <a href="/{{ snap_name }}">your published Snap</a>.
+        {% else %}
+        You can now modify {{ snap_name }} public information.
+        {% endif %}
       </p>
     </div>
   </div>

--- a/templates/publisher/account-snaps.html
+++ b/templates/publisher/account-snaps.html
@@ -201,7 +201,7 @@ My published snaps — Linux software in the Snap Store
         {% with dispute_pending = registered_snaps[snap].status == "DisputePending" %}
         <tr class="p-snapcraft-dispute-list__item">
           <td width="25%">
-            {{ snap }}
+            <a href="/{{snap}}/listing">{{ snap }}</a>
             {% if dispute_pending %}
             &nbsp;<i class="p-icon--warning p-snapcraft-dispute-list__icon"></i>
             {% endif %}

--- a/templates/publisher/listing.html
+++ b/templates/publisher/listing.html
@@ -19,7 +19,7 @@ Listing details for {% if display_title %}{{ display_title }}{% else %}{{ snap_t
           <p class="snapcraft-p-market-message u-no-margin--bottom">
             {% if private %}
             This listing is not public because the snap is set to private.
-            {% else %}
+            {% elif status == "published" %}
             Updates to this information will appear immediately on the <a href="/{{ snap_name }}">snap listing page</a>.
             {% endif %}
           </p>

--- a/tests/publisher/snaps/tests_listing.py
+++ b/tests/publisher/snaps/tests_listing.py
@@ -59,6 +59,7 @@ class GetListingPage(BaseTestCases.EndpointLoggedInErrorHandling):
             "license": "License",
             "video_urls": [],
             "categories": {"items": []},
+            "status": "published",
         }
 
         responses.add(responses.GET, self.api_url, json=payload, status=200)
@@ -115,6 +116,7 @@ class GetListingPage(BaseTestCases.EndpointLoggedInErrorHandling):
             "license": "license",
             "video_urls": [],
             "categories": {"items": []},
+            "status": "published",
         }
 
         responses.add(responses.GET, self.api_url, json=payload, status=200)
@@ -153,6 +155,7 @@ class GetListingPage(BaseTestCases.EndpointLoggedInErrorHandling):
             "license": "license",
             "video_urls": [],
             "categories": {"items": []},
+            "status": "published",
         }
 
         responses.add(responses.GET, self.api_url, json=payload, status=200)
@@ -197,6 +200,7 @@ class GetListingPage(BaseTestCases.EndpointLoggedInErrorHandling):
             "license": "license",
             "video_urls": [],
             "categories": {"items": []},
+            "status": "published",
         }
 
         responses.add(responses.GET, self.api_url, json=payload, status=200)
@@ -235,6 +239,7 @@ class GetListingPage(BaseTestCases.EndpointLoggedInErrorHandling):
             "license": "license",
             "video_urls": ["https://youtube.com/watch?v=1234"],
             "categories": {"items": []},
+            "status": "published",
         }
 
         responses.add(responses.GET, self.api_url, json=payload, status=200)
@@ -273,6 +278,7 @@ class GetListingPage(BaseTestCases.EndpointLoggedInErrorHandling):
             "license": "license",
             "video_urls": ["https://youtube.com/watch?v=1234"],
             "categories": {"items": []},
+            "status": "published",
         }
 
         responses.add(responses.GET, self.api_url, json=payload, status=200)

--- a/webapp/publisher/snaps/views.py
+++ b/webapp/publisher/snaps/views.py
@@ -414,6 +414,7 @@ def get_listing_snap(snap_name):
         "from": referrer,
         "categories": categories,
         "tour_steps": tour_steps,
+        "status": snap_details["status"],
     }
 
     return flask.render_template("publisher/listing.html", **context)


### PR DESCRIPTION
## Done

- Update `Go to listing` button link depending if the snap is published or not
- Replace `is--disabled` class with `is-disabled` (it seems it was missed when [we upgraded to vanilla v2.0.1](https://github.com/canonical-web-and-design/vanilla-framework/pull/2320))

## Issue / Card

Fixes #2533 

## QA

- Pull the branch
- Run the site using the command `./run`
- View the site locally in your web browser at: http://0.0.0.0:8004//first-snap/python/linux/push
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
1. Click `Register snap name`
2. See the 'Go to listing` button is enabled. Click it
3. See you are taken to the listing page. Note the message at the top
4. Go back to http://0.0.0.0:8004//first-snap/python/linux/push and click `Register snap name`
5. Push app to the store - `snapcraft push --release edge *.snap`
6. Click `Continue` or `Go to listing` button
7. See you are taken to the listing page. Note the message at the top is different this time
