### PR TITLE
Autofocus search

### DIFF
--- a/templates/partials/search-bar.html
+++ b/templates/partials/search-bar.html
@@ -16,7 +16,7 @@
       <div class="p-form__group">
         <label for="search-input" class="u-off-screen">Search</label>
         <div class="p-form__control u-clearfix">
-          <input class="u-no-margin--bottom" id="search-input" type="search" name="q" value="{{ query }}" />
+          <input class="u-no-margin--bottom" id="search-input" type="search" name="q" value="{{ query }}" autofocus />
         </div>
       </div>
       <button type="submit" alt="search" class="p-button--positive">Search</button>

--- a/templates/store/search.html
+++ b/templates/store/search.html
@@ -21,7 +21,7 @@
       <div class="p-form__group">
         <label for="search-input" class="u-off-screen">Search</label>
         <div class="p-form__control u-clearfix">
-          <input class="u-no-margin--bottom" id="search-input" type="search" name="q" value="{{ query }}" />
+          <input class="u-no-margin--bottom" id="search-input" type="search" name="q" value="{{ query }}" autofocus />
         </div>
       </div>
       <button type="submit" alt="search" class="p-button--positive">Search</button>


### PR DESCRIPTION
## Done

- Autofocus search input on page load

## Issue / Card

Fixes #2365 

## QA

- Pull the branch
- Run the site using the command `./run`
- View the site locally in your web browser at: http://0.0.0.0:8004/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Visit http://0.0.0.0:8004/store
- See that the search bar is autofocused so you can start typing immediately
- Search for something
- On the search results page, see the search bar is autofocused