### PR TITLE
Rearrange the tooltip for maximum viewage

### DIFF
--- a/static/js/publisher/metrics/graphs/activeDevicesGraph/tooltips.js
+++ b/static/js/publisher/metrics/graphs/activeDevicesGraph/tooltips.js
@@ -67,12 +67,12 @@ export function tooltips() {
               `<span class="snapcraft-graph-tooltip__series${
                 item.key === currentHoverKey ? " is-hovered" : ""
               }" title="${item.key}">`,
-              `<span class="snapcraft-graph-tooltip__series-name">${item.key}</span>`,
               `<span class="snapcraft-graph-tooltip__series-color"${
                 !item.count
                   ? `style="background:${this.colorScale(item.key)};"`
                   : ""
               }></span>`,
+              `<span class="snapcraft-graph-tooltip__series-name">${item.key}</span>`,
               `<span class="snapcraft-graph-tooltip__series-value">${commaValue(
                 item.value
               )}</span>`,

--- a/static/sass/_snapcraft_graph-tooltip.scss
+++ b/static/sass/_snapcraft_graph-tooltip.scss
@@ -38,7 +38,6 @@
         display: inline-block;
         height: .75rem;
         margin: {
-          left: .25rem;
           right: .25rem;
           top: 0;
         }
@@ -48,6 +47,7 @@
       &-value {
         display: inline-block;
         margin-top: 0;
+        text-align: right;
         width: calc(30% - .5rem);
       }
     }


### PR DESCRIPTION
## Done

- Re-order the tooltip content to maximize space

## Issue / Card

Fixes #my-own-issue

## QA

- Pull the branch
- Run the site using the dotrun snap with `$ dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8004/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Hit up your most popular snap
- Hover over the graph
- Be amazed by the New Tooltip Order™️
- Rejoice

## Screenshots

![Screenshot from 2020-10-22 21-51-02](https://user-images.githubusercontent.com/479384/96929285-cb72d700-14b1-11eb-8446-b7d2dff4061c.png)
