### PR TITLE
Add estimated launchpad building queue time

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ canonicalwebteam.blog==4.0.2
 canonicalwebteam.search==0.1.0
 canonicalwebteam.image-template==1.1.0
 canonicalwebteam.store-api==2.0.1
-canonicalwebteam.launchpad==0.7.2
+canonicalwebteam.launchpad==0.7.3
 django-openid-auth==0.15
 Flask-OpenID-Stateless==1.2.6
 Flask-WTF==0.14.3


### PR DESCRIPTION
## Done

- Add estimated launchpad building queue time on hover over `BUILDING SOON` in the table

## Issue / Card

Fixes #2744 

## QA

- Pull the branch
- Run the site using the command `./run`
- View the site locally in your web browser at: http://0.0.0.0:8004/<snap_name>/builds
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Trigger a new build and you should see `BUILDING SOON` in the table for one of the architectures (if this doesn't happen you are very lucky, and try again later). Hover over `BUILDING SOON` and see a tooltip saying "Queue time: up to $time"
- Keep the page open an see the time is not changing while you still see the `BUILDING SOON` status for that architecture
- The tooltip should disappear when the status is changed
