### PR TITLE
Appliance links

### DIFF
--- a/static/js/public/snap-details/channelMap.js
+++ b/static/js/public/snap-details/channelMap.js
@@ -31,7 +31,7 @@ class ChannelMap {
     let numberTracks = [];
     let stringTracks = [];
     let latestTracks = [];
-    rows.forEach((row) => {
+    rows.forEach(row => {
       // numbers are defined by any string starting any of the following patterns:
       //   just a number – 1,2,3,4,
       //   numbers on the left in a pattern – 2018.3 , 1.1, 1.1.23 ...
@@ -46,7 +46,7 @@ class ChannelMap {
     });
 
     // Ignore case
-    stringTracks.sort(function (a, b) {
+    stringTracks.sort(function(a, b) {
       return a[0].toLowerCase().localeCompare(b[0].toLowerCase());
     });
 
@@ -56,7 +56,7 @@ class ChannelMap {
     numberTracks.sort((a, b) => {
       return b[0].localeCompare(a[0], undefined, {
         numeric: true,
-        sensitivity: "base",
+        sensitivity: "base"
       });
     });
 
@@ -98,7 +98,7 @@ class ChannelMap {
     const archSelect = document.querySelector('[data-js="arch-select"]');
 
     archSelect.innerHTML = architectures
-      .map((arch) => `<option value="${arch}">${arch}</option>`)
+      .map(arch => `<option value="${arch}">${arch}</option>`)
       .join("");
 
     this.arch = this.channelMapData["amd64"] ? "amd64" : architectures[0];
@@ -126,7 +126,7 @@ class ChannelMap {
           }
         },
 
-        '[data-js="close-channel-map"]': (event) => {
+        '[data-js="close-channel-map"]': event => {
           event.preventDefault();
 
           this.closeChannelMap();
@@ -157,17 +157,17 @@ class ChannelMap {
         '[data-js="slide-install-instructions"]': (event, target) => {
           event.preventDefault();
           this.slideToInstructions(target);
-        },
+        }
       },
 
       change: {
         '[data-js="arch-select"]': (event, target) => {
           this.prepareTable(this.channelMapData[target.value]);
-        },
-      },
+        }
+      }
     });
 
-    this.events.addEvent("keyup", window, (event) => {
+    this.events.addEvent("keyup", window, event => {
       this._closeOnEscape.call(this, event);
     });
 
@@ -184,7 +184,7 @@ class ChannelMap {
     const buttonRect = this.openButton.getBoundingClientRect();
     const channelMapPosition = [
       windowWidth - buttonRect.right,
-      buttonRect.y + buttonRect.height + 16 + window.scrollY,
+      buttonRect.y + buttonRect.height + 16 + window.scrollY
     ];
 
     this.channelMapEl.style.right = `${channelMapPosition[0]}px`;
@@ -322,10 +322,18 @@ class ChannelMap {
       paramString += ` --classic`;
     }
 
+    let warning = "";
+    if (channel.indexOf("stable") === -1) {
+      warning = `Snaps on the ${channel} channel can break and change often.`;
+    }
+
     const template = this.INSTALL_TEMPLATE.split("${channel}")
       .join(channel)
       .split("${paramString}")
-      .join(paramString);
+      .join(paramString)
+      .split("${warning}")
+      .join(warning);
+
     const holder = document.querySelector(
       '[data-js="channel-map-install-details"]'
     );
@@ -381,7 +389,7 @@ class ChannelMap {
     let trimmedNumberOfTracks = 0;
 
     // Get a total number of tracks
-    Object.keys(archData).forEach((arch) => {
+    Object.keys(archData).forEach(arch => {
       numberOfTracks += archData[arch].length;
     });
 
@@ -392,7 +400,7 @@ class ChannelMap {
 
     // ...and don't do the expensive bit
     if (filtered) {
-      Object.keys(archData).forEach((track) => {
+      Object.keys(archData).forEach(track => {
         // Sort by risk
         archData[track].sort((a, b) => {
           return (
@@ -420,15 +428,15 @@ class ChannelMap {
     }
 
     // Create an array of columns
-    Object.keys(trackList).forEach((track) => {
-      trackList[track].forEach((trackInfo) => {
+    Object.keys(trackList).forEach(track => {
+      trackList[track].forEach(trackInfo => {
         const trackName = track.split("/")[0];
         rows.push([
           trackName,
           trackInfo["risk"],
           trackInfo["version"],
           trackInfo["created-at"],
-          trackInfo["confinement"],
+          trackInfo["confinement"]
         ]);
       });
     });

--- a/static/js/public/snap-details/channelMap.js
+++ b/static/js/public/snap-details/channelMap.js
@@ -31,7 +31,7 @@ class ChannelMap {
     let numberTracks = [];
     let stringTracks = [];
     let latestTracks = [];
-    rows.forEach(row => {
+    rows.forEach((row) => {
       // numbers are defined by any string starting any of the following patterns:
       //   just a number – 1,2,3,4,
       //   numbers on the left in a pattern – 2018.3 , 1.1, 1.1.23 ...
@@ -46,7 +46,7 @@ class ChannelMap {
     });
 
     // Ignore case
-    stringTracks.sort(function(a, b) {
+    stringTracks.sort(function (a, b) {
       return a[0].toLowerCase().localeCompare(b[0].toLowerCase());
     });
 
@@ -56,7 +56,7 @@ class ChannelMap {
     numberTracks.sort((a, b) => {
       return b[0].localeCompare(a[0], undefined, {
         numeric: true,
-        sensitivity: "base"
+        sensitivity: "base",
       });
     });
 
@@ -98,7 +98,7 @@ class ChannelMap {
     const archSelect = document.querySelector('[data-js="arch-select"]');
 
     archSelect.innerHTML = architectures
-      .map(arch => `<option value="${arch}">${arch}</option>`)
+      .map((arch) => `<option value="${arch}">${arch}</option>`)
       .join("");
 
     this.arch = this.channelMapData["amd64"] ? "amd64" : architectures[0];
@@ -126,7 +126,7 @@ class ChannelMap {
           }
         },
 
-        '[data-js="close-channel-map"]': event => {
+        '[data-js="close-channel-map"]': (event) => {
           event.preventDefault();
 
           this.closeChannelMap();
@@ -157,17 +157,17 @@ class ChannelMap {
         '[data-js="slide-install-instructions"]': (event, target) => {
           event.preventDefault();
           this.slideToInstructions(target);
-        }
+        },
       },
 
       change: {
         '[data-js="arch-select"]': (event, target) => {
           this.prepareTable(this.channelMapData[target.value]);
-        }
-      }
+        },
+      },
     });
 
-    this.events.addEvent("keyup", window, event => {
+    this.events.addEvent("keyup", window, (event) => {
       this._closeOnEscape.call(this, event);
     });
 
@@ -184,7 +184,7 @@ class ChannelMap {
     const buttonRect = this.openButton.getBoundingClientRect();
     const channelMapPosition = [
       windowWidth - buttonRect.right,
-      buttonRect.y + buttonRect.height + 16 + window.scrollY
+      buttonRect.y + buttonRect.height + 16 + window.scrollY,
     ];
 
     this.channelMapEl.style.right = `${channelMapPosition[0]}px`;
@@ -389,7 +389,7 @@ class ChannelMap {
     let trimmedNumberOfTracks = 0;
 
     // Get a total number of tracks
-    Object.keys(archData).forEach(arch => {
+    Object.keys(archData).forEach((arch) => {
       numberOfTracks += archData[arch].length;
     });
 
@@ -400,7 +400,7 @@ class ChannelMap {
 
     // ...and don't do the expensive bit
     if (filtered) {
-      Object.keys(archData).forEach(track => {
+      Object.keys(archData).forEach((track) => {
         // Sort by risk
         archData[track].sort((a, b) => {
           return (
@@ -428,15 +428,15 @@ class ChannelMap {
     }
 
     // Create an array of columns
-    Object.keys(trackList).forEach(track => {
-      trackList[track].forEach(trackInfo => {
+    Object.keys(trackList).forEach((track) => {
+      trackList[track].forEach((trackInfo) => {
         const trackName = track.split("/")[0];
         rows.push([
           trackName,
           trackInfo["risk"],
           trackInfo["version"],
           trackInfo["created-at"],
-          trackInfo["confinement"]
+          trackInfo["confinement"],
         ]);
       });
     });

--- a/static/sass/_snapcraft_details_heading.scss
+++ b/static/sass/_snapcraft_details_heading.scss
@@ -61,7 +61,7 @@
       margin-top: $sp-unit; // align with snap name baseline
     }
 
-    button:last-child {
+    button:last-of-type {
       margin-right: 0;
     }
 

--- a/templates/store/snap-details.html
+++ b/templates/store/snap-details.html
@@ -120,7 +120,7 @@
             {% endif %}
             {% if package_name in appliances %}
             <p class="u-no-margin--bottom">
-              Also available as:
+              Available as an
               <span class="p-tooltip--btm-center" style="z-index: 2">
                 <a href="https://ubuntu.com/appliance/{{appliances[package_name]}}" class="p-link--external">Ubuntu Appliance</a>
                 <span class="p-tooltip__message">Install a ready-made {{snap_title}} image<br />on a Raspberry Pi, an Intel NUC or try<br />it in a VM and get started.</span>

--- a/templates/store/snap-details.html
+++ b/templates/store/snap-details.html
@@ -114,10 +114,19 @@
               aria-controls="channel-map-install">
                 Install
                 {% if is_preview %}
-                  <span class="p-tooltip__message u-align--center" role="tooltip" id="{{ package_name }}-preview-channel-map">This content is being displayed for preview purposes</span>
-                {% endif %}
+              <span class="p-tooltip__message u-align--center" role="tooltip" id="{{ package_name }}-preview-channel-map">This content is being displayed for preview purposes</span>
+              {% endif %}
             </button>
-          {% endif %}
+            {% endif %}
+            {% if package_name in appliances %}
+            <p class="u-no-margin--bottom">
+              Also available as:
+              <span class="p-tooltip--btm-center" style="z-index: 2">
+                <a href="https://ubuntu.com/appliance/{{appliances[package_name]}}" class="p-link--external">Ubuntu Appliance</a>
+                <span class="p-tooltip__message">Install a ready-made {{snap_title}} image<br />on a Raspberry Pi, an Intel NUC or try<br />it in a VM and get started.</span>
+              </span>
+            </p>
+            {% endif %}
         </div>
       {% else %}
         <div class="p-snap-install-buttons">

--- a/templates/store/snap-details/_channel_map.html
+++ b/templates/store/snap-details/_channel_map.html
@@ -61,6 +61,9 @@
               </div>
             </div>
           </form>
+          {% if not has_stable %}
+          <p><i class="p-icon--warning"></i> {{ snap_title }} is only available at the unstable {{lowest_risk_available}} channel. It could break and change often.</p>
+          {% endif %}
         </div>
         <div class="u-fixed-width" data-js="channel-map-tabs">
           <nav class="p-tabs">
@@ -115,6 +118,7 @@
   </div>
   <div class="u-fixed-width">
     <p class="p-heading--4">Install ${channel} of {{ snap_title }}</p>
+    ${warning}
     <label>Ubuntu 16.04 or later?</label>
     <button data-snap="{{ package_name }}?channel=${channel}" class="p-view-store-button" data-js="open-desktop">View in Desktop store</button>
     <p class="p-form-help-text">Make sure <a href="/docs/installing-snapd">snap support</a> is enabled in your Desktop store.</p>

--- a/templates/store/snap-details/_channel_map.html
+++ b/templates/store/snap-details/_channel_map.html
@@ -39,6 +39,16 @@
           Don't have snapd? <a href="/docs/installing-snapd">Get set up for snaps</a>.
         </p>
       </div>
+      {% if package_name in appliances %}
+      <div class="u-fixed-width">
+        <hr />
+      </div>
+      <div class="u-fixed-width">
+        <p class="u-no-margin--bottom">
+          Also available as: <a href="https://ubuntu.com/appliance/{{appliances[package_name]}}" class="p-link--external">Ubuntu Appliance</a>
+        </p>
+      </div>
+      {% endif %}
     </div>
   </div>
   <div id="channel-map-versions" class="p-channel-map__tab">

--- a/templates/store/snap-details/_channel_map.html
+++ b/templates/store/snap-details/_channel_map.html
@@ -72,7 +72,7 @@
             </div>
           </form>
           {% if not has_stable %}
-          <p><i class="p-icon--warning"></i> {{ snap_title }} is only available at the unstable {{lowest_risk_available}} channel. It could break and change often.</p>
+          <p><i class="p-icon--warning"></i> {{ snap_title }} is only available on the unstable {{lowest_risk_available}} channel. It could break and change often.</p>
           {% endif %}
         </div>
         <div class="u-fixed-width" data-js="channel-map-tabs">

--- a/templates/store/snap-details/_channel_map.html
+++ b/templates/store/snap-details/_channel_map.html
@@ -45,7 +45,7 @@
       </div>
       <div class="u-fixed-width">
         <p class="u-no-margin--bottom">
-          Also available as: <a href="https://ubuntu.com/appliance/{{appliances[package_name]}}" class="p-link--external">Ubuntu Appliance</a>
+          Available as an <a href="https://ubuntu.com/appliance/{{appliances[package_name]}}" class="p-link--external">Ubuntu Appliance</a>
         </p>
       </div>
       {% endif %}

--- a/webapp/store/snap_details_views.py
+++ b/webapp/store/snap_details_views.py
@@ -181,6 +181,14 @@ def snap_details_views(store, api, handle_errors):
             "is_users_snap": is_users_snap,
             "unlisted": details["snap"]["unlisted"],
             "developer": developer,
+            # TODO: This is horrible and hacky
+            "appliances": {
+                "adguard-home": "adguard",
+                "mosquitto": "mosquitto",
+                "nextcloud": "nextcloud",
+                "plexmediaserver": "plex",
+                "openhab": "openhab",
+            },
         }
 
         return context


### PR DESCRIPTION
## Done

- Added some hackery for appliances

## Issue / Card

Fixes #2882

## QA

- Pull the branch
- Run the site using the command `./run`
- View the site locally in your web browser at: http://0.0.0.0:8004/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Visit http://0.0.0.0:8004/adguard-home, http://0.0.0.0:8004/mosquitto, http://0.0.0.0:8004/nextcloud, http://0.0.0.0:8004/plexmediaserver and http://0.0.0.0:8004/openhab and see the links. Click them - they should take you to the right ubuntu page.

## Screenshots

![image](https://user-images.githubusercontent.com/479384/84801039-941d8680-aff6-11ea-852e-ebc115dee5cb.png)
![image](https://user-images.githubusercontent.com/479384/84801067-9c75c180-aff6-11ea-8d51-4b1c0dfac2bc.png)
