### PR TITLE
Fix typo in icon upload text

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,12 +26,9 @@
     }
   },
   "lint-staged": {
-    "linters": {
-      "**/*.py": "./run exec yarn lint-python",
-      "**/*.js": "./run exec yarn lint-js",
-      "**/*.scss": "./run exec yarn lint-scss"
-    },
-    "relative": true
+    "**/*.py": "dotrun exec yarn lint-python",
+    "**/*.js": "dotrun exec yarn lint-js",
+    "**/*.scss": "dotrun exec yarn lint-scss"
   },
   "jest": {
     "testURL": "http://localhost.test",

--- a/static/js/publisher/form/icon.js
+++ b/static/js/publisher/form/icon.js
@@ -98,7 +98,7 @@ class Icon extends React.Component {
           </li>
           <li>
             <small>
-              Max resolution: <b>512 x 512 pixels</b>
+              Max resolution: <b>480 x 480 pixels</b>
             </small>
           </li>
           <li>

--- a/static/js/publisher/market/restrictions.js
+++ b/static/js/publisher/market/restrictions.js
@@ -43,11 +43,11 @@ const ICON_RESTRICTIONS = {
   accept: ["image/png", "image/jpeg", "image/svg+xml"],
   width: {
     min: 40,
-    max: 512,
+    max: 480,
   },
   height: {
     min: 40,
-    max: 512,
+    max: 480,
   },
   aspectRatio: {
     min: [1, 1],


### PR DESCRIPTION
## Done

- Fix typo when uploading a snap icon regarding max image size
- Drive by: Fix broken lint-staged config

## Issue / Card

Fixes #3144

## QA

- Pull the branch
- Run the site using the dotrun snap with `$ dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8004/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Go to a snap
- Click on "Show icon restrictions"
- Check that the guidelines say max size is 480 x 480 and not 512 x 512

