### PR TITLE
Remove button spinner on repo disconnect

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build-js": "yarn run copy-3rd-party-js && yarn run build-js-bundle",
     "copy-3rd-party-js": "mkdir -p static/js/modules && cp node_modules/d3/build/d3.min.js static/js/modules && cp node_modules/clipboard/dist/clipboard.min.js static/js/modules && cp node_modules/raven-js/dist/raven.min.js static/js/modules",
     "build-js-bundle": "webpack",
-    "serve": "./entrypoint $(hostname -I | awk '{print $1;}'):${PORT}",
+    "serve": "./entrypoint 0.0.0.0:${PORT}",
     "start": "yarn run build && concurrently --raw 'yarn run watch-scss' 'yarn run watch-js' 'yarn run serve'",
     "watch": "watch -p 'static/sass/**/*.scss' -p 'static/js/**/*.js' -c 'yarn run build'",
     "watch-scss": "watch -p 'static/sass/**/*.scss' -c 'yarn run build-css'",

--- a/static/js/publisher/builds/repoDisconnect.js
+++ b/static/js/publisher/builds/repoDisconnect.js
@@ -38,10 +38,7 @@ function initRepoDisconnect() {
       });
     });
 
-    repoDisconnectConfirm.addEventListener("click", () => {
-      setTimeout(() => {
-        repoDisconnectConfirm.classList.add("has-spinner");
-      }, 400);
+    repoDisconnectForm.addEventListener("submit", () => {
       repoDisconnectConfirm.disabled = true;
     });
   }


### PR DESCRIPTION
## Done

- Remove button spinner from repo disconnect button

## Issue / Card

Fixes #2719 

## QA

- Pull the branch
- Run the site using the command `./run`
- View the site locally in your web browser at: http://0.0.0.0:8004/<snap_name>/builds
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Go to a snap that has a repo connected and click `disconnect repo` link and then `Confirm` button. See the button is disabled once clicked and repo is disconnected.

## Screenshots

[if relevant, include a screenshot]