### PR TITLE
Show only verified snaps as verified on homepage carousel

### DIFF
--- a/static/js/public/hero-tabpanel.js
+++ b/static/js/public/hero-tabpanel.js
@@ -27,6 +27,11 @@ class HeroTabPanels {
     const panel = this.panelContainer.querySelector(
       `[aria-labelledby='${categoryName}-snaps']`
     );
+    const verifiedAccountBadge = `
+      <span class="p-verified" title="Verified account">
+        <img src="https://assets.ubuntu.com/v1/75654c90-rosette.svg">
+      </span>
+    `;
     panel.innerHTML = "";
     snaps.forEach((snap) => {
       const columnDiv = document.createElement("div");
@@ -45,9 +50,12 @@ class HeroTabPanels {
             <div class="p-media-object__content">
               <p>
                 <span class="u-off-screen">Publisher: </span>${snap.publisher}
-                <span class="p-verified" title="Verified account">
-                  <img src="https://assets.ubuntu.com/v1/75654c90-rosette.svg">
-                </span>
+                ${
+                  snap.developer_validation &&
+                  snap.developer_validation === "verified"
+                    ? verifiedAccountBadge
+                    : ""
+                }
               </p>
               <p>${snap.summary}</p>
             </div>


### PR DESCRIPTION
## Done

- Show only verified snaps as verified on homepage carousel

## Issue / Card

Fixes #3046 

## QA

- Pull the branch
- Run the site using the dotrun snap with `$ dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8004/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Go to homepage and see that not all snaps are showed as verified, only some of them.

## Screenshots

[if relevant, include a screenshot]
