### PR TITLE
Fix bug with banner removal when trying to replace it first with and invalid image

### DIFF
--- a/static/js/publisher/form/banner.js
+++ b/static/js/publisher/form/banner.js
@@ -55,6 +55,7 @@ class Banner extends React.Component {
     const { updateImageState } = this.props;
 
     this.setState({
+      errors: {},
       bannerImage: {},
     });
 

--- a/static/js/publisher/form/fileInput.js
+++ b/static/js/publisher/form/fileInput.js
@@ -82,6 +82,10 @@ class FileInput extends React.Component {
     );
 
     Promise.all(files).then((values) => {
+      // Remove the new file from input if is not valid
+      if (values[0].errors) {
+        this.input.value = "";
+      }
       fileChangedCallback(values);
     });
   }


### PR DESCRIPTION
## Done

- Fix bug with banner removal when trying to replace it first with and invalid image

## Issue / Card

Fixes https://github.com/canonical-web-and-design/snap-squad/issues/1018

## QA

- Pull the branch
- Run the site using the dotrun snap with `$ dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8004/<snap_name>/listing
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)

1. Go to snap listing page (with a banner uploaded or upload and save a banner)
2. With existing banner visible, click Edit to change banner
3. Choose image with wrong aspect ratio
4. See error message
5. Click icon to remove existing banner image
6. See error message has disappeared
7. Click "Save" to save removing to banner
8. See the banner was successfully removed 

