### PR TITLE
Change listing page title maxlenght to 40 chars

### DIFF
--- a/static/js/publisher/form.js
+++ b/static/js/publisher/form.js
@@ -331,13 +331,10 @@ function initForm(config, initialState, errors) {
       }
 
       if (inputValidation.maxLength) {
-        const count = validation[input.name].maxLength - input.value.length;
-
-        if (count < 0) {
-          inputValidation.counterEl.innerHTML = `The maximum number of characters in the title is ${
+        if (validation[input.name].maxLength === input.value.length) {
+          inputValidation.counterEl.innerHTML = `The maximum number of characters for this field is ${
             validation[input.name].maxLength
           }.`;
-          isValid = false;
           showCounter = true;
         } else {
           inputValidation.counterEl.innerHTML = "";
@@ -384,11 +381,10 @@ function initForm(config, initialState, errors) {
     if (input.maxLength > 0) {
       // save max length, but remove it from input so more chars can be entered
       inputValidation.maxLength = input.maxLength;
-      input.removeAttribute("maxlength");
 
       // prepare counter element to show how many chars need to be removed
-      const counter = document.createElement("span");
-      counter.className = "p-form-validation__counter";
+      const counter = document.createElement("p");
+      counter.className = "p-form-help-text";
       inputValidation.counterEl = counter;
       input.parentNode.appendChild(counter);
     }

--- a/static/js/publisher/form.js
+++ b/static/js/publisher/form.js
@@ -334,7 +334,9 @@ function initForm(config, initialState, errors) {
         const count = validation[input.name].maxLength - input.value.length;
 
         if (count < 0) {
-          inputValidation.counterEl.innerHTML = count;
+          inputValidation.counterEl.innerHTML = `The maximum number of characters in the title is ${
+            validation[input.name].maxLength
+          }.`;
           isValid = false;
           showCounter = true;
         } else {

--- a/static/js/publisher/form.test.js
+++ b/static/js/publisher/form.test.js
@@ -40,7 +40,7 @@ describe("initForm", () => {
     titleInput.name = "title";
     titleInput.value = initialState.title;
     titleInput.required = "true";
-    titleInput.maxlength = "64";
+    titleInput.maxlength = "40";
 
     categoriesInput = document.createElement("input");
     categoriesInput.type = "text";

--- a/static/sass/_patterns_media-object--snap.scss
+++ b/static/sass/_patterns_media-object--snap.scss
@@ -71,8 +71,8 @@
       .p-media-object__content {
         p {
           color: transparent;
-          position: relative;
           display: -webkit-box;
+          position: relative;
 
           &::before {
             background: $color-mid-light;

--- a/static/sass/_snapcraft_market.scss
+++ b/static/sass/_snapcraft_market.scss
@@ -197,9 +197,9 @@
 
       .p-market-banner__change {
         border-radius: $border-radius;
+        opacity: 1;
         outline: $bar-thickness solid $color-focus;
         outline-offset: -$bar-thickness;
-        opacity: 1;
       }
     }
 

--- a/static/sass/_snapcraft_p-build.scss
+++ b/static/sass/_snapcraft_p-build.scss
@@ -33,8 +33,8 @@
   .p-form-validation {
     .p-icon-container {
       position: absolute;
-      top: .4rem;
       right: .55rem;
+      top: .4rem;
     }
   }
 }

--- a/templates/publisher/listing.html
+++ b/templates/publisher/listing.html
@@ -108,7 +108,7 @@ Listing details for {% if display_title %}{{ display_title }}{% else %}{{ snap_t
         </div>
         <div class="col-8">
           <div class="p-form__control">
-            <input data-tour="listing-title" class="p-form-validation__input" id="snap-title" type="text" name="title" value="{{ snap_title }}" required maxlength="64"/>
+            <input data-tour="listing-title" class="p-form-validation__input" id="snap-title" type="text" name="title" value="{{ snap_title }}" required maxlength="40"/>
             {% if field_errors and field_errors['title'] %}
             <p class="p-form-validation__message">
               <strong>Error:</strong> {{ field_errors['title'] }}


### PR DESCRIPTION
## Done

- Change listing page title maxlenght to 40 chars to match store restrictions

## Issue / Card

Fixes #2843 

## QA

- Pull the branch
- Run the site using the command `./run`
- View the site locally in your web browser at: http://0.0.0.0:8004/<snap_name>/listing
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Change the title of the snap to a long name. Note a negative count is displayed once the title length is over 40 chars.
