### PR TITLE
Don't link to old endpoint

### DIFF
--- a/templates/_header.html
+++ b/templates/_header.html
@@ -87,7 +87,7 @@
             </ul>
           </li>
         {% else %}
-          <li class="p-navigation__link" role="menuitem"><a href="/account"><i class="p-icon--user"></i> Developer account</a></li>
+          <li class="p-navigation__link" role="menuitem"><a href="{{ url_for('publisher_snaps.get_account_snaps') }}"><i class="p-icon--user"></i> Developer account</a></li>
         {% endif %}
       </ul>
     </nav>


### PR DESCRIPTION
## Done

- Developer account link was going to "/account" - it's an old endpoint

## Issue / Card

Fixes #

## QA

- Pull the branch
- Run the site using the command `./run`
- View the site locally in your web browser at: http://0.0.0.0:8004/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- [List additional steps to QA the new features or prove the bug has been resolved]

## Screenshots

[if relevant, include a screenshot]