### PR TITLE
Update Store module to 2.0.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ canonicalwebteam.discourse-docs==0.11.1
 canonicalwebteam.blog==4.0.2
 canonicalwebteam.search==0.1.0
 canonicalwebteam.image-template==1.0.0
-canonicalwebteam.store-api==2.0.0
+canonicalwebteam.store-api==2.0.1
 canonicalwebteam.launchpad==0.2.9
 django-openid-auth==0.15
 Flask-OpenID-Stateless==1.2.6


### PR DESCRIPTION
## Done

In the new version is possible to change the store API URL with environment variables.

## QA

- Pull the branch
- Run the site using the command `./run`
- View the site locally in your web browser at: http://0.0.0.0:8004/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Create or edit your .env.local
- Add the following value:
```
SNAPSTORE_API_URL=https://api.staging.snapcraft.io/
```
- Use dotrun, you should see only a few snaps from the staging API.