### PR TITLE
If snap is in launchpad show webhook url on settings page

### DIFF
--- a/templates/publisher/settings.html
+++ b/templates/publisher/settings.html
@@ -216,6 +216,24 @@ Settings for {% if display_title %}{{ display_title }}{% else %}{{ snap_title }}
           </div>
         </div>
       </div>
+
+      {% if is_on_lp %}
+      <div class="row p-form__group">
+        <hr class="u-no-margin--bottom" />
+      </div>
+
+      <div class="row p-form__group">
+        <div class="col-2">
+          GitHub Webhook:
+        </div>
+        <div class="col-8">
+          <div class="p-form__control">
+            <input type="text"
+                   value="https://snapcraft.io/{{snap_name}}/webook/notify" />
+          </div>
+        </div>
+      </div>
+      {% endif %}
     </section>
   </form>
 </div>

--- a/tests/publisher/snaps/tests_post_settings.py
+++ b/tests/publisher/snaps/tests_post_settings.py
@@ -107,6 +107,22 @@ class PostMetadataSettingsPage(BaseTestCases.EndpointLoggedIn):
 
         responses.add(responses.GET, info_url, json=payload, status=200)
 
+        launchpad_url = "".join(
+            [
+                "https://api.launchpad.net",
+                "/devel/+snaps" "?ws.op=findByStoreName",
+                "&owner=%2F~build.snapcraft.io",
+                "&store_name=",
+                self.snap_name,
+            ]
+        )
+
+        launchpad_payload = {"snaps": [{"store_name": self.snap_name}]}
+
+        responses.add(
+            responses.GET, launchpad_url, json=launchpad_payload, status=200,
+        )
+
         changes = {"private": True}
 
         response = self.client.post(
@@ -114,7 +130,7 @@ class PostMetadataSettingsPage(BaseTestCases.EndpointLoggedIn):
             data={"changes": json.dumps(changes), "snap_id": self.snap_id},
         )
 
-        self.assertEqual(2, len(responses.calls))
+        self.assertEqual(3, len(responses.calls))
         called = responses.calls[0]
         self.assertEqual(self.api_url, called.request.url)
         self.assertEqual(
@@ -169,6 +185,22 @@ class PostMetadataSettingsPage(BaseTestCases.EndpointLoggedIn):
 
         responses.add(responses.GET, info_url, json=payload, status=200)
 
+        launchpad_url = "".join(
+            [
+                "https://api.launchpad.net",
+                "/devel/+snaps" "?ws.op=findByStoreName",
+                "&owner=%2F~build.snapcraft.io",
+                "&store_name=",
+                self.snap_name,
+            ]
+        )
+
+        launchpad_payload = {"snaps": [{"store_name": self.snap_name}]}
+
+        responses.add(
+            responses.GET, launchpad_url, json=launchpad_payload, status=200,
+        )
+
         changes = {"license": "newLicense", "private": False}
 
         response = self.client.post(
@@ -176,7 +208,7 @@ class PostMetadataSettingsPage(BaseTestCases.EndpointLoggedIn):
             data={"changes": json.dumps(changes), "snap_id": self.snap_id},
         )
 
-        self.assertEqual(2, len(responses.calls))
+        self.assertEqual(3, len(responses.calls))
         called = responses.calls[0]
         self.assertEqual(self.api_url, called.request.url)
         self.assertEqual(
@@ -241,6 +273,22 @@ class PostMetadataSettingsPage(BaseTestCases.EndpointLoggedIn):
 
         responses.add(responses.GET, info_url, json=payload, status=200)
 
+        launchpad_url = "".join(
+            [
+                "https://api.launchpad.net",
+                "/devel/+snaps" "?ws.op=findByStoreName",
+                "&owner=%2F~build.snapcraft.io",
+                "&store_name=",
+                self.snap_name,
+            ]
+        )
+
+        launchpad_payload = {"snaps": [{"store_name": self.snap_name}]}
+
+        responses.add(
+            responses.GET, launchpad_url, json=launchpad_payload, status=200,
+        )
+
         changes = {"description": "This is an updated description"}
 
         response = self.client.post(
@@ -248,7 +296,7 @@ class PostMetadataSettingsPage(BaseTestCases.EndpointLoggedIn):
             data={"changes": json.dumps(changes), "snap_id": self.snap_id},
         )
 
-        self.assertEqual(2, len(responses.calls))
+        self.assertEqual(3, len(responses.calls))
         called = responses.calls[0]
         self.assertEqual(self.api_url, called.request.url)
         self.assertEqual(

--- a/tests/publisher/snaps/tests_settings.py
+++ b/tests/publisher/snaps/tests_settings.py
@@ -57,6 +57,22 @@ class GetSettingsPage(BaseTestCases.EndpointLoggedInErrorHandling):
 
         responses.add(responses.GET, self.api_url, json=payload, status=200)
 
+        launchpad_url = "".join(
+            [
+                "https://api.launchpad.net",
+                "/devel/+snaps" "?ws.op=findByStoreName",
+                "&owner=%2F~build.snapcraft.io",
+                "&store_name=",
+                snap_name,
+            ]
+        )
+
+        launchpad_payload = {"snaps": [{"store_name": snap_name}]}
+
+        responses.add(
+            responses.GET, launchpad_url, json=launchpad_payload, status=200,
+        )
+
         response = self.client.get(self.endpoint_url)
 
         self.check_call_by_api_url(responses.calls)

--- a/webapp/publisher/snaps/settings_views.py
+++ b/webapp/publisher/snaps/settings_views.py
@@ -58,7 +58,7 @@ def get_settings(snap_name):
         countries.append({"key": country.alpha_2, "name": country.name})
 
     is_on_lp = False
-    lp_snap = launchpad.get_snap_by_store_name(snap_details["snap_name"])
+    lp_snap = launchpad.get_snap_by_store_name(snap_name)
     if lp_snap:
         is_on_lp = True
 


### PR DESCRIPTION
## Done

- Add Github Webhook url to settings page for snaps - if the snap is on launchpad.

## Issue / Card

Fixes #

## QA

- Pull the branch
- Run the site using the command `./run`
- View the site locally in your web browser at: http://0.0.0.0:8004/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Visit http://0.0.0.0:8004/snap_name/settings for a snap that is built with launchpad
- You should see a GitHub webhook url.
- Visit http://0.0.0.0:8004/snap_name/settings for a snap that is not build with launchpad
- You should not see a github webhook url

## Screenshots

[if relevant, include a screenshot]