### PR TITLE
Fetch builds only after the previous fetch finished

### DIFF
--- a/static/js/publisher/builds/index.js
+++ b/static/js/publisher/builds/index.js
@@ -81,7 +81,7 @@ class Builds extends React.Component {
       triggerBuildLoading,
       shouldUpdateQueueTime,
     } = this.state;
-    const { snapName, updateFreq } = this.props;
+    const { snapName } = this.props;
     const { SUCCESS, IDLE } = TriggerBuildStatus;
 
     let url = `/${snapName}/builds.json`;
@@ -117,6 +117,7 @@ class Builds extends React.Component {
             if (shouldUpdateQueueTime) {
               this.updateQueueTime();
             }
+            this.triggerFetchBuilds();
           }
         );
       })
@@ -124,7 +125,12 @@ class Builds extends React.Component {
         this.setState({
           isLoading: false,
         });
+        this.triggerFetchBuilds();
       });
+  }
+
+  triggerFetchBuilds() {
+    const { updateFreq } = this.props;
 
     if (this.fetchTimer) {
       clearTimeout(this.fetchTimer);


### PR DESCRIPTION
## Done

- Fetch new builds only after the previous fetch finished

## Issue / Card

Fixes #2889 

## QA

- Pull the branch
- Run the site using the dotrun snap with `$ dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8004/<snap_name>/builds
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- I don't know how you can QA this. But basically it should only trigger a new builds fetch 30s after the previous one has finished. Previously we were making requests every 30s, even if the last request was not finished

## Screenshots

[if relevant, include a screenshot]
