### PR TITLE
Flutter

### DIFF
--- a/templates/home/_fsf_flutter.html
+++ b/templates/home/_fsf_flutter.html
@@ -37,7 +37,7 @@
  <b>apps</b>:
    <b>flutter-gallery</b>:
       <b>command</b>: gallery
-      <b>extensions</b>: [flutter-master]
+      <b>extensions</b>: [flutter-master]</pre>
 
       {% include "home/_fsf_yaml_show_more.html" %}
 

--- a/templates/home/_fsf_flutter.html
+++ b/templates/home/_fsf_flutter.html
@@ -1,0 +1,46 @@
+<div class="row u-hide u-no-padding" data-flow-details="flutter">
+  <div class="col-6">
+    <h4>Why are snaps good for Flutter projects?</h4>
+    <ul>
+      <li>Snaps are easy to discover and install. Millions of users can browse and install snaps graphically in the Snap Store or from the command-line.</li>
+      <li>Snaps install and run the same across Linux. They bundle the exact versions of your app’s dependencies.</li>
+      <li>Snaps automatically update to the latest version. Four times a day, users’ systems will check for new versions and upgrade in the background.</li>
+      <li>Upgrades are not disruptive. Because upgrades are not in-place, users can keep your app open as it’s upgraded in the background.</li>
+      <li>Upgrades are safe. If your app fails to upgrade, users automatically roll back to the previous revision.</li>
+    </ul>
+
+    <div class="p-flow-details__continue">
+      <p>In just a few steps, you’ll have an example Flutter app in the Snap Store.</p>
+      <a class="p-button--positive" href="first-snap/c">Continue &rsaquo;</a>
+    </div>
+  </div>
+
+  <div class="col-6">
+    <h4>Here's how <a href="https://snapcraft.io/flutter-gallery">flutter-gallery</a> defines snapcraft.yaml:</h4>
+    <div class ="p-show-more is-collapsed" data-js="js-show-more">
+      <pre class="p-code-yaml"><b>name</b>: flutter-gallery
+<b>version</b>: "1.0"
+<b>summary</b>: Flutter Gallery
+<b>description</b>: |
+    A demo app for Flutter's material design and cupertino widgets, as well
+    as many other features of the Flutter SDK.[&hellip;]
+
+<b>confinement</b>: strict
+<b>base</b>: core18
+
+<b>parts</b>:
+  <b>flutter-gallery</b>:
+    <b>plugin</b>: flutter
+    <b>source</b>: https://github.com/flutter/gallery.git
+    <b>flutter-target</b>: lib/main.dart
+
+ <b>apps</b>:
+   <b>flutter-gallery</b>:
+      <b>command</b>: gallery
+      <b>extensions</b>: [flutter-master]
+
+      {% include "home/_fsf_yaml_show_more.html" %}
+
+    </div>
+  </div>
+</div>

--- a/templates/home/_fsf_flutter.html
+++ b/templates/home/_fsf_flutter.html
@@ -22,7 +22,7 @@
 <b>version</b>: "1.0"
 <b>summary</b>: Flutter Gallery
 <b>description</b>: |
-    A demo app for Flutter's material design and cupertino widgets, as well
+    A demo app for Flutter's material design [&hellip;]
     as many other features of the Flutter SDK.[&hellip;]
 
 <b>confinement</b>: strict

--- a/templates/home/_fsf_flutter.html
+++ b/templates/home/_fsf_flutter.html
@@ -11,7 +11,7 @@
 
     <div class="p-flow-details__continue">
       <p>In just a few steps, you’ll have an example Flutter app in the Snap Store.</p>
-      <a class="p-button--positive" href="first-snap/c">Continue &rsaquo;</a>
+      <a class="p-button--positive" href="first-snap/flutter">Continue &rsaquo;</a>
     </div>
   </div>
 

--- a/templates/partials/fsf_language.html
+++ b/templates/partials/fsf_language.html
@@ -209,6 +209,7 @@
   </div>
   {% include "home/_fsf_c.html" %}
   {% include "home/_fsf_electron.html" %}
+  {% include "home/_fsf_flutter.html" %}
   {% include "home/_fsf_go.html" %}
   {% include "home/_fsf_java.html" %}
   {% include "home/_fsf_moos.html" %}

--- a/templates/partials/fsf_language.html
+++ b/templates/partials/fsf_language.html
@@ -116,7 +116,7 @@
       <header class="p-card__header">
         {{
           image(
-            url="FIXME",
+            url="https://assets.ubuntu.com/v1/a661a6b5-Flutter.svg",
             alt="Flutter",
             width="97",
             height="97",

--- a/templates/partials/fsf_language.html
+++ b/templates/partials/fsf_language.html
@@ -112,6 +112,22 @@
     </a>
   </div>
   <div class="col-small-2 col-medium-3 col-2 col-lang-select">
+    <a class="p-logo-link p-card p-flow-link" href="/first-snap/flutter" data-flow-link="flutter">
+      <header class="p-card__header">
+        {{
+          image(
+            url="FIXME",
+            alt="Flutter",
+            width="97",
+            height="97",
+            hi_def=True
+          ) | safe
+        }}
+      </header>
+      <span>Flutter</span>
+    </a>
+  </div>
+  <div class="col-small-2 col-medium-3 col-2 col-lang-select">
     <a class="p-logo-link p-card p-flow-link" href="/first-snap/ruby" data-flow-link="ruby">
       <header class="p-card__header">
         {{

--- a/webapp/first_snap/content/flutter/build.yaml
+++ b/webapp/first_snap/content/flutter/build.yaml
@@ -1,0 +1,37 @@
+name: test-flutter-gallery-{name}
+linux:
+  auto:
+    - action: "Create a directory, move the downloaded snapcraft.yaml file into the new directory and navigate there:"
+      command: mkdir ~/${name} && mv ~/Downloads/snapcraft.yaml ~/${name} && cd  ~/${name}
+    - action: "Run snapcraft:"
+      command: snapcraft
+    - warning: |
+        Make sure the name matches what has been used previously (i.e <code>${name}</code>)
+  manual:
+    - action: "Return to the root directory of the project containing your snapcraft.yaml and run the snapcraft Docker image:"
+      command: docker run -v $PWD:$PWD -w $PWD snapcore/snapcraft snapcraft
+    - action: "Install the snap:"
+      command: sudo snap install --dangerous *.snap
+    - action: "List your installed snaps to confirm:"
+      command: snap list
+    - action: "Run the snap:"
+      command: ${name} -h
+    - warning: |
+        Make sure the name matches what has been used previously (i.e <code>${name}</code>)
+macos:
+  auto:
+    - action: "Create a directory, move the downloaded snapcraft.yaml file into the new directory and navigate there:"
+      command: mkdir ~/${name} && mv ~/Downloads/snapcraft.yaml ~/${name} && cd  ~/${name}
+    - action: "Run snapcraft:"
+      command: snapcraft
+  manual:
+    - action: "Return to the root directory of the project containing your snapcraft.yaml and run the snapcraft Docker image:"
+      command: docker run -v $PWD:$PWD -w $PWD snapcore/snapcraft snapcraft
+windows:
+  auto:
+    - action: Run Windows Subsystem for Linux from the Windows Start menu
+    - action: "Return to the root directory of the project containing your snapcraft.yaml and run snapcraft:"
+      command: snapcraft
+  manual:
+    - action: "Return to the root directory of the project containing your snapcraft.yaml and run the snapcraft Docker image:"
+      command: docker run -v $PWD:$PWD -w $PWD snapcore/snapcraft snapcraft

--- a/webapp/first_snap/content/flutter/package.yaml
+++ b/webapp/first_snap/content/flutter/package.yaml
@@ -1,0 +1,2 @@
+name: test-flutter-gallery-{name}
+download: git clone https://github.com/flutter/gallery

--- a/webapp/first_snap/content/flutter/snapcraft.yaml
+++ b/webapp/first_snap/content/flutter/snapcraft.yaml
@@ -1,0 +1,21 @@
+name: ${name}
+version: '1.0'
+summary: Flutter Gallery
+description: |
+  A demo app for Flutter's material design and cupertino widgets, as well 
+  as many other features of the Flutter SDK.
+
+confinement: stable
+base: core18
+
+parts:
+  ${name}:
+    plugin: flutter
+    source: https://github.com/flutter/gallery.git
+    flutter-channel: dev
+    flutter-target: lib/main.dart
+
+apps:
+  ${name}:
+    command: gallery
+    extensions: [flutter]

--- a/webapp/first_snap/content/flutter/snapcraft.yaml
+++ b/webapp/first_snap/content/flutter/snapcraft.yaml
@@ -12,10 +12,9 @@ parts:
   ${name}:
     plugin: flutter
     source: https://github.com/flutter/gallery.git
-    flutter-channel: dev
     flutter-target: lib/main.dart
 
 apps:
   ${name}:
     command: gallery
-    extensions: [flutter]
+    extensions: [flutter-master]

--- a/webapp/first_snap/content/flutter/snapcraft.yaml
+++ b/webapp/first_snap/content/flutter/snapcraft.yaml
@@ -5,7 +5,7 @@ description: |
   A demo app for Flutter's material design and cupertino widgets, as well 
   as many other features of the Flutter SDK.
 
-confinement: stable
+confinement: devmode
 base: core18
 
 parts:

--- a/webapp/first_snap/content/flutter/test.yaml
+++ b/webapp/first_snap/content/flutter/test.yaml
@@ -1,0 +1,23 @@
+name: test-flutter-gallery-{name}
+linux:
+  - action: "Install the snap:"
+    command: sudo snap install --dangerous *.snap
+  - action: "List your installed snaps to confirm:"
+    command: snap list
+  - action: "Run the snap:"
+    command: ${name} -h
+macos:
+  - action: "Create a Linux virtual machine for testing snaps:"
+    command: multipass launch -n testvm
+  - action: "Return to the directory containing the .snap file and copy it into the virtual machine:"
+    command: 'multipass copy-files ${name}*.snap testvm:'
+  - action: "Connect to the virtual machine:"
+    command: multipass shell testvm
+  - action: "Install the snap inside the virtual machine:"
+    command: sudo snap install --dangerous ${name}*.snap
+  - action: "Confirm the snap is installed by listing your installed snaps:"
+    command: snap list
+  - action: "Run the snap inside the virtual machine:"
+    command: ${name} -h
+  - action: "Exit the virtual machine:"
+    command: exit


### PR DESCRIPTION
## Done

Adds Flutter to the first-run

There is a FIXME in place of the flutter logo, which seems to be causing the test failures.  I'd recommend using this logo:  https://drive.google.com/file/d/1Ka-_VgfVS_eLeY6DMZMqsFxFgr_fnvFf/view?usp=sharing

## Issue / Card

Fixes #

## QA

- Pull the branch
- Run the site using the dotrun snap with `$ dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8004/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- [List additional steps to QA the new features or prove the bug has been resolved]

## Screenshots

[if relevant, include a screenshot]
