### PR TITLE
Add developer info for the LibreOffice snap

### DIFF
--- a/webapp/store/content/developers/snaps.yaml
+++ b/webapp/store/content/developers/snaps.yaml
@@ -173,6 +173,9 @@ hitori:
 iagno:
 - GNOME
 - https://gnome.org/
+libreoffice:
+- The Document Foundation
+- https://www.libreoffice.org/
 lightsoff:
 - GNOME
 - https://gnome.org/


### PR DESCRIPTION
## Done

Based on the work in #2705 (nice!), I added information for the LibreOffice snap.

## Issue / Card

None

## QA

- Pull the branch
- Run the site using the command `./run`
- View the site locally in your web browser at: http://0.0.0.0:8004/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- [List additional steps to QA the new features or prove the bug has been resolved]