### PR TITLE
Remove useless space

### DIFF
--- a/templates/home/_fsf_flutter.html
+++ b/templates/home/_fsf_flutter.html
@@ -33,7 +33,7 @@
     <b>source</b>: https://github.com/kenvandine/super-cool-app.git
     <b>flutter-target</b>: lib/main.dart
 
- <b>apps</b>:
+<b>apps</b>:
    <b>super-cool-app</b>:
       <b>command</b>: super_cool_app
       <b>extensions</b>: [flutter-dev]</pre>


### PR DESCRIPTION
## Done

Fixes #2940 

Remove useless space

## QA

- Pull the branch
- Run the site using the dotrun snap with `$ dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8004/
- Make sure First snap flow for flutter doens't have the space anymore in front of apps
```
apps:
   super-cool-app:
      command: super_cool_app
      extensions: [flutter-dev] 
```
