### PR TITLE
Fix URL markdown issue

### DIFF
--- a/webapp/markdown.py
+++ b/webapp/markdown.py
@@ -78,7 +78,7 @@ class DescriptionInlineGrammar(InlineGrammar):
         # Rewrite to support parentheses inside URLs:
         # https://github.com/canonical-web-and-design/snapcraft.io/issues/2424
         self.url = re.compile(
-            r"""^([(])?(https?:\/\/[^\s<]+[^<.,:;"'\]\s])(?(1)([)]))"""
+            r"""^([(])?(https?:\/\/[^\s<]+[^<.,:"'\]\s])(?(1)([)]))"""
         )
         self.text = re.compile(
             r"^[\s\S]+?(?=[\\<!\[_*`~]|\(?https?://| {2,}\n|$)"
@@ -118,10 +118,13 @@ class DescriptionInline(InlineLexer):
         output = []
         output.append(m.group(1) or "")
 
+        # Allow symbols < and > inside the URL
+        link = m.group(2).replace("&lt;", "<").replace("&gt;", ">")
+
         if self._in_link:
-            output.append(self.renderer.text(m.group(2)))
+            output.append(self.renderer.text(link))
         else:
-            output.append(self.renderer.autolink(m.group(2), False))
+            output.append(self.renderer.autolink(link, False))
 
         output.append(m.group(3) or "")
         return "".join(output)


### PR DESCRIPTION
## Done

Allow < and > symbols inside URLs

## Issue / Card

Fixes #2552

## QA

- Pull the branch
- Run the site using the command `./run`
- View the site locally in your web browser at: http://0.0.0.0:8004/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check http://0.0.0.0:8004/toto-fran and see that the URLs are displayed correctly
