### PR TITLE
Temporarily disable gevent

### DIFF
--- a/entrypoint
+++ b/entrypoint
@@ -2,7 +2,8 @@
 
 set -e
 
-RUN_COMMAND="talisker.gunicorn.gevent webapp.app:create_app() --bind $1 --worker-class gevent --max-requests 1000 --name talisker-`hostname`"
+# RUN_COMMAND="talisker.gunicorn.gevent webapp.app:create_app() --bind $1 --worker-class gevent --max-requests 1000 --name talisker-`hostname`"
+RUN_COMMAND="talisker.gunicorn webapp.app:create_app() --bind $1 --worker-class sync --workers 5 --name talisker-`hostname`"
 
 if [ "${FLASK_DEBUG}" = true ] || [ "${FLASK_DEBUG}" = 1 ]; then
     RUN_COMMAND="${RUN_COMMAND} --reload --log-level debug --timeout 9999"


### PR DESCRIPTION
## Done

Temporarily disable gevent. We want to make sure gevent is not causing issues with the user sessions.

## QA

- Pull the branch
- Run the site using the command `./run`
- View the site locally in your web browser at: http://0.0.0.0:8004/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)

- We will track the effect of this change with graylog.
