### PR TITLE
Ensure tooltips are visible within revision history tables

### DIFF
--- a/static/sass/_snapcraft_release.scss
+++ b/static/sass/_snapcraft_release.scss
@@ -384,6 +384,12 @@
   // REVISIONS LIST
 
   .p-revisions-list {
+
+    td,
+    th {
+      overflow: visible;
+    }
+
     .col-checkbox-spacer {
       padding-left: 2rem;
     }


### PR DESCRIPTION
## Done

- Override vanilla default of overflow: hidden; on td and th items.

## Issue / Card

Fixes #2622

## QA

- Pull the branch
- Run the site using the command `./run`
- View the site locally in your web browser at: http://0.0.0.0:8004/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- View a snap release page /<snap_name>/releases
- Open the history of a revision and hover over the date in the final column
- the tooltip should be fully visible

## Screenshots

![Screenshot_2020-03-20  Releases and revision history for Lukotron testing ](https://user-images.githubusercontent.com/479384/77159086-94ac8c80-6a9c-11ea-8eaa-ebb4177e6d98.png)
