### PR TITLE
Exclude tags for blog

### DIFF
--- a/webapp/blog/views.py
+++ b/webapp/blog/views.py
@@ -18,7 +18,10 @@ def init_blog(app, url_prefix):
     wordpress_api = Wordpress(session=talisker.requests.get_session())
     blog = build_blueprint(
         BlogViews(
-            api=wordpress_api, blog_title="Snapcraft Blog", tag_ids=[2996]
+            api=wordpress_api,
+            blog_title="Snapcraft Blog",
+            tag_ids=[2996],
+            excluded_tags=[3184, 3265, 3408],
         )
     )
 
@@ -68,7 +71,9 @@ def init_blog(app, url_prefix):
 
             try:
                 blog_articles, total_pages = wordpress_api.get_articles(
-                    blog_tags["id"], 3 - len(articles)
+                    tags=blog_tags["id"],
+                    tags_exclude=[3184, 3265, 3408],
+                    per_page=3 - len(articles),
                 )
             except RequestException:
                 blog_articles = []


### PR DESCRIPTION
## Done

Exclude articles that comes from tags `[3184, 3265, 3408]` like on other sites

## QA

- Pull the branch
- Run the site using the dotrun snap with `$ dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8004/maas
- Check the list of articles, make sure all articles are not 404 :smile: 
- http://0.0.0.0:8004/blog
- Make sure the blog is still working
