### PR TITLE
Added snap revision JSON endpoint

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ canonicalwebteam.discourse-docs==0.12.0
 canonicalwebteam.blog==5.0.0
 canonicalwebteam.search==0.2.1
 canonicalwebteam.image-template==1.1.0
-canonicalwebteam.store-api==2.1.1
+canonicalwebteam.store-api==2.1.2
 canonicalwebteam.launchpad==0.7.6
 django-openid-auth==0.15
 Flask-OpenID-Stateless==1.2.6

--- a/webapp/publisher/snaps/release_views.py
+++ b/webapp/publisher/snaps/release_views.py
@@ -181,3 +181,23 @@ def post_default_track(snap_name):
         return _handle_error(api_error)
 
     return flask.jsonify({"success": True})
+
+
+@login_required
+def get_snap_revision_json(snap_name, revision):
+    """
+    Return JSON object from the publisher API
+    """
+    try:
+        revision = publisher_api.get_snap_revision(
+            flask.session, snap_name, revision
+        )
+    except StoreApiResponseErrorList as api_response_error_list:
+        if api_response_error_list.status_code == 404:
+            return flask.abort(404, "No snap named {}".format(snap_name))
+        else:
+            return flask.jsonify(api_response_error_list.errors), 400
+    except (StoreApiError, ApiError) as api_error:
+        return _handle_error(api_error)
+
+    return flask.jsonify(revision)

--- a/webapp/publisher/snaps/views.py
+++ b/webapp/publisher/snaps/views.py
@@ -164,6 +164,10 @@ publisher_snaps.add_url_rule(
     view_func=release_views.post_default_track,
     methods=["POST"],
 )
+publisher_snaps.add_url_rule(
+    "/<snap_name>/releases/revision/<revision>",
+    view_func=release_views.get_snap_revision_json,
+)
 
 # Metrics views
 publisher_snaps.add_url_rule(


### PR DESCRIPTION
## Done

Added snap revision JSON endpoint

## QA

- Pull the branch
- Run the site using the dotrun snap with `$ dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8004/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Login as a publisher
- `http://0.0.0.0:8004/<your-snap>/releases/revision/<your-revision>`
- The result should be a json object
