### PR TITLE
Enable captions by default

### DIFF
--- a/templates/partials/_video.html
+++ b/templates/partials/_video.html
@@ -1,6 +1,6 @@
 {% if video.type == "youtube" %}
   <iframe id="ytplayer" type="text/html" width="818" height="460"
-          src="{{ video.url }}?autoplay=1&mute=1&modestbranding=1&rel=0" frameborder="0"></iframe>
+          src="{{ video.url }}?autoplay=1&mute=1&cc_load_policy=1&modestbranding=1&rel=0" frameborder="0"></iframe>
 {% elif video.type == "vimeo" %}
   <iframe id="vimeoplayer" width="818" height="460" frameborder="0"
           webkitallowfullscreen mozallowfullscreen allowfullscreen


### PR DESCRIPTION
## Done

- Enable captions by default

## Issue / Card

Fixes #2842 
## QA

- Pull the branch
- Run the site using the command `./run`
- View the site locally in your web browser at: http://0.0.0.0:8004/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)

- There is no easy way to test this, unless you know a snap that has a video and the video has a subtitle/cc (not auto-generated). If you do know `that snap` go to http://0.0.0.0:8004/<that_snap_name> and see the video has the captions `on` by default
If you don't know any snap that has that, just trust me. Here is an example that [has subtitle](https://www.youtube.com/embed/up21mvokyQ4?cc_load_policy=1) and [one that doesn't have](https://www.youtube.com/embed/0FC94Tgz2ho?cc_load_policy=1). Both of these have the caption turned on by default but only the one with subtitle will actually show it.

**Info**
It turns out hat you can only see the [subtitles/cc](https://developers.google.com/youtube/player_parameters#cc_load_policy) by default if the video has one. If it doesn't have one, it will show you the auto-generated one if you click the button but it will not show it by default.