### PR TITLE
Remove quote plus not required for API call

### DIFF
--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -1,5 +1,4 @@
 from math import ceil, floor
-from urllib.parse import quote_plus
 import talisker.requests
 import flask
 import webapp.helpers as helpers
@@ -157,7 +156,7 @@ def store_blueprint(store_query=None, testing=False):
 
         try:
             searched_results = api.search(
-                quote_plus(snap_searched),
+                snap_searched,
                 category=snap_category,
                 size=size,
                 page=page,
@@ -262,9 +261,7 @@ def store_blueprint(store_query=None, testing=False):
         searched_results = []
 
         try:
-            searched_results = api.search(
-                quote_plus(snap_searched), size=size, page=page
-            )
+            searched_results = api.search(snap_searched, size=size, page=page)
         except (StoreApiError, ApiError) as api_error:
             status_code, error_info = _handle_error(api_error)
 


### PR DESCRIPTION
## Done

Remove `quote_plus` not required to do API request to store.

## Issue / Card

Fixes #3036

## QA

- Pull the branch
- Run the site using the dotrun snap with `$ dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8004/store
- Search for snaps with special characters in names like: Xournal++
- Should have results in this case
