### PR TITLE
Remove build with github link from navigaton

### DIFF
--- a/templates/_header.html
+++ b/templates/_header.html
@@ -76,9 +76,6 @@
                 <a href="/account/snaps" class="p-subnav__item">My published snaps</a>
               </li>
               <li>
-                <a href="{{ BSI_URL }}/auth/authenticate" class="p-subnav__item">Build with GitHub</a>
-              </li>
-              <li>
                 <a href="/account/details" class="p-subnav__item">Account details</a>
               </li>
               <li>


### PR DESCRIPTION
## Done

- Remove `build with github` link from the navigation

## Issue / Card

Fixes #2874 

## QA

- Pull the branch
- Run the site using the dotrun snap with `$ dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8004/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See there is no `Build with Github` link in the nav

## Screenshots

![image](https://user-images.githubusercontent.com/40214246/85841831-97eb9e80-b796-11ea-975a-11f9d9a04acd.png)

