### PR TITLE
Update to Vanilla 2.13

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "sass-lint": "1.13.1",
     "swiper": "4.4.1",
     "topojson-client": "3.1.0",
-    "vanilla-framework": "2.12.1",
+    "vanilla-framework": "2.13.0",
     "watch-cli": "0.2.3",
     "webpack": "4.43.0",
     "webpack-cli": "3.3.11",

--- a/static/js/public/accordion.js
+++ b/static/js/public/accordion.js
@@ -25,7 +25,7 @@ export default function initAccordion(accordionContainerSelector) {
   document
     .querySelector(accordionContainerSelector)
     .addEventListener("click", (e) => {
-      const target = e.target.closest(".p-accordion__tab");
+      const target = e.target.closest("[class*='p-accordion__tab']");
       if (target && !target.disabled) {
         // Find any open panels within the container and close them.
         Array.from(
@@ -46,9 +46,13 @@ export default function initAccordion(accordionContainerSelector) {
         e.preventDefault();
 
         const currentPanel = button.closest(".p-accordion__group");
-        const currentToggle = currentPanel.querySelector(".p-accordion__tab");
+        const currentToggle = currentPanel.querySelector(
+          "[class*='p-accordion__tab']"
+        );
         const nextPanel = currentPanel.nextElementSibling;
-        const nextToggle = nextPanel.querySelector(".p-accordion__tab");
+        const nextToggle = nextPanel.querySelector(
+          "[class*='p-accordion__tab']"
+        );
 
         if (currentPanel && nextPanel) {
           toggleAccordion(currentToggle, false);
@@ -67,10 +71,12 @@ export function initAccordionButtons(continueButton) {
     event.preventDefault();
 
     const currentPanel = continueButton.closest(".p-accordion__group");
-    const currentToggle = currentPanel.querySelector(".p-accordion__tab");
+    const currentToggle = currentPanel.querySelector(
+      "[class*='p-accordion__tab']"
+    );
     const currentSuccess = currentPanel.querySelector(".p-icon--success");
     const nextPanel = currentPanel.nextElementSibling;
-    const nextToggle = nextPanel.querySelector(".p-accordion__tab");
+    const nextToggle = nextPanel.querySelector("[class*='p-accordion__tab']");
 
     toggleAccordion(currentToggle, false);
     if (currentSuccess) {

--- a/static/js/public/first-snap-flow.js
+++ b/static/js/public/first-snap-flow.js
@@ -263,9 +263,11 @@ function initRegisterName(formEl, notificationEl, successEl) {
     );
 
     const currentPanel = formEl.closest(".p-accordion__group");
-    const currentToggle = currentPanel.querySelector(".p-accordion__tab");
+    const currentToggle = currentPanel.querySelector(
+      ".p-accordion__tab--with-title"
+    );
     const nextPanel = currentPanel.nextElementSibling;
-    const nextToggle = nextPanel.querySelector(".p-accordion__tab");
+    const nextToggle = nextPanel.querySelector(".p-accordion__tab--with-title");
 
     const enableButton = () => {
       if (submitButton.disabled) {

--- a/templates/first-snap/build-and-test.html
+++ b/templates/first-snap/build-and-test.html
@@ -7,9 +7,9 @@
       <ol class="p-accordion__list">
         <li class="p-accordion__group">
           <button aria-expanded="true" type="button"
-            class="p-accordion__tab" id="tab1" role="tab"
+            class="p-accordion__tab--with-title" id="tab1" role="tab"
             aria-controls="#tab1-section">
-            <h4 class="u-no-margin--bottom">
+            <h4 class="p-accordion__title">
               Step 1: Build snap
             </h4>
           </button>
@@ -58,9 +58,9 @@
         </li>
         <li class="p-accordion__group">
           <button aria-expanded="false" type="button"
-            class="p-accordion__tab" id="tab2" role="tab"
+            class="p-accordion__tab--with-title" id="tab2" role="tab"
             aria-controls="#tab2-section">
-            <h4 class="u-no-margin--bottom">
+            <h4 class="p-accordion__title">
               Step 2: Test snap <span class="p-text-optional">(optional)</span>
             </h4>
           </button>

--- a/templates/first-snap/package.html
+++ b/templates/first-snap/package.html
@@ -6,8 +6,8 @@
     <div class="p-accordion" role="tablist" aria-multiselect="true">
       <ol class="p-accordion__list">
         <li class="p-accordion__group">
-          <button {% if has_user_chosen_name %}aria-expanded="false"{% else %}aria-expanded="true"{% endif %} type="button" class="p-accordion__tab" id="tab1" role="tab" aria-controls="#tab1-section" >
-            <h4 class="u-no-margin--bottom">
+          <button {% if has_user_chosen_name %}aria-expanded="false"{% else %}aria-expanded="true"{% endif %} type="button" class="p-accordion__tab--with-title" id="tab1" role="tab" aria-controls="#tab1-section" >
+            <h4 class="p-accordion__title">
               Step 1: Choose snap name
               {% if has_user_chosen_name %}<i class="p-icon--success"></i>{% endif %}
             </h4>
@@ -33,8 +33,8 @@
           </section>
         </li>
         <li class="p-accordion__group">
-          <button {% if has_user_chosen_name %}aria-expanded="true"{% else %}aria-expanded="false"{% endif %} type="button" class="p-accordion__tab" id="tab2" role="tab" aria-controls="#tab2-section">
-            <h4 class="u-no-margin--bottom">
+          <button {% if has_user_chosen_name %}aria-expanded="true"{% else %}aria-expanded="false"{% endif %} type="button" class="p-accordion__tab--with-title" id="tab2" role="tab" aria-controls="#tab2-section">
+            <h4 class="p-accordion__title">
               Step 2: Download your snapcraft.yaml
             </h4>
           </button>

--- a/templates/first-snap/push.html
+++ b/templates/first-snap/push.html
@@ -25,8 +25,8 @@
     <div class="p-accordion" role="tablist" aria-multiselect="true">
       <ol class="p-accordion__list">
         <li class="p-accordion__group">
-          <button {% if user %}disabled aria-expanded="false"{% else %}aria-expanded="true"{% endif %} type="button" class="p-accordion__tab" id="tab1" role="tab" aria-controls="#tab1-section" >
-            <h4 class="u-no-margin--bottom">
+          <button {% if user %}disabled aria-expanded="false"{% else %}aria-expanded="true"{% endif %} type="button" class="p-accordion__tab--with-title" id="tab1" role="tab" aria-controls="#tab1-section" >
+            <h4 class="p-accordion__title">
               Step 1: Create an Ubuntu One account
               {% if user %}<i class="p-icon--success"></i>{% endif %}
             </h4>
@@ -48,8 +48,8 @@
           </section>
         </li>
         <li class="p-accordion__group">
-          <button {% if not user %}disabled aria-expanded="false"{% else %}aria-expanded="true"{% endif %} type="button" class="p-accordion__tab" id="tab2" role="tab" aria-controls="#tab2-section" aria-expanded="false">
-            <h4 class="u-no-margin--bottom">
+          <button {% if not user %}disabled aria-expanded="false"{% else %}aria-expanded="true"{% endif %} type="button" class="p-accordion__tab--with-title" id="tab2" role="tab" aria-controls="#tab2-section" aria-expanded="false">
+            <h4 class="p-accordion__title">
               Step 2: Register your snap name
               <i id="register-name-success" class="p-icon--success u-hide"></i>
             </h4>
@@ -86,8 +86,8 @@
           </section>
         </li>
         <li class="p-accordion__group">
-          <button {% if not user %}disabled{% endif %} type="button" class="p-accordion__tab" id="tab3" role="tab" aria-controls="#tab3-section" aria-expanded="false">
-            <h4 class="u-no-margin--bottom">
+          <button {% if not user %}disabled{% endif %} type="button" class="p-accordion__tab--with-title" id="tab3" role="tab" aria-controls="#tab3-section" aria-expanded="false">
+            <h4 class="p-accordion__title">
               Step 3: Push to the Snap store
             </h4>
           </button>

--- a/yarn.lock
+++ b/yarn.lock
@@ -8661,10 +8661,10 @@ validate-npm-package-license@^3.0.1:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
 
-vanilla-framework@2.12.1:
-  version "2.12.1"
-  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-2.12.1.tgz#45a5265acd5cac55089322aaa1d03bd2da2334dd"
-  integrity sha512-y6O3EODqpTDp5DZG2pGP3HjMbGOOeslu4jCDRhfWtzI9znxG3D8eSlIPjjxkgTsxALup5mMuScmS9RWlbdF7cA==
+vanilla-framework@2.13.0:
+  version "2.13.0"
+  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-2.13.0.tgz#ac73e745150bcef183eb35e3ee47f3fd079ddd3e"
+  integrity sha512-EuxlGxO4SmCGL4GVzcye5aas2HGVqRhPxlTHg84Lfw1e1E4F/Coxs78i3xxkPGw3LOcfea0KU096ar1PnLNuXQ==
 
 vanilla-framework@2.4.1:
   version "2.4.1"


### PR DESCRIPTION
## Done

Updates Vanilla to 2.13 and updates first snap flow accordions to new updated class names (to use headings within accordion).

## QA

- Pull the branch
- Run the site using the command `./run`
- View the site locally in your web browser at: http://0.0.0.0:8004/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Go to first snap flow, make sure all accordions work and look as expected
- QA other accordions on the site (if any)
