### PR TITLE
Pi distro page

### DIFF
--- a/static/js/public/expandable-area.js
+++ b/static/js/public/expandable-area.js
@@ -1,4 +1,13 @@
-export default function initExpandableArea() {
+/**
+   Initializes an expandable area
+
+   @param {string} overflowSelector - CSS Selector for the element that can overflow
+   @param {string} heightMatchSelector - CSS Selector for the element that overflowSelector's height should be compared against
+*/
+export default function initExpandableArea(
+  overflowSelector,
+  heightMatchSelector
+) {
   const showMoreContainer = [].slice.call(
     document.querySelectorAll("[data-js='js-show-more']")
   );
@@ -7,6 +16,18 @@ export default function initExpandableArea() {
     showMoreContainer.forEach(el => {
       const fadeEl = el.querySelector(".p-show-more__fade");
       const linkEl = el.querySelector(".p-show-more__link");
+
+      if (overflowSelector && heightMatchSelector) {
+        const overflowEl = el.querySelector(overflowSelector);
+        const heightMatchEl = el.querySelector(heightMatchSelector);
+
+        if (overflowEl.scrollHeight <= heightMatchEl.scrollHeight) {
+          el.removeAttribute("data-js");
+          el.classList.remove("p-show-more");
+          el.removeChild(fadeEl);
+          el.removeChild(linkEl);
+        }
+      }
 
       if (fadeEl && linkEl) {
         linkEl.addEventListener("click", function(event) {

--- a/static/sass/_snapcraft_show-more.scss
+++ b/static/sass/_snapcraft_show-more.scss
@@ -12,7 +12,7 @@
 
       &.is-shallow {
         > :first-child {
-          max-height: 11.25rem;
+          max-height: 14.25rem;
         }
       }
 
@@ -51,3 +51,4 @@
     }
   }
 }
+

--- a/templates/store/snap-details/_distro-instructions-for-snap-support.html
+++ b/templates/store/snap-details/_distro-instructions-for-snap-support.html
@@ -129,5 +129,15 @@
         </span>
       </a>
     </div>
+    <div class="col-3 col-medium-3">
+      <a class="p-media-object" href="/install/{{package_name}}/raspbian">
+        <span class="p-media-object__image">
+          <img src="https://assets.ubuntu.com/v1/a8a6238c-RGB+RPi.svg" width="48" height="48" alt="">
+        </span>
+        <span class="p-media-object__details">
+          <h4 class="p-media-object__title p-heading--five u-no-margin--bottom">Raspberry Pi</h4>
+        </span>
+      </a>
+    </div>
   </div>
 </div>

--- a/templates/store/snap-details/_distro-instructions-for-snap-support.html
+++ b/templates/store/snap-details/_distro-instructions-for-snap-support.html
@@ -3,7 +3,7 @@
 </div>
 <div class="p-strip is-shallow">
   <div class="u-fixed-width">
-    <h3 class="p-heading--two">Install {{snap_title}} on your Linux distribution</h3>
+    <h3 class="p-heading--2">Install {{snap_title}} on your Linux distribution</h3>
     <p>Choose your Linux distribution to get detailed installation instructions. If yours is not shown, get more details on the <a href="/docs/installing-snapd" target="_blank">installing snapd documentation</a>.</p>
     </div>
 </div>
@@ -15,7 +15,7 @@
           <img src="https://assets.ubuntu.com/v1/feca0fc0-Distro_Logo_ArchLinux.svg" alt="">
         </span>
         <span class="p-media-object__details">
-          <h4 class="p-media-object__title p-heading--five u-no-margin--bottom">Arch Linux</h4>
+          <h4 class="p-media-object__title p-heading--5 u-no-margin--bottom">Arch Linux</h4>
         </span>
       </a>
     </div>
@@ -25,7 +25,7 @@
           <img src="https://assets.ubuntu.com/v1/acf876d9-Distro_Logo_CentOS.svg" alt="">
         </span>
         <span class="p-media-object__details">
-          <h4 class="p-media-object__title p-heading--five u-no-margin--bottom">CentOS</h4>
+          <h4 class="p-media-object__title p-heading--5 u-no-margin--bottom">CentOS</h4>
         </span>
       </a>
     </div>
@@ -35,7 +35,7 @@
           <img src="https://assets.ubuntu.com/v1/cfdc1144-Distro_Logo_Debian.svg" alt="">
         </span>
         <span class="p-media-object__details">
-          <h4 class="p-media-object__title p-heading--five u-no-margin--bottom">Debian</h4>
+          <h4 class="p-media-object__title p-heading--5 u-no-margin--bottom">Debian</h4>
         </span>
       </a>
     </div>
@@ -45,7 +45,7 @@
           <img src="https://assets.ubuntu.com/v1/c0c09661-Distro_Logo_Elementary.svg" alt="">
         </span>
         <span class="p-media-object__details">
-          <h4 class="p-media-object__title p-heading--five u-no-margin--bottom">elementary OS</h4>
+          <h4 class="p-media-object__title p-heading--5 u-no-margin--bottom">elementary OS</h4>
         </span>
       </a>
     </div>
@@ -55,7 +55,7 @@
           <img src="https://assets.ubuntu.com/v1/c93d842f-fedora.png" alt="">
         </span>
         <span class="p-media-object__details">
-          <h4 class="p-media-object__title p-heading--five u-no-margin--bottom">Fedora</h4>
+          <h4 class="p-media-object__title p-heading--5 u-no-margin--bottom">Fedora</h4>
         </span>
       </a>
     </div>
@@ -65,7 +65,7 @@
           <img src="https://assets.ubuntu.com/v1/d0593902-Distro_Logo_KDE+Neon.svg" alt="">
         </span>
         <span class="p-media-object__details">
-          <h4 class="p-media-object__title p-heading--five u-no-margin--bottom">KDE Neon</h4>
+          <h4 class="p-media-object__title p-heading--5 u-no-margin--bottom">KDE Neon</h4>
         </span>
       </a>
     </div>
@@ -75,7 +75,7 @@
           <img src="https://assets.ubuntu.com/v1/7ab50a06-Distro_Logo_Kubuntu.svg" alt="">
         </span>
         <span class="p-media-object__details">
-          <h4 class="p-media-object__title p-heading--five u-no-margin--bottom">Kubuntu</h4>
+          <h4 class="p-media-object__title p-heading--5 u-no-margin--bottom">Kubuntu</h4>
         </span>
       </a>
     </div>
@@ -85,7 +85,7 @@
           <img src="https://assets.ubuntu.com/v1/4635a0bd-Distro_Logo_Manjaro.svg" alt="">
         </span>
         <span class="p-media-object__details">
-          <h4 class="p-media-object__title p-heading--five u-no-margin--bottom">Manjaro</h4>
+          <h4 class="p-media-object__title p-heading--5 u-no-margin--bottom">Manjaro</h4>
         </span>
       </a>
     </div>
@@ -95,7 +95,7 @@
           <img src="https://assets.ubuntu.com/v1/938d67b4-Distro_Logo_LinuxMint.svg" alt="">
         </span>
         <span class="p-media-object__details">
-          <h4 class="p-media-object__title p-heading--five u-no-margin--bottom">Linux Mint</h4>
+          <h4 class="p-media-object__title p-heading--5 u-no-margin--bottom">Linux Mint</h4>
         </span>
       </a>
     </div>
@@ -105,7 +105,7 @@
           <img src="https://assets.ubuntu.com/v1/610301c6-Distro_Logo_OpenSUSE.svg" alt="">
         </span>
         <span class="p-media-object__details">
-          <h4 class="p-media-object__title p-heading--five u-no-margin--bottom">openSUSE</h4>
+          <h4 class="p-media-object__title p-heading--5 u-no-margin--bottom">openSUSE</h4>
         </span>
       </a>
     </div>
@@ -115,7 +115,7 @@
           <img src="https://assets.ubuntu.com/v1/be89e41a-red-hat-2019-primary-stacked.svg" alt="">
         </span>
         <span class="p-media-object__details">
-          <h4 class="p-media-object__title p-heading--five u-no-margin--bottom">Red Hat Enterprise Linux</h4>
+          <h4 class="p-media-object__title p-heading--5 u-no-margin--bottom">Red Hat Enterprise Linux</h4>
         </span>
       </a>
     </div>
@@ -125,7 +125,7 @@
           <img src="https://assets.ubuntu.com/v1/100386fb-Distro_Logo_Ubuntu.svg" alt="">
         </span>
         <span class="p-media-object__details">
-          <h4 class="p-media-object__title p-heading--five u-no-margin--bottom">Ubuntu</h4>
+          <h4 class="p-media-object__title p-heading--5 u-no-margin--bottom">Ubuntu</h4>
         </span>
       </a>
     </div>
@@ -135,7 +135,7 @@
           <img src="https://assets.ubuntu.com/v1/a8a6238c-RGB+RPi.svg" width="48" height="48" alt="">
         </span>
         <span class="p-media-object__details">
-          <h4 class="p-media-object__title p-heading--five u-no-margin--bottom">Raspberry Pi</h4>
+          <h4 class="p-media-object__title p-heading--5 u-no-margin--bottom">Raspberry Pi</h4>
         </span>
       </a>
     </div>

--- a/templates/store/snap-distro-install.html
+++ b/templates/store/snap-distro-install.html
@@ -69,7 +69,7 @@
     <div class="p-strip">
       <div class="row">
         <div class="col-8">
-           <h1 class="p-heading--two u-no-margin is-light">How to install {{ snap_title }}<br/> on <b>{{ distro_name }}</b></h1>
+           <h1 class="p-heading--2 u-no-margin is-light">How to install {{ snap_title }}<br/> on <b>{{ distro_name }}</b></h1>
         </div>
         {% if distro_logo_mono %}
         <div class="col-4 u-hide--small">

--- a/templates/store/snap-distro-install.html
+++ b/templates/store/snap-distro-install.html
@@ -112,12 +112,14 @@
         {% endif %}
         <div class="p-show-more is-shallow is-collapsed" data-js="js-show-more">
           <div class="row">
-            <div class="col-8 js-snap-description-text">
-              {% if summary %}<h4 data-live="summary">{{ summary }}</h4>{% endif %}
-              <div data-live="description">{{ description | safe }}</div>
+            <div class="col-8">
+              <div class="js-snap-description-text">
+                {% if summary %}<h4 data-live="summary">{{ summary }}</h4>{% endif %}
+                <div data-live="description">{{ description | safe }}</div>
+              </div>
             </div>
             <div class="col-4">
-              <div class="js-snap-description-details">
+              <div class=" js-snap-description-details">
                 {% include "store/snap-details/_details.html" %}
               </div>
             </div>
@@ -283,7 +285,10 @@
         }
 
         try {
-          snapcraft.public.initExpandableArea();
+          snapcraft.public.initExpandableArea(
+            ".js-snap-description-text",
+            ".js-snap-description-details"
+          );
         } catch(e) {
           Raven.captureException(e);
         }

--- a/webapp/store/content/distros/raspbian.yaml
+++ b/webapp/store/content/distros/raspbian.yaml
@@ -1,0 +1,15 @@
+name: Raspberry Pi
+color-1: "#c05672"
+color-2: "#a22846"
+logo: https://assets.ubuntu.com/v1/a8a6238c-RGB+RPi.svg
+logo-mono: https://assets.ubuntu.com/v1/a31b1451-rpi-b-w.svg
+install:
+  - action: |
+      On a <a href="https://www.raspberrypi.org/" class="p-link--external">Raspberry Pi</a> running the latest version of <a href="https://www.raspberrypi.org/downloads/raspbian/" class="p-link--external">Raspbian</a> snap can be installed directly from the command line:
+    command: |
+      sudo apt update
+      sudo apt install snapd
+  - action: |
+      You will also need to reboot your device:
+    command: |
+      sudo reboot


### PR DESCRIPTION
## Done

- Added a raspbian/ Raspberry Pi distro page based on https://snapcraft.io/docs/installing-snap-on-raspbian

## Issue / Card

Fixes #2667

## QA

- Pull the branch
- Run the site using the command `./run`
- View the site locally in your web browser at: http://0.0.0.0:8004/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Visit http://0.0.0.0:8004/install/rpi-imager/raspbian :exploding_head: 
  - See the page
- Visit http://0.0.0.0:8004/rpi-imager
  - scroll to the bottom of the page
  - see the raspberry pi link

## Screenshots
![Screenshot_2020-04-16 Install Raspberry Pi Imager for Linux using the Snap Store Snapcraft](https://user-images.githubusercontent.com/479384/79468158-7fbd0d80-7ff6-11ea-9e5b-f6a86135e1a4.png)
![Screenshot_2020-04-16 Install VLC on Raspberry Pi using the Snap Store Snapcraft(1)](https://user-images.githubusercontent.com/479384/79468197-89467580-7ff6-11ea-8bc9-74373cf6534f.png)
![Screenshot_2020-04-16 Install VLC on Raspberry Pi using the Snap Store Snapcraft](https://user-images.githubusercontent.com/479384/79468199-89df0c00-7ff6-11ea-9011-045fc9bf91e2.png)
