### PR TITLE
Use Vanilla layout and side navigation in docs

### DIFF
--- a/static/sass/_snapcraft_p-docs.scss
+++ b/static/sass/_snapcraft_p-docs.scss
@@ -1,86 +1,8 @@
 @mixin snapcraft-pattern-docs {
   $banner-background: #106363;
 
-  .docs-container {
-    display: flex;
-    margin: 0 auto;
-
-    // override for full width text
-    // https://github.com/canonical-web-and-design/vanilla-framework/issues/1794
-    p {
-      max-width: 100%;
-    }
-
-    .lightbox-wrapper {
-      .meta {
-        display: none;
-      }
-    }
-
-    // Discourse adds "emoji" <img>s, which are huge
-    // They need to be constrained
-    .emoji {
-      height: 1rem;
-    }
-
-    .p-sidebar {
-      border-right: .0625rem solid $color-mid-light;
-      flex: 0 0 18rem;
-    }
-
-    .p-sidebar__content {
-      padding: 1.5rem;
-
-      h3 {
-        font-size: 1rem;
-        font-weight: 400;
-        line-height: 1.5rem;
-        margin: 0;
-        padding: 0;
-      }
-
-      ul {
-        margin-left: 0;
-        padding-left: 1rem;
-
-        li {
-          padding: .125rem 0;
-        }
-
-        li:first-of-type {
-          padding-top: .5rem;
-        }
-
-        li a {
-          color: $color-dark;
-          text-decoration: none;
-
-          &.is-active {
-            position: relative;
-
-            &::before {
-              background-color: $color-mid-light;
-              bottom: -.25rem;
-              content: '';
-              left: -1rem;
-              position: absolute;
-              top: -.25rem;
-              width: .1875rem;
-            }
-          }
-        }
-      }
-    }
-
-    .p-content {
-      flex: 5;
-      overflow: hidden;
-
-      &__row {
-        margin-left: inherit;
-        padding: 0 5%;
-      }
-    }
+  .emoji {
+    height: 1rem;
   }
 
   #search-docs.snapcraft-banner-background { //sass-lint:disable-line no-ids
@@ -99,27 +21,6 @@
 
     button {
       flex-grow: 0;
-    }
-  }
-
-  @media screen and (max-width: $breakpoint-navigation-threshold) {
-    .docs-container {
-      flex-direction: column;
-
-      .p-sidebar {
-        border-bottom: .0625rem solid $color-mid-light;
-        border-right: 0;
-        flex: auto;
-        height: inherit;
-        width: 100%;
-      }
-
-      .p-sidebar__toggle {
-        background-size: 1rem;
-        cursor: pointer;
-        float: right;
-        padding: 2rem;
-      }
     }
   }
 }

--- a/static/sass/_snapcraft_p-docs.scss
+++ b/static/sass/_snapcraft_p-docs.scss
@@ -8,4 +8,11 @@
   .emoji {
     height: 1rem;
   }
+
+  // workaround z-index issue between side nav and global nav
+  // https://github.com/canonical-web-and-design/vanilla-framework/issues/3075
+  .p-side-navigation__drawer,
+  .p-side-navigation__overlay {
+    z-index: 100;
+  }
 }

--- a/static/sass/_snapcraft_p-docs.scss
+++ b/static/sass/_snapcraft_p-docs.scss
@@ -1,26 +1,11 @@
 @mixin snapcraft-pattern-docs {
   $banner-background: #106363;
 
-  .emoji {
-    height: 1rem;
-  }
-
   #search-docs.snapcraft-banner-background { //sass-lint:disable-line no-ids
     background: $banner-background;
   }
 
-  .p-docs-search {
-    display: flex;
-    width: 100%;
-
-    .p-search-box__input {
-      flex-grow: 1;
-      margin-bottom: 0;
-      margin-right: 2rem;
-    }
-
-    button {
-      flex-grow: 0;
-    }
+  .emoji {
+    height: 1rem;
   }
 }

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -44,6 +44,7 @@ $color-social-icon-foreground: $color-light;
 @include vf-p-tabs;
 @include vf-p-subnav;
 @include vf-p-side-navigation;
+@include vf-p-search-box;
 
 // vanilla utilities
 @include vf-u-floats;

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -43,6 +43,7 @@ $color-social-icon-foreground: $color-light;
 @include vf-p-code-copyable;
 @include vf-p-tabs;
 @include vf-p-subnav;
+@include vf-p-side-navigation;
 
 // vanilla utilities
 @include vf-u-floats;

--- a/templates/docs/_search-bar.html
+++ b/templates/docs/_search-bar.html
@@ -1,9 +1,9 @@
 <section id="search-docs" class="p-strip--image is-shallow snapcraft-banner-background">
   <div class="row">
-    <form class="p-docs-search p-form u-no-margin--bottom" action="/docs/search">
-      <input type="search" class="p-search-box__input u-no-margin--bottom" name="q" {% if query %}value="{{ query }}"{% endif %} placeholder="Search documentation" required/>
-      <button type="reset" class="p-search-box__reset u-off-screen" alt="reset"><i class="p-icon--close"></i></button>
-      <button type="submit" class="p-button--positive u-no-margin--bottom" alt="search">Search</button>
+    <form class="p-search-box u-no-margin--bottom" action="/docs/search">
+      <input type="search" class="p-search-box__input" name="q" {% if query %}value="{{ query }}"{% endif %} placeholder="Search documentation" required/>
+      <button type="reset" class="p-search-box__reset" alt="reset"><i class="p-icon--close">Close</i></button>
+      <button type="submit" class="p-search-box__button" alt="search"><i class="p-icon--search">Search</i></button>
     </form>
   </div>
 </section>

--- a/templates/docs/base.html
+++ b/templates/docs/base.html
@@ -34,10 +34,12 @@
 <script>
   window.addEventListener("DOMContentLoaded", function() {
     Raven.context(function() {
-      const path = window.location.pathname;
-      const active = document.querySelector(`.p-side-navigation--raw-html a[href="${path}"]`);
+      var sideNav = document.getElementById("side-nav-drawer");
+      var path = window.location.pathname;
+      var active = sideNav.querySelector(`a[href="${path}"]`);
+
       if (active) {
-        active.classList.add("is-active");
+        active.setAttribute("aria-current", "page");
       }
 
       /**
@@ -77,7 +79,21 @@
         });
       }
 
-      setupSideNavigation(document.getElementById("side-nav-drawer"));
+      setupSideNavigation(sideNav);
+
+      // scroll active side navigation item into view (without scrolling whole page)
+      var currentItem = sideNav.querySelector('[aria-current="page"]');
+
+      if (sideNav && currentItem) {
+        // calculate scroll by comparing top of side nav and top of active item
+        var currentItemOffset = currentItem.getBoundingClientRect().top;
+        var offset = currentItemOffset - sideNav.getBoundingClientRect().top;
+
+        // only scroll if active link is off screen or close to bottom of the window
+        setTimeout(function () {
+          sideNav.scrollTop = offset;
+        }, 0);
+      }
     });
   });
 </script>

--- a/templates/docs/base.html
+++ b/templates/docs/base.html
@@ -2,20 +2,30 @@
 
 {% block content %}
 {% include "docs/_search-bar.html" %}
-<div class="docs-container u-fixed-width">
-  <aside class="p-sidebar" id="navigation">
-    <div class="p-sidebar__banner u-hide--medium u-hide--large">
-      <i class="p-sidebar__toggle p-icon--menu"></i>
-    </div>
-    <div class="p-sidebar__content u-hide--small">
-      <nav class="p-sidebar-nav">
-        {{ navigation | safe }}
-      </nav>
-    </div>
-  </aside>
+<div class="p-strip">
+  <div class="row">
+    <div class="col-3">
+      <aside class="p-side-navigation--raw-html" id="side-nav-drawer">
 
-  <div class="p-content">
-    {% block content_docs %}{% endblock %}
+        <a href="#side-nav-drawer" class="p-side-navigation__toggle js-drawer-toggle" aria-controls="side-nav-drawer">
+          Toggle side navigation
+        </a>
+
+        <div class="p-side-navigation__overlay js-drawer-toggle" aria-controls="side-nav-drawer"></div>
+        <nav class="p-side-navigation__drawer">
+          <div class="p-side-navigation__drawer-header">
+            <a href="#" class="p-side-navigation__toggle--in-drawer js-drawer-toggle" aria-controls="side-nav-drawer">
+              Toggle side navigation
+            </a>
+          </div>
+          {{ navigation | safe }}
+        </nav>
+      </aside>
+    </div>
+
+    <div class="col-9">
+      {% block content_docs %}{% endblock %}
+    </div>
   </div>
 </div>
 {% endblock %}
@@ -25,20 +35,49 @@
   window.addEventListener("DOMContentLoaded", function() {
     Raven.context(function() {
       const path = window.location.pathname;
-      const active = document.querySelector(`.p-sidebar a[href="${path}"]`);
+      const active = document.querySelector(`.p-side-navigation--raw-html a[href="${path}"]`);
       if (active) {
         active.classList.add("is-active");
       }
 
-      const toggleSidebar = document.querySelector(".p-sidebar__toggle");
-      const sidebar = document.querySelector(".p-sidebar__content");
-      if (toggleSidebar) {
-        toggleSidebar.addEventListener("click", function(e) {
-          sidebar.classList.toggle("u-hide--small");
-          toggleSidebar.classList.toggle("p-icon--close");
-          toggleSidebar.classList.toggle("p-icon--menu");
+      /**
+        Toggles the expanded/collapsed classed on side navigation element.
+
+        @param {HTMLElement} sideNavigation The side navigation element.
+        @param {Boolean} show Whether to show or hide the drawer.
+      */
+      function toggleDrawer(sideNavigation, show) {
+        if (sideNavigation) {
+          if (show) {
+            sideNavigation.classList.remove('is-collapsed');
+            sideNavigation.classList.add('is-expanded');
+          } else {
+            sideNavigation.classList.remove('is-expanded');
+            sideNavigation.classList.add('is-collapsed');
+          }
+        }
+      }
+
+      /**
+        Attaches event listeners for the side navigation toggles
+        @param {HTMLElement} sideNavigation The side navigation element.
+      */
+      function setupSideNavigation(sideNavigation) {
+        var toggles = [].slice.call(sideNavigation.querySelectorAll('.js-drawer-toggle'));
+
+        toggles.forEach(function (toggle) {
+          toggle.addEventListener('click', function (event) {
+            event.preventDefault();
+            var sideNav = document.getElementById(toggle.getAttribute('aria-controls'));
+
+            if (sideNav) {
+              toggleDrawer(sideNav, !sideNav.classList.contains('is-expanded'));
+            }
+          });
         });
       }
+
+      setupSideNavigation(document.getElementById("side-nav-drawer"));
     });
   });
 </script>

--- a/templates/docs/document.html
+++ b/templates/docs/document.html
@@ -4,20 +4,18 @@
 {% block meta_title %} {{ document.title }} | Snapcraft documentation{% endblock %}
 
 {% block content_docs %}
-<div class="p-strip is-shallow">
-    <div class="p-content__row">
-        <h1>{{ document.title }}</h1>
-        {{ document.body_html | safe }}
+
+<div class="p-content__row">
+    <h1>{{ document.title }}</h1>
+    {{ document.body_html | safe }}
+</div>
+
+<div class="p-content__row">
+    <div class="p-notification--information">
+        <p class="p-notification__response">
+            Last updated {{ document.updated }}. <a href="{{ forum_url }}{{ document.topic_path }}">Help improve this document in the forum</a>.
+        </p>
     </div>
 </div>
 
-<div class="p-strip is-shallow">
-    <div class="p-content__row">
-        <div class="p-notification--information">
-            <p class="p-notification__response">
-                Last updated {{ document.updated }}. <a href="{{ forum_url }}{{ document.topic_path }}">Help improve this document in the forum</a>.
-            </p>
-        </div>
-    </div>
-</div>
 {% endblock %}


### PR DESCRIPTION
## Done

- Updates docs templates to use Vanilla grid layout and side navigation pattern
- Removes unnecessary docs layout styles
- Updates docs search to use Vanilla search box pattern


## QA

- Pull the branch
- Run the site using the command `./run`
- View the site locally in your web browser at: http://0.0.0.0:8004/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check [updated docs](https://snapcraft-io-canonical-web-and-design-pr-2765.run.demo.haus/docs/)
- Make sure content looks good on different pages (try different type of content, with images, tables, etc)
- Make sure side navigation looks and works as expected
  - active item should be marked
  - side nav should be sticky and scroll correctly
  - on small screens it should hide and work as a drawer with a toggle
- Make sure everything works on different screen sizes
- Make sure search works as expected


<img width="1150" alt="Screenshot 2020-05-19 at 13 07 00" src="https://user-images.githubusercontent.com/83575/82319340-ac878a80-99d1-11ea-83e8-5c23b35cd149.png">
