### PR TITLE
Channel map endpoint

### DIFF
--- a/static/js/publisher/release.js
+++ b/static/js/publisher/release.js
@@ -13,7 +13,7 @@ import releases from "./release/reducers";
 // https://github.com/zalmoxisus/redux-devtools-extension#12-advanced-store-setup
 const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
 
-const initReleases = (id, snapName, releasesData, channelMapsList, options) => {
+const initReleases = (id, snapName, releasesData, channelMap, options) => {
   const store = createStore(
     releases,
     {
@@ -32,8 +32,8 @@ const initReleases = (id, snapName, releasesData, channelMapsList, options) => {
       <DndProvider backend={HTML5Backend}>
         <ReleasesController
           snapName={snapName}
-          channelMapsList={channelMapsList}
           releasesData={releasesData}
+          channelMap={channelMap}
           options={options}
         />
       </DndProvider>

--- a/static/js/publisher/release/components/releasesTable/channelHeading.js
+++ b/static/js/publisher/release/components/releasesTable/channelHeading.js
@@ -1,7 +1,7 @@
 import React, { Fragment } from "react";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
-import { format, parse, distanceInWordsToNow, addDays } from "date-fns";
+import { format, parse, distanceInWordsToNow } from "date-fns";
 
 import { sortChannels } from "../../../../libs/channels";
 
@@ -291,7 +291,7 @@ const ReleasesTableChannelHeading = props => {
 
   let timeUntilExpiration;
   if (branch) {
-    const end = addDays(parse(branch.when), 30);
+    const end = parse(branch.expiration);
     timeUntilExpiration = distanceInWordsToNow(end);
   }
 
@@ -360,7 +360,7 @@ const ReleasesTableChannelHeading = props => {
 
       {timeUntilExpiration && (
         <span className="p-releases-table__branch-timeleft" title={branch.when}>
-          {timeUntilExpiration} left
+          {timeUntilExpiration}
         </span>
       )}
     </div>

--- a/static/js/publisher/release/releasesController.js
+++ b/static/js/publisher/release/releasesController.js
@@ -16,14 +16,14 @@ import { initChannelMap } from "./actions/channelMap";
 import {
   getRevisionsMap,
   initReleasesData,
-  getReleaseDataFromChannelMap
+  getReleaseDataFromChannelMapV2
 } from "./releasesState";
 
 class ReleasesController extends Component {
   constructor(props) {
     super(props);
 
-    const { releasesData, channelMapsList } = this.props;
+    const { releasesData, channelMap } = this.props;
 
     // init channel data in revisions list
     // TODO: should be done in reducers?
@@ -35,7 +35,7 @@ class ReleasesController extends Component {
     this.props.updateRevisions(revisionsMap);
     this.props.updateReleases(releasesData.releases);
     this.props.initChannelMap(
-      getReleaseDataFromChannelMap(channelMapsList, revisionsMap)
+      getReleaseDataFromChannelMapV2(channelMap, revisionsMap)
     );
   }
 
@@ -57,8 +57,8 @@ class ReleasesController extends Component {
 }
 
 ReleasesController.propTypes = {
-  channelMapsList: PropTypes.array.isRequired,
   releasesData: PropTypes.object.isRequired,
+  channelMap: PropTypes.object.isRequired,
 
   notification: PropTypes.object,
   showModal: PropTypes.bool,

--- a/static/js/publisher/release/releasesController.js
+++ b/static/js/publisher/release/releasesController.js
@@ -16,7 +16,7 @@ import { initChannelMap } from "./actions/channelMap";
 import {
   getRevisionsMap,
   initReleasesData,
-  getReleaseDataFromChannelMapV2
+  getReleaseDataFromChannelMap
 } from "./releasesState";
 
 class ReleasesController extends Component {
@@ -35,7 +35,7 @@ class ReleasesController extends Component {
     this.props.updateRevisions(revisionsMap);
     this.props.updateReleases(releasesData.releases);
     this.props.initChannelMap(
-      getReleaseDataFromChannelMapV2(channelMap, revisionsMap)
+      getReleaseDataFromChannelMap(channelMap, revisionsMap)
     );
   }
 

--- a/static/js/publisher/release/releasesState.js
+++ b/static/js/publisher/release/releasesState.js
@@ -76,6 +76,30 @@ function getReleaseDataFromChannelMap(channelMapsList, revisionsMap) {
   return releasedChannels;
 }
 
+// The same as getReleaseDataFromChannelMap but using the v2 API channel-map endpoint
+// https://dashboard.snapcraft.io/docs/v2/en/snaps.html#snap-channel-map
+function getReleaseDataFromChannelMapV2(channelMap, revisionsMap) {
+  const releasedChannels = {};
+
+  channelMap["channel-map"].forEach(mapInfo => {
+    if (!releasedChannels[mapInfo.channel]) {
+      releasedChannels[mapInfo.channel] = {};
+    }
+
+    if (
+      !releasedChannels[mapInfo.channel][mapInfo.architecture] &&
+      revisionsMap[mapInfo.revision]
+    ) {
+      releasedChannels[mapInfo.channel][mapInfo.architecture] =
+        revisionsMap[mapInfo.revision];
+      releasedChannels[mapInfo.channel][mapInfo.architecture].expiration =
+        mapInfo["expiration-date"];
+    }
+  });
+
+  return releasedChannels;
+}
+
 // for channel without release get next (less risk) channel with a release
 function getTrackingChannel(releasedChannels, track, risk, arch) {
   let tracking = null;
@@ -121,5 +145,6 @@ export {
   getTrackingChannel,
   getRevisionsMap,
   initReleasesData,
-  getReleaseDataFromChannelMap
+  getReleaseDataFromChannelMap,
+  getReleaseDataFromChannelMapV2
 };

--- a/static/js/publisher/release/releasesState.js
+++ b/static/js/publisher/release/releasesState.js
@@ -36,49 +36,8 @@ function initReleasesData(revisionsMap, releases) {
 }
 
 // transforming channel map list data into format used by this component
-function getReleaseDataFromChannelMap(channelMapsList, revisionsMap) {
-  const releasedChannels = {};
-  const releasedArchs = {};
-
-  channelMapsList.forEach(mapInfo => {
-    const { track, architecture, map } = mapInfo;
-    map.forEach(channelInfo => {
-      if (channelInfo.info === "released" || channelInfo.info === "branch") {
-        const channel =
-          track === "latest"
-            ? `${track}/${channelInfo.channel}`
-            : channelInfo.channel;
-
-        if (!releasedChannels[channel]) {
-          releasedChannels[channel] = {};
-        }
-
-        // XXX bartaz
-        // this may possibly lead to issues with revisions in multiple architectures
-        // if we have data about given revision in revision history we can store it
-        if (revisionsMap[channelInfo.revision]) {
-          releasedChannels[channel][architecture] =
-            revisionsMap[channelInfo.revision];
-          // but if for some reason we don't have full data about revision in channel map
-          // we need to ducktype it from channel info
-        } else {
-          releasedChannels[channel][architecture] = channelInfo;
-          releasedChannels[channel][architecture].architectures = [
-            architecture
-          ];
-        }
-
-        releasedArchs[architecture] = true;
-      }
-    });
-  });
-
-  return releasedChannels;
-}
-
-// The same as getReleaseDataFromChannelMap but using the v2 API channel-map endpoint
 // https://dashboard.snapcraft.io/docs/v2/en/snaps.html#snap-channel-map
-function getReleaseDataFromChannelMapV2(channelMap, revisionsMap) {
+function getReleaseDataFromChannelMap(channelMap, revisionsMap) {
   const releasedChannels = {};
 
   channelMap["channel-map"].forEach(mapInfo => {
@@ -145,6 +104,5 @@ export {
   getTrackingChannel,
   getRevisionsMap,
   initReleasesData,
-  getReleaseDataFromChannelMap,
-  getReleaseDataFromChannelMapV2
+  getReleaseDataFromChannelMap
 };

--- a/static/js/publisher/release/selectors/index.js
+++ b/static/js/publisher/release/selectors/index.js
@@ -198,34 +198,37 @@ export function getTracks(state) {
 
 export function getBranches(state) {
   let branches = [];
-  const { currentTrack } = state;
+  const { currentTrack, releases } = state;
 
   const now = parse(Date.now());
 
-  state.releases
+  releases
     .filter(t => t.branch && t.track === currentTrack)
     .sort((a, b) => {
       return isAfter(parse(b.when), parse(a.when));
     })
-    .forEach(({ track, risk, branch, when, revision }) => {
+    .forEach(item => {
+      const { track, risk, branch, when, revision } = item;
       const exists =
         branches.filter(
           b => b.track === track && b.risk === risk && b.branch === branch
         ).length > 0;
+
       if (!exists) {
         branches.push({
           track,
           risk,
           branch,
           revision,
-          when
+          when,
+          expiration: item["expiration-date"]
         });
       }
     });
 
   return branches
     .filter(b => {
-      return differenceInDays(now, parse(b.when)) <= 30;
+      return differenceInDays(parse(b.expiration), now) > 0;
     })
     .reverse();
 }

--- a/static/js/publisher/release/selectors/selectors.test.js
+++ b/static/js/publisher/release/selectors/selectors.test.js
@@ -662,8 +662,11 @@ describe("getTrackRevisions", () => {
 describe("getBranches", () => {
   it("should return branches on the currentTrack, ordered by oldest first", () => {
     const today = new Date();
-    const lessThan30DaysAgo = new Date(
-      new Date().setDate(today.getDate() - 30)
+    const expired = new Date(
+      new Date().setDate(today.getDate() - 1)
+    ).toISOString();
+    const notExpired = new Date(
+      new Date().setDate(today.getDate() + 24)
     ).toISOString();
 
     const state = {
@@ -674,28 +677,32 @@ describe("getBranches", () => {
           track: "latest",
           risk: "stable",
           revision: "1",
-          when: "2019-07-12T10:00:00Z"
+          when: today.toISOString(),
+          "expiration-date": notExpired
         },
         {
           branch: "test",
           track: "latest",
           risk: "stable",
           revision: "2",
-          when: lessThan30DaysAgo
+          when: today.toISOString(),
+          "expiration-date": notExpired
         },
         {
           branch: "test2",
           track: "latest",
           risk: "stable",
           revision: "3",
-          when: lessThan30DaysAgo
+          when: today.toISOString(),
+          "expiration-date": notExpired
         },
         {
           branch: "test",
           track: "test",
           risk: "stable",
           revision: "4",
-          when: "2019-07-12T09:30:00Z"
+          when: today.toISOString(),
+          "expiration-date": expired
         }
       ]
     };
@@ -706,14 +713,16 @@ describe("getBranches", () => {
         track: "latest",
         risk: "stable",
         revision: "3",
-        when: lessThan30DaysAgo
+        when: today.toISOString(),
+        expiration: notExpired
       },
       {
         branch: "test",
         track: "latest",
         risk: "stable",
         revision: "2",
-        when: lessThan30DaysAgo
+        when: today.toISOString(),
+        expiration: notExpired
       }
     ]);
   });

--- a/static/sass/_snapcraft_release.scss
+++ b/static/sass/_snapcraft_release.scss
@@ -121,8 +121,8 @@
   }
 
   .p-releases-table__branch-timeleft {
-    bottom: $spv-inner--small;
-    right: $sph-inner--small;
+    bottom: .8rem;
+    right: .8rem;
   }
 
   // This is to have different width items depending on

--- a/templates/publisher/release-history.html
+++ b/templates/publisher/release-history.html
@@ -40,7 +40,7 @@ Releases and revision history for {% if snap_title %}{{ snap_title }}{% else %}{
           snapcraft.release.initReleases('#release-history',
             {{ snap_name|tojson }},
             {{ release_history|tojson }},
-            {{ channel_maps_list|tojson }},
+            {{ channel_map|tojson }},
             {
               defaultTrack: {% if default_track %}{{ default_track|tojson }}{% else %}"latest"{% endif %},
               csrfToken: {{ csrf_token()|tojson }},

--- a/tests/publisher/snaps/tests_revision.py
+++ b/tests/publisher/snaps/tests_revision.py
@@ -64,9 +64,16 @@ class GetRevisionHistory(BaseTestCases.EndpointLoggedInErrorHandling):
 
         responses.add(responses.GET, self.api_url, json={}, status=200)
 
+        channel_map_url = (
+            "https://dashboard.snapcraft.io/api/v2/snaps/{}/channel-map"
+        )
+        channel_map_url = channel_map_url.format(self.snap_name)
+
+        responses.add(responses.GET, channel_map_url, json={}, status=200)
+
         response = self.client.get(self.endpoint_url)
 
-        self.assertEqual(2, len(responses.calls))
+        self.assertEqual(3, len(responses.calls))
         called = responses.calls[0]
         self.assertEqual(self.api_url, called.request.url)
         self.assertEqual(
@@ -81,3 +88,4 @@ class GetRevisionHistory(BaseTestCases.EndpointLoggedInErrorHandling):
         self.assert_template_used("publisher/release-history.html")
         self.assert_context("snap_name", self.snap_name)
         self.assert_context("release_history", {})
+        self.assert_context("channel_map", {})

--- a/webapp/api/dashboard.py
+++ b/webapp/api/dashboard.py
@@ -61,6 +61,10 @@ SNAP_RELEASE_HISTORY_URL = "".join(
     [DASHBOARD_API_V2, "snaps/{snap_name}/releases?page={page}"]
 )
 
+SNAP_CHANNEL_MAP_URL = "".join(
+    [DASHBOARD_API_V2, "snaps/{snap_name}/channel-map"]
+)
+
 
 SNAP_RELEASE = "".join([DASHBOARD_API, "snap-release/"])
 
@@ -320,6 +324,18 @@ def snap_revision_history(session, snap_id):
 def snap_release_history(session, snap_name, page=1):
     response = api_session.get(
         url=SNAP_RELEASE_HISTORY_URL.format(snap_name=snap_name, page=page),
+        headers=get_authorization_header(session),
+    )
+
+    if authentication.is_macaroon_expired(response.headers):
+        raise MacaroonRefreshRequired
+
+    return process_response(response)
+
+
+def snap_channel_map(session, snap_name):
+    response = api_session.get(
+        url=SNAP_CHANNEL_MAP_URL.format(snap_name=snap_name),
         headers=get_authorization_header(session),
     )
 


### PR DESCRIPTION
## Done

- Update to use the new channel-map endpoint, instead of the `channel-map` dict from the info endpoint
- Update branches to use the expiration date, not the creation date + 30 days

## Issue / Card

Fixes #2690 
Fixes #2775

## QA

- Pull the branch
- Run the site using the command `./run`
- View the site locally in your web browser at: http://0.0.0.0:8004/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check multiple snaps release UI's against production. Everything should be the same.
- Check both small snaps with few tracks branches and revisions (spotify or skype) and larger examples (lxd or nextcloud)