### PR TITLE
Update discourse module

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # App dependencies
 canonicalwebteam.flask_base==0.7.1
-canonicalwebteam.discourse-docs==1.0.1
+canonicalwebteam.discourse==2.1.0
 canonicalwebteam.blog==6.3.1
 canonicalwebteam.search==0.2.1
 canonicalwebteam.image-template==1.3.1

--- a/templates/_header.html
+++ b/templates/_header.html
@@ -58,7 +58,7 @@
           class="p-navigation__link {% if page_slug == 'docs' %}is-selected{% endif %}"
           role="menuitem"
         >
-          <a href="{{ url_for('discourse_docs.document_view') }}">
+          <a href="{{ url_for('docs.document_view') }}">
             Docs
           </a>
         </li>

--- a/webapp/docs/views.py
+++ b/webapp/docs/views.py
@@ -1,15 +1,15 @@
 import talisker
 
-from canonicalwebteam.discourse_docs import (
+from canonicalwebteam.discourse import (
     DiscourseAPI,
-    DiscourseDocs,
+    Docs,
     DocParser,
 )
 from canonicalwebteam.search import build_search_view
 
 
 def init_docs(app, url_prefix):
-    discourse_docs = DiscourseDocs(
+    discourse_docs = Docs(
         parser=DocParser(
             api=DiscourseAPI(
                 base_url="https://forum.snapcraft.io/",

--- a/webapp/snapcraft/views.py
+++ b/webapp/snapcraft/views.py
@@ -341,8 +341,6 @@ def snapcraft_blueprint():
             "/about/publicise",
             "/blog",
             "/iot",
-            "/docs",
-            "/tutorials",
         ]
 
         xml_sitemap = flask.render_template(

--- a/webapp/tutorials/views.py
+++ b/webapp/tutorials/views.py
@@ -3,15 +3,15 @@ import math
 import flask
 import talisker
 
-from canonicalwebteam.discourse_docs import (
+from canonicalwebteam.discourse import (
     DiscourseAPI,
-    DiscourseDocs,
+    Docs,
     DocParser,
 )
 
 
 def init_tutorials(app, url_prefix):
-    discourse_docs = DiscourseDocs(
+    discourse_docs = Docs(
         parser=DocParser(
             api=DiscourseAPI(
                 base_url="https://forum.snapcraft.io/",


### PR DESCRIPTION
## Done

- Update to use latest version of discourse  module (canonicalwebteam.discourse instead of canonicalwebteam.discourse_docs)

## Issue / Card

Fixes https://github.com/canonical-web-and-design/snapcraft.io/issues/3235

## QA

- Pull the branch
- Run the site using the dotrun snap with `$ dotrun`
- http://0.0.0.0:8004/docs
- http://0.0.0.0:8004/tutorials
- Make sure it all works as usual
