### PR TITLE
Fixes #2720: Hiding "Raspberry Pi" from installation instruction

### DIFF
--- a/templates/store/snap-details/_distro-instructions-for-snap-support.html
+++ b/templates/store/snap-details/_distro-instructions-for-snap-support.html
@@ -129,6 +129,7 @@
         </span>
       </a>
     </div>
+    {% if ("arm64" in channel_map) or ("armhf" in channel_map) %}
     <div class="col-3 col-medium-3">
       <a class="p-media-object" href="/install/{{package_name}}/raspbian">
         <span class="p-media-object__image">
@@ -139,5 +140,6 @@
         </span>
       </a>
     </div>
+    {% endif %}
   </div>
 </div>


### PR DESCRIPTION
## Done

- Hiding "Raspberry Pi" from installation instruction  section of snap details page, if "armhf" or "arm64" builds are not available for that snap.

## Issue / Card

Fixes #2720

## QA

- Pull the branch
- Run the site using the command `./run`
- View the site locally in your web browser at: http://0.0.0.0:8004/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Navigate to: http://0.0.0.0:8004/accountable2you. Raspberry Pi should not be listed as an option.
- Navigate to: http://0.0.0.0:8004/plexmediaserver. Raspberry Pi should be listed as an option.

## Screenshots
![Screenshot from 2020-05-06 14-03-57](https://user-images.githubusercontent.com/12175980/81155480-9f66a680-8fa2-11ea-915f-88ffa8cd1e24.png)
