### PR TITLE
Remove extra info call on releases endpoint

### DIFF
--- a/static/js/publisher/release/releasesState.js
+++ b/static/js/publisher/release/releasesState.js
@@ -40,7 +40,7 @@ function initReleasesData(revisionsMap, releases) {
 function getReleaseDataFromChannelMap(channelMap, revisionsMap) {
   const releasedChannels = {};
 
-  channelMap["channel-map"].forEach(mapInfo => {
+  channelMap.forEach(mapInfo => {
     if (!releasedChannels[mapInfo.channel]) {
       releasedChannels[mapInfo.channel] = {};
     }

--- a/tests/publisher/snaps/tests_revision.py
+++ b/tests/publisher/snaps/tests_revision.py
@@ -51,29 +51,25 @@ class GetRevisionHistory(BaseTestCases.EndpointLoggedInErrorHandling):
 
     @responses.activate
     def test_get_revision(self):
-        info_url = "https://dashboard.snapcraft.io/dev/api/snaps/info/{}"
+        info_url = "https://dashboard.snapcraft.io/api/v2/snaps/{}/channel-map"
         self.info_url = info_url.format(self.snap_name)
 
         payload = {
-            "snap_id": "id",
-            "title": "Test Snap",
-            "publisher": {"display-name": "test"},
+            "snap": {
+                "snap_id": "id",
+                "title": "Test Snap",
+                "publisher": {"display-name": "test"},
+            },
+            "channel-map": {},
         }
-
-        responses.add(responses.GET, self.info_url, json=payload, status=200)
 
         responses.add(responses.GET, self.api_url, json={}, status=200)
 
-        channel_map_url = (
-            "https://dashboard.snapcraft.io/api/v2/snaps/{}/channel-map"
-        )
-        channel_map_url = channel_map_url.format(self.snap_name)
-
-        responses.add(responses.GET, channel_map_url, json={}, status=200)
+        responses.add(responses.GET, self.info_url, json=payload, status=200)
 
         response = self.client.get(self.endpoint_url)
 
-        self.assertEqual(3, len(responses.calls))
+        self.assertEqual(2, len(responses.calls))
         called = responses.calls[0]
         self.assertEqual(self.api_url, called.request.url)
         self.assertEqual(

--- a/webapp/publisher/snaps/release_views.py
+++ b/webapp/publisher/snaps/release_views.py
@@ -35,10 +35,8 @@ def get_release_history(snap_name):
 
     context = {
         "snap_name": snap_name,
-        "snap_title": snap.get("title"),  # missing from channel-map endpoint
-        "publisher_name": snap.get("publisher", {}).get(
-            "display-name", {}
-        ),  # missing from channel-map endpoint
+        "snap_title": snap.get("title"),
+        "publisher_name": snap.get("publisher", {}).get("display-name", {}),
         "release_history": release_history,
         "private": snap.get("private"),
         "default_track": snap.get("default-track"),


### PR DESCRIPTION
## Done

- Remove `/info` call for release UI
- Update `title` and `publisher.display-name` to be fetched from `/channel-map` call
- Only pass through the `channel-map` dictionary to the template (rather than the entire response)
- Update `releasesState` to use this reduced `channel-map` dict.

## Issue / Card

Fixes #2833 

## QA

- Pull the branch
- Run the site using the command `./run`
- View the site locally in your web browser at: http://0.0.0.0:8004/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Visit many snaps release pages, make sure they function as expected