### PR TITLE
Make delete icon accessible

### DIFF
--- a/static/js/publisher/form/AccordionHelp.js
+++ b/static/js/publisher/form/AccordionHelp.js
@@ -12,9 +12,10 @@ class AccordionHelp extends React.Component {
     };
   }
 
-  toggleHelp() {
+  toggleHelp(e) {
     const { open } = this.state;
 
+    e.preventDefault();
     this.setState({
       open: !open
     });
@@ -32,7 +33,7 @@ class AccordionHelp extends React.Component {
     return (
       <Fragment>
         <p className="p-form-help-text">
-          <a role="button" onClick={this.toggleHelp}>
+          <a href="#" role="button" tabIndex="0" onClick={this.toggleHelp}>
             {label}
           </a>
         </p>

--- a/static/js/publisher/form/icon.js
+++ b/static/js/publisher/form/icon.js
@@ -17,8 +17,9 @@ class Icon extends React.Component {
     };
   }
 
-  removeIconHandler() {
+  removeIconHandler(e) {
     const { updateIcon } = this.props;
+    e.preventDefault();
     this.setState({
       icon: {}
     });
@@ -140,12 +141,15 @@ class Icon extends React.Component {
           </div>
           {iconUrl && (
             <div className="p-editable-icon__actions">
-              <span
+              <a
+                href="#"
+                role="button"
+                tabIndex="0"
                 className="p-editable-icon__delete"
                 onClick={this.removeIconHandler}
               >
                 <i className="p-icon--delete" />
-              </span>
+              </a>
             </div>
           )}
         </div>


### PR DESCRIPTION
## Done

- Make delete icon and show icon/image restrictions links accessible

## Issue / Card

Fixes #2826 

## QA

- Pull the branch
- Run the site using the command `./run`
- View the site locally in your web browser at: http://0.0.0.0:8004/<snap_name>/listing
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Tab through the page and see that the `delete icon` icon and the `show icon/image restrictions` links are accessible with tab key
