### PR TITLE
Fix blog links

### DIFF
--- a/webapp/blog/views.py
+++ b/webapp/blog/views.py
@@ -59,6 +59,7 @@ def init_blog(app, url_prefix):
                 blog_articles, total_pages = wordpress_api.get_articles(
                     blog_tags["id"], 3 - len(articles)
                 )
+                snapcraft_tag = wordpress_api.get_tag_by_name(f"snapcraft.io")
             except Exception:
                 blog_articles = []
 
@@ -82,9 +83,14 @@ def init_blog(app, url_prefix):
                     article, featured_image=featured_media, author=None
                 )
 
+                url = f"/blog/{transformed_article['slug']}"
+
+                if snapcraft_tag["id"] not in transformed_article["tags"]:
+                    url = f"https://ubuntu.com{url}"
+
                 articles.append(
                     {
-                        "slug": "/blog/" + transformed_article["slug"],
+                        "slug": url,
                         "title": transformed_article["title"]["rendered"],
                         "image": transformed_article["image"],
                     }


### PR DESCRIPTION
## Done

Link articles to the ubuntu blog when they are not in the snapcraft.io blog.

## Issue / Card

Fixes #2692 

## QA

- Pull the branch
- Run the site using the command `./run`
- View the site locally in your web browser at: http://0.0.0.0:8004/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check that the first blog article in https://0.0.0.0:8004/maas is linking to ubuntu.com
- Check that other blog articles are still linking correctly to snapcraft.io like https://0.0.0.0:8004/vlc
