### PR TITLE
Update store-api module

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ canonicalwebteam.discourse-docs==1.0.1
 canonicalwebteam.blog==6.0.0
 canonicalwebteam.search==0.2.1
 canonicalwebteam.image-template==1.1.0
-canonicalwebteam.store-api==2.3.0
+canonicalwebteam.store-api==2.3.3
 canonicalwebteam.launchpad==0.7.6
 django-openid-auth==0.15
 Flask-OpenID-Stateless==1.2.6

--- a/tests/publisher/snaps/tests_listing.py
+++ b/tests/publisher/snaps/tests_listing.py
@@ -65,7 +65,7 @@ class GetListingPage(BaseTestCases.EndpointLoggedInErrorHandling):
         responses.add(responses.GET, self.api_url, json=payload, status=200)
         responses.add(
             responses.GET,
-            "https://api.snapcraft.io/api/v1/snaps/sections",
+            "https://api.snapcraft.io/v2/snaps/categories?type=shared",
             json=[],
             status=200,
         )
@@ -122,7 +122,7 @@ class GetListingPage(BaseTestCases.EndpointLoggedInErrorHandling):
         responses.add(responses.GET, self.api_url, json=payload, status=200)
         responses.add(
             responses.GET,
-            "https://api.snapcraft.io/api/v1/snaps/sections",
+            "https://api.snapcraft.io/v2/snaps/categories?type=shared",
             json=[],
             status=200,
         )
@@ -161,7 +161,7 @@ class GetListingPage(BaseTestCases.EndpointLoggedInErrorHandling):
         responses.add(responses.GET, self.api_url, json=payload, status=200)
         responses.add(
             responses.GET,
-            "https://api.snapcraft.io/api/v1/snaps/sections",
+            "https://api.snapcraft.io/v2/snaps/categories?type=shared",
             json=[],
             status=200,
         )
@@ -206,7 +206,7 @@ class GetListingPage(BaseTestCases.EndpointLoggedInErrorHandling):
         responses.add(responses.GET, self.api_url, json=payload, status=200)
         responses.add(
             responses.GET,
-            "https://api.snapcraft.io/api/v1/snaps/sections",
+            "https://api.snapcraft.io/v2/snaps/categories?type=shared",
             json=[],
             status=200,
         )
@@ -245,7 +245,7 @@ class GetListingPage(BaseTestCases.EndpointLoggedInErrorHandling):
         responses.add(responses.GET, self.api_url, json=payload, status=200)
         responses.add(
             responses.GET,
-            "https://api.snapcraft.io/api/v1/snaps/sections",
+            "https://api.snapcraft.io/v2/snaps/categories?type=shared",
             json=[],
             status=200,
         )
@@ -284,7 +284,7 @@ class GetListingPage(BaseTestCases.EndpointLoggedInErrorHandling):
         responses.add(responses.GET, self.api_url, json=payload, status=200)
         responses.add(
             responses.GET,
-            "https://api.snapcraft.io/api/v1/snaps/sections",
+            "https://api.snapcraft.io/v2/snaps/categories?type=shared",
             json=[],
             status=500,
         )

--- a/tests/publisher/snaps/tests_post_listing.py
+++ b/tests/publisher/snaps/tests_post_listing.py
@@ -138,7 +138,7 @@ class PostMetadataListingPage(BaseTestCases.EndpointLoggedIn):
         responses.add(responses.GET, info_url, json=payload, status=200)
         responses.add(
             responses.GET,
-            "https://api.snapcraft.io/api/v1/snaps/sections",
+            "https://api.snapcraft.io/v2/snaps/categories?type=shared",
             json=[],
             status=200,
         )
@@ -223,7 +223,7 @@ class PostMetadataListingPage(BaseTestCases.EndpointLoggedIn):
         responses.add(responses.GET, info_url, json=payload, status=200)
         responses.add(
             responses.GET,
-            "https://api.snapcraft.io/api/v1/snaps/sections",
+            "https://api.snapcraft.io/v2/snaps/categories?type=shared",
             json=[],
             status=200,
         )
@@ -323,7 +323,7 @@ class PostMetadataListingPage(BaseTestCases.EndpointLoggedIn):
         responses.add(responses.GET, info_url, json=payload, status=200)
         responses.add(
             responses.GET,
-            "https://api.snapcraft.io/api/v1/snaps/sections",
+            "https://api.snapcraft.io/v2/snaps/categories?type=shared",
             json=[],
             status=200,
         )
@@ -387,7 +387,7 @@ class PostMetadataListingPage(BaseTestCases.EndpointLoggedIn):
         responses.add(responses.GET, info_url, json=payload, status=200)
         responses.add(
             responses.GET,
-            "https://api.snapcraft.io/api/v1/snaps/sections",
+            "https://api.snapcraft.io/v2/snaps/categories?type=shared",
             json=[],
             status=500,
         )

--- a/tests/store/tests_get_store_view.py
+++ b/tests/store/tests_get_store_view.py
@@ -8,8 +8,8 @@ class GetStoreViewTest(TestCase):
     render_templates = False
 
     def setUp(self):
-        self.categories_api_url = "".join(
-            ["https://api.snapcraft.io/api/v1/", "snaps/sections"]
+        self.categories_api_url = (
+            "https://api.snapcraft.io/v2/snaps/categories?type=shared"
         )
         self.featured_snaps_api_url = "".join(
             [

--- a/tests/store/tests_public_logic.py
+++ b/tests/store/tests_public_logic.py
@@ -239,13 +239,11 @@ class StoreLogicTest(unittest.TestCase):
 
     def test_get_categories(self):
         categories = {
-            "_embedded": {
-                "clickindex:sections": [
-                    {"name": "featured"},
-                    {"name": "test"},
-                    {"name": "development"},
-                ]
-            }
+            "categories": [
+                {"name": "featured"},
+                {"name": "test"},
+                {"name": "development"},
+            ]
         }
         category_list = logic.get_categories(categories)
         self.assertTrue(

--- a/tests/store/tests_search.py
+++ b/tests/store/tests_search.py
@@ -9,7 +9,7 @@ class GetSearchViewTest(TestCase):
 
     def setUp(self):
         self.categories_api_url = (
-            "https://api.snapcraft.io/api/v1/snaps/sections"
+            "https://api.snapcraft.io/v2/snaps/categories?type=shared"
         )
         self.search_snap_api_url = "".join(
             [

--- a/webapp/store/logic.py
+++ b/webapp/store/logic.py
@@ -254,8 +254,8 @@ def get_categories(categories_json):
 
     categories = []
 
-    if "_embedded" in categories_json:
-        for cat in categories_json["_embedded"]["clickindex:sections"]:
+    if "categories" in categories_json:
+        for cat in categories_json["categories"]:
             if (
                 cat["name"] not in categories_list
                 and cat["name"] not in blacklist


### PR DESCRIPTION
## Done

- Update store-api module to use the categories v2 endpoint

## QA

- Pull the branch
- Run the site using the dotrun snap with `$ dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8004/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check as a publisher that you get all the categories in the dropdown when you go to http://0.0.0.0:8004/<snap_name>/listing

