### PR TITLE
Add browse all and view all buttons

### DIFF
--- a/static/js/public/hero-tabpanel.js
+++ b/static/js/public/hero-tabpanel.js
@@ -32,7 +32,7 @@ class HeroTabPanels {
       const columnDiv = document.createElement("div");
       columnDiv.setAttribute("class", "col-4 u-equal-height");
       columnDiv.innerHTML = `
-        <a class="p-media-object p-media-object--snap p-card u-no-margin--bottom" href="/${
+        <a class="p-media-object p-media-object--snap p-card" href="/${
           snap.package_name
         }" title="${snap.title}${snap.summary ? " – " : ""}${snap.summary}">
           <img src="${snap.icon_url}" alt="${
@@ -60,6 +60,19 @@ class HeroTabPanels {
 
   changeTabs(target) {
     clearInterval(this.timer);
+
+    const nextCategoryName = target.getAttribute("aria-controls").split("-")[1];
+    const viewAllLinkList = this.mainContainer.querySelectorAll(
+      "[data-js='view-all']"
+    );
+    // Show the appropriate 'View all' link
+    viewAllLinkList.forEach((el) => {
+      if (el.getAttribute("id") === `view-all-${nextCategoryName}`) {
+        el.classList.remove("u-hide");
+      } else {
+        el.classList.add("u-hide");
+      }
+    });
 
     // Remove all current selected tabs
     this.tabs.forEach((tab) => {

--- a/static/sass/_button-overrides.scss
+++ b/static/sass/_button-overrides.scss
@@ -1,4 +1,20 @@
 @mixin button-overrides {
+  .p-button--outline {
+    @extend %vf-button-base;
+
+    border-color: $color-x-light;
+    color: $color-x-light;
+
+    &:visited {
+      color: $color-x-light;
+    }
+
+    &:hover,
+    &:active:hover {
+      background-color: rgba($color-mid-x-light, .2);
+    }
+  }
+
   .is-inline--right {
     margin-right: $sp-medium;
   }

--- a/static/sass/_pattern-hero-tab.scss
+++ b/static/sass/_pattern-hero-tab.scss
@@ -4,6 +4,17 @@
     opacity: 0;
     overflow: hidden;
     transition: opacity .5s ease-in;
+
+    .p-card {
+      @media screen and(min-width: $breakpoint-medium) {
+        margin-block-end: 0;
+      }
+    }
+  }
+
+  .p-hero-tab__link,
+  .p-hero-tab__link:visited {
+    color: $color-light;
   }
 
   .p-hero-tab {

--- a/templates/index.html
+++ b/templates/index.html
@@ -50,15 +50,23 @@
       </div>
       <button type="submit" alt="search" class="p-button--positive">Search</button>
     </form>
-    <p class="p-heading--5" style="margin-block-start: 1rem;">Some snaps you may like</p>
 
     <div data-js="hero-snaps-container">
+      <div class="u-fixed-width u-clearfix" style="margin-block-start: 1.5rem;">
+        <p class="p-heading--5 u-float-left">Some snaps you may like</p>
+        <p class="u-float-right">
+        {% for category in hero_categories %}
+          <a href="/search?category={{ category|lower }}" id="view-all-{{ category|lower }}" class="p-hero-tab__link{% if loop.index > 1 %} u-hide{% endif %}" data-js="view-all">View all {{ category }} snaps&nbsp;&rsaquo;</a>
+        {% endfor %}
+        </p>
+      </div>
+
       <div data-js="panels-container">
         {% for category in hero_categories %}
         <div class="p-hero-panel row u-no-padding--left u-no-padding--right{% if loop.index == 1 %} u-animate--reveal{% endif%}" id="panel-{{ category|lower }}-snaps" role="tabpanel" aria-labelledby="{{ category|lower }}-snaps">
           {% for _ in range(0, 3) %}
           <div class="col-4">
-            <div class="p-card p-media-object p-media-object--snap is-placeholder u-no-margin--bottom">
+            <div class="p-card p-media-object p-media-object--snap is-placeholder">
               <div class="p-media-object__image"></div>
               <div class="p-media-object__details">
                 <h4 class="p-media-object__title p-heading--5 u-no-margin--bottom">
@@ -87,6 +95,10 @@
           {% endfor %}
         </div>
       </div>
+    </div>
+
+    <div class="u-fixed-width u-align--center">
+      <a href="/store" class="p-button--outline">Browse all snaps</a>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Done

- Add "View all ... snaps" button
- Add "Browse all snaps" button

## Issue / Card

Fixes https://github.com/canonical-web-and-design/snap-squad/issues/1606

## QA

- Pull the branch
- Run the site using the dotrun snap with `$ dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8004/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Go to homepage and see the new links in the hero

## Screenshots

![image](https://user-images.githubusercontent.com/40214246/91556260-590ace00-e92a-11ea-9aa4-16af4b1371c8.png)

