### PR TITLE
Check for updates to GitHub Actions every weekday

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+# Set update schedule for GitHub Actions
+
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every weekday
+      interval: "daily"


### PR DESCRIPTION
This adds dependabot which is now native to GitHub to check for updates against any GitHub actions used and send PRs automatically with updates.