### PR TITLE
Add icon restriction info

### DIFF
--- a/static/js/publisher/form/icon.js
+++ b/static/js/publisher/form/icon.js
@@ -1,6 +1,7 @@
 import React, { Fragment } from "react";
 import PropTypes from "prop-types";
 
+import AccordionHelp from "./AccordionHelp";
 import FileInput from "./fileInput";
 
 class Icon extends React.Component {
@@ -80,6 +81,40 @@ class Icon extends React.Component {
     return false;
   }
 
+  renderRescrictions() {
+    return (
+      <AccordionHelp name="icon restrictions">
+        <ul>
+          <li>
+            <small>
+              Accepted image formats include: <b>PNG, JPEG & SVG files</b>
+            </small>
+          </li>
+          <li>
+            <small>
+              Min resolution: <b>40 x 40 pixels</b>
+            </small>
+          </li>
+          <li>
+            <small>
+              Max resolution: <b>512 x 512 pixels</b>
+            </small>
+          </li>
+          <li>
+            <small>
+              Aspect ratio: <b>1:1</b>
+            </small>
+          </li>
+          <li>
+            <small>
+              File size limit: <b>256kB</b>
+            </small>
+          </li>
+        </ul>
+      </AccordionHelp>
+    );
+  }
+
   render() {
     const { title, restrictions } = this.props;
     const { icon } = this.state;
@@ -114,6 +149,7 @@ class Icon extends React.Component {
             </div>
           )}
         </div>
+        {this.renderRescrictions()}
       </Fragment>
     );
   }

--- a/static/js/publisher/market/restrictions.js
+++ b/static/js/publisher/market/restrictions.js
@@ -40,7 +40,7 @@ const MEDIA_RESTRICTIONS = {
 };
 
 const ICON_RESTRICTIONS = {
-  accept: ["image/png", "image/jpeg", "image/svg"],
+  accept: ["image/png", "image/jpeg", "image/svg+xml"],
   width: {
     min: 40,
     max: 512

--- a/static/sass/_snapcraft_market.scss
+++ b/static/sass/_snapcraft_market.scss
@@ -25,7 +25,7 @@
   .p-editable-icon {
     cursor: pointer;
     display: inline-block;
-    margin-bottom: .7rem;
+    margin-bottom: 1.5rem;
     margin-right: 3.2877%;
     position: relative;
 
@@ -87,7 +87,7 @@
     display: flex;
     height: 2rem;
     justify-content: center;
-    margin-bottom: .5rem;
+    margin-bottom: 1.3rem;
     width: 2rem;
   }
 


### PR DESCRIPTION
## Done

- Add icon restriction info

## Issue / Card

Fixes #2680 

## QA

- Pull the branch
- Run the site using the command `./run`
- View the site locally in your web browser at: http://0.0.0.0:8004/<snap_name>/listing
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Note the `Show icon restrictions` button. Click on it to check the restrictions.
- Previously you were not allowed to use an SVG file to set the icon, now you can

## Screenshots

[if relevant, include a screenshot]
![image](https://user-images.githubusercontent.com/40214246/80368889-52d5e980-8885-11ea-89ab-59903108c96e.png)
