### PR TITLE
additional messages for risk levels

### DIFF
--- a/static/js/public/snap-details/channelMap.js
+++ b/static/js/public/snap-details/channelMap.js
@@ -323,22 +323,34 @@ class ChannelMap {
     }
 
     let warning = "";
-    if (channel.indexOf("stable") === -1) {
-      warning = `Snaps on the ${channel} channel can break and change often.`;
+    if (channel.indexOf("edge") > -1) {
+      warning = "Snaps on the edge channel can break and change often.";
+    } else if (channel.indexOf("beta") > -1) {
+      warning =
+        "Snaps on the beta channel may have unfinished parts, breaking changes may occur.";
+    } else if (channel.indexOf("candidate") > -1) {
+      warning =
+        "Snaps on the candidate channel need additional real world experimentation before the move to stable.";
     }
 
     const template = this.INSTALL_TEMPLATE.split("${channel}")
       .join(channel)
       .split("${paramString}")
-      .join(paramString)
-      .split("${warning}")
-      .join(warning);
+      .join(paramString);
+
+    const newDiv = document.createElement("div");
+    newDiv.innerHTML = template;
+
+    const warningEl = newDiv.querySelector("[data-js='warning']");
+    if (warningEl) {
+      warningEl.innerHTML = warning;
+    }
 
     const holder = document.querySelector(
       '[data-js="channel-map-install-details"]'
     );
 
-    holder.innerHTML = template;
+    holder.innerHTML = newDiv.innerHTML;
   }
 
   writeTable(el, data) {

--- a/templates/store/snap-details/_channel_map.html
+++ b/templates/store/snap-details/_channel_map.html
@@ -127,8 +127,8 @@
     <a href="#" data-js="slide-all-versions">&lsaquo; All versions</a>
   </div>
   <div class="u-fixed-width">
-    <p class="p-heading--4">Install ${channel} of {{ snap_title }}</p>
-    ${warning}
+  <p class="p-heading--4">Install ${channel} of {{ snap_title }}</p>
+  <span data-js="warning"></span>
     <label>Ubuntu 16.04 or later?</label>
     <button data-snap="{{ package_name }}?channel=${channel}" class="p-view-store-button" data-js="open-desktop">View in Desktop store</button>
     <p class="p-form-help-text">Make sure <a href="/docs/installing-snapd">snap support</a> is enabled in your Desktop store.</p>


### PR DESCRIPTION
## Done

- Assign template to a div and use query selector to update the warning string
- Added additional warnings.

## Issue / Card

Fixes #2898 
Fixes #2900

## QA

- Pull the branch
- Run the site using the dotrun snap with `$ dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8004/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Visit http://0.0.0.0:8004/lukewh-test
- Click the channel-map dropdown, click "install >" and "< back" on each risk to ensure the messages are there.
