### PR TITLE
Fix formatting of snap details blog post images

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ canonicalwebteam.flask_base==0.6.0
 canonicalwebteam.discourse-docs==0.11.1
 canonicalwebteam.blog==4.0.2
 canonicalwebteam.search==0.1.0
-canonicalwebteam.image-template==1.0.0
+canonicalwebteam.image-template==1.1.0
 canonicalwebteam.store-api==2.0.1
 canonicalwebteam.launchpad==0.2.9
 django-openid-auth==0.15

--- a/static/sass/_patterns_blog-post.scss
+++ b/static/sass/_patterns_blog-post.scss
@@ -23,6 +23,7 @@
 
       img:first-of-type {
         border-radius: 0;
+        display: block;
         height: auto;
         position: relative;
         width: 100%;

--- a/webapp/blog/views.py
+++ b/webapp/blog/views.py
@@ -73,6 +73,7 @@ def init_blog(app, url_prefix):
                         alt="",
                         width="346",
                         height="231",
+                        fill=True,
                         hi_def=True,
                         loading="auto",
                     )


### PR DESCRIPTION
## Done

- Update canonicalwebteam.image-template module to 1.1.0
- Add the fill option to blog posts
- Update CSS to ensure no extra space

## QA

- Pull the branch
- Run the site using the command `./run`
- View the site locally in your web browser at: http://0.0.0.0:8004/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Visit http://0.0.0.0:8004/maas
- Wait for blog posts to load
- See that the images aren't stretched compared to https://snapcraft.io/maas