### PR TITLE
Build admin settings page

### DIFF
--- a/static/sass/_snapcraft_p-form-help-text.scss
+++ b/static/sass/_snapcraft_p-form-help-text.scss
@@ -1,0 +1,7 @@
+@mixin snapcraft-p-form-help-text {
+  .p-form-help-text--nudge {
+    @extend .p-form-help-text;
+
+    margin-left: 2rem;
+  }
+}

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -322,9 +322,9 @@ $color-social-icon-foreground: $color-light;
 
 @include snapcraft-l-application;
 
-// **** Vanilla overrides & temporary bug fixes ****
+@import "snapcraft_p-form-help-text";
 
-// Temporary bug fix for https://github.com/canonical-web-and-design/vanilla-framework/issues/2791
+@include snapcraft-p-form-help-text;
 
 dl {
   margin-bottom: $spv-outer--scaleable;

--- a/templates/admin/_navigation.html
+++ b/templates/admin/_navigation.html
@@ -12,6 +12,9 @@
       <li class="p-side-navigation__item">
         <a class="p-side-navigation__link {% if current_tab == 'members' %}is-active{% endif %}" href="/admin/{{ s.id }}/members">Members</a>
       </li>
+      <div class="p-side-navigation__item">
+        <a class="p-side-navigation__link {% if current_tab == 'settings' %}is-active{% endif %}" href="/admin/{{ s.id }}/settings">Settings</a>
+      </div>
     </ul>
   </li>
   {% endfor %}

--- a/templates/admin/settings.html
+++ b/templates/admin/settings.html
@@ -1,0 +1,68 @@
+{% set current_tab = "settings" %}
+
+{% extends "/admin/admin_layout.html" %}
+
+{% block meta_title %}{{ store.name }} settings | Snapcraft{% endblock %}
+
+{% block admin_content %}
+
+{{ form }}
+
+<div class="row">
+  <div class="col-7">
+
+    <!-- IF FORM HAS SUCCESSFULLY SAVED ON POST -->
+    <div class="p-notification--positive">
+      <p class="p-notification__response" role="status">
+        <span class="p-notification__status">Success:</span>Your changes have been saved
+      </p>
+    </div>
+    <!-- ENDIF -->
+
+    <form action="/admin/{{ store.id }}/settings" method="POST">
+      <div class="p-form__group">
+        <label class="checkbox">
+          <input class="p-checkbox__input" type="checkbox" aria-labelledby="public-list-option-label">
+          <span class="p-checkbox__label" id="public-list-option-label">
+            Include this store in public lists
+        </label>
+        <div class="p-form-help-text--nudge">This store will not be listed in the store dropdowns like the one in the snap name registration form.</div>
+      </div>
+      <h2 class="p-heading--4">Manual review policy</h2>
+      <div class="p-form__group">
+        <label class="p-radio">
+          <input type="radio" class="p-radio__input" name="manual-review-policy" aria-labelledby="manual-review-policy-label-allow">
+          <span class="p-radio__label" id="manual-review-policy-label-allow">
+            Allow
+          </span>
+        </label>
+        <div class="p-form-help-text--nudge">Normal review behaviour will be applied, using the result from the automatic review tool checks.</div>
+      </div>
+      <div class="p-form__group">
+        <label class="p-radio">
+          <input type="radio" class="p-radio__input" name="manual-review-policy" aria-labelledby="manual-review-policy-label-avoid">
+          <span class="p-radio__label" id="manual-review-policy-label-avoid">
+            Avoid
+          </span>
+        </label>
+        <div class="p-form-help-text--nudge">No snap will be left in the manual review queue, even if the automatic review tool found no issues.</div>
+      </div>
+      <div class="p-form__group">
+        <label class="p-radio">
+          <input type="radio" class="p-radio__input" name="manual-review-policy" aria-labelledby="manual-review-policy-label-require">
+          <span class="p-radio__label" id="manual-review-policy-label-require">
+            Require
+          </span>
+        </label>
+        <div class="p-form-help-text--nudge">Every snap will be moved to the review queue, even if the automatic review tool found no issues.</div>
+      </div>
+      <hr>
+      <div class="u-align--right">
+        <button class="p-button--positive" type="submit">Save changes</button>
+      </div>
+    </form>
+  </div>
+</div>
+
+{% endblock %}
+

--- a/webapp/admin/views.py
+++ b/webapp/admin/views.py
@@ -73,3 +73,19 @@ def get_members(store_id):
     return flask.render_template(
         "admin/members.html", stores=stores, store=store, members=members
     )
+
+
+@admin.route("/admin/<store_id>/settings")
+@login_required
+def get_settings(store_id):
+    try:
+        stores = admin_api.get_stores(flask.session)
+        store = admin_api.get_store(flask.session, store_id, stores)
+    except StoreApiResponseErrorList as api_response_error_list:
+        return _handle_error_list(api_response_error_list.errors)
+    except (StoreApiError, ApiError) as api_error:
+        return _handle_error(api_error)
+
+    return flask.render_template(
+        "admin/settings.html", stores=stores, store=store
+    )


### PR DESCRIPTION
## Done

Add template for admin store settings

## Issue / Card

Fixes #3211

## QA

- Pull the branch
- Run the site using the dotrun snap with `$ dotrun`
- View the site locally in your web browser at: http://localhost:8004/admin/ahnuP3quahti9vis8aiw/settings
- Check that there is a form for the settings
- Check that there is a success notification at the top of the page
