### PR TITLE
Remove 'key' from 'progressive' following changes in the API

### DIFF
--- a/static/js/publisher/release/actions/pendingReleases.js
+++ b/static/js/publisher/release/actions/pendingReleases.js
@@ -8,8 +8,6 @@ export const UPDATE_PROGRESSIVE_RELEASE_PERCENTAGE =
 export const PAUSE_PROGRESSIVE_RELEASE = "PAUSE_PROGRESSIVE_RELEASE";
 export const RESUME_PROGRESSIVE_RELEASE = "RESUME_PROGRESSIVE_RELEASE";
 export const CANCEL_PROGRESSIVE_RELEASE = "CANCEL_PROGRESSIVE_RELEASE";
-export const SET_TEMP_PROGRESSIVE_KEYS = "SET_TEMP_PROGRESSIVE_KEYS";
-export const REMOVE_TEMP_PROGRESSIVE_KEYS = "REMOVE_TEMP_PROGRESSIVE_KEYS";
 
 import { getPendingChannelMap, getReleases } from "../selectors";
 
@@ -41,11 +39,7 @@ export function releaseRevision(revision, channel, progressive) {
         Object.keys(pendingReleases[revision]).forEach(channel => {
           const release = pendingReleases[revision][channel];
 
-          if (
-            release.progressive &&
-            release.progressive.key === null &&
-            percentage === 100
-          ) {
+          if (release.progressive && percentage === 100) {
             percentage = release.progressive.percentage;
           }
         });
@@ -55,7 +49,6 @@ export function releaseRevision(revision, channel, progressive) {
       // of releases on release. In actions/releases.js the key is either
       // updated, or the progressive object is removed completely
       progressive = {
-        key: null,
         percentage: percentage,
         paused: false
       };
@@ -73,59 +66,42 @@ export function releaseRevision(revision, channel, progressive) {
   };
 }
 
-export function setProgressiveReleasePercentage(key, percentage) {
+export function setProgressiveReleasePercentage(percentage) {
   return {
     type: SET_PROGRESSIVE_RELEASE_PERCENTAGE,
     payload: {
-      key,
       percentage
     }
   };
 }
 
-export function updateProgressiveReleasePercentage(key, percentage) {
+export function updateProgressiveReleasePercentage(percentage) {
   return {
     type: UPDATE_PROGRESSIVE_RELEASE_PERCENTAGE,
     payload: {
-      key,
       percentage
     }
   };
 }
 
-export function pauseProgressiveRelease(key) {
+export function pauseProgressiveRelease() {
   return {
-    type: PAUSE_PROGRESSIVE_RELEASE,
-    payload: key
+    type: PAUSE_PROGRESSIVE_RELEASE
   };
 }
 
-export function resumeProgressiveRelease(key) {
+export function resumeProgressiveRelease() {
   return {
-    type: RESUME_PROGRESSIVE_RELEASE,
-    payload: key
+    type: RESUME_PROGRESSIVE_RELEASE
   };
 }
 
-export function cancelProgressiveRelease(key, previousRevision) {
+export function cancelProgressiveRelease(previousRevision) {
   return {
     type: CANCEL_PROGRESSIVE_RELEASE,
     payload: {
-      key,
       previousRevision
     }
-  };
-}
-
-export function setTemporaryProgressiveReleaseKeys() {
-  return {
-    type: SET_TEMP_PROGRESSIVE_KEYS
-  };
-}
-
-export function removeTemporaryProgressiveReleaseKeys() {
-  return {
-    type: REMOVE_TEMP_PROGRESSIVE_KEYS
   };
 }
 

--- a/static/js/publisher/release/actions/pendingReleases.test.js
+++ b/static/js/publisher/release/actions/pendingReleases.test.js
@@ -16,8 +16,6 @@ import {
   PAUSE_PROGRESSIVE_RELEASE,
   RESUME_PROGRESSIVE_RELEASE,
   CANCEL_PROGRESSIVE_RELEASE,
-  SET_TEMP_PROGRESSIVE_KEYS,
-  REMOVE_TEMP_PROGRESSIVE_KEYS,
   releaseRevision,
   promoteRevision,
   promoteChannel,
@@ -27,9 +25,7 @@ import {
   updateProgressiveReleasePercentage,
   pauseProgressiveRelease,
   resumeProgressiveRelease,
-  cancelProgressiveRelease,
-  setTemporaryProgressiveReleaseKeys,
-  removeTemporaryProgressiveReleaseKeys
+  cancelProgressiveRelease
 } from "./pendingReleases";
 
 describe("pendingReleases actions", () => {
@@ -97,7 +93,6 @@ describe("pendingReleases actions", () => {
       expect(
         store.dispatch(releaseRevision(revision, channel)).payload.progressive
       ).toEqual({
-        key: null,
         percentage: 100,
         paused: false
       });
@@ -299,79 +294,50 @@ describe("pendingReleases actions", () => {
   });
 
   describe("setProgressiveReleasePercentage", () => {
-    const key = "progressive-test";
     const percentage = 42;
 
     it("should create an action to set release progressive percentage", () => {
-      expect(setProgressiveReleasePercentage(key, percentage).type).toBe(
+      expect(setProgressiveReleasePercentage(percentage).type).toBe(
         SET_PROGRESSIVE_RELEASE_PERCENTAGE
       );
     });
 
-    it("should supply a payload with key", () => {
-      expect(
-        setProgressiveReleasePercentage(key, percentage).payload.key
-      ).toEqual(key);
-    });
-
     it("should supply a payload with percentage", () => {
       expect(
-        setProgressiveReleasePercentage(key, percentage).payload.percentage
+        setProgressiveReleasePercentage(percentage).payload.percentage
       ).toEqual(percentage);
     });
   });
 
   describe("updateProgressiveReleasePercentage", () => {
-    const key = "progressive-test";
     const percentage = 50;
 
     it("should create an action to update release percentage", () => {
-      expect(updateProgressiveReleasePercentage(key, percentage).type).toBe(
+      expect(updateProgressiveReleasePercentage(percentage).type).toBe(
         UPDATE_PROGRESSIVE_RELEASE_PERCENTAGE
       );
     });
 
-    it("should supply a payload with key", () => {
-      expect(
-        updateProgressiveReleasePercentage(key, percentage).payload.key
-      ).toEqual(key);
-    });
-
     it("should supply a payload with percentage", () => {
       expect(
-        updateProgressiveReleasePercentage(key, percentage).payload.percentage
+        updateProgressiveReleasePercentage(percentage).payload.percentage
       ).toEqual(percentage);
     });
   });
 
   describe("pauseProgressiveRelease", () => {
-    const key = "progressive-test";
-
     it("should create an action to pause a release", () => {
-      expect(pauseProgressiveRelease(key).type).toBe(PAUSE_PROGRESSIVE_RELEASE);
-    });
-
-    it("should supply a key as the payload", () => {
-      expect(pauseProgressiveRelease(key).payload).toBe(key);
+      expect(pauseProgressiveRelease().type).toBe(PAUSE_PROGRESSIVE_RELEASE);
     });
   });
 
   describe("resumeProgressiverelease", () => {
-    const key = "progressive-test";
-
     it("should create an action to resume a release", () => {
-      expect(resumeProgressiveRelease(key).type).toBe(
-        RESUME_PROGRESSIVE_RELEASE
-      );
-    });
-
-    it("should supply a key as the payload", () => {
-      expect(resumeProgressiveRelease(key).payload).toBe(key);
+      expect(resumeProgressiveRelease().type).toBe(RESUME_PROGRESSIVE_RELEASE);
     });
   });
 
   describe("cancelProgressiverelease", () => {
-    const key = "progressive-test";
     const previousRevision = {
       architectures: ["amd64"],
       attributes: {},
@@ -390,37 +356,15 @@ describe("pendingReleases actions", () => {
     };
 
     it("should create an action to cancel a release", () => {
-      expect(cancelProgressiveRelease(key, previousRevision).type).toBe(
+      expect(cancelProgressiveRelease(previousRevision).type).toBe(
         CANCEL_PROGRESSIVE_RELEASE
-      );
-    });
-
-    it("should supply a key in the payload", () => {
-      expect(cancelProgressiveRelease(key, previousRevision).payload.key).toBe(
-        key
       );
     });
 
     it("should supply a revision in the payload", () => {
       expect(
-        cancelProgressiveRelease(key, previousRevision).payload.previousRevision
+        cancelProgressiveRelease(previousRevision).payload.previousRevision
       ).toBe(previousRevision);
-    });
-  });
-
-  describe("setTemporaryprogressivereleasekeys", () => {
-    it("should create an action to set temporary progressive release keys", () => {
-      expect(setTemporaryProgressiveReleaseKeys().type).toBe(
-        SET_TEMP_PROGRESSIVE_KEYS
-      );
-    });
-  });
-
-  describe("removeTemporaryprogressivereleasekeys", () => {
-    it("should create an action to remove temporary progressive release keys", () => {
-      expect(removeTemporaryProgressiveReleaseKeys().type).toBe(
-        REMOVE_TEMP_PROGRESSIVE_KEYS
-      );
     });
   });
 });

--- a/static/js/publisher/release/actions/releases.js
+++ b/static/js/publisher/release/actions/releases.js
@@ -1,7 +1,6 @@
 import {
   RISKS_WITH_AVAILABLE as RISKS,
-  DEFAULT_ERROR_MESSAGE as ERROR_MESSAGE,
-  TEMP_KEY
+  DEFAULT_ERROR_MESSAGE as ERROR_MESSAGE
 } from "../constants";
 
 import { hideNotification, showNotification } from "./globalNotification";
@@ -119,7 +118,6 @@ export function handleReleaseResponse(
 }
 
 export function releaseRevisions() {
-  const progressiveKey = `ui-progressive-release-${new Date().getTime()}`;
   const mapToRelease = pendingRelease => {
     let progressive = null;
 
@@ -128,10 +126,6 @@ export function releaseRevisions() {
       pendingRelease.progressive.percentage < 100
     ) {
       progressive = pendingRelease.progressive;
-
-      if (progressive.key === null || progressive.key.indexOf(TEMP_KEY) === 0) {
-        progressive.key = progressiveKey;
-      }
     }
 
     return {

--- a/static/js/publisher/release/components/releasesConfirm.js
+++ b/static/js/publisher/release/components/releasesConfirm.js
@@ -39,12 +39,7 @@ class ReleasesConfirm extends Component {
     });
 
     if (this.state.percentage && +this.state.percentage !== 100) {
-      const timestamp = new Date().getTime();
-
-      this.props.setProgressiveReleasePercentage(
-        `progressive-release-${timestamp}`,
-        +this.state.percentage
-      );
+      this.props.setProgressiveReleasePercentage(+this.state.percentage);
     }
 
     this.props.releaseRevisions().then(() => {
@@ -152,8 +147,8 @@ const mapDispatchToProps = dispatch => {
   return {
     releaseRevisions: () => dispatch(releaseRevisions()),
     cancelPendingReleases: () => dispatch(cancelPendingReleases()),
-    setProgressiveReleasePercentage: (key, percentage) =>
-      dispatch(setProgressiveReleasePercentage(key, percentage)),
+    setProgressiveReleasePercentage: percentage =>
+      dispatch(setProgressiveReleasePercentage(percentage)),
     triggerGAEvent: (...eventProps) => dispatch(triggerGAEvent(...eventProps))
   };
 };

--- a/static/js/publisher/release/components/releasesConfirmDetails/index.js
+++ b/static/js/publisher/release/components/releasesConfirmDetails/index.js
@@ -2,11 +2,7 @@ import React, { useState } from "react";
 import { connect } from "react-redux";
 import PropTypes from "prop-types";
 
-import {
-  updateProgressiveReleasePercentage,
-  setTemporaryProgressiveReleaseKeys,
-  removeTemporaryProgressiveReleaseKeys
-} from "../../actions/pendingReleases";
+import { updateProgressiveReleasePercentage } from "../../actions/pendingReleases";
 import { isProgressiveReleaseEnabled } from "../../selectors";
 
 import progressiveTypes from "./types";
@@ -19,9 +15,7 @@ import CloseChannelsRow from "./closeChannelsRow";
 const ReleasesConfirmDetails = ({
   updates,
   isProgressiveReleaseEnabled,
-  updateProgressiveReleasePercentage,
-  setTemporaryProgressiveReleaseKeys,
-  removeTemporaryProgressiveReleaseKeys
+  updateProgressiveReleasePercentage
 }) => {
   const [useGlobal, setGlobal] = useState(true);
   const [globalPercentage, setGlobalPercentage] = useState(100);
@@ -45,16 +39,11 @@ const ReleasesConfirmDetails = ({
   const toggleGlobal = () => {
     const newUseGlobal = !useGlobal;
     setGlobal(newUseGlobal);
-    if (!newUseGlobal) {
-      setTemporaryProgressiveReleaseKeys();
-    } else {
-      removeTemporaryProgressiveReleaseKeys();
-    }
   };
 
   const updatePercentage = percentage => {
     setGlobalPercentage(percentage);
-    updateProgressiveReleasePercentage(null, percentage);
+    updateProgressiveReleasePercentage(percentage);
   };
 
   return (
@@ -111,9 +100,7 @@ const ReleasesConfirmDetails = ({
 ReleasesConfirmDetails.propTypes = {
   updates: PropTypes.object.isRequired,
   isProgressiveReleaseEnabled: PropTypes.bool,
-  updateProgressiveReleasePercentage: PropTypes.func,
-  setTemporaryProgressiveReleaseKeys: PropTypes.func,
-  removeTemporaryProgressiveReleaseKeys: PropTypes.func
+  updateProgressiveReleasePercentage: PropTypes.func
 };
 
 const mapStateToProps = state => ({
@@ -122,12 +109,8 @@ const mapStateToProps = state => ({
 
 const mapDispatchToProps = dispatch => {
   return {
-    updateProgressiveReleasePercentage: (key, percentage) =>
-      dispatch(updateProgressiveReleasePercentage(key, percentage)),
-    setTemporaryProgressiveReleaseKeys: () =>
-      dispatch(setTemporaryProgressiveReleaseKeys()),
-    removeTemporaryProgressiveReleaseKeys: () =>
-      dispatch(removeTemporaryProgressiveReleaseKeys())
+    updateProgressiveReleasePercentage: percentage =>
+      dispatch(updateProgressiveReleasePercentage(percentage))
   };
 };
 

--- a/static/js/publisher/release/components/releasesConfirmDetails/progressiveRow.js
+++ b/static/js/publisher/release/components/releasesConfirmDetails/progressiveRow.js
@@ -19,14 +19,13 @@ class ProgressiveRow extends React.Component {
   onChangeHandler(percentage) {
     const {
       updateProgressiveReleasePercentage,
-      updateGlobalPercentage,
-      release
+      updateGlobalPercentage
     } = this.props;
 
     if (updateGlobalPercentage) {
       updateGlobalPercentage(percentage);
     }
-    updateProgressiveReleasePercentage(release.progressive.key, percentage);
+    updateProgressiveReleasePercentage(percentage);
   }
 
   render() {
@@ -146,8 +145,8 @@ ProgressiveRow.propTypes = {
 
 const mapDispatchToProps = dispatch => {
   return {
-    updateProgressiveReleasePercentage: (key, percentage) =>
-      dispatch(updateProgressiveReleasePercentage(key, percentage))
+    updateProgressiveReleasePercentage: percentage =>
+      dispatch(updateProgressiveReleasePercentage(percentage))
   };
 };
 

--- a/static/js/publisher/release/components/revisionsListRowProgressive.js
+++ b/static/js/publisher/release/components/revisionsListRowProgressive.js
@@ -52,19 +52,19 @@ const RevisionsListRowProgressive = ({
     if (!pendingProgressiveState) {
       releaseRevision(revision, channel, progressiveState);
     }
-    pauseProgressiveRelease(progressiveState.key);
+    pauseProgressiveRelease();
   };
 
   const handleResumeProgressiveRelease = () => {
     if (!pendingProgressiveState) {
       releaseRevision(revision, channel, progressiveState);
     }
-    resumeProgressiveRelease(progressiveState.key);
+    resumeProgressiveRelease();
   };
 
   const handleCancelProgressiveRelease = () => {
     releaseRevision(revision, channel, progressiveState);
-    cancelProgressiveRelease(progressiveState.key, previousRevision);
+    cancelProgressiveRelease(previousRevision);
     setDraggable(false);
   };
 
@@ -72,7 +72,7 @@ const RevisionsListRowProgressive = ({
     if (!pendingProgressiveState) {
       releaseRevision(revision, channel, progressiveState);
     }
-    updateProgressiveReleasePercentage(progressiveState.key, percentage);
+    updateProgressiveReleasePercentage(percentage);
   };
 
   if (progressiveState) {
@@ -186,12 +186,12 @@ const mapDispatchToProps = dispatch => {
   return {
     releaseRevision: (revision, channel, progressive) =>
       dispatch(releaseRevision(revision, channel, progressive)),
-    updateProgressiveReleasePercentage: (key, percentage) =>
-      dispatch(updateProgressiveReleasePercentage(key, percentage)),
-    pauseProgressiveRelease: key => dispatch(pauseProgressiveRelease(key)),
-    resumeProgressiveRelease: key => dispatch(resumeProgressiveRelease(key)),
-    cancelProgressiveRelease: (key, previousRevision) =>
-      dispatch(cancelProgressiveRelease(key, previousRevision))
+    updateProgressiveReleasePercentage: percentage =>
+      dispatch(updateProgressiveReleasePercentage(percentage)),
+    pauseProgressiveRelease: () => dispatch(pauseProgressiveRelease()),
+    resumeProgressiveRelease: () => dispatch(resumeProgressiveRelease()),
+    cancelProgressiveRelease: previousRevision =>
+      dispatch(cancelProgressiveRelease(previousRevision))
   };
 };
 

--- a/static/js/publisher/release/constants.js
+++ b/static/js/publisher/release/constants.js
@@ -19,8 +19,6 @@ const AVAILABLE_REVISIONS_SELECT_LAUNCHPAD =
 const DEFAULT_ERROR_MESSAGE =
   "There was an error while processing your request, please try again later.";
 
-const TEMP_KEY = "ui-temp-";
-
 const REVISION_STATUS = {
   PUBLISHED: "Published",
   UNPUBLISHED: "Unpublished",
@@ -44,6 +42,5 @@ export {
   BUILD,
   RISKS,
   RISKS_WITH_AVAILABLE,
-  TEMP_KEY,
   REVISION_STATUS
 };

--- a/static/js/publisher/release/reducers/pendingReleases.test.js
+++ b/static/js/publisher/release/reducers/pendingReleases.test.js
@@ -7,9 +7,7 @@ import {
   UPDATE_PROGRESSIVE_RELEASE_PERCENTAGE,
   PAUSE_PROGRESSIVE_RELEASE,
   RESUME_PROGRESSIVE_RELEASE,
-  CANCEL_PROGRESSIVE_RELEASE,
-  SET_TEMP_PROGRESSIVE_KEYS,
-  REMOVE_TEMP_PROGRESSIVE_KEYS
+  CANCEL_PROGRESSIVE_RELEASE
 } from "../actions/pendingReleases";
 import { CLOSE_CHANNEL } from "../actions/pendingCloses";
 
@@ -206,7 +204,6 @@ describe("pendingReleases", () => {
           revision: { revision: 1, architectures: ["abc42", "test64"] },
           channel: "test/edge",
           progressive: {
-            key: "progressive-test",
             percentage: 10,
             paused: false
           }
@@ -296,7 +293,6 @@ describe("pendingReleases", () => {
             revision: { revision: 1, architectures: ["amd64"] },
             channel: "latest/stable",
             progressive: {
-              key: "progressive-test",
               percentage: 10,
               paused: false
             }
@@ -371,7 +367,6 @@ describe("pendingReleases", () => {
             revision: { revision: 1, architectures: ["amd64"] },
             channel: "latest/stable",
             progressive: {
-              key: "progressive-test",
               percentage: 10,
               paused: true
             }
@@ -589,7 +584,6 @@ describe("pendingReleases", () => {
     let setProgressiveAction = {
       type: SET_PROGRESSIVE_RELEASE_PERCENTAGE,
       payload: {
-        key: "progressive-test",
         percentage: 50
       }
     };
@@ -667,7 +661,6 @@ describe("pendingReleases", () => {
             revision: { revision: 1, architectures: ["abc42", "test64"] },
             channel: "test/edge",
             progressive: {
-              key: "progressive-test",
               percentage: 20,
               paused: false
             }
@@ -690,7 +683,6 @@ describe("pendingReleases", () => {
     let updateProgressiveAction = {
       type: UPDATE_PROGRESSIVE_RELEASE_PERCENTAGE,
       payload: {
-        key: "progressive-test",
         percentage: 50
       }
     };
@@ -732,7 +724,6 @@ describe("pendingReleases", () => {
             revision: { revision: 1, architectures: ["abc42", "test64"] },
             channel: "test/edge",
             progressive: {
-              key: "progressive-test",
               percentage: 20,
               paused: false
             }
@@ -743,7 +734,6 @@ describe("pendingReleases", () => {
             revision: { revision: 2, architectures: ["abc42", "test64"] },
             channel: "test/edge",
             progressive: {
-              key: "progressive-other",
               percentage: 20,
               paused: true
             },
@@ -768,15 +758,6 @@ describe("pendingReleases", () => {
           }
         });
       });
-
-      it("should not update progressive releases with different key", () => {
-        const result = pendingReleases(
-          stateWithProgressiveReleases,
-          updateProgressiveAction
-        );
-
-        expect(result[2]).toEqual(stateWithProgressiveReleases[2]);
-      });
     });
   });
 
@@ -784,7 +765,6 @@ describe("pendingReleases", () => {
     const cancelProgressiveReleaseAction = {
       type: CANCEL_PROGRESSIVE_RELEASE,
       payload: {
-        key: "progressive-test",
         previousRevision: {
           architectures: ["amd64"],
           revision: 2
@@ -832,7 +812,6 @@ describe("pendingReleases", () => {
             revision: { revision: 1, architectures: ["amd64"] },
             channel: "latest/stable",
             progressive: {
-              key: "progressive-test",
               percentage: 10,
               paused: true
             }
@@ -868,7 +847,6 @@ describe("pendingReleases", () => {
             revision: { revision: 1, architectures: ["amd64"] },
             channel: "latest/stable",
             progressive: {
-              key: "progressive-test",
               percentage: 10,
               paused: false
             }
@@ -877,7 +855,6 @@ describe("pendingReleases", () => {
             revision: { revision: 1, architectures: ["amd64"] },
             channel: "latest/candidate",
             progressive: {
-              key: "progressive-test",
               percentage: 10,
               paused: false
             }
@@ -905,68 +882,6 @@ describe("pendingReleases", () => {
             }
           }
         });
-      });
-    });
-  });
-
-  describe("temp state", () => {
-    const stateWithoutTemp = {
-      "1": {
-        "latest/edge": {
-          progressive: {
-            key: null
-          }
-        },
-        "latest/candidate": {
-          progressive: {
-            key: null
-          }
-        },
-        "latest/stable": {
-          progressive: {
-            key: "progressive-test"
-          }
-        }
-      }
-    };
-
-    const stateWithTemp = {
-      "1": {
-        "latest/edge": {
-          progressive: {
-            key: "ui-temp-0"
-          }
-        },
-        "latest/candidate": {
-          progressive: {
-            key: "ui-temp-1"
-          }
-        },
-        "latest/stable": {
-          progressive: {
-            key: "progressive-test"
-          }
-        }
-      }
-    };
-
-    describe("on SET_TEMP_PROGRESSIVE_KEYS", () => {
-      it("should set a temporary key on any pendingReleases with a null key", () => {
-        const result = pendingReleases(stateWithoutTemp, {
-          type: SET_TEMP_PROGRESSIVE_KEYS
-        });
-
-        expect(result).toEqual(stateWithTemp);
-      });
-    });
-
-    describe("on REMOVE_TEMP_PROGRESSIVE_KEYS", () => {
-      it("should remove the temporary key for any pendingReleases", () => {
-        const result = pendingReleases(stateWithTemp, {
-          type: REMOVE_TEMP_PROGRESSIVE_KEYS
-        });
-
-        expect(result).toEqual(stateWithoutTemp);
       });
     });
   });

--- a/static/js/publisher/release/selectors/index.js
+++ b/static/js/publisher/release/selectors/index.js
@@ -298,12 +298,7 @@ export function getProgressiveState(state, channel, arch, isPending) {
   if (release && release.revision) {
     // If the release is pending we don't want to look up the previous state, as it will be
     // for an outdated release
-    if (
-      !isPending &&
-      release &&
-      release.progressive &&
-      release.progressive.key
-    ) {
+    if (!isPending && release && release.progressive) {
       progressiveStatus = jsonClone(release.progressive);
 
       previousRevision = allReleases[1];


### PR DESCRIPTION
## Done

- Removed references to the "key" for progressive releases
- **THIS BREAKS THE UNRELEASED PROGRESSIVE RELEASES FEATURE**

## QA

- Pull the branch
- Run the site using the command `./run`
- View the site locally in your web browser at: http://0.0.0.0:8004/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- The main QA steps are to ensure the Releases UI works as before/ expected - **without** the progressive releases feature enabled.