### PR TITLE
Update supported releases

### DIFF
--- a/webapp/store/content/distros/ubuntu.yaml
+++ b/webapp/store/content/distros/ubuntu.yaml
@@ -6,7 +6,7 @@ logo-mono: https://assets.ubuntu.com/v1/20ba8b71-Distro_Logo_Ubuntu_White.svg
 install:
   -
     action: |
-      If you’re running <a href="https://www.ubuntu.com/">Ubuntu 16.04 LTS (Xenial Xerus)</a> or later, including <a href="https://www.ubuntu.com/desktop/features">Ubuntu 18.04 LTS (Bionic Beaver)</a>, <a href="https://wiki.ubuntu.com/CosmicCuttlefish/ReleaseNotes">Ubuntu 18.10 (Cosmic Cuttlefish)</a> and <a href="https://wiki.ubuntu.com/DiscoDingo/ReleaseNotes">Ubuntu 19.04 (Disco Dingo)</a>, you don’t need to do anything. Snap is already installed and ready to go.
+      If you’re running <a href="https://www.ubuntu.com/">Ubuntu 16.04 LTS (Xenial Xerus)</a> or later, including <a href="https://www.ubuntu.com/desktop/features">Ubuntu 18.04 LTS (Bionic Beaver)</a> and <a href="https://wiki.ubuntu.com/FocalFossa/ReleaseNotes">Ubuntu 20.04 LTS (Focal Fossa)</a>, you don’t need to do anything. Snap is already installed and ready to go.
   -
     action: |
       For versions of Ubuntu between <a href="https://wiki.ubuntu.com/TrustyTahr/ReleaseNotes">14.04 LTS (Trusty Tahr)</a> and <a href="https://wiki.ubuntu.com/WilyWerewolf/ReleaseNotes">15.10 (Wily Werewolf)</a>, as well as Ubuntu flavours that don’t include <em>snap</em> by default, <em>snap</em> can be installed from the Ubuntu Software Centre by searching for <em>snapd</em>.


### PR DESCRIPTION
Remove the EOL releases and add 20.04

## Done

Checked which releases are supported. Removed unsupported ones, and added in 20.04 LTS.

## Issue / Card

Reported at https://forum.snapcraft.io/t/outdated-snapcraft-info-at-every-ubuntu-package/19316

## QA

Did all this! dotrun is rather neat!

- Pull the branch
- Run the site using the dotrun snap with `$ dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8004/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)

Made sure I didn't put a duff link in there, or break existing links.

## Screenshots


![Screenshot from 2020-08-10 17-21-26](https://user-images.githubusercontent.com/1841272/89805818-1c6b6400-db2e-11ea-8b2b-8a23efa54c60.png)
