### PR TITLE
Handle no repos

### DIFF
--- a/static/js/publisher/builds/components/repoConnect.js
+++ b/static/js/publisher/builds/components/repoConnect.js
@@ -11,6 +11,7 @@ const ERROR = "ERROR";
 const SNAP_NAME_DOES_NOT_MATCH = "SNAP_NAME_DOES_NOT_MATCH";
 const MISSING_YAML_FILE = "MISSING_YAML_FILE";
 const SUCCESS = "SUCCESS";
+const NO_REPOS = "NO_REPOS";
 
 class RepoConnect extends React.Component {
   constructor(props) {
@@ -137,7 +138,8 @@ class RepoConnect extends React.Component {
       .catch(() => {
         this.setState({
           isRepoListDisabled: false,
-          status: ERROR
+          status: ERROR,
+          error: { type: NO_REPOS }
         });
       });
   }
@@ -255,6 +257,28 @@ class RepoConnect extends React.Component {
     );
   }
 
+  renderNoReposError() {
+    const { selectedOrganization } = this.state;
+    return (
+      <div className="u-fixed-width">
+        <p>
+          <strong>Can’t list repos: </strong>
+          We were not able to find or access any repos in {selectedOrganization}
+          . If you are an admin of the organization please check the{" "}
+          <a
+            href={`https://github.com/orgs/${selectedOrganization}/policies/applications/1231227`}
+            className="p-link-external"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            application access policy
+          </a>{" "}
+          for Snapcraft .
+        </p>
+      </div>
+    );
+  }
+
   renderError() {
     const { snapName, error } = this.state;
 
@@ -283,11 +307,16 @@ class RepoConnect extends React.Component {
 
   renderErrorMessage() {
     const { error } = this.state;
+    if (!error) {
+      return this.renderError();
+    }
     switch (error.type) {
       case SNAP_NAME_DOES_NOT_MATCH:
         return this.renderNameError();
       case MISSING_YAML_FILE:
         return this.renderMissingYamlError();
+      case NO_REPOS:
+        return this.renderNoReposError();
       default:
         return this.renderError();
     }

--- a/tests/api/test_github.py
+++ b/tests/api/test_github.py
@@ -2,6 +2,7 @@ from os import getenv
 from vcr_unittest import VCRTestCase
 from webapp.api.github import GitHub
 from werkzeug.exceptions import Unauthorized
+from requests.exceptions import HTTPError
 
 
 class GitHubTest(VCRTestCase):
@@ -55,10 +56,13 @@ class GitHubTest(VCRTestCase):
         self.assertEqual(True, case1)
 
         # The user doesn't have permissions for this repo
-        case2 = self.client.check_permissions_over_repo(
-            "canonical-web-and-design", "snapcraft.io", ["write"]
+        self.assertRaises(
+            HTTPError,
+            self.client.check_permissions_over_repo,
+            "canonical-web-and-design",
+            "snapcraft.io",
+            ["write"],
         )
-        self.assertEqual(False, case2)
 
     def test_get_snapcraft_yaml_location(self):
         # /snapcraft.yaml is present

--- a/webapp/api/github.py
+++ b/webapp/api/github.py
@@ -215,21 +215,18 @@ class GitHub:
           }
         }"""
         )
-        repositories = []
-        try:
-            response = self._gql_request(gql)["viewer"]["organization"][
-                "repositories"
-            ]
-            page_info = response["pageInfo"]
-            repositories = self._get_nodes(response["edges"])
+        response = self._gql_request(gql)["viewer"]["organization"][
+            "repositories"
+        ]
 
-            if page_info["hasNextPage"]:
-                next_page = self.get_org_repositories(
-                    org_login, page_info["endCursor"]
-                )
-                repositories.extend(next_page)
-        except Exception as e:
-            raise Exception(e)
+        page_info = response["pageInfo"]
+        repositories = self._get_nodes(response["edges"])
+
+        if page_info["hasNextPage"]:
+            next_page = self.get_org_repositories(
+                org_login, page_info["endCursor"]
+            )
+            repositories.extend(next_page)
 
         return repositories
 

--- a/webapp/api/github.py
+++ b/webapp/api/github.py
@@ -215,17 +215,21 @@ class GitHub:
           }
         }"""
         )
-        response = self._gql_request(gql)["viewer"]["organization"][
-            "repositories"
-        ]
-        page_info = response["pageInfo"]
-        repositories = self._get_nodes(response["edges"])
+        repositories = []
+        try:
+            response = self._gql_request(gql)["viewer"]["organization"][
+                "repositories"
+            ]
+            page_info = response["pageInfo"]
+            repositories = self._get_nodes(response["edges"])
 
-        if page_info["hasNextPage"]:
-            next_page = self.get_org_repositories(
-                org_login, page_info["endCursor"]
-            )
-            repositories.extend(next_page)
+            if page_info["hasNextPage"]:
+                next_page = self.get_org_repositories(
+                    org_login, page_info["endCursor"]
+                )
+                repositories.extend(next_page)
+        except Exception as e:
+            raise Exception(e)
 
         return repositories
 

--- a/webapp/api/github.py
+++ b/webapp/api/github.py
@@ -239,7 +239,7 @@ class GitHub:
         response = self._request(
             "GET",
             f"repos/{owner}/{repo}/collaborators/{username}/permission",
-            raise_exceptions=False,
+            raise_exceptions=True,
         )
         return response.json().get("permission") in permissions
 


### PR DESCRIPTION
## Done

- Added specific error when repo's can't be found
- Updated error rendering method to show generic error if no "type" is defined.

## Issue / Card

Fixes #2742 

## QA

- Pull the branch
- In `/webapp/api/github.py:219` replace `"repositories"` with `"test"]["test"`
- Run the site using the command `./run`
- View the site locally in your web browser at: http://0.0.0.0:8004/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Visit the build page for a snap that isn't connected to a github repo
- Select an organization
- You should see an error with a link to github

## Screenshots

![image](https://user-images.githubusercontent.com/479384/81811250-3f30b100-951c-11ea-920f-17419d88a1eb.png)
