### PR TITLE
Show unlisted visibility in the snaps table

### DIFF
--- a/templates/publisher/account-snaps.html
+++ b/templates/publisher/account-snaps.html
@@ -168,10 +168,12 @@ My published snaps — Linux software in the Snap Store
             </a>
           </td>
           <td role="gridcell" aria-label="Visibility">
-            {% if snaps[snap].private %}
-            Private
+            {% if snaps[snap].unlisted %}
+              Unlisted
+            {% elif snaps[snap].private %}
+              Private
             {% else %}
-            Public
+              Public
             {% endif %}
           </td>
           <td role="gridcell" aria-label="Owner">


### PR DESCRIPTION
## Done

- Show unlisted visibility in the snaps table

## Issue / Card

Fixes https://github.com/canonical-web-and-design/snapcraft.io/issues/1623

## QA

- Pull the branch
- Run the site using the dotrun snap with `$ dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8004/snaps
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- If you don't have any `Unlisted` snaps, go to http://0.0.0.0:8004/<snap_name>/settings and set it to `Unlisted`
- Now go back to http://0.0.0.0:8004/snaps and see that visibility is `Unlisted` in the table for the snap you've jut changed

## Screenshots

[if relevant, include a screenshot]
