### PR TITLE
Fix marketo response index error

### DIFF
--- a/webapp/api/marketo.py
+++ b/webapp/api/marketo.py
@@ -84,7 +84,11 @@ class MarketoApi:
         response = self.request(
             method="GET", url=LEAD_BY_EMAIL, url_args=dict(email=email)
         )
-        return response["result"][0]
+        if "result" in response and len(response["result"]) > 0:
+            return response["result"][0]
+
+        else:
+            return None
 
     def get_newsletter_subscription(self, lead_id):
         response = self.request(

--- a/webapp/publisher/views.py
+++ b/webapp/publisher/views.py
@@ -87,13 +87,14 @@ def get_account_details():
     # if anything fails, just continue and don't show
     # this section
     try:
-        marketo_user = marketo.get_user(flask_user["email"])
-        marketo_subscribed = marketo.get_newsletter_subscription(
-            marketo_user["id"]
-        )
         subscribed_to_newsletter = False
-        if marketo_subscribed.get("snapcraftnewsletter"):
-            subscribed_to_newsletter = True
+        marketo_user = marketo.get_user(flask_user["email"])
+        if marketo_user:
+            marketo_subscribed = marketo.get_newsletter_subscription(
+                marketo_user["id"]
+            )
+            if marketo_subscribed.get("snapcraftnewsletter"):
+                subscribed_to_newsletter = True
 
         subscriptions = {"newsletter": subscribed_to_newsletter}
     except Exception:


### PR DESCRIPTION
## Done

- Fix marketo response index error

## Issue / Card

Fixes #2276 
Error on sentry: https://sentry.is.canonical.com/canonical/snapcraft-io/issues/2776/

## QA

- Pull the branch
- Run the site using the command `./run`
- View the site locally in your web browser at: http://0.0.0.0:8004/account/details
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- I don't know how to QA this.
