### PR TITLE
Add to sitemap: tutorials, docs, install pages

### DIFF
--- a/templates/sitemap.xml
+++ b/templates/sitemap.xml
@@ -21,6 +21,15 @@
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
+
+  {% for distro in distros %}
+  <url>
+    <loc>{{ base_url }}/install/{{ snap["name"] }}/{{ distro }}</loc>
+    <lastmod>{{ snap["last_udpated"] }}</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.4</priority>
+  </url>
+  {% endfor %}
   {% endfor %}
 
   {% for post in blog_posts %}
@@ -28,7 +37,23 @@
     <loc>{{ base_url }}/blog/{{ post["slug"] }}</loc>
     <lastmod>{{ post["last_udpated"] }}</lastmod>
     <changefreq>monthly</changefreq>
-    <priority>0.4</priority>
+    <priority>0.2</priority>
+  </url>
+  {% endfor %}
+
+  {% for doc in docs %}
+  <url>
+    <loc>{{ doc }}</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.3</priority>
+  </url>
+  {% endfor %}
+
+  {% for tutorial in tutorials %}
+  <url>
+    <loc>{{ tutorial }}</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.2</priority>
   </url>
   {% endfor %}
 </urlset>

--- a/webapp/snapcraft/views.py
+++ b/webapp/snapcraft/views.py
@@ -269,6 +269,19 @@ def snapcraft_blueprint():
 
     @snapcraft.route("/sitemap.xml")
     def sitemap():
+        links = [
+            "/store",
+            "/about",
+            "/about/publish",
+            "/about/listing",
+            "/about/release",
+            "/about/publicise",
+            "/blog",
+            "/iot",
+            "/docs",
+            "/tutorials",
+        ]
+
         snaps = []
         page = 0
         url = f"https://api.snapcraft.io/api/v1/snaps/search?page={page}"
@@ -298,6 +311,22 @@ def snapcraft_blueprint():
                 url = snaps_response["_links"]["next"]["href"]
             else:
                 url = None
+
+        distros = [
+            "arch",
+            "centos",
+            "debian",
+            "elementary",
+            "fedora",
+            "kde-neon",
+            "kubuntu",
+            "manjaro",
+            "mint",
+            "opensuse",
+            "raspbian",
+            "rhel",
+            "ubuntu",
+        ]
 
         blog_posts = []
         page = 1
@@ -332,18 +361,10 @@ def snapcraft_blueprint():
 
             page = page + 1
 
-        links = [
-            "/store",
-            "/about",
-            "/about/publish",
-            "/about/listing",
-            "/about/release",
-            "/about/publicise",
-            "/blog",
-            "/iot",
-            "/docs",
-            "/tutorials",
-        ]
+        response = requests.get("https://snapcraft.io/docs/sitemap.txt")
+        docs = response.content.decode("utf-8").splitlines()
+        response = requests.get("https://snapcraft.io/tutorials/sitemap.txt")
+        tutorials = response.content.decode("utf-8").splitlines()
 
         xml_sitemap = flask.render_template(
             "sitemap.xml",
@@ -351,11 +372,13 @@ def snapcraft_blueprint():
             snaps=snaps,
             links=links,
             blog_posts=blog_posts,
+            distros=distros,
+            docs=docs,
+            tutorials=tutorials,
         )
         response = flask.make_response(xml_sitemap)
         response.headers["Content-Type"] = "application/xml"
         response.headers["Cache-Control"] = "public, max-age=43200"
-
         return response
 
     return snapcraft

--- a/webapp/snapcraft/views.py
+++ b/webapp/snapcraft/views.py
@@ -361,10 +361,18 @@ def snapcraft_blueprint():
 
             page = page + 1
 
-        response = requests.get("https://snapcraft.io/docs/sitemap.txt")
-        docs = response.content.decode("utf-8").splitlines()
-        response = requests.get("https://snapcraft.io/tutorials/sitemap.txt")
-        tutorials = response.content.decode("utf-8").splitlines()
+        docs = []
+        tutorials = []
+        try:
+            response = requests.get("https://snapcraft.io/docs/sitemap.txt")
+            docs = response.content.decode("utf-8").splitlines()
+
+            response = requests.get(
+                "https://snapcraft.io/tutorials/sitemap.txt"
+            )
+            tutorials = response.content.decode("utf-8").splitlines()
+        except Exception:
+            pass
 
         xml_sitemap = flask.render_template(
             "sitemap.xml",


### PR DESCRIPTION
## Done

Add missing pages to the sitemap

Add tutorials, docs and distro install pages.

## QA

- Pull the branch
- Run the site using the dotrun snap with `$ dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8004/sitemap.xml
- This page takes a while but is heavily cached
- In there there should be the docs, tutorials and install pages
