### PR TITLE
Update Vanilla to 2.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "swiper": "^4.4.1",
     "topojson-client": "^3.0.0",
     "uglifyjs-webpack-plugin": "^2.0.1",
-    "vanilla-framework": "^2.10.0",
+    "vanilla-framework": "^2.11.0",
     "watch-cli": "^0.2.2",
     "webpack": "^4.22.0",
     "webpack-cli": "^3.1.2",

--- a/static/sass/_patterns_form-multiselect.scss
+++ b/static/sass/_patterns_form-multiselect.scss
@@ -14,9 +14,8 @@
     @extend %vf-clearfix;
     align-content: flex-start;
     align-items: flex-start;
-    border: 1px solid $color-mid-light;
-    border-radius: .125rem;
-    box-shadow: inset 0 1px 1px $box-shadow-color;
+    border: 1px solid $colors--light-theme--border-high-contrast;
+    box-shadow: inset 0 1px 1px $color-input-shadow;
     display: flex;
     flex-wrap: wrap;
     justify-content: flex-start;
@@ -34,8 +33,8 @@
     }
 
     &.is-focused {
-      outline: 1px solid $color-link;
-      outline-offset: 2px;
+      outline: $bar-thickness solid $color-focus;
+      outline-offset: -$bar-thickness;
     }
 
     .p-multiselect__item {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7873,10 +7873,10 @@ vanilla-framework@2.4.1:
   resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-2.4.1.tgz#36ef374e90b8457a07e55cf33be1bcfd07092c84"
   integrity sha512-St8LdmoMpWSFWvFRDBNjFcdfWo/nOMwrkRPJN+dR0vOHP/Jb1UqOSxw+wDxkiGrpeRb0VPFwCuz/2u0RWb0xuQ==
 
-vanilla-framework@^2.10.0:
-  version "2.10.0"
-  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-2.10.0.tgz#74c0cba977ce058552aa4443cccaa6bbf9308e9e"
-  integrity sha512-otQLBXzRBLyiN8RFtHP0E19Iy2p3Frbm7E4TIU7Q7LN+ScmfmgAc7InqbYXvTL9oIATTs0sBD7T/2Fzezgmalg==
+vanilla-framework@^2.11.0:
+  version "2.11.0"
+  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-2.11.0.tgz#a99e1047027e51483964ed1e5f1c681d085a79a2"
+  integrity sha512-4tOppDQi6CRvVjPSaDHgukGYZYiewkn6hKxQIL+h9lgNrGHH/qSHxKXUIplCsFASRdaYCYpPMs3oeFS1xk/KVw==
 
 verbalize@^0.1.2:
   version "0.1.2"


### PR DESCRIPTION
## Done

In preparation for docs pages improvements we need to update Vanilla to latest version.


## QA

- Pull the branch
- Run the site using the command `./run`
- View the site locally in your web browser at: http://0.0.0.0:8004/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check different pages if they don't break
  - check link colors (were updated in Vanilla)
  - check form elements
  - check docs pages (images, emoji)
- Check any snap listing page for publisher - make sure licence field has matching styles with other form inputs