### PR TITLE
Update snap store privacy notice

### DIFF
--- a/templates/_footer.html
+++ b/templates/_footer.html
@@ -48,7 +48,7 @@
   <div class="u-fixed-width">
     <ul class="p-inline-list--middot u-no-margin--bottom">
       <li class="p-inline-list__item">
-        <a class="p-link--soft" accesskey="6" href="https://www.ubuntu.com/legal"><small>Legal information</small></a>
+        <a class="p-link--soft" accesskey="6" href="https://ubuntu.com/legal/terms-and-policies/snap-store-terms"><small>Terms of Service</small></a>
       </li>
       <li class="p-inline-list__item">
         <a class="p-link--soft" accesskey="7" href="https://www.ubuntu.com/legal/data-privacy"><small>Data privacy</small></a>

--- a/templates/publisher/developer_programme_agreement.html
+++ b/templates/publisher/developer_programme_agreement.html
@@ -12,9 +12,9 @@
 
   <div class="row">
     <div class="p-card">
-      <h2 class="p-heading--4">Canonical Terms of Service &amp; Privacy Notice</h2>
+      <h2 class="p-heading--4">Snap Store Terms of Service and Privacy Notice</h2>
       <p class="p-card__content">
-        <a class="p-link--external" href="https://www.ubuntu.com/legal/terms-and-policies/developer-terms-and-conditions" target="_blank">Developer Terms and Conditions</a>
+        <a class="p-link--external" href="https://ubuntu.com/legal/terms-and-policies/snap-store-terms" target="_blank">Snap Store Terms of Service</a>
       </p>
       <p class="p-card__content">
         <a class="p-link--external" href="https://www.ubuntu.com/legal/data-privacy/snap-store" target="_blank">Privacy Notice</a>


### PR DESCRIPTION
## Done

- Update link in the footer [Terms of Service](https://ubuntu.com/legal/terms-and-policies/snap-store-terms)
- Update `/account/agreement` Snap Store Terms of Service and Privacy Notice

## Issue / Card

Fixes #3114 

## QA

- Pull the branch
- Run the site using the dotrun snap with `$ dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8004/account/agreement
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that "Canonical Terms of Service & Privacy Notice" ---> "Snap Store Terms of Service and Privacy Notice"
- See that "Developer Terms and Conditions" ---> "Snap Store Terms of Service" and points to https://ubuntu.com/legal/terms-and-policies/snap-store-terms
- See that "Legal information" in the footer became "Terms of service" and points to https://ubuntu.com/legal/terms-and-policies/snap-store-terms

## Screenshots

![image](https://user-images.githubusercontent.com/40214246/96721639-55cd1500-13a4-11eb-89d8-b8a2fb6aad8d.png)

