### PR TITLE
Fix issue with BSI webhooks

### DIFF
--- a/webapp/api/github.py
+++ b/webapp/api/github.py
@@ -329,6 +329,22 @@ class GitHub:
 
         return hmac.compare_digest(digest, signature)
 
+    def validate_bsi_webhook_secret(self, owner, name, payload, signature):
+        """
+        Return True if the webhook contain a valid secret in BSI
+        """
+        key = bytes(GITHUB_WEBHOOK_SECRET, "UTF-8")
+        hmac_gen = hmac.new(key, None, sha1)
+        hmac_gen.update(bytes(owner, "UTF-8"))
+        hmac_gen.update(bytes(name, "UTF-8"))
+        final_key = bytes(hmac_gen.hexdigest(), "UTF-8")
+        final_hmac = hmac.new(final_key, payload, sha1)
+
+        # Add append prefix to match the GitHub request format
+        digest = f"sha1={final_hmac.hexdigest()}"
+
+        return hmac.compare_digest(digest, signature)
+
     def get_hooks(self, owner, repo, page=1):
         """
         Return all the webhooks in the repo

--- a/webapp/publisher/snaps/build_views.py
+++ b/webapp/publisher/snaps/build_views.py
@@ -480,10 +480,13 @@ def post_github_webhook(snap_name=None, github_owner=None, github_repo=None):
 
     github = GitHub()
 
-    if not github.validate_webhook_signature(
-        flask.request.data, flask.request.headers.get("X-Hub-Signature")
-    ):
-        return ("Invalid secret", 403)
+    signature = flask.request.headers.get("X-Hub-Signature")
+
+    if not github.validate_webhook_signature(flask.request.data, signature):
+        if not github.validate_bsi_webhook_secret(
+            gh_owner, gh_repo, flask.request.data, signature
+        ):
+            return ("Invalid secret", 403)
 
     validation = validate_repo(
         GITHUB_SNAPCRAFT_USER_TOKEN, lp_snap["store_name"], gh_owner, gh_repo


### PR DESCRIPTION
## Done

Support BSI webhooks secrets

## Issue / Card

Fixes #2949

## QA

- Pull the branch
- Run the site using the dotrun snap with `$ dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8004/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Use ngrok and change an old BSI webhook to your ngrok URL
- Create a push event
