### PR TITLE
Revision status

### DIFF
--- a/static/js/publisher/release/components/releasesTable/cellViews.js
+++ b/static/js/publisher/release/components/releasesTable/cellViews.js
@@ -3,7 +3,11 @@ import PropTypes from "prop-types";
 
 import RevisionLabel from "../revisionLabel";
 
-import { isInDevmode, isRevisionBuiltOnLauchpad } from "../../helpers";
+import {
+  isInDevmode,
+  isRevisionBuiltOnLauchpad,
+  canBeReleased
+} from "../../helpers";
 import { useDragging, Handle } from "../dnd";
 
 // content of a cell when channel is closed
@@ -114,6 +118,15 @@ export const RevisionInfo = ({
     buildIcon = <i className="p-icon--lp" />;
   }
 
+  const releasable = canBeReleased(revision);
+
+  const blockedMessage = revision => (
+    <Fragment>
+      Can’t be released: <b>{revision.status}.</b>
+      <br />
+    </Fragment>
+  );
+
   return (
     <Fragment>
       <span className="p-release-data__info">
@@ -132,6 +145,7 @@ export const RevisionInfo = ({
         {isPending && "Pending release of:"}
 
         <div className="p-tooltip__group">
+          {!releasable && blockedMessage(revision)}
           Revision: <b>{revision.revision}</b>
           <br />
           Version: <b>{revision.version}</b>

--- a/static/js/publisher/release/components/releasesTable/channelHeading.js
+++ b/static/js/publisher/release/components/releasesTable/channelHeading.js
@@ -30,7 +30,7 @@ import {
   EDGE
 } from "../../constants";
 
-import { getChannelName, isInDevmode } from "../../helpers";
+import { getChannelName, isInDevmode, canBeReleased } from "../../helpers";
 import ChannelMenu from "../channelMenu";
 
 const disabledBecauseDevmode = (
@@ -296,8 +296,10 @@ const ReleasesTableChannelHeading = props => {
   }
 
   const promoteRevisions = targetChannel => {
-    Object.values(rowRevisions).forEach(revision =>
-      props.promoteRevision(revision, targetChannel)
+    Object.values(rowRevisions).forEach(
+      revision =>
+        canBeReleased(revision) &&
+        props.promoteRevision(revision, targetChannel)
     );
   };
 

--- a/static/js/publisher/release/components/releasesTable/droppableRow.js
+++ b/static/js/publisher/release/components/releasesTable/droppableRow.js
@@ -10,7 +10,7 @@ import { triggerGAEvent } from "../../actions/gaEventTracking";
 
 import { STABLE, CANDIDATE, BETA, EDGE } from "../../constants";
 
-import { getChannelName, isInDevmode } from "../../helpers";
+import { getChannelName, isInDevmode, canBeReleased } from "../../helpers";
 
 import ReleasesTableChannelRow from "./channelRow";
 
@@ -52,7 +52,9 @@ const ReleasesTableDroppableRow = props => {
   const [{ isOver, canDrop, item }, drop] = useDrop({
     accept: DND_ITEM_REVISIONS,
     drop: item => {
-      item.revisions.forEach(r => promoteRevision(r, channel));
+      item.revisions.forEach(
+        r => canBeReleased(r) && promoteRevision(r, channel)
+      );
 
       if (item.revisions.length > 1) {
         triggerGAEvent(

--- a/static/js/publisher/release/components/releasesTable/releaseCell.js
+++ b/static/js/publisher/release/components/releasesTable/releaseCell.js
@@ -6,7 +6,7 @@ import { AVAILABLE } from "../../constants";
 import { getTrackingChannel } from "../../releasesState";
 
 import HistoryIcon from "../historyIcon";
-import { getChannelName } from "../../helpers";
+import { getChannelName, canBeReleased } from "../../helpers";
 import { DND_ITEM_REVISIONS } from "../dnd";
 
 import { toggleHistory } from "../../actions/history";
@@ -81,8 +81,9 @@ const ReleasesTableReleaseCell = props => {
     filters.risk === risk &&
     filters.branch === branchName;
   const isHighlighted = isPending || (isUnassigned && currentRevision);
+  const releasable = canBeReleased(currentRevision);
 
-  const canDrag = currentRevision && !isChannelPendingClose;
+  const canDrag = currentRevision && !isChannelPendingClose && releasable;
 
   const item = {
     revisions: [currentRevision],

--- a/static/js/publisher/release/components/releasesTable/revisionCell.js
+++ b/static/js/publisher/release/components/releasesTable/revisionCell.js
@@ -3,6 +3,7 @@ import PropTypes from "prop-types";
 
 import { DND_ITEM_REVISIONS } from "../dnd";
 
+import { canBeReleased } from "../../helpers";
 import { ReleasesTableCellView, RevisionInfo, EmptyInfo } from "./cellViews";
 
 // releases table cell with data for a specific revision (unrelated to channel map)
@@ -16,7 +17,10 @@ const ReleasesTableRevisionCell = props => {
   };
 
   return (
-    <ReleasesTableCellView item={item} canDrag={!!revision}>
+    <ReleasesTableCellView
+      item={item}
+      canDrag={!!revision && canBeReleased(revision)}
+    >
       {revision ? (
         <RevisionInfo revision={revision} showVersion={showVersion} />
       ) : (

--- a/static/js/publisher/release/components/revisionsListRow.js
+++ b/static/js/publisher/release/components/revisionsListRow.js
@@ -111,15 +111,14 @@ const RevisionsListRow = props => {
       )}
       {canShowProgressiveReleases && (
         <td>
-          {revision.release &&
-            showProgressive && (
-              <RevisionsListRowProgressive
-                setDraggable={setDraggable}
-                channel={channel}
-                architecture={revision.release.architecture}
-                revision={revision}
-              />
-            )}
+          {revision.release && showProgressive && (
+            <RevisionsListRowProgressive
+              setDraggable={setDraggable}
+              channel={channel}
+              architecture={revision.release.architecture}
+              revision={revision}
+            />
+          )}
         </td>
       )}
       {progressiveBeingCancelled && (
@@ -130,22 +129,21 @@ const RevisionsListRow = props => {
       {showChannels && <td>{revision.channels.join(", ")}</td>}
       <td className="u-align--right">
         {isPending && <em>pending release</em>}
-        {!isPending &&
-          !progressiveBeingCancelled && (
+        {!isPending && !progressiveBeingCancelled && (
+          <span
+            className="p-tooltip p-tooltip--btm-center"
+            aria-describedby={`revision-uploaded-${revision.revision}`}
+          >
+            {distanceInWords(new Date(), revisionDate, { addSuffix: true })}
             <span
-              className="p-tooltip p-tooltip--btm-center"
-              aria-describedby={`revision-uploaded-${revision.revision}`}
+              className="p-tooltip__message u-align--center"
+              role="tooltip"
+              id={`revision-uploaded-${revision.revision}`}
             >
-              {distanceInWords(new Date(), revisionDate, { addSuffix: true })}
-              <span
-                className="p-tooltip__message u-align--center"
-                role="tooltip"
-                id={`revision-uploaded-${revision.revision}`}
-              >
-                {format(revisionDate, "YYYY-MM-DD HH:mm")}
-              </span>
+              {format(revisionDate, "YYYY-MM-DD HH:mm")}
             </span>
-          )}
+          </span>
+        )}
       </td>
     </tr>
   );
@@ -183,7 +181,4 @@ const mapDispatchToProps = dispatch => {
   };
 };
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(RevisionsListRow);
+export default connect(mapStateToProps, mapDispatchToProps)(RevisionsListRow);

--- a/static/js/publisher/release/components/revisionsListRow.js
+++ b/static/js/publisher/release/components/revisionsListRow.js
@@ -5,6 +5,7 @@ import { connect } from "react-redux";
 import distanceInWords from "date-fns/distance_in_words_strict";
 import format from "date-fns/format";
 
+import { canBeReleased } from "../helpers";
 import { getChannelString } from "../../../libs/channels";
 import { useDragging, DND_ITEM_REVISIONS, Handle } from "./dnd";
 import { toggleRevision } from "../actions/channelMap";
@@ -30,7 +31,11 @@ const RevisionsListRow = props => {
     progressiveBeingCancelled
   } = props;
 
-  const [canDrag, setDraggable] = useState(!progressiveBeingCancelled);
+  const releasable = canBeReleased(revision);
+
+  const [canDrag, setDraggable] = useState(
+    !progressiveBeingCancelled && releasable
+  );
 
   const revisionDate = revision.release
     ? new Date(revision.release.when)
@@ -59,7 +64,9 @@ const RevisionsListRow = props => {
   const id = `revision-check-${revision.revision}`;
   const className = `p-revisions-list__row ${
     progressiveBeingCancelled ? "" : "is-draggable"
-  } ${isActive ? "is-active" : ""} ${isSelectable ? "is-clickable" : ""} ${
+  } ${isActive ? "is-active" : ""} ${
+    isSelectable && releasable ? "is-clickable" : ""
+  } ${
     isPending || isSelected || progressiveBeingCancelled ? "is-pending" : ""
   } ${isGrabbing ? "is-grabbing" : ""} ${isDragging ? "is-dragging" : ""}`;
 
@@ -74,17 +81,18 @@ const RevisionsListRow = props => {
       ref={drag}
       key={id}
       className={className}
-      onClick={isSelectable ? revisionSelectChange : null}
+      onClick={isSelectable && releasable ? revisionSelectChange : null}
     >
-      <td>{!progressiveBeingCancelled && <Handle />}</td>
+      <td>{!progressiveBeingCancelled && releasable && <Handle />}</td>
       <td>
         {isSelectable ? (
           <Fragment>
             <input
               type="checkbox"
-              checked={isSelected}
+              checked={isSelected && releasable}
               id={id}
               onChange={revisionSelectChange}
+              disabled={!releasable}
             />
             <label
               className="p-revisions-list__revision is-inline-label"
@@ -111,14 +119,15 @@ const RevisionsListRow = props => {
       )}
       {canShowProgressiveReleases && (
         <td>
-          {revision.release && showProgressive && (
-            <RevisionsListRowProgressive
-              setDraggable={setDraggable}
-              channel={channel}
-              architecture={revision.release.architecture}
-              revision={revision}
-            />
-          )}
+          {revision.release &&
+            showProgressive && (
+              <RevisionsListRowProgressive
+                setDraggable={setDraggable}
+                channel={channel}
+                architecture={revision.release.architecture}
+                revision={revision}
+              />
+            )}
         </td>
       )}
       {progressiveBeingCancelled && (
@@ -129,21 +138,22 @@ const RevisionsListRow = props => {
       {showChannels && <td>{revision.channels.join(", ")}</td>}
       <td className="u-align--right">
         {isPending && <em>pending release</em>}
-        {!isPending && !progressiveBeingCancelled && (
-          <span
-            className="p-tooltip p-tooltip--btm-center"
-            aria-describedby={`revision-uploaded-${revision.revision}`}
-          >
-            {distanceInWords(new Date(), revisionDate, { addSuffix: true })}
+        {!isPending &&
+          !progressiveBeingCancelled && (
             <span
-              className="p-tooltip__message u-align--center"
-              role="tooltip"
-              id={`revision-uploaded-${revision.revision}`}
+              className="p-tooltip p-tooltip--btm-center"
+              aria-describedby={`revision-uploaded-${revision.revision}`}
             >
-              {format(revisionDate, "YYYY-MM-DD HH:mm")}
+              {distanceInWords(new Date(), revisionDate, { addSuffix: true })}
+              <span
+                className="p-tooltip__message u-align--center"
+                role="tooltip"
+                id={`revision-uploaded-${revision.revision}`}
+              >
+                {format(revisionDate, "YYYY-MM-DD HH:mm")}
+              </span>
             </span>
-          </span>
-        )}
+          )}
       </td>
     </tr>
   );
@@ -181,4 +191,7 @@ const mapDispatchToProps = dispatch => {
   };
 };
 
-export default connect(mapStateToProps, mapDispatchToProps)(RevisionsListRow);
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(RevisionsListRow);

--- a/static/js/publisher/release/constants.js
+++ b/static/js/publisher/release/constants.js
@@ -21,6 +21,15 @@ const DEFAULT_ERROR_MESSAGE =
 
 const TEMP_KEY = "ui-temp-";
 
+const REVISION_STATUS = {
+  PUBLISHED: "Published",
+  UNPUBLISHED: "Unpublished",
+  MANUAL_REVIEW_PENDING: "ManualReviewPending",
+  NEEDS_INFORMATION: "NeedsInformation",
+  AUTOMATICALLY_REJECTED: "AutomaticallyRejected",
+  REJECTED: "Rejected"
+};
+
 export {
   AVAILABLE_REVISIONS_SELECT_LAUNCHPAD,
   AVAILABLE_REVISIONS_SELECT_UNRELEASED,
@@ -35,5 +44,6 @@ export {
   BUILD,
   RISKS,
   RISKS_WITH_AVAILABLE,
-  TEMP_KEY
+  TEMP_KEY,
+  REVISION_STATUS
 };

--- a/static/js/publisher/release/helpers.js
+++ b/static/js/publisher/release/helpers.js
@@ -1,4 +1,4 @@
-import { AVAILABLE } from "./constants";
+import { AVAILABLE, REVISION_STATUS } from "./constants";
 import { getChannelString } from "../../libs/channels";
 
 export function isInDevmode(revision) {
@@ -65,4 +65,10 @@ export function isSameVersion(revisions) {
 
 export function jsonClone(obj) {
   return JSON.parse(JSON.stringify(obj));
+}
+
+export function canBeReleased(revision) {
+  const allowed = [REVISION_STATUS.PUBLISHED, REVISION_STATUS.UNPUBLISHED];
+
+  return revision && allowed.includes(revision.status);
 }


### PR DESCRIPTION
## Done

- If a revision can't be released, add the reason WHY to the tooltip
- Remove the ability to drag revisions that can't be released (and the drag handle)
- In the unreleased section disable the checkbox and don't allow revisions to be dragged.

## Issue / Card

Fixes #2031 

## QA

- Pull the branch
- Run the site using the command `./run`
- View the site locally in your web browser at: http://0.0.0.0:8004/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Visit http://0.0.0.0:8004/snap_name/releases where snap_name is the name of a snap with a blocked revision (I can share one with you if required)
- See the tooltip for the revision
- Try and stage that revision to be promoted (you shouldn't be able to)