### PR TITLE
Don't show distro pages for non rpi snaps

### DIFF
--- a/webapp/store/snap_details_views.py
+++ b/webapp/store/snap_details_views.py
@@ -402,6 +402,14 @@ def snap_details_views(store, api, handle_errors):
             flask.abort(404)
 
         context = _get_context_snap_details(snap_name)
+
+        if distro == "raspbian":
+            if (
+                "armhf" not in context["channel_map"]
+                and "arm64" not in context["channel_map"]
+            ):
+                return flask.render_template("404.html"), 404
+
         context.update(
             {
                 "distro": distro,


### PR DESCRIPTION
## Done

- For raspbian - 404 the install page if the snap isn't available for armhf or arm64

## Issue / Card

Fixes #2753 

## QA

- Pull the branch
- Run the site using the command `./run`
- View the site locally in your web browser at: http://0.0.0.0:8004/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Visit https://snapcraft.io/install/rpi-imager/raspbian - 200, see the page
- Visit https://snapcraft.io/install/skype/raspbian - 404, don't see the page