### PR TITLE
Remove email subscription functionality

### DIFF
--- a/templates/publisher/builds.html
+++ b/templates/publisher/builds.html
@@ -157,16 +157,7 @@ Builds for
         <h4>If you can't find a repository &hellip;</h4>
         <p>Want to <strong>use a private repo</strong>? We're working hard on
           making
-          these buildable. If you like, we can e-mail you when we're ready.</p>
-      </div>
-      <div class="row">
-        <div class="col-4">
-          <input type="text" id="exampleInputEmail1"
-            placeholder="Email address">
-        </div>
-        <div class="col-4">
-          <button class="p-button--neutral">Keep me posted</button>
-        </div>
+          these buildable.</p>
       </div>
       <div class="u-fixed-width">
         <p><strong>Don't have admin permission</strong>? Ask a repo admin to


### PR DESCRIPTION
## Done

Remove email subscription functionality

## QA

- Pull the branch
- Run the site using the command `./run`
- View the site locally in your web browser at: http://0.0.0.0:8004/[snap-name]/builds
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See the email input and button are no more