### PR TITLE
Invalid snapcraft yaml

### DIFF
--- a/static/js/publisher/builds/components/repoConnect.js
+++ b/static/js/publisher/builds/components/repoConnect.js
@@ -27,7 +27,7 @@ class RepoConnect extends React.Component {
       status: null,
       snapName: this.props.snapName,
       yamlFilePath: null,
-      errorType: null
+      error: null
     };
 
     this.handleRepoSelect = this.handleRepoSelect.bind(this);
@@ -49,7 +49,8 @@ class RepoConnect extends React.Component {
     this.setState(
       {
         selectedRepo: selectedRepo,
-        status: null
+        status: null,
+        error: null
       },
       () => this.checkRepo(selectedRepo)
     );
@@ -132,7 +133,8 @@ class RepoConnect extends React.Component {
           } else {
             this.setState({
               isRepoListDisabled: false,
-              status: result.error.type,
+              error: result.error,
+              status: ERROR,
               yamlSnap: result.error.gh_snap_name
                 ? result.error.gh_snap_name
                 : null,
@@ -210,28 +212,39 @@ class RepoConnect extends React.Component {
   }
 
   renderError() {
-    const { snapName } = this.state;
+    const { snapName, error } = this.state;
 
-    return (
-      <div className="u-fixed-width">
-        <p>
-          <strong>Error: </strong>
-          We were not able to check if your repository can be linked to{" "}
-          {snapName}. Please check your internet connection and{" "}
-          <a onClick={this.handleRefreshButtonClick}>try again</a>.
-        </p>
-      </div>
-    );
+    if (error.message) {
+      return (
+        <div className="u-fixed-width">
+          <p>
+            <strong>Error: </strong>
+            {error.message}
+          </p>
+        </div>
+      );
+    } else {
+      return (
+        <div className="u-fixed-width">
+          <p>
+            <strong>Error: </strong>
+            We were not able to check if your repository can be linked to{" "}
+            {snapName}. Please check your internet connection and{" "}
+            <a onClick={this.handleRefreshButtonClick}>try again</a>.
+          </p>
+        </div>
+      );
+    }
   }
 
-  renderMessage() {
-    const { status } = this.state;
-    switch (status) {
+  renderErrorMessage() {
+    const { error } = this.state;
+    switch (error.type) {
       case SNAP_NAME_DOES_NOT_MATCH:
         return this.renderNameError();
       case MISSING_YAML_FILE:
         return this.renderMissingYamlError();
-      case ERROR:
+      default:
         return this.renderError();
     }
   }
@@ -243,11 +256,7 @@ class RepoConnect extends React.Component {
 
   renderButton() {
     const { status } = this.state;
-    if (
-      status === ERROR ||
-      status === SNAP_NAME_DOES_NOT_MATCH ||
-      status === MISSING_YAML_FILE
-    ) {
+    if (status === ERROR) {
       return (
         <button
           className="p-tooltip--btm-center"
@@ -277,8 +286,6 @@ class RepoConnect extends React.Component {
         icon = "";
         break;
       case ERROR:
-      case MISSING_YAML_FILE:
-      case SNAP_NAME_DOES_NOT_MATCH:
         icon = " is-error";
         break;
       case SUCCESS:
@@ -335,7 +342,7 @@ class RepoConnect extends React.Component {
           </div>
           <div className="col-2">{this.renderButton()}</div>
         </div>
-        {this.renderMessage()}
+        {status === ERROR && this.renderErrorMessage()}
       </Fragment>
     );
   }

--- a/static/js/publisher/builds/components/repoConnect.js
+++ b/static/js/publisher/builds/components/repoConnect.js
@@ -157,66 +157,82 @@ class RepoConnect extends React.Component {
     this.checkRepo(this.state.selectedRepo);
   }
 
-  renderMessage() {
+  renderNameError() {
     const {
-      status,
-      selectedRepo,
-      selectedOrganization,
-      yamlFilePath,
+      yamlSnap,
       snapName,
-      yamlSnap
+      selectedOrganization,
+      selectedRepo,
+      yamlFilePath
     } = this.state;
-    if (status === SNAP_NAME_DOES_NOT_MATCH) {
-      return (
-        <div className="u-fixed-width">
-          <p>
-            <strong>Name mismatch: </strong>
-            {`the snapcraft.yaml uses the snap name "${yamlSnap}", but you've registered the name "${snapName}". `}
-            <a
-              className="p-link--external"
-              href={`https://github.com/${selectedOrganization}/${selectedRepo}/edit/master/${yamlFilePath}`}
-            >
-              Update your snapcraft.yaml to continue.
-            </a>
-          </p>
-        </div>
-      );
-    } else if (status === MISSING_YAML_FILE) {
-      return (
-        <div className="u-fixed-width">
-          <p>
-            <strong>Missing snapcraft.yaml: </strong>
-            this repo needs a snapcraft.yaml file, so that Snapcraft can make it
-            buildable, installable and runnable.
-          </p>
-          <p>
-            <a href="https://snapcraft.io/docs/creating-a-snap">
-              Learn the basics
-            </a>
-            , or{" "}
-            <a className="p-link--external" href={this.getTemplateUrl()}>
-              get started with a template.
-            </a>
-          </p>
-          <p>
-            Don’t have snapcraft?{" "}
-            <a href="https://snapcraft.io/docs/snapcraft-overview">
-              Install it on your own PC for testing.
-            </a>
-          </p>
-        </div>
-      );
-    } else if (status === ERROR) {
-      return (
-        <div className="u-fixed-width">
-          <p>
-            <strong>Error: </strong>
-            We were not able to check if your repository can be linked to{" "}
-            {snapName}. Please check your internet connection and{" "}
-            <a onClick={this.handleRefreshButtonClick}>try again</a>.
-          </p>
-        </div>
-      );
+
+    return (
+      <div className="u-fixed-width">
+        <p>
+          <strong>Name mismatch: </strong>
+          {`the snapcraft.yaml uses the snap name "${yamlSnap}", but you've registered the name "${snapName}". `}
+          <a
+            className="p-link--external"
+            href={`https://github.com/${selectedOrganization}/${selectedRepo}/edit/master/${yamlFilePath}`}
+          >
+            Update your snapcraft.yaml to continue.
+          </a>
+        </p>
+      </div>
+    );
+  }
+
+  renderMissingYamlError() {
+    return (
+      <div className="u-fixed-width">
+        <p>
+          <strong>Missing snapcraft.yaml: </strong>
+          this repo needs a snapcraft.yaml file, so that Snapcraft can make it
+          buildable, installable and runnable.
+        </p>
+        <p>
+          <a href="https://snapcraft.io/docs/creating-a-snap">
+            Learn the basics
+          </a>
+          , or{" "}
+          <a className="p-link--external" href={this.getTemplateUrl()}>
+            get started with a template.
+          </a>
+        </p>
+        <p>
+          Don’t have snapcraft?{" "}
+          <a href="https://snapcraft.io/docs/snapcraft-overview">
+            Install it on your own PC for testing.
+          </a>
+        </p>
+      </div>
+    );
+  }
+
+  renderError() {
+    const { snapName } = this.state;
+
+    return (
+      <div className="u-fixed-width">
+        <p>
+          <strong>Error: </strong>
+          We were not able to check if your repository can be linked to{" "}
+          {snapName}. Please check your internet connection and{" "}
+          <a onClick={this.handleRefreshButtonClick}>try again</a>.
+        </p>
+      </div>
+    );
+  }
+
+  renderMessage() {
+    const { status } = this.state;
+    switch (status) {
+      case SNAP_NAME_DOES_NOT_MATCH:
+        return this.renderNameError();
+      case MISSING_YAML_FILE:
+        return this.renderMissingYamlError();
+      case ERROR:
+        return this.renderError();
     }
   }
 

--- a/webapp/publisher/snaps/build_views.py
+++ b/webapp/publisher/snaps/build_views.py
@@ -204,7 +204,7 @@ def validate_repo(github_token, snap_name, gh_owner, gh_repo):
             result["error"] = {
                 "type": "INVALID_YAML_FILE",
                 "message": (
-                    'Invalid snapcraft.yaml: there was an issue parsing the "'
+                    "Invalid snapcraft.yaml: there was an issue parsing the "
                     f"snapcraft.yaml for {snap_name}."
                 ),
             }


### PR DESCRIPTION
## Done

- Small refactor to the way errors are handled to allow backend error messages to be surfaced when we don't want a frontend override.

## Issue / Card

Fixes #2661

## QA

- Pull the branch
- Run the site using the command `./run`
- View the site locally in your web browser at: http://0.0.0.0:8004/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Create a snap
- Create a repo with an invalid yaml file
- Visit http://0.0.0.0:8004/snap_name/builds
- Try to add that repo
- See the error
- Ensure other errors still work (missing yaml and name mismatch)