### PR TITLE
Better handle snap details blog posts that don't have images

### DIFF
--- a/static/js/public/snap-details/blog-posts.js
+++ b/static/js/public/snap-details/blog-posts.js
@@ -32,8 +32,7 @@ class BlogPosts {
     this.modifiers = modifiers;
   }
 
-  fetch(callback) {
-    const _callback = callback || null;
+  fetch() {
     return fetch(`${this.url}${this.path}`)
       .then(response => response.json())
       .then(posts => {
@@ -56,7 +55,11 @@ class BlogPosts {
           }
           let postHTML = this.template.innerHTML;
           Object.keys(post).forEach(key => {
-            postHTML = postHTML.split("${" + key + "}").join(post[key]);
+            if (post[key]) {
+              postHTML = postHTML.split("${" + key + "}").join(post[key]);
+            } else {
+              postHTML = postHTML.split("${" + key + "}").join("");
+            }
           });
           const containerClasses = [`col-${cols}`];
           if (post.slug.indexOf("http") === 0) {
@@ -74,7 +77,6 @@ class BlogPosts {
 
         return posts;
       })
-      .then(_callback)
       .catch(error => {
         throw new Error(error);
       });
@@ -103,7 +105,7 @@ function snapDetailsPosts(
 
   blogPosts.path = snap;
 
-  blogPosts.fetch(function(posts) {
+  blogPosts.fetch().then(posts => {
     if (posts.length > 0 && showOnSuccessSelector) {
       const showOnSuccess = document.querySelector(showOnSuccessSelector);
       if (showOnSuccess) {

--- a/templates/partials/blog-card--minimal.html
+++ b/templates/partials/blog-card--minimal.html
@@ -1,7 +1,9 @@
 <div class="{{ container_class }}">
+  {% if article.image %}
   <a href="{{ article.slug }}">
     {{ article.image }}
   </a>
+  {% endif %}
   <h3 class="p-heading--4">
     <a href="{{ article.slug }}">{{ article.title.rendered|safe }}</a>
   </h3>


### PR DESCRIPTION
## Done

- Handle image being "null" - I'll improve this with a default image in a new commit later
- Removed the superfluous _callback param on fetch - just work with the Promise

## Issue / Card

Fixes #2838

## QA

- Pull the branch
- Run the site using the command `./run`
- View the site locally in your web browser at: http://0.0.0.0:8004/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Visit http://0.0.0.0:8004/intellij-idea-ultimate you should see two blog posts, one with an image, one without