### PR TITLE
Update /about/listing headings

### DIFF
--- a/templates/about/listing.html
+++ b/templates/about/listing.html
@@ -12,7 +12,7 @@
     After you&rsquo;ve tested the snap and you&rsquo;re happy it works as intended, here are 6 things you can do to make the snap store listing really pop and significantly increase the likelihood that the application will get noticed and widely used. <a href="/snaps">Login to your Snapcraft</a> account and take your store listing to the next level.
   </p>
   <div class="p-strip is-shallow">
-    <h2 class="p-muted-heading">
+    <h2 class="p-heading--5">
       Title
     </h2>
     <h3 class="p-heading--2">
@@ -32,7 +32,7 @@
     }}
   </div>
   <div class="p-strip is-shallow">
-    <h2 class="p-muted-heading">
+    <h2 class="p-heading--5">
       Subtitle
     </h2>
     <h3 class="p-heading--2">
@@ -52,7 +52,7 @@
     }}
   </div>
   <div class="p-strip is-shallow">
-    <h2 class="p-muted-heading">
+    <h2 class="p-heading--5">
       Icon
     </h2>
     <h3 class="p-heading--2">
@@ -72,7 +72,7 @@
     }}
   </div>
   <div class="p-strip is-shallow">
-    <h2 class="p-muted-heading">
+    <h2 class="p-heading--5">
       Screenshots & Video
     </h2>
     <h3 class="p-heading--2">
@@ -95,7 +95,7 @@
     }}
   </div>
   <div class="p-strip is-shallow">
-    <h2 class="p-muted-heading">
+    <h2 class="p-heading--5">
       Description
     </h2>
     <h3 class="p-heading--2">
@@ -115,7 +115,7 @@
     }}
   </div>
   <div class="p-strip is-shallow">
-    <h2 class="p-muted-heading">
+    <h2 class="p-heading--5">
       Category
     </h2>
     <h3 class="p-heading--2">
@@ -135,7 +135,7 @@
     }}
   </div>
   <div class="p-strip is-shallow">
-    <h2 class="p-muted-heading">
+    <h2 class="p-heading--5">
       Banner
     </h2>
     <h3 class="p-heading--2">


### PR DESCRIPTION
## Done

- Update /about/listing headings to be `p-heading--5`

## Issue / Card

Fixes #3027 

## QA

- Pull the branch
- Run the site using the dotrun snap with `$ dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8004/about/listing
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that `Title`, `Subtitle`, etc. look better than before

## Screenshots

[if relevant, include a screenshot]
