### PR TITLE
Remove hardcode of default track for node

### DIFF
--- a/tests/tests_templates_utils.py
+++ b/tests/tests_templates_utils.py
@@ -74,14 +74,6 @@ class TemplateUtilsTest(unittest.TestCase):
         )
         self.assertTrue(result, "sudo snap install skype --classic")
 
-    def test_install_snippet_with_classic_and_default_track(self):
-        result = template_utils.install_snippet(
-            "node", "10", "stable", "classic"
-        )
-        self.assertTrue(
-            result, "sudo snap install node --channel=10/stable --classic"
-        )
-
     def test_install_snippet_with_non_stable_risk_level(self):
         result = template_utils.install_snippet("test", "latest", "edge", "")
         self.assertTrue(result, "sudo snap install test --edge")

--- a/webapp/helpers.py
+++ b/webapp/helpers.py
@@ -51,14 +51,6 @@ def get_licenses():
     return licenses
 
 
-def get_default_track(snap_name):
-    # until default tracks are supported by the API we special case node
-    # to use 10, rather then latest
-    default_track = "10" if snap_name == "node" else None
-
-    return default_track
-
-
 def get_file(filename, replaces={}):
     """
     Reads a file, replaces occurences of all the keys in `replaces` with

--- a/webapp/publisher/snaps/metrics_views.py
+++ b/webapp/publisher/snaps/metrics_views.py
@@ -12,7 +12,6 @@ from canonicalwebteam.store_api.exceptions import (
 )
 
 # Local
-from webapp import helpers
 from webapp.helpers import api_session
 from webapp.api.exceptions import ApiError
 from webapp.decorators import login_required
@@ -174,11 +173,13 @@ def publisher_snap_metrics(snap_name):
 
     nodata = not any([country_devices, active_devices])
 
-    # until default tracks are supported by the API we special case node
-    # to use 10, rather then latest
-    default_track = helpers.get_default_track(snap_name)
-
     annotations = {"name": "annotations", "series": [], "buckets": []}
+
+    default_track = (
+        details.get("default-track")
+        if details.get("default-track")
+        else "latest"
+    )
 
     for category in details["categories"]["items"]:
         date = category["since"].split("T")[0]

--- a/webapp/store/snap_details_views.py
+++ b/webapp/store/snap_details_views.py
@@ -108,15 +108,11 @@ def snap_details_views(store, api, handle_errors):
 
         videos = logic.get_videos(details["snap"]["media"])
 
-        # until default tracks are supported by the API we special case node
-        # to use 10, rather then latest
-        default_track = helpers.get_default_track(details["name"])
-        if not default_track:
-            default_track = (
-                details.get("default-track")
-                if details.get("default-track")
-                else "latest"
-            )
+        default_track = (
+            details.get("default-track")
+            if details.get("default-track")
+            else "latest"
+        )
 
         lowest_risk_available = logic.get_lowest_available_risk(
             channel_maps_list, default_track


### PR DESCRIPTION
## Done

**This pull request can be merged once Node has setup the default track to be the prefered track**

Now that default tracks are handled by the API we can enter in contact with node so they can set their default track to their latest LTS 12.

At the moment this was coded in the backend as an exception for node and is one LTS late.

## Issue / Card

Fixes https://github.com/canonical-web-and-design/snapcraft.io/issues/2952

## QA

- Pull the branch
- Run the site using the dotrun snap with `$ dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8004/
- Go on /node 
- **For now there is no default track so the track is the latest (15)**
- Check that the listing/metrics/releases pages are working 