### PR TITLE
Remove GitHub webhook when disconnecting a repo

### DIFF
--- a/webapp/api/github.py
+++ b/webapp/api/github.py
@@ -363,3 +363,11 @@ class GitHub:
         self._request("POST", f"repos/{owner}/{repo}/hooks", data=data)
 
         return True
+
+    def remove_hook(self, owner, repo, hook_id):
+        """
+        Remove GitHub webhook in a repo
+        """
+        self._request("DELETE", f"repos/{owner}/{repo}/hooks/{hook_id}")
+
+        return True

--- a/webapp/publisher/snaps/build_views.py
+++ b/webapp/publisher/snaps/build_views.py
@@ -314,9 +314,12 @@ def post_snap_builds(snap_name):
         launchpad.create_snap(snap_name, git_url, macaroon)
 
         # Create webhook in the repo, it should also trigger the first build
-        github.create_hook(
-            owner, repo, f"https://snapcraft.io/{snap_name}/webhook/notify"
-        )
+        github_hook_url = f"https://snapcraft.io/{snap_name}/webhook/notify"
+        hook = github.get_hook_by_url(owner, repo, github_hook_url)
+
+        # We create the webhook if doesn't exist already in this repo
+        if not hook:
+            github.create_hook(owner, repo, github_hook_url)
 
         flask.flash("The GitHub repository was linked correctly.", "positive")
     elif lp_snap["git_repository_url"] != git_url:
@@ -379,7 +382,24 @@ def post_disconnect_repo(snap_name):
     except ApiError as api_error:
         return _handle_error(api_error)
 
+    lp_snap = launchpad.get_snap_by_store_name(snap_name)
     launchpad.delete_snap(details["snap_name"])
+
+    # Try to remove the GitHub webhook if possible
+    if flask.session.get("github_auth_secret"):
+        github = GitHub(flask.session.get("github_auth_secret"))
+
+        gh_owner, gh_repo = lp_snap["git_repository_url"][19:].split("/")
+        old_hook = github.get_hook_by_url(
+            gh_owner,
+            gh_repo,
+            f"https://snapcraft.io/{snap_name}/webhook/notify",
+        )
+
+        if old_hook:
+            github.remove_hook(
+                gh_owner, gh_repo, old_hook["id"],
+            )
 
     return flask.redirect(
         flask.url_for(".get_snap_builds", snap_name=snap_name)


### PR DESCRIPTION
## Done

- Remove GitHub webhook

## QA

- Pull the branch
- Run the site using the command `./run`
- View the site locally in your web browser at: http://0.0.0.0:8004/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Try to disconnect a repo from a Snap and check that the webhook is removed when you are authenticated on GitHub
