### PR TITLE
Ask users to login again when macaroon-permission-required

### DIFF
--- a/webapp/publisher/views.py
+++ b/webapp/publisher/views.py
@@ -58,6 +58,13 @@ def _handle_error(api_error: ApiError):
 
 
 def _handle_error_list(errors):
+    if (
+        len(errors) == 1
+        and errors[0]["code"] == "macaroon-permission-required"
+    ):
+        authentication.empty_session(flask.session)
+        return flask.redirect("/login?next=" + flask.request.path)
+
     codes = [
         f"{error['code']}: {error.get('message', 'No message')}"
         for error in errors


### PR DESCRIPTION
## Done

Ask users to login again when macaroon-permission-required

## Issue / Card

Fixes #2617

## QA

- Pull the branch
- Run the site using the command `./run`
- View the site locally in your web browser at: http://0.0.0.0:8004/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Difficult to replicate the production issue,  you can follow the same QA instructions: https://github.com/canonical-web-and-design/snapcraft.io/pull/2613
