### PR TITLE
Improve devel / devmode revision messaging

### DIFF
--- a/static/js/publisher/release/components/releasesTable/cellViews.js
+++ b/static/js/publisher/release/components/releasesTable/cellViews.js
@@ -170,7 +170,7 @@ export const RevisionInfo = ({
 
         {isInDevmode(revision) && (
           <div className="p-tooltip__group">
-            Revisions in <b>devmode</b> or with grade <b>devel</b> can&#39;t
+            Revisions in <b>devmode</b> or with grade <b>devel</b> can’t
             <br />
             be promoted to stable or candidate channels.
           </div>

--- a/static/js/publisher/release/components/releasesTable/cellViews.js
+++ b/static/js/publisher/release/components/releasesTable/cellViews.js
@@ -170,9 +170,9 @@ export const RevisionInfo = ({
 
         {isInDevmode(revision) && (
           <div className="p-tooltip__group">
-            Revisions in devmode can’t be promoted
+            Revisions in <b>devmode</b> or with grade <b>devel</b> can&#39;t
             <br />
-            to stable or candidate channels.
+            be promoted to stable or candidate channels.
           </div>
         )}
       </span>


### PR DESCRIPTION
## Done

- Add extra text to the tooltip for a revision if an item is either devmode or grade: devel

## Issue / Card

Fixes #2600 

## QA

- Pull the branch
- Run the site using the command `./run`
- View the site locally in your web browser at: http://0.0.0.0:8004/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Go to /<snap_name>/releases
- If you have a snap that's grade: devel or you have a devmode revision - release it to a channel
- Once release, hovering over the revision should display a tooltip

## Screenshots
![Screenshot_2020-03-20  Releases and revision history for Lukotron testing (1)](https://user-images.githubusercontent.com/479384/77163799-ca567300-6aa6-11ea-9a16-89785ab516c1.png)
