### PR TITLE
Fix empty store_name issue

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ canonicalwebteam.blog==4.0.2
 canonicalwebteam.search==0.1.0
 canonicalwebteam.image-template==1.0.0
 canonicalwebteam.store-api==2.0.0
-canonicalwebteam.launchpad==0.2.8
+canonicalwebteam.launchpad==0.2.9
 django-openid-auth==0.15
 Flask-OpenID-Stateless==1.2.6
 Flask-WTF==0.14.3

--- a/webapp/publisher/snaps/build_views.py
+++ b/webapp/publisher/snaps/build_views.py
@@ -293,7 +293,7 @@ def post_snap_builds(snap_name):
         lp_snap_name = md5(git_url.encode("UTF-8")).hexdigest()
 
         try:
-            repo_exist = bool(launchpad.get_snap(lp_snap_name))
+            repo_exist = launchpad.get_snap(lp_snap_name)
         except HTTPError as e:
             if e.response.status_code == 404:
                 repo_exist = False
@@ -301,11 +301,20 @@ def post_snap_builds(snap_name):
                 raise e
 
         if repo_exist:
-            error_msg = (
-                "The specified GitHub repository is being used by another snap"
-            )
-            flask.flash(error_msg, "negative")
-            return flask.redirect(redirect_url)
+            # The user registered the repo in BSI but didn't register a name
+            # We can remove it and continue with the normal process
+            if not repo_exist["store_name"]:
+                # This conditional should be removed when issue 2657 is solved
+                launchpad._request(
+                    path=repo_exist["self_link"][32:], method="DELETE"
+                )
+            else:
+                flask.flash(
+                    "The specified repository is being used by another snap:"
+                    f" {repo_exist['store_name']}",
+                    "negative",
+                )
+                return flask.redirect(redirect_url)
 
         macaroon = api.get_package_upload_macaroon(
             session=flask.session, snap_name=snap_name, channels=["edge"]


### PR DESCRIPTION
## Done

Fixes an issue for people who use BSI to register a repo but don't assign a name to the snap when they try to use that repo using snapcraft.io they get an error telling them that the repo is being used for another snap.

## Issue / Card

Fixes #2647

## QA

- Pull the branch
- Run the site using the command `./run`
- Go to BSI and register a repo but don't register a snap name
- View the site locally in your web browser at: http://0.0.0.0:8004/
- Now in snapcraft go to the builds tab in a snap that is not linked to a repo.
- Use the same repo that you used in BSI, everything should be fine
