### PR TITLE
Add missing category JSON for snaps

### DIFF
--- a/templates/store/snap-details.html
+++ b/templates/store/snap-details.html
@@ -25,6 +25,11 @@
       "name": "{{ snap_title }}",
       "description": "{{ summary }}",
       "datePublished": "{{ last_updated_raw }}",
+      {% if categories|length > 0 %}
+      "applicationCategory": "{{ categories[0]['name'] }}",
+      {% else %}
+      "applicationCategory": "other",
+      {% endif %}
       {% if screenhots and screenshots|length > 0 %}
       "screenshot": "{{ screenshots[0] }}",
       {% endif %}


### PR DESCRIPTION
## Done

`applicationCategory` is a required property in the JSON+ld schema

## QA

- Pull the branch
- Run the site using the dotrun snap with `$ dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8004/toto
- make sure snaps have `applicationCategory` in their JSON+Ld description (see end of html) :)
- You can test here: https://search.google.com/test/rich-results
- Make sure it's all green
