### PR TITLE
Fix forEach error for hero tabpanel on homepage

### DIFF
--- a/static/js/public/hero-tabpanel.js
+++ b/static/js/public/hero-tabpanel.js
@@ -9,8 +9,8 @@ class HeroTabPanels {
       this.panelContainer = this.mainContainer.querySelector(
         "[data-js='panels-container']"
       );
-      this.tabs = this.mainContainer.querySelectorAll(
-        "[data-js='carousel-tab']"
+      this.tabs = [].slice.call(
+        this.mainContainer.querySelectorAll("[data-js='carousel-tab']")
       );
 
       if (this.panelContainer) {
@@ -70,8 +70,8 @@ class HeroTabPanels {
     clearInterval(this.timer);
 
     const nextCategoryName = target.getAttribute("aria-controls").split("-")[1];
-    const viewAllLinkList = this.mainContainer.querySelectorAll(
-      "[data-js='view-all']"
+    const viewAllLinkList = [].slice.call(
+      this.mainContainer.querySelectorAll("[data-js='view-all']")
     );
     // Show the appropriate 'View all' link
     viewAllLinkList.forEach((el) => {


### PR DESCRIPTION
## Done

- Fix forEach error for hero tabpanel on homepage

## Issue / Card

Fixes #3150 

## QA

- Pull the branch
- Run the site using the dotrun snap with `$ dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8004/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Perhaps you should open the demo in https://browserstack.com using Chrome 50 version
- Open the console and see there are no errors 

## Screenshots

![image](https://user-images.githubusercontent.com/40214246/97161655-07d65980-1776-11eb-9eea-363926fbeaf9.png)
