### PR TITLE
Fix GitHub signature issue

### DIFF
--- a/webapp/api/github.py
+++ b/webapp/api/github.py
@@ -289,15 +289,17 @@ class GitHub:
 
         return False
 
-    def gen_webhook_secret(self, owner, repo):
+    def validate_webhook_signature(self, payload, signature):
         """
-        Generate the same secret that we receive from a GitHub webhook.
+        Generate the payload signature and compare with the given one
         """
         key = bytes(GITHUB_WEBHOOK_SECRET, "UTF-8")
-        hm = hmac.new(key, digestmod=sha1)
-        hm.update(owner.encode("UTF-8"))
-        hm.update(repo.encode("UTF-8"))
-        return hm.hexdigest()
+        hmac_gen = hmac.new(key, payload, sha1)
+
+        # Add append prefix to match the GitHub request format
+        digest = f"sha1={hmac_gen.hexdigest()}"
+
+        return hmac.compare_digest(digest, signature)
 
     def get_hooks(self, owner, repo, page=1):
         """

--- a/webapp/publisher/snaps/build_views.py
+++ b/webapp/publisher/snaps/build_views.py
@@ -338,10 +338,9 @@ def post_github_webhook(snap_name=None, github_owner=None, github_repo=None):
         return ("The repository does not match the one used by this Snap", 403)
 
     github = GitHub()
-    valid_secret = github.gen_webhook_secret(gh_owner, gh_repo)
 
-    if valid_secret != flask.request.headers.get("X-Hub-Signature").replace(
-        "sha1=", ""
+    if not github.validate_webhook_signature(
+        flask.request.data, flask.request.headers.get("X-Hub-Signature")
     ):
         return ("Invalid secret", 403)
 


### PR DESCRIPTION
## Done

Fixed an issue with the signature for GitHub webhooks

## Issue / Card

Fixes #2578

## QA

- Pull the branch
- Run the site using the command `./run`
- View the site locally in your web browser at: http://0.0.0.0:8004/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Install ngrok - [snap](https://snapcraft.io/ngrok)
- Run `ngrok http 8004` and copy the generated URL
- Go to repo of a snap and modify the webhook URL to use the ngrok one, like:
`https://8ba32eb9.ngrok.io/testfran123/webhook/notify`
- A new build for the snap should happen
