### PR TITLE
Return 401 when no authenticated on GitHub

### DIFF
--- a/webapp/publisher/github/views.py
+++ b/webapp/publisher/github/views.py
@@ -1,6 +1,7 @@
 import flask
 from webapp.api.github import GitHub
 from webapp.decorators import login_required
+from werkzeug.exceptions import Unauthorized
 
 publisher_github = flask.Blueprint(
     "github", __name__, template_folder="/templates", static_folder="/static"
@@ -13,9 +14,15 @@ def get_repos():
     github = GitHub(flask.session.get("github_auth_secret"))
     org = flask.request.args.get("org")
 
-    if org:
-        repos = github.get_org_repositories(org)
-    else:
-        repos = github.get_user_repositories()
+    try:
+        if org:
+            repos = github.get_org_repositories(org)
+        else:
+            repos = github.get_user_repositories()
+    except Unauthorized:
+        return (
+            flask.jsonify({"error": "You need to be authenticated on GitHub"}),
+            401,
+        )
 
     return flask.jsonify(repos)


### PR DESCRIPTION
## Done

Return 401 when no authenticated on GitHub

## Issue / Card

Fixes #2625

## QA

- Pull the branch
- Run the site using the command `./run`
- View the site locally in your web browser at: http://0.0.0.0:8004/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Go to /publisher/github/get-repos without being logged on GitHub in Snapcraft:
https://snapcraft-io-canonical-web-and-design-pr-2629.run.demo.haus/publisher/github/get-repos
