### PR TITLE
Bug fixes on builds

### DIFF
--- a/templates/publisher/builds.html
+++ b/templates/publisher/builds.html
@@ -63,7 +63,7 @@ Builds for
     </div>
     {% endif %}
 
-    {% if not github_repository_exists or not yaml_file_exists %}
+    {% if github_repository and (not github_repository_exists or not yaml_file_exists) %}
     <section class="p-strip is-shallow">
       <div class="u-fixed-width">
         <div class="p-notification--negative">

--- a/webapp/publisher/snaps/build_views.py
+++ b/webapp/publisher/snaps/build_views.py
@@ -346,20 +346,12 @@ def post_snap_builds(snap_name):
                 raise e
 
         if repo_exist:
-            # The user registered the repo in BSI but didn't register a name
-            # We can remove it and continue with the normal process
-            if not repo_exist["store_name"]:
-                # This conditional should be removed when issue 2657 is solved
-                launchpad.request(
-                    path=repo_exist["self_link"], method="DELETE"
-                )
-            else:
-                flask.flash(
-                    "The specified repository is being used by another snap:"
-                    f" {repo_exist['store_name']}",
-                    "negative",
-                )
-                return flask.redirect(redirect_url)
+            flask.flash(
+                "The specified repository is being used by another snap:"
+                f" {repo_exist['store_name']}",
+                "negative",
+            )
+            return flask.redirect(redirect_url)
 
         macaroon = publisher_api.get_package_upload_macaroon(
             session=flask.session, snap_name=snap_name, channels=["edge"]


### PR DESCRIPTION
## Done

- The warning message for snaps linked with deleted repos is appearing for snaps not linked to any repo.
- Remove not needed code for compatibility with old snaps on BSI.

## QA

- Pull the branch
- Run the site using the dotrun snap with `$ dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8004/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Go to a new snap the message shouldn't appear.
- Go to a snap with a deleted repo the message should appear.

## Screenshots

Bug:
![Screenshot from 2020-07-22 10-35-59](https://user-images.githubusercontent.com/6353928/88160976-4e606900-cc07-11ea-9863-2b7a5d2f39c9.png)

