### PR TITLE
Enable default track selection

### DIFF
--- a/static/js/publisher/release/components/defaultTrackModifier.js
+++ b/static/js/publisher/release/components/defaultTrackModifier.js
@@ -94,7 +94,7 @@ class DefaultTrackModifier extends Component {
 
   renderClearLink() {
     return (
-      <p>
+      <p className="u-no-margin--bottom">
         This is the default track for the snap.&nbsp;
         <a
           className="p-tooltip p-tooltip--btm-right"

--- a/static/js/publisher/release/components/releasesHeading.js
+++ b/static/js/publisher/release/components/releasesHeading.js
@@ -52,7 +52,7 @@ class ReleasesHeading extends Component {
             </Wrap>
           </h4>
         </div>
-        <div className="col-6">
+        <div className="col-6" style={{ marginTop: "0.25rem" }}>
           {tracks.length > 1 && <DefaultTrackModifier />}
         </div>
       </div>

--- a/static/js/publisher/release/components/releasesHeading.js
+++ b/static/js/publisher/release/components/releasesHeading.js
@@ -5,7 +5,7 @@ import { connect } from "react-redux";
 import { setCurrentTrack } from "../actions/currentTrack";
 import { getTracks } from "../selectors";
 
-//import DefaultTrackModifier from "./defaultTrackModifier";
+import DefaultTrackModifier from "./defaultTrackModifier";
 
 class ReleasesHeading extends Component {
   onTrackChange(event) {
@@ -52,9 +52,9 @@ class ReleasesHeading extends Component {
             </Wrap>
           </h4>
         </div>
-        {/*<div className="col-6">
+        <div className="col-6">
           {tracks.length > 1 && <DefaultTrackModifier />}
-      </div>*/}
+        </div>
       </div>
     );
   }


### PR DESCRIPTION
## Done

- Uncomment the default track code

## QA

- Pull the branch
- Run the site using the command `./run`
- Update your environment to use staging (see [HACKING](https://github.com/canonical-web-and-design/snapcraft.io/blob/master/HACKING.md))
- View the site locally in your web browser at: http://0.0.0.0:8004/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Visit a snap's release page that has multiple tracks (you may need to ask me to share one with you on staging - just send me a message with your staging email address)
- See that you can change the default track