### PR TITLE
Use new summary button for loading builds

### DIFF
--- a/static/js/publisher/builds/components/buildsTable.js
+++ b/static/js/publisher/builds/components/buildsTable.js
@@ -3,6 +3,7 @@ import PropTypes from "prop-types";
 import { formatDistance, parseISO } from "date-fns";
 
 import ModularTable from "@canonical/react-components/dist/components/ModularTable";
+import SummaryButton from "@canonical/react-components/dist/components/SummaryButton";
 
 import { UserFacingStatus, createDuration } from "../helpers";
 
@@ -33,7 +34,15 @@ StatusCell.propTypes = {
   queueTime: PropTypes.object,
 };
 
-const BuildsTable = ({ builds, singleBuild, snapName, queueTime }) => {
+const BuildsTable = ({
+  builds,
+  singleBuild,
+  snapName,
+  queueTime,
+  totalBuilds,
+  isLoading,
+  showMoreHandler,
+}) => {
   const columns = React.useMemo(
     () => [
       {
@@ -95,12 +104,28 @@ const BuildsTable = ({ builds, singleBuild, snapName, queueTime }) => {
 
   const data = React.useMemo(() => builds, [builds]);
 
+  const remainingBuilds = totalBuilds - builds.length;
+  const showMoreCount = remainingBuilds > 15 ? 15 : remainingBuilds;
+
+  const footer =
+    remainingBuilds > 0 ? (
+      <div className="u-align--right">
+        <SummaryButton
+          summary={`Showing ${builds.length} out of ${totalBuilds} builds.`}
+          label={`Show ${showMoreCount} more`}
+          isLoading={isLoading}
+          onClick={showMoreHandler}
+        />
+      </div>
+    ) : null;
+
   return (
     <React.Fragment>
       <ModularTable
         columns={columns}
         data={data}
         emptyMsg="Waiting for builds..."
+        footer={footer}
       />
     </React.Fragment>
   );
@@ -111,6 +136,9 @@ BuildsTable.propTypes = {
   snapName: PropTypes.string,
   singleBuild: PropTypes.bool,
   queueTime: PropTypes.object,
+  totalBuilds: PropTypes.number,
+  isLoading: PropTypes.bool,
+  showMoreHandler: PropTypes.func,
 };
 
 export default BuildsTable;

--- a/static/js/publisher/builds/index.js
+++ b/static/js/publisher/builds/index.js
@@ -200,12 +200,7 @@ class Builds extends React.Component {
       queueTime,
     } = this.state;
     const { totalBuilds, singleBuild, snapName } = this.props;
-
     const { ERROR } = TriggerBuildStatus;
-
-    const remainingBuilds = totalBuilds - builds.length;
-
-    const showMoreCount = remainingBuilds > 15 ? 15 : remainingBuilds;
 
     return (
       <Fragment>
@@ -220,21 +215,10 @@ class Builds extends React.Component {
           singleBuild={singleBuild}
           snapName={snapName}
           queueTime={queueTime}
+          totalBuilds={totalBuilds}
+          isLoading={isLoading}
+          showMoreHandler={this.showMoreHandler}
         />
-        {builds.length < totalBuilds && (
-          <div className="p-show-more__link-container">
-            {isLoading && (
-              <span className="p-show-more__link">
-                <i className="p-icon--spinner u-animation--spin" />
-              </span>
-            )}
-            {!isLoading && (
-              <a className="p-show-more__link" onClick={this.showMoreHandler}>
-                Show {showMoreCount} more
-              </a>
-            )}
-          </div>
-        )}
       </Fragment>
     );
   }

--- a/static/sass/_snapcraft_release.scss
+++ b/static/sass/_snapcraft_release.scss
@@ -520,7 +520,9 @@
     width: .875rem;
   }
 
-  .p-action-button {
+  // .p-action-button is a class name used by ActionButton from react-components
+  // TODO: rename release UI p-action-button here to something else to avoid collisions
+  .p-release-buttons .p-action-button {
     background: none;
     border: 0;
     display: block;

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -63,6 +63,7 @@ $color-social-icon-foreground: $color-light;
 @include vf-u-hide;
 @include vf-u-show;
 @include vf-u-layout;
+@include vf-u-text-muted;
 @include vf-u-truncate;
 
 @import "snapcraft_custom-cols";


### PR DESCRIPTION
## Done

Updates ModularTable in builds view to use new SummaryButton for loading more builds.

Because of CSS class name clash between react-components ActionButton and release UI `p-action-button` scope of release UI CSS selector was changed.

## Issue / Card

Fixes https://github.com/canonical-web-and-design/vanilla-squad/issues/904

## QA

- Pull the branch
- Run the site using the dotrun snap with `$ dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8004/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Go to builds of some snap
- Make sure table renders correctly
- Make sure loading more builds work correctly
- Make sure summary disappears when all builds are loaded
- Check if buttons in release UI display as expected

## Screenshots

<img width="1283" alt="Screenshot 2020-10-08 at 12 19 21" src="https://user-images.githubusercontent.com/83575/95446453-9e2a1300-0960-11eb-81d3-ffb0d5ce4800.png">
