### PR TITLE
Show queue time only for the 'Building Soon' builds

### DIFF
--- a/static/js/publisher/builds/index.js
+++ b/static/js/publisher/builds/index.js
@@ -256,9 +256,10 @@ class Builds extends React.Component {
                 </Fragment>
               ),
               className: "has-icon",
-              title: queueTime[build.arch_tag]
-                ? `Queue time: up to ${queueTime[build.arch_tag]}`
-                : null,
+              title:
+                build.queue_time && queueTime[build.arch_tag]
+                  ? `Queue time: up to ${queueTime[build.arch_tag]}`
+                  : null,
             },
             {
               content: build.datebuilt


### PR DESCRIPTION
## Done

- Show queue time only for the 'Building Soon' builds

## Issue / Card

Fixes #2983 

## QA

- Pull the branch
- Run the site using the dotrun snap with `$ dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8004/<snap_name>/builds
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Trigger a new build and hover over items in the `Result` column. You should see a `Queue time ...` tooltip only when you hover over a `Building soon` build and not older `Released` builds as currently happens

## Screenshots

[if relevant, include a screenshot]
