### PR TITLE
Add about pages images

### DIFF
--- a/templates/about/index.html
+++ b/templates/about/index.html
@@ -44,7 +44,7 @@
   <div class="p-strip is-shallow">
     {{
       image(
-        url="https://assets.ubuntu.com/v1/143fff51-DO+NOT+USE%21.jpg",
+        url="https://assets.ubuntu.com/v1/c6335a68-01+A+universal+store+x2.png",
         alt="",
         width="725",
         height="240",
@@ -65,7 +65,7 @@
   <div class="p-strip is-shallow">
     {{
       image(
-        url="https://assets.ubuntu.com/v1/143fff51-DO+NOT+USE%21.jpg",
+        url="https://assets.ubuntu.com/v1/1dff8c80-02+Built%2C+published+and+hosted+for+free+x2.png",
         alt="",
         width="725",
         height="240",
@@ -84,7 +84,7 @@
   <div class="p-strip is-shallow">
     {{
       image(
-        url="https://assets.ubuntu.com/v1/143fff51-DO+NOT+USE%21.jpg",
+        url="https://assets.ubuntu.com/v1/9aeb6b02-03+Software+distribution+in+your+hands+x2.png",
         alt="",
         width="725",
         height="240",
@@ -103,7 +103,7 @@
   <div class="p-strip is-shallow">
     {{
       image(
-        url="https://assets.ubuntu.com/v1/143fff51-DO+NOT+USE%21.jpg",
+        url="https://assets.ubuntu.com/v1/f7ca8e0f-04+Open+source%2C+but+not+only+x2.png",
         alt="",
         width="725",
         height="240",

--- a/templates/about/publicise.html
+++ b/templates/about/publicise.html
@@ -25,7 +25,7 @@
     </p>
     {{
       image(
-        url="https://assets.ubuntu.com/v1/143fff51-DO+NOT+USE%21.jpg",
+        url="https://assets.ubuntu.com/v1/756a1334-01+Weekly+active+devices+x2.png",
         alt="",
         width="725",
         height="240",
@@ -38,7 +38,7 @@
     <p>If you open the dropdown above this chart in the Metrics page, you will be able to select different options to segment your users. These include the OS they are running your snaps with, what channel they are using (stable, candidate, beta or edge) and what version of your software they are on. This will help you visualise the rhythm at which your software updates are being adopted.</p>
     {{
       image(
-        url="https://assets.ubuntu.com/v1/143fff51-DO+NOT+USE%21.jpg",
+        url="https://assets.ubuntu.com/v1/f57edf52-02+Snap+users+by+OS%2C+channel+or+version+x2.png",
         alt="",
         width="725",
         height="240",
@@ -55,7 +55,7 @@
     </p>
     {{
       image(
-        url="https://assets.ubuntu.com/v1/143fff51-DO+NOT+USE%21.jpg",
+        url="https://assets.ubuntu.com/v1/4cdae87f-03+Snap+users+by+territory+x2.png",
         alt="",
         width="725",
         height="240",
@@ -77,7 +77,7 @@
       <div class="col-4">
         {{
           image(
-            url="https://assets.ubuntu.com/v1/143fff51-DO+NOT+USE%21.jpg",
+            url="https://assets.ubuntu.com/v1/88f33387-04+Snap+Store+buttons+x2.png",
             alt="",
             width="344",
             height="208",
@@ -98,7 +98,7 @@
       <div class="col-4">
         {{
           image(
-            url="https://assets.ubuntu.com/v1/143fff51-DO+NOT+USE%21.jpg",
+          url="https://assets.ubuntu.com/v1/5f95707d-05+GitHub+badges+x2.png",
             alt="",
             width="344",
             height="208",

--- a/templates/about/publish.html
+++ b/templates/about/publish.html
@@ -14,7 +14,7 @@
     </p>
     {{
       image(
-        url="https://assets.ubuntu.com/v1/143fff51-DO+NOT+USE%21.jpg",
+        url="https://assets.ubuntu.com/v1/fba1c583-01+Publish+from+your+developer+workstation+x2.png",
         alt="",
         width="725",
         height="240",
@@ -46,7 +46,7 @@
     <h3 class="p-heading--4">Build for multiple architectures from a single GitHub commit</h3>
     {{
       image(
-        url="https://assets.ubuntu.com/v1/143fff51-DO+NOT+USE%21.jpg",
+        url="https://assets.ubuntu.com/v1/a51b92b9-02+Publish+with+our+Build+service+x2.png",
         alt="",
         width="725",
         height="240",
@@ -62,7 +62,7 @@
     <h3 class="p-heading--4">Travis CI, Circle CI and GitHub Actions are all supported</h3>
     {{
       image(
-        url="https://assets.ubuntu.com/v1/143fff51-DO+NOT+USE%21.jpg",
+    url="https://assets.ubuntu.com/v1/83c3eb35-03+Publish+with+a+third+party+CI+system+x2.png",
         alt="",
         width="725",
         height="240",
@@ -78,7 +78,7 @@
     <h2>Publish with your own infrastructure</h2>
     {{
       image(
-        url="https://assets.ubuntu.com/v1/143fff51-DO+NOT+USE%21.jpg",
+        url="https://assets.ubuntu.com/v1/0a49a2f3-04+Publish+with+your+own+infrastructure.png",
         alt="",
         width="725",
         height="240",

--- a/templates/about/release.html
+++ b/templates/about/release.html
@@ -20,7 +20,7 @@
     </p>
     {{
       image(
-        url="https://assets.ubuntu.com/v1/143fff51-DO+NOT+USE%21.jpg",
+        url="https://assets.ubuntu.com/v1/ed2752f0-01+Release+UI+x2.png",
         alt="",
         width="725",
         height="320",
@@ -37,7 +37,7 @@
     </p>
     {{
       image(
-        url="https://assets.ubuntu.com/v1/143fff51-DO+NOT+USE%21.jpg",
+        url="https://assets.ubuntu.com/v1/369b18fa-02+Announcing+updates+x2.png",
         alt="",
         width="725",
         height="320",


### PR DESCRIPTION
## Done

Add missing images for the about pages

## Issue / Card

Fixes #1604

## QA

- Pull the branch
- Run the site using the dotrun snap with `$ dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8004/about
- Go through all the images in the about pages (see navigation) and make sure it makes sense and that this image is not in here anymore: 

![image](https://user-images.githubusercontent.com/2707508/90896506-b0a1ba80-e3bb-11ea-88f0-44f6b596b8c8.png)
