### PR TITLE
Replace placeholder images

### DIFF
--- a/templates/about/listing.html
+++ b/templates/about/listing.html
@@ -23,7 +23,7 @@
     </p>
     {{
       image(
-        url="https://assets.ubuntu.com/v1/143fff51-DO+NOT+USE%21.jpg",
+        url="https://assets.ubuntu.com/v1/5e42de7c-01+Title.jpg",
         alt="",
         width="725",
         height="320",
@@ -43,7 +43,7 @@
     </p>
     {{
       image(
-        url="https://assets.ubuntu.com/v1/143fff51-DO+NOT+USE%21.jpg",
+        url="https://assets.ubuntu.com/v1/abbb50ce-02+Summary.jpg",
         alt="",
         width="725",
         height="320",
@@ -63,7 +63,7 @@
     </p>
     {{
       image(
-        url="https://assets.ubuntu.com/v1/143fff51-DO+NOT+USE%21.jpg",
+        url="https://assets.ubuntu.com/v1/0d100b15-03+Icon.jpg",
         alt="",
         width="725",
         height="320",
@@ -86,7 +86,7 @@
     </p>
     {{
       image(
-        url="https://assets.ubuntu.com/v1/143fff51-DO+NOT+USE%21.jpg",
+        url="https://assets.ubuntu.com/v1/709c455c-04+Screenshots.jpg",
         alt="",
         width="725",
         height="320",
@@ -106,7 +106,7 @@
     </p>
     {{
       image(
-        url="https://assets.ubuntu.com/v1/143fff51-DO+NOT+USE%21.jpg",
+        url="https://assets.ubuntu.com/v1/75cf35e8-05+Description.jpg",
         alt="",
         width="725",
         height="320",
@@ -126,7 +126,7 @@
     </p>
     {{
       image(
-        url="https://assets.ubuntu.com/v1/143fff51-DO+NOT+USE%21.jpg",
+        url="https://assets.ubuntu.com/v1/5e538b40-06+Category.jpg",
         alt="",
         width="725",
         height="320",
@@ -147,7 +147,7 @@
     <p>We recommend you upload a banner at least 1920 x 640 pixels or greater, up to 4320 x 1440 pixels.</p>
     {{
       image(
-        url="https://assets.ubuntu.com/v1/143fff51-DO+NOT+USE%21.jpg",
+        url="https://assets.ubuntu.com/v1/b81ed89f-07+Banner.jpg",
         alt="",
         width="725",
         height="320",


### PR DESCRIPTION
## Done

- Replace placeholder images on `/about/listing`

## Issue / Card

Fixes #

## QA

- Pull the branch
- Run the site using the dotrun snap with `$ dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8004/about/listing
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See the page looks good

## Screenshots

[if relevant, include a screenshot]
