### PR TITLE
Remove hard coded categories

### DIFF
--- a/webapp/docs/views.py
+++ b/webapp/docs/views.py
@@ -16,7 +16,6 @@ def init_docs(app, url_prefix):
                 session=talisker.requests.get_session(),
             ),
             index_topic_id=11127,
-            category_id=15,
             url_prefix=url_prefix,
         ),
         document_template="docs/document.html",


### PR DESCRIPTION
## Done

Remove categories for docs since not required

## QA

- Pull the branch
- Run the site using the dotrun snap with `$ dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8004/docs
- docs should work as usual
