### PR TITLE
Add start script in packages.json for dotrun

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "copy-3rd-party-js": "mkdir -p static/js/modules && cp node_modules/d3/build/d3.min.js static/js/modules && cp node_modules/clipboard/dist/clipboard.min.js static/js/modules && cp node_modules/raven-js/dist/raven.min.js static/js/modules",
     "build-js-bundle": "webpack",
     "serve": "./entrypoint 0.0.0.0:${PORT}",
+    "start": "yarn run build && yarn run serve",
     "watch": "watch -p 'static/sass/**/*.scss' -p 'static/js/**/*.js' -c 'yarn run build'",
     "watch-scss": "watch -p 'static/sass/**/*.scss' -c 'yarn run build-css'",
     "watch-js": "webpack --watch",


### PR DESCRIPTION
## Done

Added `start` script in our package.json so we can use `$ dotrun` to start the project

## QA

- Pull the branch
- Install dotrun snap
- Run: `dotrun` in the project folder
- View the site locally in your web browser at: http://0.0.0.0:8004/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
