### PR TITLE
distros: ask debian users to install core snap

### DIFF
--- a/webapp/store/content/distros/debian.yaml
+++ b/webapp/store/content/distros/debian.yaml
@@ -10,3 +10,4 @@ install:
     command: |
       sudo apt update
       sudo apt install snapd
+      sudo snap install core


### PR DESCRIPTION
This brings the "Enable snapd" instructions in line with what is
documented at https://snapcraft.io/docs/installing-snap-on-debian.

The versions of snapd that ship with Debian stable and oldstable do not
fully support base snaps, which is required to successfully install many
snaps.

This commit addresses that issue by asking the user to upgrade snapd as
part of the installation process.

[Screenshot](https://i.imgur.com/vxApYyf.png)
