### PR TITLE
Show something when repo is added

### DIFF
--- a/templates/publisher/builds.html
+++ b/templates/publisher/builds.html
@@ -16,7 +16,7 @@ Builds for
     data-js="js-form">
     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
 
-    {% if snap_builds %}
+    {% if github_repository %}
     <div class="snapcraft-p-sticky js-sticky-bar">
       <div class="row">
         <p class="p-heading--four u-no-margin--bottom">
@@ -28,9 +28,7 @@ Builds for
         </p>
       </div>
     </div>
-    {% endif %}
-
-    {% if not github_repository %}
+    {% else %}
     <div class="snapcraft-p-sticky js-sticky-bar">
       <div class="row">
         <ul class="p-inline-list u-no-margin--bottom">


### PR DESCRIPTION
## Done

- When adding a repo when the page loads and you get an empty page with a notification saying that the connection was successful, but then nothing happens until you refresh - this fixes that.

## Issue / Card

Fixes #

## QA

- Pull the branch
- Run the site using the command `./run`
- View the site locally in your web browser at: http://0.0.0.0:8004/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Add a repo to a snap, don't see a blank screen

## Screenshots

[if relevant, include a screenshot]