### PR TITLE
Shorten build table statuses

### DIFF
--- a/static/js/publisher/builds/helpers.js
+++ b/static/js/publisher/builds/helpers.js
@@ -24,19 +24,14 @@ export const UserFacingStatus = {
     6,
     WONT_RELEASE
   ),
-  [RELEASED]: createStatus("Built and released", "Released", 5, "released"),
+  [RELEASED]: createStatus("Released", "Released", 5, "released"),
   [RELEASE_FAILED]: createStatus(
     "Built, failed to release",
     "Failed",
     4,
     RELEASE_FAILED
   ),
-  [RELEASING_SOON]: createStatus(
-    "Built, releasing soon",
-    "Releasing",
-    3,
-    RELEASING_SOON
-  ),
+  [RELEASING_SOON]: createStatus("Releasing", "Releasing", 3, RELEASING_SOON),
   [IN_PROGRESS]: createStatus("In progress", "In progress", 2, IN_PROGRESS),
   [FAILED_TO_BUILD]: createStatus(
     "Failed to build",


### PR DESCRIPTION
## Done

- Shorten build table statuses:
Built and Released → Released
Build, releasing soon → Releasing

## Issue / Card

Fixes #2891 

## QA

- Pull the branch
- Run the site using the dotrun snap with `$ dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8004/<snap_name>/builds
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Trigger a new build and notice the statuses: `Releasing` instead of "Built and released" & `Releasing` instead of "Build, releasing soon"

## Screenshots

[if relevant, include a screenshot]
