### PR TITLE
Set width and height to thumbnails

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
 # App dependencies
 canonicalwebteam.flask_base==0.6.4
 canonicalwebteam.discourse-docs==1.0.1
-canonicalwebteam.blog==6.2.6
+canonicalwebteam.blog==6.3.1
 canonicalwebteam.search==0.2.1
-canonicalwebteam.image-template==1.3.0
+canonicalwebteam.image-template==1.3.1
 canonicalwebteam.store-api==2.3.6
 canonicalwebteam.launchpad==0.7.8
 django-openid-auth==0.16

--- a/webapp/blog/views.py
+++ b/webapp/blog/views.py
@@ -14,7 +14,11 @@ from webapp.helpers import get_yaml
 
 
 def init_blog(app, url_prefix):
-    blog_api = BlogAPI(session=talisker.requests.get_session())
+    blog_api = BlogAPI(
+        session=talisker.requests.get_session(),
+        thumbnail_width=354,
+        thumbnail_height=199,
+    )
     blog = build_blueprint(
         BlogViews(
             api=blog_api,


### PR DESCRIPTION
## Done

- Fix blog article thumbnails.

## QA

https://snapcraft.io/blog
Check the thumbnails, you will notice they do not have the same size.
https://snapcraft-io-3085.demos.haus/blog
Check the thumbnails, you will notice they all have the same size(354x199) and cover the whole width of the block.

## Issue

Part of: https://github.com/canonical-web-and-design/canonicalwebteam.blog/pull/153

## Screenshots

Before:
![image](https://user-images.githubusercontent.com/6387619/94823129-6a4c6c00-03fb-11eb-85ca-ce44b67cdbfc.png)

After:
![image](https://user-images.githubusercontent.com/6387619/94824250-b5b34a00-03fc-11eb-9afc-a6b60dfad1ac.png)
