### PR TITLE
Added queue_time when fetching the builds data

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ canonicalwebteam.blog==4.0.2
 canonicalwebteam.search==0.1.0
 canonicalwebteam.image-template==1.1.0
 canonicalwebteam.store-api==2.0.1
-canonicalwebteam.launchpad==0.2.9
+canonicalwebteam.launchpad==0.7.2
 django-openid-auth==0.15
 Flask-OpenID-Stateless==1.2.6
 Flask-WTF==0.14.3


### PR DESCRIPTION
## Done

- Update launchpad lib to v0.7.2 and update `_request` to be `request`.
- Added queue_time property when fetching the builds data

## Issue / Card

Fixes #2771

## QA

- Pull the branch
- Run the site using the command `./run`
- View the site locally in your web browser at: http://0.0.0.0:8004/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Trigger a build and see the JSON data when the table is updated.
