### PR TITLE
Builds table updates

### DIFF
--- a/static/js/publisher/builds/helpers.js
+++ b/static/js/publisher/builds/helpers.js
@@ -33,7 +33,7 @@ export const UserFacingStatus = {
   ),
   [RELEASING_SOON]: createStatus(
     "Built, releasing soon",
-    "Built",
+    "Releasing",
     3,
     "releasing_soon"
   ),
@@ -48,10 +48,18 @@ export const UserFacingStatus = {
 };
 
 function createStatus(statusMessage, shortStatusMessage, priority, badge) {
+  const loadingStatus = [IN_PROGRESS, RELEASING_SOON];
+  let icon;
+  if (badge.indexOf("failed") > -1) {
+    icon = "error";
+  } else if (loadingStatus.indexOf(badge) > -1) {
+    icon = "spinner u-animation--spin";
+  }
+
   return {
     statusMessage,
     shortStatusMessage,
-    icon: badge.indexOf("failed") > -1 ? "error" : false,
+    icon: icon,
     priority,
     badge
   };

--- a/static/js/publisher/builds/helpers.js
+++ b/static/js/publisher/builds/helpers.js
@@ -11,40 +11,35 @@ const UNKNOWN = "unknown";
 export const UserFacingStatus = {
   // Used only when there is no build returned from LP.
   // When build is returned from LP (scheduled) it's 'Building soon' for BSI.
-  [NEVER_BUILT]: createStatus("Never built", "Never built", 8, "never_built"),
-  [BUILDING_SOON]: createStatus(
-    "Building soon",
-    "Building",
-    7,
-    "building_soon"
-  ),
+  [NEVER_BUILT]: createStatus("Never built", "Never built", 8, NEVER_BUILT),
+  [BUILDING_SOON]: createStatus("Building soon", "Building", 7, BUILDING_SOON),
   [WONT_RELEASE]: createStatus(
     "Built, won’t be released",
     "Built",
     6,
-    "wont_release"
+    WONT_RELEASE
   ),
   [RELEASED]: createStatus("Built and released", "Released", 5, "released"),
   [RELEASE_FAILED]: createStatus(
     "Built, failed to release",
     "Failed",
     4,
-    "release_failed"
+    RELEASE_FAILED
   ),
   [RELEASING_SOON]: createStatus(
     "Built, releasing soon",
     "Releasing",
     3,
-    "releasing_soon"
+    RELEASING_SOON
   ),
-  [IN_PROGRESS]: createStatus("In progress", "In progress", 2, "in_progress"),
+  [IN_PROGRESS]: createStatus("In progress", "In progress", 2, IN_PROGRESS),
   [FAILED_TO_BUILD]: createStatus(
     "Failed to build",
     "Failed",
     1,
-    "failed_to_build"
+    FAILED_TO_BUILD
   ),
-  [UNKNOWN]: createStatus("Unknown", "Unknown", 8, "never_built")
+  [UNKNOWN]: createStatus("Unknown", "Unknown", 8, NEVER_BUILT)
 };
 
 function createStatus(statusMessage, shortStatusMessage, priority, badge) {

--- a/static/js/publisher/builds/index.js
+++ b/static/js/publisher/builds/index.js
@@ -118,10 +118,14 @@ class Builds extends React.Component {
       return {
         columns: [
           {
-            content: singleBuild ? (
-              `#${build.id}`
+            content: build.id ? (
+              singleBuild ? (
+                `#${build.id}`
+              ) : (
+                <a href={`/${snapName}/builds/${build.id}`}>#{build.id}</a>
+              )
             ) : (
-              <a href={`/${snapName}/builds/${build.id}`}>#{build.id}</a>
+              ""
             )
           },
           {

--- a/static/js/publisher/builds/index.js
+++ b/static/js/publisher/builds/index.js
@@ -104,7 +104,11 @@ class Builds extends React.Component {
     const showMoreCount = remainingBuilds > 15 ? 15 : remainingBuilds;
 
     const rows = builds.map(build => {
-      const status = UserFacingStatus[build.status];
+      let buildStatus = build.status;
+      if (build.status === "in_progress" && build.duration) {
+        buildStatus = "releasing_soon";
+      }
+      const status = UserFacingStatus[buildStatus];
       let icon;
 
       if (status.icon) {
@@ -165,7 +169,7 @@ class Builds extends React.Component {
               content: "Architecture"
             },
             {
-              content: "Duration",
+              content: "Build Duration",
               className: "u-hide--small"
             },
             {
@@ -173,7 +177,8 @@ class Builds extends React.Component {
               className: "has-icon"
             },
             {
-              content: ""
+              content: "Build Finished",
+              className: "u-align-text--right"
             }
           ]}
           rows={rows}

--- a/webapp/publisher/snaps/build_views.py
+++ b/webapp/publisher/snaps/build_views.py
@@ -324,6 +324,10 @@ def post_build(snap_name):
     if not launchpad.is_snap_building(details["snap_name"]):
         launchpad.build_snap(details["snap_name"])
 
+        flask.flash(
+            "Build triggered", "positive",
+        )
+
     return flask.redirect(
         flask.url_for(".get_snap_builds", snap_name=snap_name)
     )


### PR DESCRIPTION
## Done

- The header "Duration" is specific to the build duration, so renamed at larger screen sizes to "Build duration"
- The time in the last column again is specific to the build so added a header "Build finished"
- Added a spinner icon for "In progress" and "releasing soon"
- Renamed the small screen version of the "Built, releasing soon" from "Built" to "Releasing". "Built" suggests a finished state, "Releasing" suggests something is still happening (which is is)
- Set the snap to releasing soon if the build is "in progress" but also has a "finished" time. It doesn't make sense to have a finished time if it's still in progress.

## Issue / Card

Fixes #

## QA

- Pull the branch
- Run the site using the command `./run`
- View the site locally in your web browser at: http://0.0.0.0:8004/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Do some commits on a snap that's linked to build and see more dynamic and accurate table.

## Screenshots

![Screenshot_2020-03-11  Builds for test-snap-lukewh-3 ](https://user-images.githubusercontent.com/479384/76402794-d3936180-637b-11ea-94f6-587fa08a0914.png)
![Screenshot_2020-03-11  Builds for test-snap-lukewh-3 (1)](https://user-images.githubusercontent.com/479384/76402795-d42bf800-637b-11ea-8871-150e2df595bb.png)
![Screenshot_2020-03-11  Builds for test-snap-lukewh-3 (2)](https://user-images.githubusercontent.com/479384/76402796-d4c48e80-637b-11ea-8f32-dcb4810ec89c.png)
![Screenshot_2020-03-11  Builds for test-snap-lukewh-3 (3)](https://user-images.githubusercontent.com/479384/76402799-d4c48e80-637b-11ea-82e4-9ce899af2662.png)
![Screenshot_2020-03-11  Builds for test-snap-lukewh-3 (4)](https://user-images.githubusercontent.com/479384/76403026-2ff68100-637c-11ea-911f-d5e9f8ce68f1.png)
