### PR TITLE
remove extra slash in blog url

### DIFF
--- a/webapp/blog/content/blog-posts.yaml
+++ b/webapp/blog/content/blog-posts.yaml
@@ -1,5 +1,5 @@
 ncspot:
-  uri: https://www.omgubuntu.co.uk//2020/02/spotify-cli-client-ncspot
+  uri: https://www.omgubuntu.co.uk/2020/02/spotify-cli-client-ncspot
   image: https://149366088.v2.pressablecdn.com/wp-content/uploads/2020/02/ncspot-spotify-cli-app.jpg
   title: Listen to Spotify from the Command Line with ‘ncspot’
 


### PR DESCRIPTION
## Done

[List of work items including drive-bys]

## Issue / Card

Fixes #

## QA

- Pull the branch
- Run the site using the command `./run`
- View the site locally in your web browser at: http://0.0.0.0:8004/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- [List additional steps to QA the new features or prove the bug has been resolved]

## Screenshots

[if relevant, include a screenshot]