### PR TITLE
Remove extra slash for badge URLs

### DIFF
--- a/static/js/publisher/publicise.js
+++ b/static/js/publisher/publicise.js
@@ -223,7 +223,7 @@ const getBadgeHTML = (snapName, badgeName, showName) => {
 };
 
 const getBadgeMarkdown = (snapName, badgeName, showName) => {
-  return `[![${snapName}](https://snapcraft.io/${getBadgePath(
+  return `[![${snapName}](https://snapcraft.io${getBadgePath(
     snapName,
     badgeName,
     showName


### PR DESCRIPTION
## Done

- Remove extra slash for GitHub badge URLs

Fixes https://github.com/canonical-web-and-design/snapcraft.io/issues/3083

## QA

- Compare GitHub Markdown badge:
- https://snapcraft.io/testfran4/publicise/badges (There is an extra slash in the URL)
- https://snapcraft-io-3084.demos.haus/testfran4/publicise/badges (The URL should be fine)
