### PR TITLE
Remove external link from navigation "Forum"

### DIFF
--- a/templates/_header.html
+++ b/templates/_header.html
@@ -62,7 +62,7 @@
             Tutorials
           </a>
         </li>
-        <li class="p-navigation__link" role="menuitem"><a class="p-link--external" href="https://forum.snapcraft.io/categories">Forum</a></li>
+        <li class="p-navigation__link" role="menuitem"><a href="https://forum.snapcraft.io/categories">Forum</a></li>
       </ul>
 
       <ul class="p-navigation__links" role="menu">


### PR DESCRIPTION
## Done

[List of work items including drive-bys]

## Issue / Card

Fixes #

## QA

- Pull the branch
- Run the site using the dotrun snap with `$ dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8004/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See there is n external link icon for "Forum" in the nav

## Screenshots

[if relevant, include a screenshot]
