### PR TITLE
Add message if linked repo does not exists

### DIFF
--- a/templates/publisher/builds.html
+++ b/templates/publisher/builds.html
@@ -63,6 +63,22 @@ Builds for
     </div>
     {% endif %}
 
+    {% if not github_repository_exists or not yaml_file_exists %}
+    <section class="p-strip is-shallow">
+      <div class="u-fixed-width">
+        <div class="p-notification--negative">
+          <p class="p-notification__response">
+            {% if not github_repository_exists %}
+            Your snap is linked to <a href="https://github.com/{{ github_repository }}" class="p-link--external">{{ github_repository }}</a>, but this repository doesn&rsquo;t exist. <a href="/{{ snap_name }}/builds" aria-controls="repo-disconnect-modal">Disconnect repo</a>.
+            {% elif not yaml_file_exists %}
+            This repository doesn&rsquo;t contain snapcraft.yaml. More on <a href="https://snapcraft.io/docs/creating-snapcraft-yaml">how to create it</a>.
+            {% endif %}
+          </p>
+        </div>
+      </div>
+    </section>
+    {% endif %}
+
 
     {% with messages = get_flashed_messages(with_categories=true) %}
     {% if messages %}

--- a/webapp/api/github.py
+++ b/webapp/api/github.py
@@ -245,6 +245,18 @@ class GitHub:
 
         return permission in user_permissions
 
+    def check_if_repo_exists(self, owner, repo):
+        """
+        Return True if GitHub repo exists
+        """
+        response = self._request(
+            "GET", f"repos/{owner}/{repo}", raise_exceptions=False,
+        )
+        if response.status_code == 404:
+            return False
+        elif response.status_code == 200:
+            return True
+
     def get_snapcraft_yaml_location(self, owner, repo):
         """
         Return the snapcraft.yaml file location in the GitHub repo

--- a/webapp/publisher/snaps/build_views.py
+++ b/webapp/publisher/snaps/build_views.py
@@ -119,14 +119,14 @@ def get_snap_builds(snap_name):
         context["github_repository"] = lp_snap["git_repository_url"][19:]
         github_owner, github_repo = context["github_repository"].split("/")
 
+        context["github_repository_exists"] = github.check_if_repo_exists(
+            github_owner, github_repo
+        )
+
         context["yaml_file_exists"] = github.get_snapcraft_yaml_location(
             github_owner, github_repo
         )
 
-        if not context["yaml_file_exists"]:
-            flask.flash(
-                "This repository doesn't contain a snapcraft.yaml", "negative"
-            )
         context.update(get_builds(lp_snap, slice(0, BUILDS_PER_PAGE)))
 
         context["snap_builds_enabled"] = bool(context["snap_builds"])


### PR DESCRIPTION
## Done

- Add message if linked repo does not exists

## Issue / Card

Fixes #2854 

## QA

- Pull the branch
- Run the site using the dotrun snap with `$ dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8004/<snap_name>/builds
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- The snap should have a repo connected. 
- Delete the yaml file from the repo, then refresh the page. See the error message.
- Delete the repo from GitHub, then refresh the page. See a new error message.

## Screenshots

No repo message:
![image](https://user-images.githubusercontent.com/40214246/87774206-28f4e900-c81c-11ea-986c-5b045681d87e.png)

No yaml file message:
![image](https://user-images.githubusercontent.com/40214246/87774349-52157980-c81c-11ea-9896-31c5a2988a21.png)

