### PR TITLE
Add about page

### DIFF
--- a/static/js/public/about/index.js
+++ b/static/js/public/about/index.js
@@ -1,0 +1,3 @@
+import { SideNavigation } from "./side-navigation";
+
+export { SideNavigation };

--- a/static/js/public/about/side-navigation.js
+++ b/static/js/public/about/side-navigation.js
@@ -1,0 +1,60 @@
+class SideNavigation {
+  constructor(selector) {
+    const sideNavigations = document.querySelectorAll(selector);
+
+    if (sideNavigations) {
+      this.initEvents(sideNavigations);
+    }
+  }
+
+  initEvents(sideNavigations) {
+    // Setup all side navigations on the page.
+    sideNavigations.forEach((sideNavigation) =>
+      this.setupSideNavigation(sideNavigation)
+    );
+  }
+
+  /**
+    Attaches event listeners for the side navigation toggles
+    @param {HTMLElement} sideNavigation The side navigation element.
+  */
+  setupSideNavigation(sideNavigation) {
+    const toggles = sideNavigation.querySelectorAll(".js-drawer-toggle");
+
+    toggles.forEach((toggle) => {
+      toggle.addEventListener("click", (event) => {
+        event.preventDefault();
+        const sideNav = document.getElementById(
+          toggle.getAttribute("aria-controls")
+        );
+
+        if (sideNav) {
+          this.toggleDrawer(
+            sideNav,
+            !sideNav.classList.contains("is-expanded")
+          );
+        }
+      });
+    });
+  }
+
+  /**
+    Toggles the expanded/collapsed classed on side navigation element.
+
+    @param {HTMLElement} sideNavigation The side navigation element.
+    @param {Boolean} show Whether to show or hide the drawer.
+  */
+  toggleDrawer(sideNavigation, show) {
+    if (sideNavigation) {
+      if (show) {
+        sideNavigation.classList.remove("is-collapsed");
+        sideNavigation.classList.add("is-expanded");
+      } else {
+        sideNavigation.classList.remove("is-expanded");
+        sideNavigation.classList.add("is-collapsed");
+      }
+    }
+  }
+}
+
+export { SideNavigation };

--- a/templates/_header.html
+++ b/templates/_header.html
@@ -23,6 +23,14 @@
           </a>
         </li>
         <li
+          class="p-navigation__link {% if page_slug == 'about' %}is-selected{% endif %}"
+          role="menuitem"
+        >
+          <a href="/about">
+            About
+          </a>
+        </li>
+        <li
           class="p-navigation__link {% if page_slug == 'blog' %}is-selected{% endif %}"
           role="menuitem"
         >

--- a/templates/about/_about_layout.html
+++ b/templates/about/_about_layout.html
@@ -1,0 +1,51 @@
+{% extends webapp_config['LAYOUT'] %}
+
+{% set page_slug="about" %}
+
+{% block content %}
+<section class="p-strip">
+  <div class="row">
+    <div class="col-3">
+      <div class="p-side-navigation" id="drawer">
+        <a href="#drawer" class="p-side-navigation__toggle js-drawer-toggle" aria-controls="drawer">
+          Toggle side navigation
+        </a>
+
+        <div class="p-side-navigation__overlay js-drawer-toggle" aria-controls="drawer"></div>
+
+        <div class="p-side-navigation__drawer">
+          <div class="p-side-navigation__drawer-header">
+            <a href="#" class="p-side-navigation__toggle--in-drawer js-drawer-toggle" aria-controls="drawer">
+              Toggle side navigation
+            </a>
+          </div>
+
+          <ul class="p-side-navigation__list">
+            <li class="p-side-navigation__item">
+              <a class="p-side-navigation__link{% if request.path == '/about' %} is-active{% endif %}" href="/about">About snaps</a>
+            </li>
+            <li class="p-side-navigation__item ">
+              <a class="p-side-navigation__link{% if request.path == '/about/publish' %} is-active{% endif %}" href="/about/publish">Publish to the Snap Store</a>
+            </li>
+            <li class="p-side-navigation__item ">
+              <a class="p-side-navigation__link{% if request.path == '/about/listing' %} is-active{% endif %}" href="/about/listing">Your snap page</a>
+            </li>
+            <li class="p-side-navigation__item ">
+              <a class="p-side-navigation__link{% if request.path == '/about/release' %} is-active{% endif %}" href="/about/release">Releasing your snap</a>
+            </li>
+            <li class="p-side-navigation__item ">
+              <a class="p-side-navigation__link{% if request.path == '/about/publicise' %} is-active{% endif %}" href="/about/publicise">Publicise and measure</a>
+            </li>
+          </ul>
+
+        </div>
+      </div>
+    </div>
+    <div class="col-8 col-start-large-5">
+
+      {% block about_content %}{% endblock about_content %}
+
+    </div>
+  </div>
+</section>
+{% endblock %}

--- a/templates/about/index.html
+++ b/templates/about/index.html
@@ -1,0 +1,121 @@
+{% extends 'about/_about_layout.html' %}
+
+{% block meta_copydoc %}https://docs.google.com/document/d/1mNCqEBZCv9SAprALkSjlwNVyP52ivsQ-fnDQuIS6kBk{% endblock meta_copydoc %}
+
+{% block meta_description %}Snaps are app packages for desktop, cloud and IoT that are easy to install, secure, cross&dash;platform and dependency&dash;free.{% endblock %}
+
+{% block meta_title %}About Snaps | Snapcraft{% endblock %}
+
+{% block about_content %}
+  <h1 class="p-heading--2">About Snaps</h1>
+  <p>
+    Snaps are app packages for desktop, cloud and IoT that are easy to install, secure, cross&dash;platform and dependency&dash;free. Snaps are discoverable and installable from the Snap Store, the app store for Linux with an audience of millions.
+  </p>
+  <div class="p-strip is-shallow">
+    <div class="row">
+      <div class="col-4">
+        <h4>Snap</h4>
+        <p>
+          A snap is a bundle of an app and its dependencies that works without modification across Linux distributions.
+        </p>
+      </div>
+      <div class="col-4">
+        <h4>Snapd</h4>
+        <p>
+          Snapd is the background service that manages and maintains your snaps, automatically.
+        </p>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-4">
+        <h4>Snap Store</h4>
+        <p>
+          The Snap Store provides a place to upload snaps, and for users to browse and install the software they want.
+        </p>
+      </div>
+      <div class="col-4">
+        <h4>Snapcraft</h4>
+        <p>
+          Snapcraft is the command and the framework used to build and publish snaps.
+        </p>
+      </div>
+    </div>
+  </div>
+  <div class="p-strip is-shallow">
+    {{
+      image(
+        url="https://assets.ubuntu.com/v1/143fff51-DO+NOT+USE%21.jpg",
+        alt="",
+        width="725",
+        height="240",
+        hi_def=True
+      ) | safe
+    }}
+    <h2>
+      A universal store
+    </h2>
+    <h3 class="p-heading--4">
+      Snaps run not only on desktops but also on IoT devices, servers and clouds
+    </h3>
+    <p>
+      Snaps work across Linux on many distributions and versions. Bundle your dependencies and assets, to simplify installs to a single standard command.
+    </p>
+    <a href="/iot" class="p-button--neutral">Learn more about snaps in IoT</a>
+  </div>
+  <div class="p-strip is-shallow">
+    {{
+      image(
+        url="https://assets.ubuntu.com/v1/143fff51-DO+NOT+USE%21.jpg",
+        alt="",
+        width="725",
+        height="240",
+        hi_def=True
+      ) | safe
+    }}
+    <h2>Built, published and hosted for free</h2>
+    <h3 class="p-heading--4">
+      Our build infrastructure and the Snap Store makes building and publishing snaps a breeze
+    </h3>
+    <p>
+      Whether your project is hosted on GitHub or not, you can leverage our build system to both build and release to the edge channel, ensuring users always stay up&dash;to&dash;date.
+    </p>
+    <a href="/build" class="p-button--neutral">Learn more about our Build service</a>
+  </div>
+  <div class="p-strip is-shallow">
+    {{
+      image(
+        url="https://assets.ubuntu.com/v1/143fff51-DO+NOT+USE%21.jpg",
+        alt="",
+        width="725",
+        height="240",
+        hi_def=True
+      ) | safe
+    }}
+    <h2>Software distribution in your hands</h2>
+    <h3 class="p-heading--4">
+      With Snapcraft, you are in control of when and how you publish your Snap
+    </h3>
+    <p>
+      With channels users can find their preferred balance between stability and the latest features. Though nothing is enforced, users expect the “Stable” channel to be well tested and updated less frequently, whereas the “Edge” channel is where they&rsquo;ll get the latest release as soon as it&rsquo;s available.
+    </p>
+    <a href="/docs/channels" class="p-button--neutral">Learn more about channels</a>
+  </div>
+  <div class="p-strip is-shallow">
+    {{
+      image(
+        url="https://assets.ubuntu.com/v1/143fff51-DO+NOT+USE%21.jpg",
+        alt="",
+        width="725",
+        height="240",
+        hi_def=True
+      ) | safe
+    }}
+    <h2>Open source, but not only</h2>
+    <h3 class="p-heading--4">
+      Snaps can bundle both proprietary applications and open source
+    </h3>
+    <p>
+      If you build proprietary software you can use the “Proprietary” license. For open source projects we support SPDX expressions so you can let your users know exactly what license your project uses.
+    </p>
+  </div>
+{% endblock %}

--- a/templates/about/listing.html
+++ b/templates/about/listing.html
@@ -1,0 +1,11 @@
+{% extends 'about/_about_layout.html' %}
+
+{% block meta_copydoc %}https://docs.google.com/document/d/1Mt_nUa2U95xuimPSTvBuqWm6PEvRffHDUzzHUzMOuSE{% endblock meta_copydoc %}
+
+{% block meta_description %}{% endblock %}
+
+{% block meta_title %}About Listing | Snapcraft{% endblock %}
+
+{% block about_content %}
+
+{% endblock %}

--- a/templates/about/publicise.html
+++ b/templates/about/publicise.html
@@ -1,0 +1,11 @@
+{% extends 'about/_about_layout.html' %}
+
+{% block meta_copydoc %}https://docs.google.com/document/d/1xDFNtlpV8pKcYixVrri-h0LF_1OoRXTK40CYpvRLwe4{% endblock meta_copydoc %}
+
+{% block meta_description %}{% endblock %}
+
+{% block meta_title %}About Publicising | Snapcraft{% endblock %}
+
+{% block about_content %}
+
+{% endblock %}

--- a/templates/about/publish.html
+++ b/templates/about/publish.html
@@ -1,0 +1,11 @@
+{% extends 'about/_about_layout.html' %}
+
+{% block meta_copydoc %}https://docs.google.com/document/d/1XY0pi68cGyNVb7f0qcobhjBVup0fX17O0vH5f5UdThw{% endblock meta_copydoc %}
+
+{% block meta_description %}{% endblock %}
+
+{% block meta_title %}About Publishing | Snapcraft{% endblock %}
+
+{% block about_content %}
+
+{% endblock %}

--- a/templates/about/release.html
+++ b/templates/about/release.html
@@ -1,0 +1,11 @@
+{% extends 'about/_about_layout.html' %}
+
+{% block meta_copydoc %}https://docs.google.com/document/d/1irw5lVtulOzUK6yNkslJgcocZuomPhpViHu3VgEKVSc{% endblock meta_copydoc %}
+
+{% block meta_description %}{% endblock %}
+
+{% block meta_title %}About Releasing | Snapcraft{% endblock %}
+
+{% block about_content %}
+
+{% endblock %}

--- a/webapp/snapcraft/views.py
+++ b/webapp/snapcraft/views.py
@@ -230,6 +230,26 @@ def snapcraft_blueprint():
             status_code,
         )
 
+    @snapcraft.route("/about")
+    def about():
+        return flask.render_template("about/index.html")
+
+    @snapcraft.route("/about/publish")
+    def about_publish():
+        return flask.render_template("about/publish.html")
+
+    @snapcraft.route("/about/listing")
+    def about_listing():
+        return flask.render_template("about/listing.html")
+
+    @snapcraft.route("/about/release")
+    def about_release():
+        return flask.render_template("about/release.html")
+
+    @snapcraft.route("/about/publicise")
+    def about_publicise():
+        return flask.render_template("about/publicise.html")
+
     @snapcraft.route("/community")
     def community_redirect():
         return flask.redirect("/")

--- a/webpack.config.entry.js
+++ b/webpack.config.entry.js
@@ -3,8 +3,9 @@ module.exports = {
   base: "./static/js/base/base.js",
   release: "./static/js/publisher/release.js",
   public: "./static/js/public/public.js",
+  about: "./static/js/public/about/index.js",
   // TODO:
   // publisher bundle is big (webpack warning) - try to chunk it down
   // https://github.com/canonical-web-and-design/snapcraft.io/issues/1246
-  publisher: "./static/js/publisher/publisher.js"
+  publisher: "./static/js/publisher/publisher.js",
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -11,8 +11,8 @@ const production = process.env.ENVIRONMENT !== "devel";
 const minimizer = production
   ? [
       new TerserPlugin({
-        sourceMap: true
-      })
+        sourceMap: true,
+      }),
     ]
   : [];
 
@@ -20,15 +20,15 @@ module.exports = {
   entry: entry,
   output: {
     filename: "[name].js",
-    path: __dirname + "/static/js/dist"
+    path: __dirname + "/static/js/dist",
   },
   mode: production ? "production" : "development",
   devtool: production ? "source-map" : "eval-source-map",
   module: {
-    rules: rules
+    rules: rules,
   },
   optimization: {
     minimize: true,
-    minimizer
-  }
+    minimizer,
+  },
 };

--- a/webpack.config.rules.js
+++ b/webpack.config.rules.js
@@ -29,6 +29,10 @@ module.exports = [
     use: ["expose-loader?exposes=snapcraft.publisher", "babel-loader"],
   },
   {
+    test: require.resolve(__dirname + "/static/js/public/about/index.js"),
+    use: ["expose-loader?exposes=snapcraft.about", "babel-loader"],
+  },
+  {
     test: require.resolve(__dirname + "/static/js/public/public.js"),
     use: ["expose-loader?exposes=snapcraft.public", "babel-loader"],
   },


### PR DESCRIPTION
## Done

- Add about pages infrastructure and basic layout
- Add `/about` page

## Issue / Card

Fixes https://github.com/canonical-web-and-design/snap-squad/issues/1594

## QA

- Pull the branch
- Run the site using the dotrun snap with `$ dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8004/about
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare the page to [copy doc](https://docs.google.com/document/d/1mNCqEBZCv9SAprALkSjlwNVyP52ivsQ-fnDQuIS6kBk/edit#) and [design](https://app.zeplin.io/project/5cc1b1eae442ed2da911b809/screen/5ea836f6574a9325f2d353ce)


## Screenshot

![image](https://user-images.githubusercontent.com/40214246/89383495-7ca87300-d6f4-11ea-8e1d-e57cb20240eb.png)
