### PR TITLE
Fix default tracks on Release UI

### DIFF
--- a/static/js/publisher/release/releasesState.js
+++ b/static/js/publisher/release/releasesState.js
@@ -59,30 +59,6 @@ function getReleaseDataFromChannelMap(channelMap, revisionsMap) {
   return releasedChannels;
 }
 
-// The same as getReleaseDataFromChannelMap but using the v2 API channel-map endpoint
-// https://dashboard.snapcraft.io/docs/v2/en/snaps.html#snap-channel-map
-function getReleaseDataFromChannelMapV2(channelMap, revisionsMap) {
-  const releasedChannels = {};
-
-  channelMap["channel-map"].forEach(mapInfo => {
-    if (!releasedChannels[mapInfo.channel]) {
-      releasedChannels[mapInfo.channel] = {};
-    }
-
-    if (
-      !releasedChannels[mapInfo.channel][mapInfo.architecture] &&
-      revisionsMap[mapInfo.revision]
-    ) {
-      releasedChannels[mapInfo.channel][mapInfo.architecture] =
-        revisionsMap[mapInfo.revision];
-      releasedChannels[mapInfo.channel][mapInfo.architecture].expiration =
-        mapInfo["expiration-date"];
-    }
-  });
-
-  return releasedChannels;
-}
-
 // for channel without release get next (less risk) channel with a release
 function getTrackingChannel(releasedChannels, track, risk, arch) {
   let tracking = null;
@@ -128,6 +104,5 @@ export {
   getTrackingChannel,
   getRevisionsMap,
   initReleasesData,
-  getReleaseDataFromChannelMap,
-  getReleaseDataFromChannelMapV2
+  getReleaseDataFromChannelMap
 };

--- a/static/js/publisher/release/releasesState.js
+++ b/static/js/publisher/release/releasesState.js
@@ -59,6 +59,30 @@ function getReleaseDataFromChannelMap(channelMap, revisionsMap) {
   return releasedChannels;
 }
 
+// The same as getReleaseDataFromChannelMap but using the v2 API channel-map endpoint
+// https://dashboard.snapcraft.io/docs/v2/en/snaps.html#snap-channel-map
+function getReleaseDataFromChannelMapV2(channelMap, revisionsMap) {
+  const releasedChannels = {};
+
+  channelMap["channel-map"].forEach(mapInfo => {
+    if (!releasedChannels[mapInfo.channel]) {
+      releasedChannels[mapInfo.channel] = {};
+    }
+
+    if (
+      !releasedChannels[mapInfo.channel][mapInfo.architecture] &&
+      revisionsMap[mapInfo.revision]
+    ) {
+      releasedChannels[mapInfo.channel][mapInfo.architecture] =
+        revisionsMap[mapInfo.revision];
+      releasedChannels[mapInfo.channel][mapInfo.architecture].expiration =
+        mapInfo["expiration-date"];
+    }
+  });
+
+  return releasedChannels;
+}
+
 // for channel without release get next (less risk) channel with a release
 function getTrackingChannel(releasedChannels, track, risk, arch) {
   let tracking = null;
@@ -104,5 +128,6 @@ export {
   getTrackingChannel,
   getRevisionsMap,
   initReleasesData,
-  getReleaseDataFromChannelMap
+  getReleaseDataFromChannelMap,
+  getReleaseDataFromChannelMapV2
 };

--- a/webapp/publisher/snaps/release_views.py
+++ b/webapp/publisher/snaps/release_views.py
@@ -43,6 +43,8 @@ def get_release_history(snap_name):
     except ApiError as api_error:
         return _handle_error(api_error)
 
+    snap = channel_map.get("snap", {})
+
     context = {
         "snap_name": snap_name,
         "snap_title": info["title"],  # missing from channel-map endpoint
@@ -50,8 +52,8 @@ def get_release_history(snap_name):
             "display-name"
         ],  # missing from channel-map endpoint
         "release_history": release_history,
-        "private": channel_map.get("private"),
-        "default_track": channel_map.get("default_track"),
+        "private": snap.get("private"),
+        "default_track": snap.get("default-track"),
         "channel_map": channel_map,
     }
 


### PR DESCRIPTION
## Done

- Update the key for default-tracks from the channel-map endpoint

## Issue / Card

Fixes #2820 

## QA

- Pull the branch
- Run the site using the command `./run`
- View the site locally in your web browser at: http://0.0.0.0:8004/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Visit http://0.0.0.0:8004/maas/releases
- See that the track dropdown is set to 2.7