### PR TITLE
Mirror flutter logo

### DIFF
--- a/templates/partials/fsf_language.html
+++ b/templates/partials/fsf_language.html
@@ -116,7 +116,7 @@
       <header class="p-card__header">
         {{
           image(
-            url="https://assets.ubuntu.com/v1/a661a6b5-Flutter.svg",
+            url="https://assets.ubuntu.com/v1/d654c17e-Flutter_logo.svg",
             alt="Flutter",
             width="97",
             height="97",


### PR DESCRIPTION
## Done

Fix flutter Logo that was mirrored on first snap flow languages


# QA

Check the link and make sure the logo is the same than the flutter one: https://flutter.dev/ :smile: 

- `dotrun`
- http://0.0.0.0:8004
- Make sure the flutter logo in the list of languages is the correct one

## Issue / Card

Fixes #2937 
