### PR TITLE
Show error: GitHub repository is being used by another snap

### DIFF
--- a/templates/publisher/builds.html
+++ b/templates/publisher/builds.html
@@ -189,6 +189,7 @@ Builds for
     {% endif %}
   </form>
 
+  {% if github_repository %}
   <section class="p-strip is-shallow">
     <div class="u-fixed-width">
       <h4 class="u-float-left">Latest builds</h4>
@@ -228,6 +229,7 @@ Builds for
       </div>
     </div>
   </section>
+  {% endif %}
 </div>
 
 {% endblock %}
@@ -237,16 +239,19 @@ Builds for
 {% endblock %}
 
 {% block scripts %}
-
 <script>
   window.addEventListener("DOMContentLoaded", function () {
     Raven.context(function () {
+      snapcraft.publisher.stickyListingBar();
+
+      {% if github_repository %}
       snapcraft.publisher.initBuilds('#builds-wrapper',
         {{ snap_name | tojson }},
         {{ snap_builds | tojson }},
         {{ total_builds | tojson }}
       );
-      snapcraft.publisher.stickyListingBar();
+      {% endif %}
+
       {% if github_orgs and github_user %}
         snapcraft.publisher.initRepoConnect('[data-js="repo-connect"]', {{ github_orgs | tojson }}, {{ github_user | tojson }}, {{ snap_name | tojson }});
       {% endif %}


### PR DESCRIPTION
## Done

- Show an error when someone is trying to link a repo twice.
- Hide builds table when not needed

## Issue / Card

Fixes #2638

## QA

- Pull the branch
- Run the site using the command `./run`
- View the site locally in your web browser at: http://0.0.0.0:8004/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Register a new Snap in Snapcraft
- Try to link it with the repo of another of your snaps, you need to change the name in the snapcraft.yaml to match with the new snap to see the error.

## Screenshots

![Screenshot from 2020-03-31 13-35-59](https://user-images.githubusercontent.com/6353928/78028207-8d1b9c00-7356-11ea-9a38-53432d2b2c7e.png)
