### PR TITLE
Update docs search navigation

### DIFF
--- a/static/sass/_patterns_pagination.scss
+++ b/static/sass/_patterns_pagination.scss
@@ -17,4 +17,9 @@
       }
     }
   }
+
+  // 10.07.2020 - Ovi: This can be remove once this issue is closed
+  .p-pagination__link--previous {
+    margin-inline-end: .5rem;
+  }
 }

--- a/templates/docs/search.html
+++ b/templates/docs/search.html
@@ -33,23 +33,19 @@
     </div>
   </div>
   {% endfor %}
-  <div class="p-strip p-pagination">
-    {% if  results.queries and results.queries.previousPage %}
-    <a
-      class="p-pagination__link--previous"
-      href="/docs/search?q={{ query }}&amp;start={{ results.queries.previousPage.0.startIndex }}{% if siteSearch %}&amp;siteSearch={{ siteSearch }}{% endif %}"
-      >
-      <span class="p-pagination__label">Previous</span>
-    </a>
-    {% endif %}
-    {% if results.queries and results.queries.nextPage %}
-    <a
-      class="p-pagination__link--next"
-      href="/docs/search?q={{ query }}&amp;start={{ results.queries.nextPage.0.startIndex }}{% if siteSearch %}&amp;siteSearch={{ siteSearch }}{% endif %}"
-      >
-      <span class="p-pagination__label">Next</span>
-    </a>
-    {% endif %}
+  <div class="p-strip">
+    <ul class="p-pagination">
+      {% if  results.queries and results.queries.previousPage %}
+        <li class="p-pagination__item">
+          <a class="p-pagination__link--previous" href="/docs/search?q={{ query }}&amp;start={{ results.queries.previousPage.0.startIndex }}{% if siteSearch %}&amp;siteSearch={{ siteSearch }}{% endif %}" title="Previous page"><i class="p-icon--contextual-menu">Previous page</i>Previous</a>
+        </li>
+      {% endif %}
+      {% if results.queries and results.queries.nextPage %}
+        <li class="p-inline-list__item">
+          <a class="p-pagination__link--next" href="/docs/search?q={{ query }}&amp;start={{ results.queries.nextPage.0.startIndex }}{% if siteSearch %}&amp;siteSearch={{ siteSearch }}{% endif %}" title="Next page">Next<i class="p-icon--contextual-menu">Next page</i></a>
+        </li>
+      {% endif %}
+    </ul>
   </div>
   {% else %}
   <div class="p-strip">
@@ -73,5 +69,5 @@
     </div>
   </div>
   {% endif %}
-  </div>
+</div>
 {% endblock %}


### PR DESCRIPTION
## Done

- Update pagination for docs search

## Issue / Card

Fixes #2933

## QA

- Pull the branch
- Run the site using the dotrun snap with `$ dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8004/docs/search
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Search for a term and see the pagination buttons look good

## Screenshots

![image](https://user-images.githubusercontent.com/40214246/87146851-7d8be780-c2a3-11ea-800f-ade834814d88.png)

