### PR TITLE
Allow users without organizations to build snaps

### DIFF
--- a/static/js/publisher/builds/components/repoConnect.js
+++ b/static/js/publisher/builds/components/repoConnect.js
@@ -367,9 +367,6 @@ RepoConnect.propTypes = {
  * @param {string} snapName
  */
 function init(selector, organizations, user, snapName) {
-  if (snapName === "openhab") {
-    console.log(selector, organizations, user, snapName);
-  }
   const el = document.querySelector(selector);
 
   // Add user login to the organization list
@@ -392,8 +389,6 @@ function init(selector, organizations, user, snapName) {
       />,
       el
     );
-  } else {
-    throw new Error(`Builds ${selector} doesn't exist`);
   }
 }
 

--- a/static/js/publisher/builds/components/repoConnect.js
+++ b/static/js/publisher/builds/components/repoConnect.js
@@ -392,6 +392,8 @@ function init(selector, organizations, user, snapName) {
       />,
       el
     );
+  } else {
+    throw new Error(`Builds ${selector} doesn't exist`);
   }
 }
 

--- a/static/js/publisher/builds/components/repoConnect.js
+++ b/static/js/publisher/builds/components/repoConnect.js
@@ -367,6 +367,9 @@ RepoConnect.propTypes = {
  * @param {string} snapName
  */
 function init(selector, organizations, user, snapName) {
+  if (snapName === "openhab") {
+    console.log(selector, organizations, user, snapName);
+  }
   const el = document.querySelector(selector);
 
   // Add user login to the organization list

--- a/templates/publisher/builds.html
+++ b/templates/publisher/builds.html
@@ -255,7 +255,7 @@ Builds for
       snapcraft.publisher.initRepoDisconnect();
       {% endif %}
 
-      {% if github_orgs and github_user %}
+      {% if github_orgs or github_user %}
         snapcraft.publisher.initRepoConnect('[data-js="repo-connect"]', {{ github_orgs | tojson }}, {{ github_user | tojson }}, {{ snap_name | tojson }});
       {% endif %}
     });

--- a/templates/publisher/builds.html
+++ b/templates/publisher/builds.html
@@ -255,7 +255,7 @@ Builds for
       snapcraft.publisher.initRepoDisconnect();
       {% endif %}
 
-      {% if github_orgs or github_user %}
+      {% if github_user %}
         snapcraft.publisher.initRepoConnect('[data-js="repo-connect"]', {{ github_orgs | tojson }}, {{ github_user | tojson }}, {{ snap_name | tojson }});
       {% endif %}
     });


### PR DESCRIPTION
## Done

- Remove check for github repos before invoking connect repo JS. This was preventing people not part of an organization from adding repos.

## QA

- Pull the branch
- Run the site using the command `./run`
- View the site locally in your web browser at: http://0.0.0.0:8004/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Create a new github user, and a repo
- Visit the build page for a snap
- You should be able to see that user and the repo in the dropdowns