### PR TITLE
Improve metatags for snap pages

### DIFF
--- a/templates/_layout.html
+++ b/templates/_layout.html
@@ -48,14 +48,19 @@
       <meta property="og:type" content="{% block meta_type %}website{% endblock %}"/>
       <meta property="og:description" content="{{ self.meta_description() }}"/>
       <meta property="og:image" content="{% block meta_image %}https://assets.ubuntu.com/v1/e635d1ef-snapcraft_green-red_hex.png{% endblock %}" />
+      <meta property="og:image:width" content="{% block meta_image_width %}1080{% endblock %}" />
+      <meta property="og:image:height" content="{% block meta_image_height %}772{% endblock %}" />
+      <meta property="og:image:alt" content="{% block meta_image_alt %}Snapcraft banner{% endblock %}" />
       <meta property="og:url" content="https://snapcraft.io{% block meta_path %}{{ path }}{% endblock %}" />
-      <meta property="twitter:card" content="summary_large_image" />
+      <meta property="twitter:card" content="{% block meta_twitter_card %}summary_large_image{% endblock %}">
       <meta property="twitter:site" content="@snapcraftio" />
       <meta property="twitter:creator" content="@snapcraftio" />
+      <meta property="twitter:image" content="{{ self.meta_image() }}">
       <meta property="twitter:url" content="https://snapcraft.io{{ self.meta_path() }}" />
     {% endblock %}
 
     {% block extra_meta %}{% endblock %}
+    <link rel="canonical" href="https://snapcraft.io{{ request.path }}" />
 
     <link rel="icon" type="image/png" href="https://assets.ubuntu.com/v1/fdc99abe-ico_16px.png" sizes="16x16" />
     <link rel="icon" type="image/png" href="https://assets.ubuntu.com/v1/0f3c662c-ico_32px.png" sizes="32x32" />

--- a/templates/_layout.html
+++ b/templates/_layout.html
@@ -47,9 +47,9 @@
       <meta property="og:site_name" content="Snapcraft"/>
       <meta property="og:type" content="{% block meta_type %}website{% endblock %}"/>
       <meta property="og:description" content="{{ self.meta_description() }}"/>
-      <meta property="og:image" content="{% block meta_image %}https://assets.ubuntu.com/v1/e635d1ef-snapcraft_green-red_hex.png{% endblock %}" />
-      <meta property="og:image:width" content="{% block meta_image_width %}1080{% endblock %}" />
-      <meta property="og:image:height" content="{% block meta_image_height %}772{% endblock %}" />
+      <meta property="og:image" content="{% block meta_image %}https://assets.ubuntu.com/v1/4726d040-Snap+logo+white+bg.jpg{% endblock %}" />
+      <meta property="og:image:width" content="{% block meta_image_width %}1200{% endblock %}" />
+      <meta property="og:image:height" content="{% block meta_image_height %}630{% endblock %}" />
       <meta property="og:image:alt" content="{% block meta_image_alt %}Snapcraft banner{% endblock %}" />
       <meta property="og:url" content="https://snapcraft.io{% block meta_path %}{{ path }}{% endblock %}" />
       <meta property="twitter:card" content="{% block meta_twitter_card %}summary_large_image{% endblock %}" />

--- a/templates/_layout.html
+++ b/templates/_layout.html
@@ -52,10 +52,10 @@
       <meta property="og:image:height" content="{% block meta_image_height %}772{% endblock %}" />
       <meta property="og:image:alt" content="{% block meta_image_alt %}Snapcraft banner{% endblock %}" />
       <meta property="og:url" content="https://snapcraft.io{% block meta_path %}{{ path }}{% endblock %}" />
-      <meta property="twitter:card" content="{% block meta_twitter_card %}summary_large_image{% endblock %}">
+      <meta property="twitter:card" content="{% block meta_twitter_card %}summary_large_image{% endblock %}" />
       <meta property="twitter:site" content="@snapcraftio" />
       <meta property="twitter:creator" content="@snapcraftio" />
-      <meta property="twitter:image" content="{{ self.meta_image() }}">
+      <meta property="twitter:image" content="{{ self.meta_image() }}" />
       <meta property="twitter:url" content="https://snapcraft.io{{ self.meta_path() }}" />
     {% endblock %}
 

--- a/templates/store/snap-details.html
+++ b/templates/store/snap-details.html
@@ -3,14 +3,13 @@
 {% block meta_copydoc %}{% endblock %}
 
 {% block meta_title %}Install {{ snap_title }} for Linux using the Snap Store | Snapcraft{% endblock %}
-
 {% block meta_description %}Get the latest version of {{ snap_title }} for Linux - {{ summary }}{% endblock %}
+{% block meta_image %}{% if icon_url %}{{ icon_url }}{% else %}https://assets.ubuntu.com/v1/be6eb412-snapcraft-missing-icon.svg{% endif %}{% endblock %}
 
-{% if icon_url %}
-  {% block meta_image %}
-    {{ icon_url }}
-  {% endblock %}
-{% endif %}
+{% block meta_image_width %}200{% endblock %}
+{% block meta_image_height %}200{% endblock %}
+{% block meta_twitter_card %}summary{% endblock %}
+{% block meta_image_alt %}{{ snap_title }} snap logo{% endblock %}
 
 {% block extra_meta %}
   {% if unlisted %}


### PR DESCRIPTION
## Done

Improve metatags for snap pages

## QA

- Pull the branch
- Run the site using the dotrun snap with `$ dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8004/
-  Make sure now all snaps have an icon (or give missing icon)
- Test on card validator and facebook debugger if it works well too (use demo for this):

https://cards-dev.twitter.com/validator
https://developers.facebook.com/tools/debug/