### PR TITLE
Allow builds from collaborators

### DIFF
--- a/static/js/publisher/builds/components/repoConnect.js
+++ b/static/js/publisher/builds/components/repoConnect.js
@@ -90,7 +90,11 @@ class RepoConnect extends React.Component {
       .then(result => {
         let newRepoList = result
           .map(el => {
-            return { value: el.name };
+            if (el.nameWithOwner.indexOf(`${user.login}/`) === 0) {
+              return { value: el.nameWithOwner.replace(`${user.login}/`, "") };
+            } else {
+              return { value: el.nameWithOwner };
+            }
           })
           .sort(this.sortByValue);
         this.setState({

--- a/static/js/publisher/builds/components/repoConnect.js
+++ b/static/js/publisher/builds/components/repoConnect.js
@@ -373,6 +373,7 @@ function init(selector, organizations, user, snapName) {
   let _organizations = organizations.map(item => {
     return { value: item.login };
   });
+
   _organizations = [
     { value: "Select organization", disabled: true },
     { value: user.login },

--- a/static/js/publisher/builds/components/repoConnect.js
+++ b/static/js/publisher/builds/components/repoConnect.js
@@ -49,6 +49,9 @@ class RepoConnect extends React.Component {
    * @returns {string}
    */
   static orgRepoString(selectedOrganization, selectedRepo) {
+    if (!selectedRepo) {
+      return selectedOrganization;
+    }
     if (selectedRepo.indexOf("/") !== -1) {
       return selectedRepo;
     }
@@ -78,8 +81,9 @@ class RepoConnect extends React.Component {
    * @param organization
    */
   handleOrganizationSelect(selectedOrganization) {
-    this.setState({ selectedOrganization: selectedOrganization }, () =>
-      this.fetchRepoList()
+    this.setState(
+      { selectedOrganization: selectedOrganization, selectedRepo: "" },
+      () => this.fetchRepoList()
     );
   }
 
@@ -111,10 +115,16 @@ class RepoConnect extends React.Component {
             // they may also have their own fork
             // so we need to differentiate, this just shows
             // the upstream org name in the repo list
-            if (el.nameWithOwner.indexOf(`${user.login}/`) === 0) {
-              return { value: el.nameWithOwner.replace(`${user.login}/`, "") };
+            if (el.nameWithOwner) {
+              if (el.nameWithOwner.indexOf(`${user.login}/`) === 0) {
+                return {
+                  value: el.nameWithOwner.replace(`${user.login}/`, "")
+                };
+              } else {
+                return { value: el.nameWithOwner };
+              }
             } else {
-              return { value: el.nameWithOwner };
+              return { value: el.name };
             }
           })
           .sort(this.sortByValue);

--- a/static/js/publisher/builds/components/repoConnect.js
+++ b/static/js/publisher/builds/components/repoConnect.js
@@ -31,13 +31,29 @@ class RepoConnect extends React.Component {
     };
 
     this.handleRepoSelect = this.handleRepoSelect.bind(this);
-    this.handleOrganiationSelect = this.handleOrganiationSelect.bind(this);
+    this.handleOrganizationSelect = this.handleOrganizationSelect.bind(this);
     this.fetchRepoList = this.fetchRepoList.bind(this);
     this.handleRefreshButtonClick = this.handleRefreshButtonClick.bind(this);
   }
 
   sortByValue(a, b) {
     return a.value.localeCompare(b.value);
+  }
+
+  /**
+   * Create a string from orgname/repo or username/orgname/repo
+   *
+   * @param {string} selectedOrganization
+   * @param {string} selectedRepo
+   *
+   * @returns {string}
+   */
+  static orgRepoString(selectedOrganization, selectedRepo) {
+    if (selectedRepo.indexOf("/") !== -1) {
+      return selectedRepo;
+    }
+
+    return `${selectedOrganization}/${selectedRepo}`;
   }
 
   /**
@@ -61,7 +77,7 @@ class RepoConnect extends React.Component {
    *
    * @param organization
    */
-  handleOrganiationSelect(selectedOrganization) {
+  handleOrganizationSelect(selectedOrganization) {
     this.setState({ selectedOrganization: selectedOrganization }, () =>
       this.fetchRepoList()
     );
@@ -90,6 +106,11 @@ class RepoConnect extends React.Component {
       .then(result => {
         let newRepoList = result
           .map(el => {
+            // a user may have access to a repo in an org
+            // but they're not part of that org
+            // they may also have their own fork
+            // so we need to differentiate, this just shows
+            // the upstream org name in the repo list
             if (el.nameWithOwner.indexOf(`${user.login}/`) === 0) {
               return { value: el.nameWithOwner.replace(`${user.login}/`, "") };
             } else {
@@ -119,7 +140,11 @@ class RepoConnect extends React.Component {
   checkRepo(selectedRepo) {
     const { snapName, repoList, selectedOrganization } = this.state;
     if (selectedRepo && repoList.some(el => el.value === selectedRepo)) {
-      const url = `/${snapName}/builds/validate-repo?repo=${selectedOrganization}/${selectedRepo}`;
+      const orgRepo = RepoConnect.orgRepoString(
+        selectedOrganization,
+        selectedRepo
+      );
+      const url = `/${snapName}/builds/validate-repo?repo=${orgRepo}`;
 
       this.setState({
         isRepoListDisabled: true,
@@ -172,6 +197,11 @@ class RepoConnect extends React.Component {
       yamlFilePath
     } = this.state;
 
+    const orgRepo = RepoConnect.orgRepoString(
+      selectedOrganization,
+      selectedRepo
+    );
+
     return (
       <div className="u-fixed-width">
         <p>
@@ -179,7 +209,7 @@ class RepoConnect extends React.Component {
           {`the snapcraft.yaml uses the snap name "${yamlSnap}", but you've registered the name "${snapName}". `}
           <a
             className="p-link--external"
-            href={`https://github.com/${selectedOrganization}/${selectedRepo}/edit/master/${yamlFilePath}`}
+            href={`https://github.com/${orgRepo}/edit/master/${yamlFilePath}`}
           >
             Update your snapcraft.yaml to continue.
           </a>
@@ -255,7 +285,11 @@ class RepoConnect extends React.Component {
 
   getTemplateUrl() {
     const { selectedOrganization, selectedRepo, snapName } = this.state;
-    return `https://github.com/${selectedOrganization}/${selectedRepo}/new/master?filename=snap%2Fsnapcraft.yaml&value=%0A%20%20%23%20After%20registering%20a%20name%20on%20build.snapcraft.io%2C%20commit%20an%20uncommented%20line%3A%0A%20%20%23%20name%3A%20${snapName}%0A%20%20version%3A%20%270.1%27%20%23%20just%20for%20humans%2C%20typically%20%271.2%2Bgit%27%20or%20%271.3.2%27%0A%20%20summary%3A%20Single-line%20elevator%20pitch%20for%20your%20amazing%20snap%20%23%2079%20char%20long%20summary%0A%20%20description%3A%20%7C%0A%20%20%20%20This%20is%20my-snap%27s%20description.%20You%20have%20a%20paragraph%20or%20two%20to%20tell%20the%0A%20%20%20%20most%20important%20story%20about%20your%20snap.%20Keep%20it%20under%20100%20words%20though%2C%0A%20%20%20%20we%20live%20in%20tweetspace%20and%20your%20description%20wants%20to%20look%20good%20in%20the%20snap%0A%20%20%20%20store.%0A%0A%20%20grade%3A%20devel%20%23%20must%20be%20%27stable%27%20to%20release%20into%20candidate%2Fstable%20channels%0A%20%20confinement%3A%20devmode%20%23%20use%20%27strict%27%20once%20you%20have%20the%20right%20plugs%20and%20slots%0A%0A%20%20parts%3A%0A%20%20%20%20my-part%3A%0A%20%20%20%20%20%20%23%20See%20%27snapcraft%20plugins%27%0A%20%20%20%20%20%20plugin%3A%20nil%0A%20%20`;
+    const orgRepo = RepoConnect.orgRepoString(
+      selectedOrganization,
+      selectedRepo
+    );
+    return `https://github.com/${orgRepo}/new/master?filename=snap%2Fsnapcraft.yaml&value=%0A%20%20%23%20After%20registering%20a%20name%20on%20build.snapcraft.io%2C%20commit%20an%20uncommented%20line%3A%0A%20%20%23%20name%3A%20${snapName}%0A%20%20version%3A%20%270.1%27%20%23%20just%20for%20humans%2C%20typically%20%271.2%2Bgit%27%20or%20%271.3.2%27%0A%20%20summary%3A%20Single-line%20elevator%20pitch%20for%20your%20amazing%20snap%20%23%2079%20char%20long%20summary%0A%20%20description%3A%20%7C%0A%20%20%20%20This%20is%20my-snap%27s%20description.%20You%20have%20a%20paragraph%20or%20two%20to%20tell%20the%0A%20%20%20%20most%20important%20story%20about%20your%20snap.%20Keep%20it%20under%20100%20words%20though%2C%0A%20%20%20%20we%20live%20in%20tweetspace%20and%20your%20description%20wants%20to%20look%20good%20in%20the%20snap%0A%20%20%20%20store.%0A%0A%20%20grade%3A%20devel%20%23%20must%20be%20%27stable%27%20to%20release%20into%20candidate%2Fstable%20channels%0A%20%20confinement%3A%20devmode%20%23%20use%20%27strict%27%20once%20you%20have%20the%20right%20plugs%20and%20slots%0A%0A%20%20parts%3A%0A%20%20%20%20my-part%3A%0A%20%20%20%20%20%20%23%20See%20%27snapcraft%20plugins%27%0A%20%20%20%20%20%20plugin%3A%20nil%0A%20%20`;
   }
 
   renderButton() {
@@ -318,6 +352,12 @@ class RepoConnect extends React.Component {
       repoList,
       status
     } = this.state;
+
+    const orgRepo = RepoConnect.orgRepoString(
+      selectedOrganization,
+      selectedRepo
+    );
+
     return (
       <Fragment>
         <div className="row">
@@ -325,12 +365,12 @@ class RepoConnect extends React.Component {
             <input
               type="hidden"
               name="github_repository"
-              value={`${selectedOrganization}/${selectedRepo}`}
+              value={`${orgRepo}`}
             />
             <Select
               options={organizations}
               selectedOption={selectedOrganization}
-              updateSelection={this.handleOrganiationSelect}
+              updateSelection={this.handleOrganizationSelect}
             />
           </div>
           <div className={`col-6 p-form-validation${this.renderIcon()}`}>

--- a/static/js/publisher/builds/index.js
+++ b/static/js/publisher/builds/index.js
@@ -18,8 +18,15 @@ class Builds extends React.Component {
       isLoading: false,
       fetchSize: 15,
       fetchStart: 0,
+      isTooSlow: false,
       builds: props.builds ? props.builds : []
     };
+
+    this.initTimer = setTimeout(() => {
+      this.setState({
+        isTooSlow: true
+      });
+    }, 35000);
 
     this.showMoreHandler = this.showMoreHandler.bind(this);
 
@@ -55,13 +62,12 @@ class Builds extends React.Component {
     fetch(url)
       .then(res => res.json())
       .then(result => {
-        const newBuilds = builds;
-
         this.setState({
           isLoading: false,
+          isTooSlow: builds.length === 0 && result.snap_builds.length === 0,
           builds: fromStart
             ? result.snap_builds
-            : newBuilds.concat(result.snap_builds)
+            : builds.slice().concat(result.snap_builds)
         });
       })
       .catch(() => {
@@ -94,7 +100,7 @@ class Builds extends React.Component {
   }
 
   render() {
-    const { builds, isLoading } = this.state;
+    const { builds, isLoading, isTooSlow } = this.state;
     const { totalBuilds, singleBuild, snapName } = this.props;
 
     const remainingBuilds = totalBuilds - builds.length;
@@ -176,6 +182,16 @@ class Builds extends React.Component {
 
     return (
       <Fragment>
+        {isTooSlow && (
+          <div className="u-fixed-width">
+            <div className="p-notification--caution">
+              <div className="p-notification__response">
+                Builds seem to be taking a while, try refreshing the page. If
+                the issue persists, try triggering a new build.
+              </div>
+            </div>
+          </div>
+        )}
         <MainTable
           headers={[
             {

--- a/templates/publisher/builds.html
+++ b/templates/publisher/builds.html
@@ -192,7 +192,7 @@ Builds for
 
   {% if github_repository %}
   <section class="p-strip is-shallow">
-    <div class="u-fixed-width">
+    <div class="u-fixed-width u-clearfix">
       <h4 class="u-float-left">Latest builds</h4>
       <form action="/{{ snap_name }}/builds/trigger-build" method="POST">
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />

--- a/webapp/api/github.py
+++ b/webapp/api/github.py
@@ -161,6 +161,7 @@ class GitHub:
                 ) {
               edges {
                 node {
+                  name
                   nameWithOwner
                 }
               }

--- a/webapp/api/github.py
+++ b/webapp/api/github.py
@@ -161,7 +161,7 @@ class GitHub:
                 ) {
               edges {
                 node {
-                  name
+                  nameWithOwner
                 }
               }
               pageInfo {

--- a/webapp/api/github.py
+++ b/webapp/api/github.py
@@ -155,7 +155,6 @@ class GitHub:
                 repositories(
                     first: 100,
                     privacy: PUBLIC,
-                    ownerAffiliations: [OWNER],
                 """
             + (f'after: "{end_cursor}"' if end_cursor else "")
             + """

--- a/webapp/publisher/snaps/build_views.py
+++ b/webapp/publisher/snaps/build_views.py
@@ -363,7 +363,7 @@ def post_snap_builds(snap_name):
             # We create the webhook if doesn't exist already in this repo
             if not hook:
                 github.create_hook(owner, repo, github_hook_url)
-        except ApiError:
+        except HTTPError:
             flask.flash(
                 "The GitHub Webhook could not be created. "
                 "Please trigger a new build manually.",
@@ -444,7 +444,7 @@ def post_disconnect_repo(snap_name):
                 github.remove_hook(
                     gh_owner, gh_repo, old_hook["id"],
                 )
-        except ApiError:
+        except HTTPError:
             pass
 
     return flask.redirect(


### PR DESCRIPTION
## Done

- Remove the requirement for a user to be the owner of a repo to add it
- Update the JS to handle this change:
  - In repo list, prefix non-user repos with the organization e.g. org/repo to differentiate between upstream and a fork

## QA

- Pull the branch
- Run the site using the command `./run`
- View the site locally in your web browser at: http://0.0.0.0:8004/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)