### PR TITLE
5 year metrics

### DIFF
--- a/templates/publisher/metrics.html
+++ b/templates/publisher/metrics.html
@@ -41,6 +41,7 @@ Publisher metrics for {{ snap_title }}
             <option value="6m"{% if metric_period == '6m' %} selected="selected"{% endif %}>Past 6 months</option>
             <option value="1y"{% if metric_period == '1y' %} selected="selected"{% endif %}>Past year</option>
             <option value="2y"{% if metric_period == '2y' %} selected="selected"{% endif %}>Past 2 years</option>
+            <option value="5y"{% if metric_period == '5y' %} selected="selected"{% endif %}>Past 5 years</option>
           </select>
         </div>
         <div class="col-3">


### PR DESCRIPTION
## Done

- Add 5 year option to metrics page

## Issue / Card

Fixes #2641 

## QA

- Pull the branch
- Run the site using the command `./run`
- View the site locally in your web browser at: http://0.0.0.0:8004/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Visit http://0.0.0.0:8004/snap_name/metrics?period=5y
- See 5 years of metrics