### PR TITLE
Update Dockerfile: Remove unnecessary ADD

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,6 @@ RUN yarn run build-js
 # ===
 FROM ubuntu:focal
 
-ADD . .
 # Install python and import python dependencies
 RUN apt-get update && apt-get install --no-install-recommends --yes python3-lib2to3 python3-setuptools python3-pkg-resources ca-certificates libsodium-dev
 COPY --from=python-dependencies /root/.local/lib/python3.8/site-packages /root/.local/lib/python3.8/site-packages


### PR DESCRIPTION
## Done

There is an extra ADD not needed in our Docker image, this issue was causing the following problem: https://github.com/docker/cli/issues/2587#issuecomment-644796611

## QA
- `DOCKER_BUILDKIT=1 docker build --build-arg BUILD_ID=test --tag test .`
- `docker run -ti -p "8004:80" --env SECRET_KEY=secret_key test`
- Check http://0.0.0.0:8004