### PR TITLE
Update to Vanilla 2.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "swiper": "^4.4.1",
     "topojson-client": "^3.0.0",
     "uglifyjs-webpack-plugin": "^2.0.1",
-    "vanilla-framework": "^2.11.0",
+    "vanilla-framework": "2.12.0",
     "watch-cli": "^0.2.2",
     "webpack": "^4.22.0",
     "webpack-cli": "^3.1.2",

--- a/static/sass/_snapcraft_p-docs.scss
+++ b/static/sass/_snapcraft_p-docs.scss
@@ -8,11 +8,4 @@
   .emoji {
     height: 1rem;
   }
-
-  // workaround z-index issue between side nav and global nav
-  // https://github.com/canonical-web-and-design/vanilla-framework/issues/3075
-  .p-side-navigation__drawer,
-  .p-side-navigation__overlay {
-    z-index: 100;
-  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7870,6 +7870,11 @@ validate-npm-package-license@^3.0.1:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
 
+vanilla-framework@2.12.0:
+  version "2.12.0"
+  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-2.12.0.tgz#f9f4c2e79df26b6e2a3950f6440fdb38b8645943"
+  integrity sha512-fR5WVY2j0NPkl0i1qdD0trC8aNRf76yJV6cRxnMiHBQdEEeSBKhFTwzl0r8FEZ/kX+b1sXmI+hyWNp8XF0Yc8g==
+
 vanilla-framework@2.4.1:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-2.4.1.tgz#36ef374e90b8457a07e55cf33be1bcfd07092c84"
@@ -7879,11 +7884,6 @@ vanilla-framework@2.8.0:
   version "2.8.0"
   resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-2.8.0.tgz#ec20ed3bf4fc2f1ce2d42075edb7a58c26f56982"
   integrity sha512-fIxO7/BtCmj7aMAFCxxk19fqRB9HVZBv1typ7YL4AEiJhq8Za3qDCLuxjiSP0tFvKzXUtrI7y4KGHYMrFIevKg==
-
-vanilla-framework@^2.11.0:
-  version "2.11.0"
-  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-2.11.0.tgz#a99e1047027e51483964ed1e5f1c681d085a79a2"
-  integrity sha512-4tOppDQi6CRvVjPSaDHgukGYZYiewkn6hKxQIL+h9lgNrGHH/qSHxKXUIplCsFASRdaYCYpPMs3oeFS1xk/KVw==
 
 verbalize@^0.1.2:
   version "0.1.2"


### PR DESCRIPTION
## Done

- Updated to latest Vanilla
- Removed local workaround (now fixed in Vanilla)

## QA

- Pull the branch
- Run the site using the command `./run`
- View the site locally in your web browser at: http://0.0.0.0:8004/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check if docs pages work as expected (on small screen there should be no issue with global navigation)
- Check if new icons look good

