### PR TITLE
Fix multiselect always highlighted first option

### DIFF
--- a/static/js/publisher/form/multiselect.js
+++ b/static/js/publisher/form/multiselect.js
@@ -144,7 +144,7 @@ class MultiSelect extends React.Component {
     this.searchInput.focus();
     this.setState({
       showSearch: true,
-      highlightedOption: this.state.highlightedOption || 0,
+      highlightedOption: this.state.highlightedOption,
     });
   }
 
@@ -155,7 +155,7 @@ class MultiSelect extends React.Component {
    */
   handleKeypress(event) {
     if (this.state.showSearch) {
-      let highlighted = this.state.highlightedOption;
+      let highlighted = this.state.highlightedOption || 0;
       let results = this.state.searchResults;
 
       switch (event.key) {
@@ -186,6 +186,7 @@ class MultiSelect extends React.Component {
           break;
         case "Tab":
           this.blur();
+          highlighted = null;
           break;
         default:
           break;
@@ -231,6 +232,7 @@ class MultiSelect extends React.Component {
   blur() {
     this.setState({
       showSearch: false,
+      highlightedOption: null,
     });
 
     this.props.updateHandler(this.state.selected);


### PR DESCRIPTION
## Done

- Fix multiselect always highlighted first option

## Issue / Card

Fixes #2976

## QA

- Pull the branch
- Run the site using the dotrun snap with `$ dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8004/<snap_name>/settings
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Navigate to `selected territories` and add some countries using the keyboard
- Refresh the page and do the same thing again using the mouse. See the first item in the list is not always highlighted


## Screenshots

[if relevant, include a screenshot]
