### PR TITLE
Add about/release page

### DIFF
--- a/templates/about/listing.html
+++ b/templates/about/listing.html
@@ -2,10 +2,157 @@
 
 {% block meta_copydoc %}https://docs.google.com/document/d/1Mt_nUa2U95xuimPSTvBuqWm6PEvRffHDUzzHUzMOuSE{% endblock meta_copydoc %}
 
-{% block meta_description %}{% endblock %}
+{% block meta_description %}After you&rsquo;ve tested the snap and you&rsquo;re happy it works as intended, here are 6 things you can do to make the snap store listing really pop and significantly increase the likelihood that the application will get noticed and widely used.{% endblock %}
 
 {% block meta_title %}About Listing | Snapcraft{% endblock %}
 
 {% block about_content %}
-
+  <h1 class="p-heading--2">Make the most out of your snap page</h1>
+  <p>
+    After you&rsquo;ve tested the snap and you&rsquo;re happy it works as intended, here are 6 things you can do to make the snap store listing really pop and significantly increase the likelihood that the application will get noticed and widely used. <a href="/snaps">Login to your Snapcraft</a> account and take your store listing to the next level.
+  </p>
+  <div class="p-strip is-shallow">
+    <h2 class="p-muted-heading">
+      Title
+    </h2>
+    <h3 class="p-heading--2">
+      Distinctive, easy to spell
+    </h3>
+    <p>
+      Your snap&rsquo;s name will be most likely the way users look for you in the store. You will want to make sure your name stands out from the bunch, but also that it is easy to spell and gives an idea of what the snap might do. Be accurate with the case and spacing, and remember you have up to 64 characters.
+    </p>
+    {{
+      image(
+        url="https://assets.ubuntu.com/v1/143fff51-DO+NOT+USE%21.jpg",
+        alt="",
+        width="725",
+        height="320",
+        hi_def=True
+      ) | safe
+    }}
+  </div>
+  <div class="p-strip is-shallow">
+    <h2 class="p-muted-heading">
+      Subtitle
+    </h2>
+    <h3 class="p-heading--2">
+      Short and clear
+    </h3>
+    <p>
+      You have up to 79 characters for your summary and you will want to make sure you resonate with your audience here. The summary is intended to give a short description of what your app does and what it&rsquo;s top features are. This will often be used to determine the value your app brings to the table, so keep it short and don&rsquo;t be generic.
+    </p>
+    {{
+      image(
+        url="https://assets.ubuntu.com/v1/143fff51-DO+NOT+USE%21.jpg",
+        alt="",
+        width="725",
+        height="320",
+        hi_def=True
+      ) | safe
+    }}
+  </div>
+  <div class="p-strip is-shallow">
+    <h2 class="p-muted-heading">
+      Icon
+    </h2>
+    <h3 class="p-heading--2">
+      First impressions matter
+    </h3>
+    <p>
+      Your snap&rsquo;s icon is one of the first things users see about your app. It is important that it communicates quality and simplicity, as well as hinting at functionality. Make it pop by making it recognisable and avoid adding too much detail, these won’t show well in small sizes. We recommend your icon is 512x512 pixels.
+    </p>
+    {{
+      image(
+        url="https://assets.ubuntu.com/v1/143fff51-DO+NOT+USE%21.jpg",
+        alt="",
+        width="725",
+        height="320",
+        hi_def=True
+      ) | safe
+    }}
+  </div>
+  <div class="p-strip is-shallow">
+    <h2 class="p-muted-heading">
+      Screenshots & Video
+    </h2>
+    <h3 class="p-heading--2">
+      What your snap does, visually
+    </h3>
+    <p>
+      Your snap&rsquo;s gallery will communicate what using it is like, it showcases the UI, and gives a preview of what to expect from it. The gallery can include up to 5 items that can be videos, gifs and images. We recommend using gifs or videos to generate more engagement, particularly when embedded in social campaigns. The store supports embedding videos from YouTube, Vimeo and Asciinema, the latter is excellent for showcasing your terminal applications.
+    </p>
+    <p>
+      If the application is cross-platform, upload screenshots taken from a Linux workstation rather than reusing screenshots from other platforms.
+    </p>
+    {{
+      image(
+        url="https://assets.ubuntu.com/v1/143fff51-DO+NOT+USE%21.jpg",
+        alt="",
+        width="725",
+        height="320",
+        hi_def=True
+      ) | safe
+    }}
+  </div>
+  <div class="p-strip is-shallow">
+    <h2 class="p-muted-heading">
+      Description
+    </h2>
+    <h3 class="p-heading--2">
+      Highlighted features
+    </h3>
+    <p>
+      Your description should highlight the most important features and accurately describe your snap. Write it in a way that is engaging, with the right tone of voice for your audience. Remember to write the most important information first, and put all your efforts into the first sentence to catch the reader&rsquo;s attention.
+    </p>
+    {{
+      image(
+        url="https://assets.ubuntu.com/v1/143fff51-DO+NOT+USE%21.jpg",
+        alt="",
+        width="725",
+        height="320",
+        hi_def=True
+      ) | safe
+    }}
+  </div>
+  <div class="p-strip is-shallow">
+    <h2 class="p-muted-heading">
+      Category
+    </h2>
+    <h3 class="p-heading--2">
+      Other snaps that are similar
+    </h3>
+    <p>
+      You can choose up to two categories amongst which your app will be featured. The category will aid discoverability and helps the user determine whether your app fits their needs. Make sure the category is relevant to your snap.
+    </p>
+    {{
+      image(
+        url="https://assets.ubuntu.com/v1/143fff51-DO+NOT+USE%21.jpg",
+        alt="",
+        width="725",
+        height="320",
+        hi_def=True
+      ) | safe
+    }}
+  </div>
+  <div class="p-strip is-shallow">
+    <h2 class="p-muted-heading">
+      Banner
+    </h2>
+    <h3 class="p-heading--2">
+      Get featured on the snap store
+    </h3>
+    <p>
+      Each week the Snap Advocacy team refresh the <a href="/search?category=featured">featured snap category</a> in the store. Only Snaps with a banner qualify for promotion in the top spot. Uploading a banner does not guarantee the application will be featured, but it helps, and being featured typically generates a significant volume of new users.
+    </p>
+    <p>We recommend you upload a banner at least 1920 x 640 pixels or greater, up to 4320 x 1440 pixels.</p>
+    {{
+      image(
+        url="https://assets.ubuntu.com/v1/143fff51-DO+NOT+USE%21.jpg",
+        alt="",
+        width="725",
+        height="320",
+        hi_def=True
+      ) | safe
+    }}
+  </div>
 {% endblock %}

--- a/templates/about/release.html
+++ b/templates/about/release.html
@@ -2,10 +2,47 @@
 
 {% block meta_copydoc %}https://docs.google.com/document/d/1irw5lVtulOzUK6yNkslJgcocZuomPhpViHu3VgEKVSc{% endblock meta_copydoc %}
 
-{% block meta_description %}{% endblock %}
+{% block meta_description %}Snapcraft allows you to release your snaps either by using the command line tool or the visual interface on our website.{% endblock %}
 
 {% block meta_title %}About Releasing | Snapcraft{% endblock %}
 
 {% block about_content %}
-
+  <div class="p-strip is-shallow u-no-padding--top">
+    <h1 class="p-heading--2">Releasing your snap</h1>
+    <h2 class="p-heading--4">
+      Release UI
+    </h2>
+    <p>
+      Snapcraft allows you to release your snaps either by using the command line tool or the visual interface on our website. If you visit your snap page, you will find a “Release” tab in which you can see which version of your software is released to each channel and architecture. The UI is a simple drag-and-drop table where you can move around the revisions of your snap, until you’re happy, before committing.
+    </p>
+    <p>
+      If you use our <a href="/build">build service</a> all revisions built at the same time will be tagged as a set, allowing you to work on related revisions easily. Built revisions will also automatically be released to the edge channel &mdash; no&dash;hassle continuous deployment.
+    </p>
+    {{
+      image(
+        url="https://assets.ubuntu.com/v1/143fff51-DO+NOT+USE%21.jpg",
+        alt="",
+        width="725",
+        height="320",
+        hi_def=True
+      ) | safe
+    }}
+  </div>
+  <div class="p-strip is-shallow">
+    <h2 class="p-heading--4">
+      Announcing updates
+    </h2>
+    <p>
+      Releasing your snap is only the first step - you also need to tell your users about it. On the <a href="/about/publicise">publicise page</a> there&rsquo;s information about badges and buttons you can use to help promote and inform users about your snap and it&rsquo;s status. We provide a badge that appears when your snap is trending on the Store to show visitors to your site that your snap is something to take a look at.
+    </p>
+    {{
+      image(
+        url="https://assets.ubuntu.com/v1/143fff51-DO+NOT+USE%21.jpg",
+        alt="",
+        width="725",
+        height="320",
+        hi_def=True
+      ) | safe
+    }}
+  </div>
 {% endblock %}


### PR DESCRIPTION
## Done

- Add `/about/release`
-Add `/about/listing`

## Issue / Card

Fixes https://github.com/canonical-web-and-design/snap-squad/issues/1597

## QA

- Pull the branch
- Run the site using the dotrun snap with `$ dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8004/about/release
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Go to http://0.0.0.0:8004/about/release and compare to [copy doc](https://docs.google.com/document/d/1irw5lVtulOzUK6yNkslJgcocZuomPhpViHu3VgEKVSc) and [design](https://app.zeplin.io/project/5cc1b1eae442ed2da911b809/screen/5ed50412b257ca512de6852b)
- Go to http://0.0.0.0:8004/about/listing and compare to [copy doc](https://docs.google.com/document/d/1Mt_nUa2U95xuimPSTvBuqWm6PEvRffHDUzzHUzMOuSE/edit) and [design](https://app.zeplin.io/project/5cc1b1eae442ed2da911b809/screen/5ea83a7f7295fb26a961ff0d)

## Screenshots

[if relevant, include a screenshot]
