### PR TITLE
Disable categories dropdown when API call fail

### DIFF
--- a/templates/publisher/listing.html
+++ b/templates/publisher/listing.html
@@ -149,6 +149,7 @@ Listing details for {% if display_title %}{{ display_title }}{% else %}{{ snap_t
             <div class="col-8 col-start-large-3">
               <p class="p-form-help-text">
                 {% if not categories %}
+                <i class="p-icon--warning"></i>
                 There has been a problem obtaining the available categories, please try again later.
                 {% else %}
                 Include a category and your snap will be better ranked within the Snap Store.

--- a/templates/publisher/listing.html
+++ b/templates/publisher/listing.html
@@ -129,7 +129,7 @@ Listing details for {% if display_title %}{{ display_title }}{% else %}{{ snap_t
               {% if snap_categories.categories[0] %}
               value="{{ snap_categories.categories[0] }}"
               {% endif %}
-              {% if snap_categories.locked %} disabled="disabled"{% endif %}
+              {% if snap_categories.locked or not categories %} disabled="disabled"{% endif %}
               >
               <option value="">Select category</option>
               {% for category in categories %}
@@ -148,8 +148,12 @@ Listing details for {% if display_title %}{{ display_title }}{% else %}{{ snap_t
           <div class="js-categories-category1-help-text row {% if snap_categories.categories[0] %}u-hide{% endif %}">
             <div class="col-8 col-start-large-3">
               <p class="p-form-help-text">
+                {% if not categories %}
+                There has been a problem obtaining the available categories, please try again later.
+                {% else %}
                 Include a category and your snap will be better ranked within the Snap Store.
                 It will also allow users to discover your snap via browsing the available categories.
+                {% endif %}
               </p>
             </div>
           </div>


### PR DESCRIPTION
## Done

Disable categories dropdown when API call fail

## Issue / Card

Fixes #2693 

## QA

- Pull the branch
- Run the site using the command `./run`
- View the site locally in your web browser at: http://0.0.0.0:8004/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Use dotrun snap to start the site.
- Edit `.venv/lib/python3.6/site-packages/canonicalwebteam/store_api/store.py`.
- Add `raise StoreApiResponseError("error", 666)` in line 181
- Go to /<snap_name>/listing/ the dropdown should be disabled and you should see a temporary error message.

## Screenshots

![Screenshot from 2020-04-27 11-30-25](https://user-images.githubusercontent.com/6353928/80362981-6f6d2400-887b-11ea-8ff3-3d1b3486e744.png)
