### PR TITLE
Fix tutorial styling

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "sass-lint": "1.13.1",
     "swiper": "4.4.1",
     "topojson-client": "3.1.0",
-    "vanilla-framework": "2.13.0",
+    "vanilla-framework": "2.14.0",
     "watch-cli": "0.2.3",
     "webpack": "4.43.0",
     "webpack-cli": "3.3.11",

--- a/static/sass/_snapcraft_p-tutorials.scss
+++ b/static/sass/_snapcraft_p-tutorials.scss
@@ -1,4 +1,8 @@
 @mixin snapcraft-pattern-tutorials {
+  .p-tutorial__sidenav {
+    padding-block-start: $spv-inner--small;
+  }
+
   .p-tutorial__nav {
     margin-left: 0;
     padding-top: $sp-medium;
@@ -43,16 +47,21 @@
     }
   }
 
+  .p-tutorial-content {
+    margin-top: -20rem; // ensure header is visible when navigating between steps (pt. 1 of 2)
+  }
+
   .p-tutorial-section {
     display: none;
 
     &:target {
       display: block;
+      padding-top: 20rem; // ensure header is visible when navigating between steps (pt. 2 of 2)
     }
   }
 
   .p-tutorials-meter {
-    background-image: url('#{$assets-path}3b601b5d-snapcraft_difficulty_tutorials.svg');
+    background-image: url("#{$assets-path}3b601b5d-snapcraft_difficulty_tutorials.svg");
     background-position-x: -75px;
     background-position-y: center;
     background-repeat: no-repeat;
@@ -143,7 +152,6 @@
   }
 
   .p-tutorial__feedback-options {
-
     .p-inline-list__item {
       .has-color {
         display: none;

--- a/templates/tutorials/tutorial.html
+++ b/templates/tutorials/tutorial.html
@@ -13,125 +13,127 @@
   </div>
 </section>
 
-<div class="docs-container u-fixed-width">
-  <aside class="p-sidebar" id="navigation">
-    <div class="p-sidebar__banner u-hide--medium u-hide--large">
-      <i class="p-sidebar__toggle p-icon--menu"></i>
-    </div>
-    <div class="p-sidebar__content u-hide--small u-no-padding--left">
-      <nav class="p-sidebar-nav">
-        <ol class="p-stepped-list p-tutorial__nav">
-          {% for section in document.sections %}
-            <li class="p-stepped-list__item p-tutorial__nav-item">
-              <p class="p-stepped-list__title p-tutorial__nav-title u-no-margin--bottom">
-                <a href="#{{ loop.index }}-{{ section['slug'] }}" class="p-tutorial__nav-link">
-                  {{ section["title"]}}
-                </a>
-              </p>
-            </li>
-          {% endfor %}
-        </ol>
-      </nav>
-    </div>
-  </aside>
-  <div class="p-content">
-    <div class="p-strip is-shallow">
-      <div class="p-content__row">
-        {% for section in document.sections %}
+<div class="row">
+  <div class="col-3">
+    <aside class="p-tutorial__sidenav" id="navigation">
+      <div class="u-hide--medium u-hide--large">
+        <i class=" p-icon--menu"></i>
+      </div>
+      <div class="u-hide--small">
+        <nav>
+          <ol class="p-stepped-list p-tutorial__nav">
+            {% for section in document.sections %}
+              <li class="p-stepped-list__item p-tutorial__nav-item">
+                <p class="p-stepped-list__title p-tutorial__nav-title u-no-margin--bottom">
+                  <a href="#{{ loop.index }}-{{ section['slug'] }}" class="p-tutorial__nav-link">
+                    {{ section["title"]}}
+                  </a>
+                </p>
+              </li>
+            {% endfor %}
+          </ol>
+        </nav>
+      </div>
+    </aside>
+  </div>
+  <div class="col-9">
+    <div class="p-strip is-shallow  p-tutorial-content">
+      {% for section in document.sections %}
         <section class="p-tutorial-section" id="{{ loop.index }}-{{ section['slug']}}">
           <h2 class="p-heading--3">{{ loop.index }}. {{ section["title"]}}</h2>
-          <article class="p-tutorial-section__content">
+          <article>
             {{ section.content | safe }}
           </article>
 
           {% if loop.last %}
-          <div class="p-tutorial__feedback-options">
-            <p>Was this tutorial useful?</p>
-            <ul class="p-inline-list">
-              <li class="p-inline-list__item">
-                <img class="p-tutorial__feedback-icon" src="https://assets.ubuntu.com/v1/aca5f600-Helpful-yes.svg" alt="Positive response" data-feedback-value="positive">
-                <img class="p-tutorial__feedback-icon has-color" src="https://assets.ubuntu.com/v1/784c0dc9-Helpful-yes-green.svg" alt="" data-feedback-value="positive">
-              </li>
-              <li class="p-inline-list__item">
-                <img class="p-tutorial__feedback-icon" src="https://assets.ubuntu.com/v1/5dacff00-Helpful-unsure.svg" alt="Neutral response" data-feedback-value="neutral">
-                <img class="p-tutorial__feedback-icon has-color" src="https://assets.ubuntu.com/v1/b601b52c-Helpful-unsure-orange.svg" alt="" data-feedback-value="neutral">
-              </li>
-              <li class="p-inline-list__item">
-                <img class="p-tutorial__feedback-icon" src="https://assets.ubuntu.com/v1/4ff77e8e-Helpful-no.svg" alt="Negative response" data-feedback-value="negative">
-                <img class="p-tutorial__feedback-icon has-color" src="https://assets.ubuntu.com/v1/b45bf2a3-Helpful-no-red.svg" alt="" data-feedback-value="negative">
-              </li>
-            </ul>
-          </div>
-          <div class="p-tutorial__feedback-result p-notification--positive u-hide">
-            <p class="p-notification__response">Thank you for your feedback.</p>
-          </div>
+            <div class="p-tutorial__feedback-options">
+              <p>Was this tutorial useful?</p>
+              <ul class="p-inline-list">
+                <li class="p-inline-list__item">
+                  <img class="p-tutorial__feedback-icon" src="https://assets.ubuntu.com/v1/aca5f600-Helpful-yes.svg" alt="Positive response" data-feedback-value="positive">
+                  <img class="p-tutorial__feedback-icon has-color" src="https://assets.ubuntu.com/v1/784c0dc9-Helpful-yes-green.svg" alt="" data-feedback-value="positive">
+                </li>
+                <li class="p-inline-list__item">
+                  <img class="p-tutorial__feedback-icon" src="https://assets.ubuntu.com/v1/5dacff00-Helpful-unsure.svg" alt="Neutral response" data-feedback-value="neutral">
+                  <img class="p-tutorial__feedback-icon has-color" src="https://assets.ubuntu.com/v1/b601b52c-Helpful-unsure-orange.svg" alt="" data-feedback-value="neutral">
+                </li>
+                <li class="p-inline-list__item">
+                  <img class="p-tutorial__feedback-icon" src="https://assets.ubuntu.com/v1/4ff77e8e-Helpful-no.svg" alt="Negative response" data-feedback-value="negative">
+                  <img class="p-tutorial__feedback-icon has-color" src="https://assets.ubuntu.com/v1/b45bf2a3-Helpful-no-red.svg" alt="" data-feedback-value="negative">
+                </li>
+              </ul>
+            </div>
+            <div class="p-tutorial__feedback-result p-notification--positive u-hide">
+              <p class="p-notification__response">Thank you for your feedback.</p>
+            </div>
           {% endif %}
 
           <hr class="u-sv3">
-          <footer class="p-tutorial-section__footer row u-no-padding--left u-no-padding--right">
-            <div class="col-6 col-small-2 col-medium-3 u-vertically-center">
-              <a class="p-tutorial__bug-link" href="https://forum.snapcraft.io{{ document.topic_path }}">
-                <small>Suggest changes&nbsp;&rsaquo;</small>
-              </a>
-            </div>
-            <div class="col-6 col-small-2 col-medium-3 u-align--right">
-              <div class="p-tutorial__duration">
-                <small>
-                  <span class="u-hide--small">about</span>
-                  {% if section["remaining_duration"] %}
+          <footer>
+            <ul class="p-inline-list--stretch">
+              <li class="p-inline-list__item">
+                <a href="https://forum.snapcraft.io{{ document.topic_path }}">
+                  <small>Suggest changes&nbsp;&rsaquo;</small>
+                </a>
+              </li>
+              <li class="p-inline-list__item u-align--right">
+                <div class="p-tutorial__duration">
+                  <small>
+                    <span class="u-hide--small">about</span>
+                    {% if section["remaining_duration"] %}
                     {{ section["remaining_duration"] }}
-                  {% else %}
+                    {% else %}
                     0
+                    {% endif %}
+                    minutes to go
+                  </small>
+                </div>
+                <div class="p-tutorial__pagination">
+                  {% if loop.first %}
+                    <button class="p-tutorial__pagination-item--prev p-button--neutral has-icon u-no-margin--bottom" disabled style="margin-right: 1rem;">
+                      <i class="p-icon--contextual-menu">Previous step</i>
+                    </button>
+                  {% else %}
+                    <a href="#{{ loop.index - 1 }}-{{ loop.previtem['slug'] }}" class="p-tutorial__pagination-item--prev p-button--neutral has-icon u-no-margin--bottom" style="margin-right: 1rem;">
+                      <i class="p-icon--contextual-menu">Previous step</i>
+                    </a>
                   {% endif %}
-                  minutes to go
-                </small>
-              </div>
-              <div class="p-tutorial__pagination">
-                {% if loop.first %}
-                  <button class="p-tutorial__pagination-item--prev p-button--neutral has-icon u-no-margin--bottom" disabled style="margin-right: 1rem;">
-                    <i class="p-icon--contextual-menu">Previous step</i>
-                  </button>
-                {% else %}
-                  <a href="#{{ loop.index - 1 }}-{{ loop.previtem['slug'] }}" class="p-tutorial__pagination-item--prev p-button--neutral has-icon u-no-margin--bottom" style="margin-right: 1rem;">
-                    <i class="p-icon--contextual-menu">Previous step</i>
-                  </a>
-                {% endif %}
 
-                {% if loop.last %}
-                  <button class="p-tutorial__pagination-item--next p-button--neutral has-icon u-no-margin--bottom" disabled>
-                    <i class="p-icon--contextual-menu">Next step</i>
-                  </button>
-                {% else %}
-                  <a href="#{{ loop.index + 1 }}-{{ loop.nextitem['slug'] }}" class="p-tutorial__pagination-item--next p-button--neutral has-icon u-no-margin--bottom">
-                    <i class="p-icon--contextual-menu">Next step</i>
-                  </a>
-                {% endif %}
-              </div>
-            </div>
+                  {% if loop.last %}
+                    <button class="p-tutorial__pagination-item--next p-button--neutral has-icon u-no-margin--bottom" disabled>
+                      <i class="p-icon--contextual-menu">Next step</i>
+                    </button>
+                  {% else %}
+                    <a href="#{{ loop.index + 1 }}-{{ loop.nextitem['slug'] }}" class="p-tutorial__pagination-item--next p-button--neutral has-icon u-no-margin--bottom">
+                      <i class="p-icon--contextual-menu">Next step</i>
+                    </a>
+                  {% endif %}
+                </div>
+              </li>
+            </ul>
           </footer>
         </section>
-        {% endfor %}
-      </div>
+      {% endfor %}
     </div>
   </div>
 </div>
 
 <!-- end of tutorial feedback -->
 <script>
-  (function() {
+  (function () {
     var tutorialFeedbackOptions = document.querySelector('.p-tutorial__feedback-options');
     var tutorialFeedbackIcons = document.querySelectorAll('.p-tutorial__feedback-icon');
     var tutorialFeedbackResult = document.querySelector('.p-tutorial__feedback-result');
 
-    [].forEach.call(tutorialFeedbackIcons, function(icon) {
-      icon.addEventListener('click', function(e) {
+    [].forEach.call(tutorialFeedbackIcons, function (icon) {
+      icon.addEventListener('click', function (e) {
         var feedbackValue = e.target.getAttribute('data-feedback-value');
         dataLayer.push({
-          'event' : 'GAEvent',
-          'eventCategory' : 'feedback',
-          'eventAction' : feedbackValue,
-          'eventLabel' : feedbackValue,
-          'eventValue' : undefined
+          'event': 'GAEvent',
+          'eventCategory': 'feedback',
+          'eventAction': feedbackValue,
+          'eventLabel': feedbackValue,
+          'eventValue': undefined
         });
 
         tutorialFeedbackOptions.classList.add('u-hide');
@@ -142,73 +144,73 @@
 </script>
 
 <script>
-(function() {
-  function setActiveLink(navigationItems) {
-    [].forEach.call(navigationItems, function(item) {
-      var link = item.querySelector('.p-tutorial__nav-link');
-      if (link.getAttribute('href') === window.location.hash) {
-        item.classList.add('is-active');
-      } else {
-        item.classList.remove('is-active');
-      }
-    });
-  };
+  (function () {
+    function setActiveLink(navigationItems) {
+      [].forEach.call(navigationItems, function (item) {
+        var link = item.querySelector('.p-tutorial__nav-link');
+        if (link.getAttribute('href') === window.location.hash) {
+          item.classList.add('is-active');
+        } else {
+          item.classList.remove('is-active');
+        }
+      });
+    };
 
-  var navigationItems = document.querySelectorAll('.p-tutorial__nav-item');
-  var toggleButton = document.querySelector('.p-tutorial__nav-toggle');
+    var navigationItems = document.querySelectorAll('.p-tutorial__nav-item');
+    var toggleButton = document.querySelector('.p-tutorial__nav-toggle');
 
-  setActiveLink(navigationItems);
-
-  window.addEventListener('hashchange', function(e) {
-    e.preventDefault();
     setActiveLink(navigationItems);
-  });
 
-  sectionIds = [];
+    window.addEventListener('hashchange', function (e) {
+      e.preventDefault();
+      setActiveLink(navigationItems);
+    });
 
-  var tutorialSections = document.querySelectorAll('.p-tutorial__content section');
-  [].forEach.call(tutorialSections, function(section) {
-    sectionIds.push(section.id);
-  });
+    sectionIds = [];
 
-  // Navigate to first tutorial step on load if no URL hash
-  if (!window.location.hash) {
-    var firstSectionLink = document.querySelector('.p-tutorial__nav-link');
-    window.location.hash = firstSectionLink.getAttribute('href');
-  } else {
-    // Redirect #0, #1 etc. to the correct section
-    match = window.location.hash.match(/^#(\d+)$/);
+    var tutorialSections = document.querySelectorAll('.p-tutorial__content section');
+    [].forEach.call(tutorialSections, function (section) {
+      sectionIds.push(section.id);
+    });
 
-    if (match) {
-      index = parseInt(match[1]);
-      sectionId = sectionIds[index];
-      window.location.hash = '#' + sectionId;
-      window.location.reload();
+    // Navigate to first tutorial step on load if no URL hash
+    if (!window.location.hash) {
+      var firstSectionLink = document.querySelector('.p-tutorial__nav-link');
+      window.location.hash = firstSectionLink.getAttribute('href');
+    } else {
+      // Redirect #0, #1 etc. to the correct section
+      match = window.location.hash.match(/^#(\d+)$/);
+
+      if (match) {
+        index = parseInt(match[1]);
+        sectionId = sectionIds[index];
+        window.location.hash = '#' + sectionId;
+        window.location.reload();
+      }
     }
-  }
-})();
+  })();
 </script>
 
 <script>
-  (function() {
+  (function () {
     var polls = document.querySelectorAll('.poll');
 
-    [].forEach.call(polls, function(poll) {
+    [].forEach.call(polls, function (poll) {
       var answers = poll.querySelectorAll('[type="radio"]');
       var pollId = poll.getAttribute('data-poll-name');
 
-      [].forEach.call(answers, function(answer) {
-        answer.addEventListener('change', function(e) {
+      [].forEach.call(answers, function (answer) {
+        answer.addEventListener('change', function (e) {
           var answerLabel = document.querySelector('label[for="' + e.target.id + '"]');
           var eventLabel = answerLabel.innerText;
           var eventAction = document.getElementById(pollId).innerText;
 
           dataLayer.push({
-            'event' : 'GAEvent',
-            'eventCategory' : 'survey',
-            'eventAction' : eventAction,
-            'eventLabel' : eventLabel,
-            'eventValue' : undefined
+            'event': 'GAEvent',
+            'eventCategory': 'survey',
+            'eventAction': eventAction,
+            'eventLabel': eventLabel,
+            'eventValue': undefined
           });
         });
       });
@@ -217,16 +219,16 @@
 </script>
 
 <script>
-  (function() {
+  (function () {
     var toggleSidebar = document.querySelector('.p-sidebar__toggle');
-      var sidebar = document.querySelector('.p-sidebar__content');
-      if (toggleSidebar) {
-        toggleSidebar.addEventListener('click', function(e) {
-          sidebar.classList.toggle('u-hide--small');
-          toggleSidebar.classList.toggle('p-icon--close');
-          toggleSidebar.classList.toggle('p-icon--menu');
-        });
-      }
+    var sidebar = document.querySelector('.p-sidebar__content');
+    if (toggleSidebar) {
+      toggleSidebar.addEventListener('click', function (e) {
+        sidebar.classList.toggle('u-hide--small');
+        toggleSidebar.classList.toggle('p-icon--close');
+        toggleSidebar.classList.toggle('p-icon--menu');
+      });
+    }
   })();
 </script>
 {% endblock %}

--- a/yarn.lock
+++ b/yarn.lock
@@ -8661,10 +8661,10 @@ validate-npm-package-license@^3.0.1:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
 
-vanilla-framework@2.13.0:
-  version "2.13.0"
-  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-2.13.0.tgz#ac73e745150bcef183eb35e3ee47f3fd079ddd3e"
-  integrity sha512-EuxlGxO4SmCGL4GVzcye5aas2HGVqRhPxlTHg84Lfw1e1E4F/Coxs78i3xxkPGw3LOcfea0KU096ar1PnLNuXQ==
+vanilla-framework@2.14.0:
+  version "2.14.0"
+  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-2.14.0.tgz#acf62caa8d934e372bb4ab54682223871ebbb2d0"
+  integrity sha512-sTFlE83yuQZZUhn8hoX72nVqOAOMoihGVXeTX9MOCwXQCHt4YVz/+fD3ZbZA+tt9K/9Bim1kH0EfhpOJ3Bv7Ig==
 
 vanilla-framework@2.4.1:
   version "2.4.1"


### PR DESCRIPTION
## Done

- Fix tutorial styling
- Upgrade vanilla to 2.14.0

## Issue / Card

Fixes #2934 

## QA

- Pull the branch
- Run the site using the dotrun snap with `$ dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8004/tutorials
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Click on a tutorial and see it looks right compared to https://snapcraft.io/tutorials/snap-download#1-introduction
- Visit various pages and note there are no issues because of vanilla upgrade

## Screenshots

![image](https://user-images.githubusercontent.com/40214246/87031149-9381a580-c1da-11ea-9106-b7139c5ba45f.png)

