### PR TITLE
Make snap name max 40 characters

### DIFF
--- a/templates/publisher/register-snap.html
+++ b/templates/publisher/register-snap.html
@@ -89,7 +89,7 @@ Register new Snap name
         <div class="p-form-validation">
           <label for="snap-name">Snap name</label>
           <div class="p-form-validation__field">
-            <input class="p-form-validation__input" type="text" name="snap-name" id="snap-name" required maxlength="64" value="{{ snap_name }}" />
+            <input class="p-form-validation__input" type="text" name="snap-name" id="snap-name" required maxlength="40" value="{{ snap_name }}" />
           </div>
         </div>
         <div class="p-form-validation">


### PR DESCRIPTION
## Done

- Make snap name max 40 characters

## Issue / Card

Fixes #

## QA

- Pull the branch
- Run the site using the dotrun snap with `$ dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8004/register-snap
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See snap name can be no more than 40 chars

## Screenshots

[if relevant, include a screenshot]
