### PR TITLE
Add architecture metrics on publisher page

### DIFF
--- a/templates/publisher/metrics.html
+++ b/templates/publisher/metrics.html
@@ -50,6 +50,7 @@ Publisher metrics for {{ snap_title }}
             <option value="version"{% if active_device_metric == 'version' %} selected="selected"{% endif %}>By version</option>
             <option value="os"{% if active_device_metric == 'os' %} selected="selected"{% endif %}>By OS</option>
             <option value="channel"{% if active_device_metric == 'channel' %} selected="selected"{% endif %}>By channel</option>
+            <option value="architecture"{% if active_device_metric == 'architecture' %} selected="selected"{% endif %}>By architecture</option>
           </select>
         </div>
         <div class="col-12">

--- a/webapp/publisher/snaps/logic.py
+++ b/webapp/publisher/snaps/logic.py
@@ -82,7 +82,7 @@ def verify_base_metrics(active_devices):
 
     :return: The base metric if it's available, 'version' if not
     """
-    if active_devices not in ("version", "os", "channel"):
+    if active_devices not in ("version", "os", "channel", "architecture"):
         return "version"
 
     return active_devices
@@ -131,6 +131,8 @@ def get_installed_based_metric(installed_base_metric):
         return "weekly_installed_base_by_operating_system"
     elif installed_base_metric == "channel":
         return "weekly_installed_base_by_channel"
+    elif installed_base_metric == "architecture":
+        return "weekly_installed_base_by_architecture"
 
 
 def is_snap_on_stable(channel_maps_list):


### PR DESCRIPTION
## Done

Add metrics graph for weekly architecture

## Issue / Card

Fixes https://github.com/canonical-web-and-design/snapcraft.io/issues/1680

## QA

- Pull the branch
- Run the site using the dotrun snap with `$ dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8004/<snap>/metrics
- Chose `By architecture`
- The metrics graph should reflect the architectures