### PR TITLE
Add outline to elements to match vanilla

### DIFF
--- a/static/sass/_patterns_form-multiselect.scss
+++ b/static/sass/_patterns_form-multiselect.scss
@@ -2,6 +2,7 @@
   $box-shadow-color: rgba(0, 0, 0, .12);
 
   .p-multiselect__wrapper {
+    margin-bottom: $input-margin-bottom;
     margin-top: .5rem;
   }
 
@@ -20,6 +21,7 @@
     flex-wrap: wrap;
     justify-content: flex-start;
     line-height: 1.5rem;
+    margin-bottom: $input-margin-bottom;
     margin-top: $spv-outer--small;
     min-width: 10em;
     padding: 0 .5rem;
@@ -49,6 +51,7 @@
       .p-multiselect__item-remove {
         cursor: pointer;
         height: .75em;
+        margin-bottom: .125rem;
         margin-left: .5rem;
         width: .75em;
       }

--- a/static/sass/_snapcraft_market.scss
+++ b/static/sass/_snapcraft_market.scss
@@ -65,6 +65,11 @@
       &:hover img:not([src=""]) + .p-editable-icon__change {
         opacity: 1;
       }
+
+      &:focus {
+        outline: $bar-thickness solid $color-focus;
+        outline-offset: -$bar-thickness;
+      }
     }
 
     &:hover {
@@ -182,7 +187,8 @@
     .p-market-banner__image-holder:hover,
     .p-market-banner__image-holder.is-focused {
       .p-market-banner__image {
-        border: 1px solid $color-link;
+        outline: $bar-thickness solid $color-focus;
+        outline-offset: -$bar-thickness;
       }
 
       .p-market-banner__remove {
@@ -190,8 +196,9 @@
       }
 
       .p-market-banner__change {
-        border: 1px solid $color-link;
         border-radius: $border-radius;
+        outline: $bar-thickness solid $color-focus;
+        outline-offset: -$bar-thickness;
         opacity: 1;
       }
     }

--- a/static/sass/_snapcraft_market_screenshots.scss
+++ b/static/sass/_snapcraft_market_screenshots.scss
@@ -30,6 +30,11 @@
     position: relative;
     width: $screenshot-thumb-size;
 
+    &:focus {
+      outline: $bar-thickness solid $color-focus;
+      outline-offset: -$bar-thickness;
+    }
+
     .p-listing-images__delete-image {
       background: $color-x-light;
       border-radius: 0 .125rem 0 0;
@@ -62,7 +67,8 @@
 
     &:not(.is-empty):hover,
     &:not(.is-empty):focus {
-      border: 1px solid $color-link;
+      outline: $bar-thickness solid $color-focus;
+      outline-offset: -$bar-thickness;
 
       .p-listing-images__delete-image {
         opacity: 1;

--- a/templates/publisher/listing.html
+++ b/templates/publisher/listing.html
@@ -407,7 +407,7 @@ Listing details for {% if display_title %}{{ display_title }}{% else %}{{ snap_t
               <p class="p-form-help-text u-no-margin">The license(s) under which you will release your snap.<br />Multiple licenses can be selected to indicate alternative choices.</p>
             </div>
             <input type="radio" name="license-type" value="custom" id="license-custom-option" {% if license_type == 'custom' %}checked="checked"{% endif %} />
-            <label for="license-custom-option">Custom SPDX expression</label>
+            <label for="license-custom-option" style="margin-bottom: 1.2rem;">Custom SPDX expression</label>
             <textarea
               type="text"
               id="license-custom-input"


### PR DESCRIPTION
## Done

- Add vanilla outline to all elements on the `listing` page
- Align licence `X` icon with the text

## Issue / Card

Fixes #2757

## QA

- Pull the branch
- Run the site using the command `./run`
- View the site locally in your web browser at: http://0.0.0.0:8004/<snap_name>/listing
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- `Tab` thorough all the elements and see the new outline from vanilla (thicker and lighter colour)
- Scroll to the license and see more space between the description text and the input element
- Also note the `x` icon is aligned with the text

## Screenshots

[if relevant, include a screenshot]
![image](https://user-images.githubusercontent.com/40214246/82233874-8823a380-9928-11ea-8f66-8edc5f56778a.png)
