### PR TITLE
Fix button spacing on mobile

### DIFF
--- a/static/sass/_snapcraft_market.scss
+++ b/static/sass/_snapcraft_market.scss
@@ -123,7 +123,12 @@
     }
 
     [class*="p-button"]:not([class*="p-button__"]) {
+      margin-bottom: 0;
       margin-right: $sph-inner;
+
+      @media screen and (max-width: $breakpoint-x-small) {
+        margin-bottom: 1rem;
+      }
 
       &:last-child {
         margin-right: 0;

--- a/templates/publisher/listing.html
+++ b/templates/publisher/listing.html
@@ -26,12 +26,12 @@ Listing details for {% if display_title %}{{ display_title }}{% else %}{{ snap_t
         </div>
         <div class="col-5">
           <div class="u-align--right u-clearfix">
-            <button class="js-listing-preview p-button--base u-no-margin--bottom p-tooltip p-tooltip--btm-center" form="preview-form" area-describedby="preview-tooltip">
+            <button class="js-listing-preview p-button--base p-tooltip p-tooltip--btm-center" form="preview-form" area-describedby="preview-tooltip">
               Preview
               <span class="p-tooltip__message" role="tooltip" id="preview-tooltip">Previews will only work in the same browser, locally</span>
             </button>
-            <a class="p-button--neutral js-form-revert u-no-margin--bottom" href="/account/snaps/{{ snap_name }}/listing">Revert</a>
-            <button type="submit" class="p-button--positive p-button-spinner js-form-submit u-no-margin--bottom" name="submit_apply" value="Save">
+            <a class="p-button--neutral js-form-revert" href="/account/snaps/{{ snap_name }}/listing">Revert</a>
+            <button type="submit" class="p-button--positive u-no-margin--bottom p-button-spinner js-form-submit" name="submit_apply" value="Save">
               {#
               to force dark icon variant we need a fake --dark class name:
               https://github.com/vanilla-framework/vanilla-framework/issues/1817

--- a/templates/publisher/settings.html
+++ b/templates/publisher/settings.html
@@ -17,8 +17,8 @@ Settings for {% if display_title %}{{ display_title }}{% else %}{{ snap_title }}
       <div class="row">
         <div class="col-5 col-start-large-8">
           <div class="u-align--right u-clearfix">
-            <a class="p-button--neutral js-form-revert u-no-margin--bottom" href="/{{ snap_name }}/settings">Revert</a>
-            <button type="submit" class="p-button--positive p-button-spinner js-form-submit u-no-margin--bottom" name="submit_apply" value="Save">
+            <a class="p-button--neutral js-form-revert" href="/{{ snap_name }}/settings">Revert</a>
+            <button type="submit" class="p-button--positive u-no-margin--bottom p-button-spinner js-form-submit" name="submit_apply" value="Save">
               {#
               to force dark icon variant we need a fake --dark class name:
               https://github.com/vanilla-framework/vanilla-framework/issues/1817

--- a/templates/store/snap-details.html
+++ b/templates/store/snap-details.html
@@ -58,8 +58,8 @@
         </div>
         <div class="col-5 --dark">
           <div class="u-align--right u-clearfix">
-            <button class="p-button--base u-no-margin--bottom js-edit">Edit</button>
-            <button class="p-button--neutral u-no-margin--bottom js-revert" disabled="disabled">Revert</button>
+            <button class="p-button--base js-edit">Edit</button>
+            <button class="p-button--neutral js-revert" disabled="disabled">Revert</button>
             <span class="--dark">
               <button class="p-button--positive u-no-margin--bottom js-save" disabled="disabled">Save</button>
             </span>


### PR DESCRIPTION
## Done

- Fix button spacing on mobile in the sticky header on the following pages: `/<snap_name>/listing`, `/<snap_name>/settings` and `/<snap_name>/preview`

## Issue / Card

Fixes https://github.com/canonical-web-and-design/snap-squad/issues/940

## QA

- Pull the branch
- Run the site using the command `./run`
- View the site locally in your web browser at: http://0.0.0.0:8004/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Go to `/<snap_name>/listing`, `/<snap_name>/settings` and `/<snap_name>/preview`, and see on mobile layout there is space between the buttons in the sticky header

## Screenshots

[if relevant, include a screenshot]
![image](https://user-images.githubusercontent.com/40214246/80509216-036ce780-8971-11ea-8a58-b6c230c86530.png)
