### PR TITLE
Remove snap that links to 404

### DIFF
--- a/webapp/snapcraft/views.py
+++ b/webapp/snapcraft/views.py
@@ -49,13 +49,6 @@ def snapcraft_blueprint():
                 "publisher": "SORACOM Snap Administrator",
             },
             {
-                "package_name": "thinger-maker-server",
-                "icon_url": "/".join([icon_host, "2017/03/thinger_256.png"]),
-                "title": "Thinger.io Maker Server",
-                "origin": "thinger",
-                "publisher": "Alvaro Luis Bustamante",
-            },
-            {
                 "package_name": "nymea",
                 "icon_url": "/".join(
                     [icon_host, "2018/03/icon.svg_UYFdU9y.png"]


### PR DESCRIPTION
## Done

Remove snap that links to 404 on iot page

## QA

- Pull the branch
- Run the site using the dotrun snap with `$ dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8004/iot
- Make sure all snaps don't 404