### PR TITLE
Updated flutter first-snap example to a simplier app that already has a linux target

### DIFF
--- a/templates/home/_fsf_flutter.html
+++ b/templates/home/_fsf_flutter.html
@@ -16,28 +16,27 @@
   </div>
 
   <div class="col-6">
-    <h4>Here's how <a href="https://snapcraft.io/flutter-gallery">flutter-gallery</a> defines snapcraft.yaml:</h4>
+    <h4>Here's how <a href="https://snapcraft.io/super-cool-app">super-cool-app</a> defines snapcraft.yaml:</h4>
     <div class ="p-show-more is-collapsed" data-js="js-show-more">
-      <pre class="p-code-yaml"><b>name</b>: flutter-gallery
+      <pre class="p-code-yaml"><b>name</b>: super-cool-app
 <b>version</b>: "1.0"
-<b>summary</b>: Flutter Gallery
+<b>summary</b>: Super Cool App
 <b>description</b>: |
-    A demo app for Flutter's material design [&hellip;]
-    as many other features of the Flutter SDK.[&hellip;]
+    Super Cool App that does everything! [&hellip;]
 
 <b>confinement</b>: strict
 <b>base</b>: core18
 
 <b>parts</b>:
-  <b>flutter-gallery</b>:
+  <b>super-cool-app</b>:
     <b>plugin</b>: flutter
-    <b>source</b>: https://github.com/flutter/gallery.git
+    <b>source</b>: https://github.com/kenvandine/super-cool-app.git
     <b>flutter-target</b>: lib/main.dart
 
  <b>apps</b>:
-   <b>flutter-gallery</b>:
-      <b>command</b>: gallery
-      <b>extensions</b>: [flutter-master]</pre>
+   <b>super-cool-app</b>:
+      <b>command</b>: super_cool_app
+      <b>extensions</b>: [flutter-dev]</pre>
 
       {% include "home/_fsf_yaml_show_more.html" %}
 

--- a/webapp/first_snap/content/flutter/build.yaml
+++ b/webapp/first_snap/content/flutter/build.yaml
@@ -1,4 +1,4 @@
-name: test-flutter-gallery-{name}
+name: test-super-cool-app-{name}
 linux:
   auto:
     - action: "Create a directory, move the downloaded snapcraft.yaml file into the new directory and navigate there:"

--- a/webapp/first_snap/content/flutter/package.yaml
+++ b/webapp/first_snap/content/flutter/package.yaml
@@ -1,2 +1,2 @@
-name: test-flutter-gallery-{name}
-download: git clone https://github.com/flutter/gallery
+name: test-super-cool-app-{name}
+download: git clone https://github.com/kenvandine/super-cool-app

--- a/webapp/first_snap/content/flutter/snapcraft.yaml
+++ b/webapp/first_snap/content/flutter/snapcraft.yaml
@@ -1,20 +1,18 @@
 name: ${name}
 version: '1.0'
-summary: Flutter Gallery
-description: |
-  A demo app for Flutter's material design and cupertino widgets, as well 
-  as many other features of the Flutter SDK.
+summary: Super Cool App
+description: Super Cool App that does everything!
 
-confinement: devmode
+confinement: strict
 base: core18
 
 parts:
   ${name}:
     plugin: flutter
-    source: https://github.com/flutter/gallery.git
+    source: https://github.com/kenvandine/super-cool-app.git
     flutter-target: lib/main.dart
 
 apps:
   ${name}:
-    command: gallery
-    extensions: [flutter-master]
+    command: super_cool_app
+    extensions: [flutter-dev]

--- a/webapp/first_snap/content/flutter/test.yaml
+++ b/webapp/first_snap/content/flutter/test.yaml
@@ -1,4 +1,4 @@
-name: test-flutter-gallery-{name}
+name: test-super-cool-app-{name}
 linux:
   - action: "Install the snap:"
     command: sudo snap install --dangerous *.snap


### PR DESCRIPTION
The first-snap example for flutter pointed to a source project that wasn't configured to build for linux.  This PR updates it to point to a project that is.

## QA

- Pull the branch
- Run the site using the dotrun snap with `$ dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8004/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- [List additional steps to QA the new features or prove the bug has been resolved]

## Screenshots

[if relevant, include a screenshot]
