### PR TITLE
Show the developer for Canonical and Snapcrafters snapped snaps

### DIFF
--- a/templates/store/_snap-header-developer-information.html
+++ b/templates/store/_snap-header-developer-information.html
@@ -1,0 +1,10 @@
+{% if developer[1] %}
+<a href="{{ developer[1] }}" class="p-link--external">
+  {% endif %}
+  <span class="p-tooltip p-tooltip--top-center">
+    {{ developer[0] }}
+    <span class="p-tooltip__message">Developer</span>
+  </span>
+  {% if developer[1] %}
+</a>
+{% endif %}

--- a/templates/store/_snap-header-information.html
+++ b/templates/store/_snap-header-information.html
@@ -1,6 +1,6 @@
 {% if has_publisher_page %}
   <a href="/publisher/{{ username }}" title="View all snaps from {{ display_name(publisher, username) }}">{{ display_name(publisher, username) }}</a>
-  {% else %}
+{% else %}
   <span class="p-tooltip--top-center">
     {{ display_name(publisher, username) }}
     <span class="p-tooltip__message">Publisher</span>

--- a/templates/store/_snap-header-information.html
+++ b/templates/store/_snap-header-information.html
@@ -1,7 +1,10 @@
 {% if has_publisher_page %}
   <a href="/publisher/{{ username }}" title="View all snaps from {{ display_name(publisher, username) }}">{{ display_name(publisher, username) }}</a>
-{% else %}
-{{ display_name(publisher, username) }}
+  {% else %}
+  <span class="p-tooltip--top-center">
+    {{ display_name(publisher, username) }}
+    <span class="p-tooltip__message">Publisher</span>
+  </span>
 {% endif %}
 {% if developer_validation and developer_validation == VERIFIED_PUBLISHER %}
   <span class="p-verified p-tooltip p-tooltip--top-center" aria-describedby="{{ package_name }}-tooltip">

--- a/templates/store/snap-details/_snap_heading_data.html
+++ b/templates/store/snap-details/_snap_heading_data.html
@@ -16,9 +16,17 @@
 <div class="p-snap-heading__title">
   <h1 class="p-heading--2 p-snap-heading__name" data-live="title">{{ snap_title }}</h1>
   <div class="u-hide u-show--small">
+    {% if developer %}
+    {% include 'store/_snap-header-developer-information.html' %}
+    {% endif %}
     {% include 'store/_snap-header-information.html' %}
   </div>
   <ul class="p-inline-list--middot">
+    {% if developer %}
+      <li class="p-inline-list__item u-hide--small">
+        {% include 'store/_snap-header-developer-information.html' %}
+      </li>
+    {% endif %}
     <li class="p-inline-list__item u-hide--small">
       {% include 'store/_snap-header-information.html' %}
     </li>

--- a/webapp/blog/views.py
+++ b/webapp/blog/views.py
@@ -25,7 +25,7 @@ def init_blog(app, url_prefix):
 
         third_party_blogs = get_yaml("blog/content/blog-posts.yaml")
 
-        if snap in third_party_blogs:
+        if third_party_blogs and snap in third_party_blogs:
             post = third_party_blogs[snap]
             cdn_image = "/".join(
                 [

--- a/webapp/store/content/developers/snaps.yaml
+++ b/webapp/store/content/developers/snaps.yaml
@@ -1,0 +1,117 @@
+android-studio:
+- Android
+- https://developer.android.com/android-studio
+atom:
+- GitHub
+- https://atom.io/
+brackets:
+- Brackets
+- http://brackets.io/
+discord:
+- Discord
+- https://discordapp.com/
+eog:
+- GNOME
+- https://gnome.org/
+ffmpeg:
+- FFmpeg
+- https://www.ffmpeg.org/
+fkill:
+- Sindre Sorhus
+- https://github.com/sindresorhus/fkill
+flightgear:
+- FlightGear
+- https://www.flightgear.org/
+get-iplayer:
+- dinkypumpkin
+- https://github.com/get-iplayer/get_iplayer
+ghost-desktop:
+- ghost
+- https://ghost.org/
+gimp:
+- GIMP
+- https://gimp.org/
+gitter-desktop:
+- Gitter
+- https://gitter.im/
+gnome-calculator:
+- GNOME
+- https://gnome.org/
+gnome-calendar:
+- GNOME
+- https://gnome.org/
+gnome-characters:
+- GNOME
+- https://gnome.org/
+gnome-clocks:
+- GNOME
+- https://gnome.org/
+gnome-contacts:
+- GNOME
+- https://gnome.org/
+gnome-dictionary:
+- GNOME
+- https://gnome.org/
+gnome-sudoku:
+- GNOME
+- https://gnome.org/
+gnome-system-monitor:
+- GNOME
+- https://gnome.org/
+irssi:
+- Irssi
+- https://irssi.org/
+jenkins:
+- Jenkins
+- https://jenkins.io/
+mattermost-desktop:
+- Mattermost
+- https://mattermost.com/
+minetest:
+- Minetest
+- https://www.minetest.net/
+mumble:
+- Mumble
+- https://www.mumble.info/
+mutt:
+- Mutt
+- http://www.mutt.org/
+offlineimap:
+- OfflineIMAP
+- http://www.offlineimap.org/
+opentoonz:
+- Dwango
+- https://opentoonz.github.io/
+scummvm:
+- ScummVM
+- https://www.scummvm.org/
+sdlpop:
+- NagyD
+- https://github.com/NagyD/SDLPoP
+signal-desktop:
+- Signal
+- https://signal.org/download/
+simplenote:
+- Simplenote
+- https://simplenote.com/
+sublime-merge:
+- Sublime
+- https://www.sublimetext.com/
+sublime-text:
+- Sublime
+- https://www.sublimetext.com/
+teleconsole:
+- Gravitational
+- https://www.teleconsole.com/
+thelounge:
+- The Lounge
+- https://thelounge.chat/
+wire:
+- Wire
+- https://wire.com/
+wordpress-desktop:
+- WordPress.com
+- https://apps.wordpress.com/
+wormhole:
+- Brian Warner
+- https://github.com/warner

--- a/webapp/store/content/developers/snaps.yaml
+++ b/webapp/store/content/developers/snaps.yaml
@@ -1,3 +1,4 @@
+---
 android-studio:
 - Android
 - https://developer.android.com/android-studio
@@ -10,9 +11,6 @@ brackets:
 discord:
 - Discord
 - https://discordapp.com/
-eog:
-- GNOME
-- https://gnome.org/
 ffmpeg:
 - FFmpeg
 - https://www.ffmpeg.org/
@@ -115,3 +113,75 @@ wordpress-desktop:
 wormhole:
 - Brian Warner
 - https://github.com/warner
+eog:
+- GNOME
+- https://gnome.org/
+epiphany:
+- GNOME
+- https://gnome.org/
+evince:
+- GNOME
+- https://gnome.org/
+five-or-more:
+- GNOME
+- https://gnome.org/
+gedit:
+- GNOME
+- https://gnome.org/
+glade:
+- GNOME
+- https://gnome.org/
+gnome-2048:
+- GNOME
+- https://gnome.org/
+gnome-chess:
+- GNOME
+- https://gnome.org/
+gnome-klotski:
+- GNOME
+- https://gnome.org/
+gnome-font-viewer:
+- GNOME
+- https://gnome.org/
+gnome-logs:
+- GNOME
+- https://gnome.org/
+gnome-mahjongg:
+- GNOME
+- https://gnome.org/
+gnome-mines:
+- GNOME
+- https://gnome.org/
+gnome-nibbles:
+- GNOME
+- https://gnome.org/
+gnome-robots:
+- GNOME
+- https://gnome.org/
+gnome-recipes:
+- GNOME
+- https://gnome.org/
+gnome-taquin:
+- GNOME
+- https://gnome.org/
+gnome-tetravex:
+- GNOME
+- https://gnome.org/
+hitori:
+- GNOME
+- https://gnome.org/
+iagno:
+- GNOME
+- https://gnome.org/
+lightsoff:
+- GNOME
+- https://gnome.org/
+quadrapassel:
+- GNOME
+- https://gnome.org/
+swll-foop:
+- GNOME
+- https://gnome.org/
+tali:
+- GNOME
+- https://gnome.org/

--- a/webapp/store/logic.py
+++ b/webapp/store/logic.py
@@ -5,6 +5,7 @@ from urllib.parse import parse_qs, urlparse
 
 import humanize
 from dateutil import parser
+from webapp import helpers
 
 
 def get_n_random_snaps(snaps, choice_number):
@@ -458,3 +459,21 @@ def promote_snap_with_icon(snaps):
         snaps.insert(0, snaps.pop(snap_with_icon_index))
 
     return snaps
+
+
+def get_snap_developer(snap_name):
+    """Is this a special snap published by Canonical?
+    Show some developer information
+
+    :param snap_name: The name of a snap
+
+    :returns: a list of [display_name, url]
+
+    """
+    filename = f"store/content/developers/snaps.yaml"
+    snaps = helpers.get_yaml(filename, typ="rt")
+
+    if snaps and snap_name in snaps:
+        return snaps[snap_name]
+
+    return None

--- a/webapp/store/snap_details_views.py
+++ b/webapp/store/snap_details_views.py
@@ -143,6 +143,8 @@ def snap_details_views(store, api, handle_errors):
         # build list of categories of a snap
         categories = logic.get_snap_categories(details["snap"]["categories"])
 
+        developer = logic.get_snap_developer(details["name"])
+
         context = {
             "snap-id": details.get("snap-id"),
             # Data direct from details API
@@ -177,6 +179,7 @@ def snap_details_views(store, api, handle_errors):
             "last_updated_raw": last_updated,
             "is_users_snap": is_users_snap,
             "unlisted": details["snap"]["unlisted"],
+            "developer": developer,
         }
 
         return context


### PR DESCRIPTION
## Done

- Added the developer for certain snaps

## QA

- Pull the branch
- Run the site using the command `./run`
- View the site locally in your web browser at: http://0.0.0.0:8004/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Visit http://0.0.0.0:8004/gnome-calendar
- The header should include both the developer "Gnome" and the publisher "Canonical"