### PR TITLE
Centre align the icon in the middle for buttons

### DIFF
--- a/static/js/publisher/tour/tourStepCard.js
+++ b/static/js/publisher/tour/tourStepCard.js
@@ -77,13 +77,13 @@ export default function TourStepCard({
           <button
             disabled={currentStepIndex === 0}
             onClick={onPrevClick}
-            className="p-button--neutral is-inline has-icon u-no-margin--bottom"
+            className="p-button--neutral has-icon u-no-margin--bottom"
           >
             <i className="p-icon--contextual-menu is-prev">Previous step</i>
           </button>
           <button
             onClick={isLastStep ? onFinishClick : onNextClick}
-            className="p-button--positive is-inline has-icon u-no-margin--bottom u-no-margin--right"
+            className="p-button--positive has-icon u-no-margin--bottom u-no-margin--right"
           >
             {isLastStep ? (
               "Finish tour"

--- a/static/sass/_snapcraft_builds.scss
+++ b/static/sass/_snapcraft_builds.scss
@@ -1,10 +1,12 @@
 @mixin snapcraft-builds {
-  .has-icon {
-    padding-left: 1.5rem;
+  table {
+    .has-icon {
+      padding-left: 1.5rem;
 
-    [class^="p-icon"] {
-      margin-left: -1.5rem;
-      margin-right: .5rem;
+      [class^="p-icon"] {
+        margin-left: -1.5rem;
+        margin-right: .5rem;
+      }
     }
   }
 }


### PR DESCRIPTION
## Done

- Centre align the icon in the middle for buttons

## Issue / Card

Fixes #2886 

## QA

- Pull the branch
- Run the site using the command `./run`
- View the site locally in your web browser at: http://0.0.0.0:8004/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Go to http://0.0.0.0:8004/<snap_name>/listing and click the tour button. Note the arrows in the `next` & `previous` buttons are in the centre
- Go to http://0.0.0.0:8004/tutorials/snap-download#1-introduction and note the arrows in the buttons at the button are in the centre

## Screenshots

![image](https://user-images.githubusercontent.com/40214246/84756714-10927400-afbb-11ea-91e3-69fa32b8e3be.png)

![image](https://user-images.githubusercontent.com/40214246/84756906-551e0f80-afbb-11ea-97d9-108816922da1.png)
