### PR TITLE
Show queue time when needs_building

### DIFF
--- a/static/js/publisher/builds/index.js
+++ b/static/js/publisher/builds/index.js
@@ -66,7 +66,7 @@ class Builds extends React.Component {
       const isBuildingSoon =
         build.status === "building_soon" && build.queue_time;
       if (isBuildingSoon) {
-        newQueueTime = queueTime[build.arch_tag]
+        newQueueTime[build.arch_tag] = queueTime[build.arch_tag]
           ? queueTime[build.arch_tag]
           : build.queue_time;
       }


### PR DESCRIPTION
## Done

- Show queue time when `needs_building`

## Issue / Card

Fixes #2781 

## QA

- Pull the branch
- Run the site using the command `./run`
- View the site locally in your web browser at: http://0.0.0.0:8004/<snap_name>/builds
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Trigger a new build when Launchpad is busy and you should see `BUILDING SOON` in the table for one of the architectures. Hover over `BUILDING SOON` and see a tooltip saying "Queue time: up to $time"
