### PR TITLE
Issue 3030 - Center aligned the text under the logos

### DIFF
--- a/templates/partials/fsf_language.html
+++ b/templates/partials/fsf_language.html
@@ -6,7 +6,7 @@
 
 <div class="row js-fsf-language-select" id="language">
   <div class="col-small-2 col-medium-3 col-2 col-lang-select--{% if layout_no_of_columns==12 %}3{% elif layout_no_of_columns==8 %}4{% endif%}">
-    <a class="p-card p-logo-link p-flow-link" href="/first-snap/python" data-flow-link="python">
+    <a class="p-card p-logo-link p-flow-link u-align--center" href="/first-snap/python" data-flow-link="python">
       <header class="p-card__header">
         {{
           image(
@@ -22,7 +22,7 @@
     </a>
   </div>
   <div class="col-small-2 col-medium-3 col-2 col-lang-select--{% if layout_no_of_columns==12 %}3{% elif layout_no_of_columns==8 %}4{% endif %}">
-    <a class="p-logo-link p-card p-flow-link" href="/first-snap/pre-built" data-flow-link="pre-built">
+    <a class="p-logo-link p-card p-flow-link u-align--center" href="/first-snap/pre-built" data-flow-link="pre-built">
       <header class="p-card__header">
         {{
           image(
@@ -38,7 +38,7 @@
     </a>
   </div>
   <div class="col-small-2 col-medium-3 col-2 col-lang-select--{% if layout_no_of_columns==12 %}3{% elif layout_no_of_columns==8 %}4{% endif %}">
-    <a class="p-logo-link p-card p-flow-link" href="/first-snap/c" data-flow-link="c">
+    <a class="p-logo-link p-card p-flow-link u-align--center" href="/first-snap/c" data-flow-link="c">
       <header class="p-card__header">
         {{
           image(
@@ -54,7 +54,7 @@
     </a>
   </div>
   <div class="col-small-2 col-medium-3 col-2 col-lang-select--{% if layout_no_of_columns==12 %}3{% elif layout_no_of_columns==8 %}4{% endif %}">
-    <a class="p-logo-link p-card p-flow-link" href="/first-snap/golang" data-flow-link="go">
+    <a class="p-logo-link p-card p-flow-link u-align--center" href="/first-snap/golang" data-flow-link="go">
       <header class="p-card__header">
         {{
           image(
@@ -70,7 +70,7 @@
     </a>
   </div>
   <div class="col-small-2 col-medium-3 col-2 col-lang-select--{% if layout_no_of_columns==12 %}3{% elif layout_no_of_columns==8 %}4{% endif %}">
-    <a class="p-logo-link p-card p-flow-link" href="/first-snap/java" data-flow-link="java">
+    <a class="p-logo-link p-card p-flow-link u-align--center" href="/first-snap/java" data-flow-link="java">
       <header class="p-card__header">
         {{
           image(
@@ -86,7 +86,7 @@
     </a>
   </div>
   <div class="col-small-2 col-medium-3 col-2 col-lang-select--{% if layout_no_of_columns==12 %}3{% elif layout_no_of_columns==8 %}4{% endif %}">
-    <a class="p-logo-link p-card p-flow-link" href="/first-snap/node" data-flow-link="node">
+    <a class="p-logo-link p-card p-flow-link u-align--center" href="/first-snap/node" data-flow-link="node">
       <header class="p-card__header">
         {{
           image(
@@ -102,7 +102,7 @@
     </a>
   </div>
   <div class="col-small-2 col-medium-3 col-2 col-lang-select--{% if layout_no_of_columns==12 %}3{% elif layout_no_of_columns==8 %}4{% endif %}">
-    <a class="p-logo-link p-card p-flow-link" href="/docs/build-snaps/electron" data-flow-link="electron">
+    <a class="p-logo-link p-card p-flow-link u-align--center" href="/docs/build-snaps/electron" data-flow-link="electron">
       <header class="p-card__header">
         {{
           image(
@@ -118,7 +118,7 @@
     </a>
   </div>
   <div class="col-small-2 col-medium-3 col-2 col-lang-select--{% if layout_no_of_columns==12 %}3{% elif layout_no_of_columns==8 %}4{% endif %}">
-    <a class="p-logo-link p-card p-flow-link" href="/first-snap/flutter" data-flow-link="flutter">
+    <a class="p-logo-link p-card p-flow-link u-align--center" href="/first-snap/flutter" data-flow-link="flutter">
       <header class="p-card__header">
         {{
           image(
@@ -134,7 +134,7 @@
     </a>
   </div>
   <div class="col-small-2 col-medium-3 col-2 col-lang-select--{% if layout_no_of_columns==12 %}3{% elif layout_no_of_columns==8 %}4{% endif %}">
-    <a class="p-logo-link p-card p-flow-link" href="/first-snap/ruby" data-flow-link="ruby">
+    <a class="p-logo-link p-card p-flow-link u-align--center" href="/first-snap/ruby" data-flow-link="ruby">
       <header class="p-card__header">
         {{
           image(
@@ -150,7 +150,7 @@
     </a>
   </div>
   <div class="col-small-2 col-medium-3 col-2 col-lang-select--{% if layout_no_of_columns==12 %}3{% elif layout_no_of_columns==8 %}4{% endif %}">
-    <a class="p-logo-link p-card p-flow-link" href="/first-snap/rust" data-flow-link="rust">
+    <a class="p-logo-link p-card p-flow-link u-align--center" href="/first-snap/rust" data-flow-link="rust">
       <header class="p-card__header">
         {{
           image(
@@ -166,7 +166,7 @@
     </a>
   </div>
   <div class="col-small-2 col-medium-3 col-2 col-lang-select--{% if layout_no_of_columns==12 %}3{% elif layout_no_of_columns==8 %}4{% endif %}">
-    <a class="p-logo-link p-card p-flow-link" href="/first-snap/moos" data-flow-link="moos">
+    <a class="p-logo-link p-card p-flow-link u-align--center" href="/first-snap/moos" data-flow-link="moos">
       <header class="p-card__header">
         {{
           image(
@@ -182,7 +182,7 @@
     </a>
   </div>
   <div class="col-small-2 col-medium-3 col-2 col-lang-select--{% if layout_no_of_columns==12 %}3{% elif layout_no_of_columns==8 %}4{% endif %}">
-    <a class="p-logo-link p-card p-flow-link" href="/first-snap/ros" data-flow-link="ros">
+    <a class="p-logo-link p-card p-flow-link u-align--center" href="/first-snap/ros" data-flow-link="ros">
       <header class="p-card__header">
         {{
           image(
@@ -198,7 +198,7 @@
     </a>
   </div>
   <div class="col-small-2 col-medium-3 col-2 col-lang-select--{% if layout_no_of_columns==12 %}3{% elif layout_no_of_columns==8 %}4{% endif %}">
-    <a class="p-logo-link p-card p-flow-link" href="/first-snap/ros2" data-flow-link="ros2">
+    <a class="p-logo-link p-card p-flow-link u-align--center" href="/first-snap/ros2" data-flow-link="ros2">
       <header class="p-card__header">
         {{
           image(


### PR DESCRIPTION
Fixes #3030 

Center aligned the text under the logos in the 'how to snap an app' section on the homepage.