### PR TITLE
Do not open lightbox in a new window on mobile

### DIFF
--- a/static/js/public/snap-details/screenshots.js
+++ b/static/js/public/snap-details/screenshots.js
@@ -1,5 +1,4 @@
 import lightbox from "./../../publisher/market/lightbox";
-import { isMobile } from "../../libs/mobile";
 import { Swiper, Navigation } from "swiper/dist/js/swiper.esm";
 import { SCREENSHOTS_CONFIG } from "../../config/swiper.config";
 import iframeSize from "../../libs/iframeSize";
@@ -13,12 +12,7 @@ function clickCallback(event) {
   const images = filterImages();
 
   if (url) {
-    if (isMobile()) {
-      window.open(url, "_blank");
-      window.focus();
-    } else {
-      lightbox.openLightbox(url, images);
-    }
+    lightbox.openLightbox(url, images);
   }
 }
 

--- a/static/sass/_patterns_maas_modal.scss
+++ b/static/sass/_patterns_maas_modal.scss
@@ -97,7 +97,7 @@ $color-modal-controls: rgba($color-x-dark, .2);
     width: 2rem;
 
     @media screen and (max-width: $breakpoint-medium) {
-      background-position: top 20px right 20px;
+      background-position: top 1rem right 1rem;
     }
   }
 


### PR DESCRIPTION
## Done

- Fix lightbox opening in a new window on mobile

## Issue / Card

Fixes #2001 

## QA

- Pull the branch
- Run the site using the command `./run`
- View the site locally in your web browser at: http://0.0.0.0:8004/wonderwall
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- CLick on the images and see the lightbox appear. Do the same on mobile. The output should be similar. 

## Screenshots

![image](https://user-images.githubusercontent.com/40214246/80585189-c81ef700-8a0a-11ea-8777-29b9852498c2.png)

![image](https://user-images.githubusercontent.com/40214246/80585221-da009a00-8a0a-11ea-92d1-972b04b45e39.png)
