### PR TITLE
Missing yarn.lock in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN --mount=type=cache,target=/root/.cache/pip pip3 install --user --requirement
 # ===
 FROM node:12-slim AS yarn-dependencies
 WORKDIR /srv
-ADD package.json .
+ADD package.json yarn.lock .
 RUN --mount=type=cache,target=/usr/local/share/.cache/yarn yarn install
 
 


### PR DESCRIPTION
## Done

- `yarn.lock` file is missing before doing the build

## QA

1. `DOCKER_BUILDKIT=1 docker build --build-arg BUILD_ID=test --tag test .`
2. `docker run -ti -p "8004:80" --env SECRET_KEY=secret_key test`
3. Check http://localhost:8004/
