### PR TITLE
Handle OS names with a / in them

### DIFF
--- a/webapp/metrics/metrics.py
+++ b/webapp/metrics/metrics.py
@@ -78,7 +78,7 @@ def _capitalize_os_name(os_name):
         "zorin": "Zorin OS",
     }
 
-    name, version = os_name.split("/")
+    name, version = os_name.rsplit("/", 1)
 
     if version != "-":
         return " ".join([capitalized_oses.get(name, name), version])


### PR DESCRIPTION
## Done

- Split on only the last "/" in OS names. The delimiter between NAME/VERSION

## Issue / Card

Fixes #2635 

## QA

- Pull the branch
- Run the site using the command `./run`
- View the site locally in your web browser at: http://0.0.0.0:8004/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Visit http://0.0.0.0:8004/powershell/metrics?active-devices=os
- The page should load ok