### PR TITLE
Update supported openSUSE Leap versions

### DIFF
--- a/webapp/store/content/distros/opensuse.yaml
+++ b/webapp/store/content/distros/opensuse.yaml
@@ -6,7 +6,7 @@ logo-mono: https://assets.ubuntu.com/v1/e4e63887-Distro_Logo_OpenSUSE_White.svg
 install:
   -
     action: |
-      Snap can be installed from the command line on openSUSE Leap 15 and Tumbleweed.
+      Snap can be installed from the command line on openSUSE Leap 15.x and Tumbleweed.
   -
     action: |
       You need first add the <em>snappy</em> repository from the terminal. Leap 15.2 users, for example, can do this with the following command:

--- a/webapp/store/content/distros/opensuse.yaml
+++ b/webapp/store/content/distros/opensuse.yaml
@@ -6,15 +6,15 @@ logo-mono: https://assets.ubuntu.com/v1/e4e63887-Distro_Logo_OpenSUSE_White.svg
 install:
   -
     action: |
-      Snap can be installed from the command line on openSUSE Leap 42.3, Leap 15 and Tumbleweed.
+      Snap can be installed from the command line on openSUSE Leap 15 and Tumbleweed.
   -
     action: |
-      You need first add the <em>snappy</em> repository from the terminal. Leap 15 users, for example, can do this with the following command:
+      You need first add the <em>snappy</em> repository from the terminal. Leap 15.2 users, for example, can do this with the following command:
     command: |
-      sudo zypper addrepo --refresh https://download.opensuse.org/repositories/system:/snappy/openSUSE_Leap_15.0 snappy
+      sudo zypper addrepo --refresh https://download.opensuse.org/repositories/system:/snappy/openSUSE_Leap_15.2 snappy
   -
     action: |
-      Swap out <code>openSUSE_Leap_15.0</code> for either <code>openSUSE_Leap_42.3</code> or <code>openSUSE_Tumbleweed</code> if you’re using a different version of openSUSE.
+      Swap out <code>openSUSE_Leap_15.2</code> for <code>openSUSE_Leap_15.1</code>, <code>openSUSE_Leap_15.0</code>, or <code>openSUSE_Tumbleweed</code> if you’re using a different version of openSUSE.
   -
     action: |
       With the repository added, import its GPG key:


### PR DESCRIPTION
## Done

This commit removes references to Leap 42.3.
Additionally, it adds references for Leap 15.1 and 15.2.
The example has been updated to use the latest Leap repository, 15.2.

## Issue / Card

Fixes #3043 

The repository for Leap 42.3 no longer exists.
Leap 42.3 is no longer supported, so this is not unexpected.
The currently available repositories can be found here:
https://download.opensuse.org/repositories/system:/snappy/
Leap 15.1 and 15.2 are now available in addition to 15.0.

## QA

- Pull the branch
- Run the site using the dotrun snap with `$ dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8004/docs/installing-snap-on-opensuse
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Verify that the openSUSE repositories named are available here: https://download.opensuse.org/repositories/system:/snappy/

## Screenshots

[if relevant, include a screenshot]
