### PR TITLE
Remove logout redirect through BSI

### DIFF
--- a/tests/publisher/tests_account_logout.py
+++ b/tests/publisher/tests_account_logout.py
@@ -17,29 +17,4 @@ class LogoutRedirects(BaseTestCases.BaseAppTesting):
 
         self.assertEqual(302, response.status_code)
 
-        self.assertEqual(
-            (
-                "https://login.ubuntu.com/+logout"
-                "?return_to=http%3A%2F%2Flocalhost%2F&return_now=True"
-            ),
-            response.location,
-        )
-
-    def test_no_redirect_logout(self):
-        bad_param_response = self.client.get(
-            self.endpoint_url + "?no_redirect=false"
-        )
-
-        self.assertEqual(302, bad_param_response.status_code)
-        self.assertEqual(
-            (
-                "https://login.ubuntu.com/+logout"
-                "?return_to=http%3A%2F%2Flocalhost%2F&return_now=True"
-            ),
-            bad_param_response.location,
-        )
-
-        response = self.client.get(self.endpoint_url + "?no_redirect=true")
-
-        self.assertEqual(302, response.status_code)
         self.assertEqual("http://localhost/", response.location)

--- a/webapp/login/views.py
+++ b/webapp/login/views.py
@@ -1,5 +1,4 @@
 import os
-from urllib.parse import quote
 
 import flask
 from canonicalwebteam.store_api.stores.snapstore import SnapPublisher
@@ -17,8 +16,6 @@ login = flask.Blueprint(
 )
 
 LOGIN_URL = os.getenv("LOGIN_URL", "https://login.ubuntu.com")
-
-BSI_URL = os.getenv("BSI_URL", "https://build.snapcraft.io")
 
 LP_CANONICAL_TEAM = "canonical"
 
@@ -101,13 +98,6 @@ def after_login(resp):
 
 @login.route("/logout")
 def logout():
-    no_redirect = flask.request.args.get("no_redirect", default="false")
     authentication.empty_session(flask.session)
 
-    if no_redirect == "true":
-        return flask.redirect("/")
-    else:
-        redirect_url = quote(flask.request.url_root, safe="")
-        return flask.redirect(
-            f"{LOGIN_URL}/+logout?return_to={redirect_url}&return_now=True"
-        )
+    return flask.redirect("/")


### PR DESCRIPTION
## Done

- Remove redirect to BSI on logout

## Issue / Card

Fixes #2906 

## QA

- Pull the branch
- Run the site using the dotrun snap with `$ dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8004/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Logout
- Be redirected to /
