### PR TITLE
Integrate cookie-policy v3.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@babel/plugin-transform-runtime": "7.11.5",
     "@babel/preset-env": "7.11.5",
     "@babel/preset-react": "7.10.4",
-    "@canonical/cookie-policy": "3.0.3",
+    "@canonical/cookie-policy": "3.0.4",
     "@canonical/global-nav": "2.4.3",
     "@canonical/react-components": "0.12.0",
     "@testing-library/react": "11.0.4",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@babel/plugin-transform-runtime": "7.11.5",
     "@babel/preset-env": "7.11.5",
     "@babel/preset-react": "7.10.4",
+    "@canonical/cookie-policy": "3.0.3",
     "@canonical/global-nav": "2.4.3",
     "@canonical/react-components": "0.12.0",
     "@testing-library/react": "11.0.4",

--- a/run
+++ b/run
@@ -45,7 +45,7 @@ Commands
 ##
 
 # Define docker images versions
-dev_image="canonicalwebteam/dev:v1.6.7"
+dev_image="canonicalwebteam/dev:1.6.8"
 if [ -n "${DOCKER_REGISTRY:-}" ]; then
     dev_image="${DOCKER_REGISTRY}/${dev_image}"
 fi

--- a/static/js/base/cookie-policy.js
+++ b/static/js/base/cookie-policy.js
@@ -1,0 +1,3 @@
+import { cookiePolicy } from "@canonical/cookie-policy";
+
+cookiePolicy();

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -11,6 +11,9 @@ $breakpoint-navigation-threshold: 800px;
 // vanilla patterns
 @import "vanilla-framework/scss/vanilla";
 
+// import cookie policy
+@import "@canonical/cookie-policy/build/css/cookie-policy";
+
 // make social icons match footer p-strip--light color
 $color-social-icon-foreground: $color-light;
 

--- a/templates/_footer.html
+++ b/templates/_footer.html
@@ -54,6 +54,9 @@
         <a class="p-link--soft" accesskey="7" href="https://www.ubuntu.com/legal/data-privacy"><small>Data privacy</small></a>
       </li>
       <li class="p-inline-list__item">
+        <a class="p-link--soft js-revoke-cookie-manager" href=""><small>Manage your tracker settings</small></a>
+      </li>
+      <li class="p-inline-list__item">
         <a class="p-link--soft" accesskey="8" href="https://status.snapcraft.io/"><small>Service status</small></a>
       </li>
       <li class="p-inline-list__item">

--- a/templates/_layout.html
+++ b/templates/_layout.html
@@ -71,6 +71,7 @@
     {% block header %}
     <!-- JS that is needed right away -->
     <script src="{{ static_url('js/dist/global-nav.js') }}"></script>
+    <script src="{{ static_url('js/dist/cookie-policy.js') }}"></script>
 
     {% include "_header.html" %}
     {% endblock %}

--- a/webpack.config.entry.js
+++ b/webpack.config.entry.js
@@ -1,4 +1,5 @@
 module.exports = {
+  "cookie-policy": "./static/js/base/cookie-policy.js",
   "global-nav": "./static/js/base/global-nav.js",
   base: "./static/js/base/base.js",
   release: "./static/js/publisher/release.js",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1096,10 +1096,10 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@canonical/cookie-policy@3.0.3":
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/@canonical/cookie-policy/-/cookie-policy-3.0.3.tgz#77ff09de8cc91c3bd12d23bfeaaf23a0206995ad"
-  integrity sha512-cTNrBAO+w5Akrn32Arkp/YGgT9KXTUuCMAgE8ipABBtkEIQ2Z708mTkZ3FNgefxPvMuDuLCVvKhvHik31SEShg==
+"@canonical/cookie-policy@3.0.4":
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/@canonical/cookie-policy/-/cookie-policy-3.0.4.tgz#c2d6d990dc0993344a9bf5c244374e3f51fe34f1"
+  integrity sha512-pI65cRFh9xU2xo3d9R8ifGbQoH72tk3p8xh/4ANuj9kREeh9G/gcim/iHQS7IffSocHT9l6ZtUXBcQ12m/CBMw==
 
 "@canonical/global-nav@2.4.3":
   version "2.4.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1096,6 +1096,11 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
+"@canonical/cookie-policy@3.0.3":
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/@canonical/cookie-policy/-/cookie-policy-3.0.3.tgz#77ff09de8cc91c3bd12d23bfeaaf23a0206995ad"
+  integrity sha512-cTNrBAO+w5Akrn32Arkp/YGgT9KXTUuCMAgE8ipABBtkEIQ2Z708mTkZ3FNgefxPvMuDuLCVvKhvHik31SEShg==
+
 "@canonical/global-nav@2.4.3":
   version "2.4.3"
   resolved "https://registry.yarnpkg.com/@canonical/global-nav/-/global-nav-2.4.3.tgz#9d552bad1968537c4b952747b27d5d3db21cf327"


### PR DESCRIPTION
## Done
- Integrate cookie-policy v3.0.3
- Bump the docker image for ./run to 1.6.8
- Add link to manage tracking settings to the footer

## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/3273

## QA
- Pull the branch
- Run the site using the dotrun snap with `$ dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8004/
- Check the cookie policy appears
- Check the manager opens and works
- Make a selection and the notification should disappear
- Scroll to the footer and click the Manage link in the footer
- See that manager appears again. 
