### PR TITLE
List Launchpad builds with status 'Needs building'

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ canonicalwebteam.blog==4.0.2
 canonicalwebteam.search==0.1.0
 canonicalwebteam.image-template==1.1.0
 canonicalwebteam.store-api==2.0.1
-canonicalwebteam.launchpad==0.7.5
+canonicalwebteam.launchpad==0.7.6
 django-openid-auth==0.15
 Flask-OpenID-Stateless==1.2.6
 Flask-WTF==0.14.3

--- a/webapp/publisher/snaps/build_views.py
+++ b/webapp/publisher/snaps/build_views.py
@@ -55,7 +55,7 @@ def get_builds(lp_snap, selection):
             "queue_time": None,
         }
 
-        if status == "building_soon":
+        if build["buildstate"] == "Needs building":
             if not builders_status:
                 builders_status = launchpad.get_builders_status()
 
@@ -247,7 +247,7 @@ def get_snap_builds_json(snap_name):
 
     start = flask.request.args.get("start", 0, type=int)
     size = flask.request.args.get("size", 15, type=int)
-    build_slice = slice(start, start + size)
+    build_slice = slice(start, size)
 
     # Get built snap in launchpad with this store name
     lp_snap = launchpad.get_snap_by_store_name(details["snap_name"])


### PR DESCRIPTION
## Done

- List builds with status 'Needs building'.
- Include estimated time for 'Needs building' builds.
- Fix pagination.

## Issue / Card

Fixes #2749

## QA

- Pull the branch
- Run the site using the command `./run`
- View the site locally in your web browser at: http://0.0.0.0:8004/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Go to any snap, trigger a build. Check that builds with the status "Needs building" on Launchpad are listed as "Building soon" in the table.
