### PR TITLE
Add cloudinary to install distro logos

### DIFF
--- a/templates/store/snap-details/_distro-instructions-for-snap-support.html
+++ b/templates/store/snap-details/_distro-instructions-for-snap-support.html
@@ -12,7 +12,15 @@
     <div class="col-3 col-medium-3">
       <a class="p-media-object" href="/install/{{package_name}}/arch">
         <span class="p-media-object__image">
-          <img src="https://assets.ubuntu.com/v1/feca0fc0-Distro_Logo_ArchLinux.svg" alt="">
+            {{
+                image(
+                    url="https://assets.ubuntu.com/v1/feca0fc0-Distro_Logo_ArchLinux.svg",
+                    alt="",
+                    width="48",
+                    height="48",
+                    hi_def=True
+                ) | safe
+            }}
         </span>
         <span class="p-media-object__details">
           <h4 class="p-media-object__title p-heading--5 u-no-margin--bottom">Arch Linux</h4>
@@ -22,7 +30,15 @@
     <div class="col-3 col-medium-3">
       <a class="p-media-object" href="/install/{{package_name}}/centos">
         <span class="p-media-object__image">
-          <img src="https://assets.ubuntu.com/v1/acf876d9-Distro_Logo_CentOS.svg" alt="">
+            {{
+                image(
+                    url="https://assets.ubuntu.com/v1/acf876d9-Distro_Logo_CentOS.svg",
+                    alt="",
+                    width="48",
+                    height="48",
+                    hi_def=True
+                ) | safe
+            }}
         </span>
         <span class="p-media-object__details">
           <h4 class="p-media-object__title p-heading--5 u-no-margin--bottom">CentOS</h4>
@@ -32,7 +48,15 @@
     <div class="col-3 col-medium-3">
       <a class="p-media-object" href="/install/{{package_name}}/debian">
         <span class="p-media-object__image">
-          <img src="https://assets.ubuntu.com/v1/cfdc1144-Distro_Logo_Debian.svg" alt="">
+            {{
+                image(
+                    url="https://assets.ubuntu.com/v1/cfdc1144-Distro_Logo_Debian.svg",
+                    alt="",
+                    width="48",
+                    height="48",
+                    hi_def=True
+                ) | safe
+            }}
         </span>
         <span class="p-media-object__details">
           <h4 class="p-media-object__title p-heading--5 u-no-margin--bottom">Debian</h4>
@@ -42,7 +66,15 @@
     <div class="col-3 col-medium-3">
       <a class="p-media-object" href="/install/{{package_name}}/elementary">
         <span class="p-media-object__image">
-          <img src="https://assets.ubuntu.com/v1/c0c09661-Distro_Logo_Elementary.svg" alt="">
+            {{
+                image(
+                    url="https://assets.ubuntu.com/v1/c0c09661-Distro_Logo_Elementary.svg",
+                    alt="",
+                    width="48",
+                    height="48",
+                    hi_def=True
+                ) | safe
+            }}
         </span>
         <span class="p-media-object__details">
           <h4 class="p-media-object__title p-heading--5 u-no-margin--bottom">elementary OS</h4>
@@ -52,7 +84,15 @@
     <div class="col-3 col-medium-3">
       <a class="p-media-object" href="/install/{{package_name}}/fedora">
         <span class="p-media-object__image">
-          <img src="https://assets.ubuntu.com/v1/c93d842f-fedora.png" alt="">
+            {{
+                image(
+                    url="https://assets.ubuntu.com/v1/c93d842f-fedora.png",
+                    alt="",
+                    width="48",
+                    height="48",
+                    hi_def=True
+                ) | safe
+            }}
         </span>
         <span class="p-media-object__details">
           <h4 class="p-media-object__title p-heading--5 u-no-margin--bottom">Fedora</h4>
@@ -62,7 +102,15 @@
     <div class="col-3 col-medium-3">
       <a class="p-media-object" href="/install/{{package_name}}/kde-neon">
         <span class="p-media-object__image">
-          <img src="https://assets.ubuntu.com/v1/d0593902-Distro_Logo_KDE+Neon.svg" alt="">
+            {{
+                image(
+                    url="https://assets.ubuntu.com/v1/d0593902-Distro_Logo_KDE+Neon.svg",
+                    alt="",
+                    width="48",
+                    height="48",
+                    hi_def=True
+                ) | safe
+            }}
         </span>
         <span class="p-media-object__details">
           <h4 class="p-media-object__title p-heading--5 u-no-margin--bottom">KDE Neon</h4>
@@ -72,7 +120,15 @@
     <div class="col-3 col-medium-3">
       <a class="p-media-object" href="/install/{{package_name}}/kubuntu">
         <span class="p-media-object__image">
-          <img src="https://assets.ubuntu.com/v1/7ab50a06-Distro_Logo_Kubuntu.svg" alt="">
+            {{
+                image(
+                    url="https://assets.ubuntu.com/v1/7ab50a06-Distro_Logo_Kubuntu.svg",
+                    alt="",
+                    width="48",
+                    height="48",
+                    hi_def=True
+                ) | safe
+            }}
         </span>
         <span class="p-media-object__details">
           <h4 class="p-media-object__title p-heading--5 u-no-margin--bottom">Kubuntu</h4>
@@ -82,7 +138,15 @@
     <div class="col-3 col-medium-3">
       <a class="p-media-object" href="/install/{{package_name}}/manjaro">
         <span class="p-media-object__image">
-          <img src="https://assets.ubuntu.com/v1/4635a0bd-Distro_Logo_Manjaro.svg" alt="">
+            {{
+                image(
+                    url="https://assets.ubuntu.com/v1/4635a0bd-Distro_Logo_Manjaro.svg",
+                    alt="",
+                    width="48",
+                    height="48",
+                    hi_def=True
+                ) | safe
+            }}
         </span>
         <span class="p-media-object__details">
           <h4 class="p-media-object__title p-heading--5 u-no-margin--bottom">Manjaro</h4>
@@ -92,7 +156,15 @@
     <div class="col-3 col-medium-3">
       <a class="p-media-object" href="/install/{{package_name}}/mint">
         <span class="p-media-object__image">
-          <img src="https://assets.ubuntu.com/v1/938d67b4-Distro_Logo_LinuxMint.svg" alt="">
+            {{
+                image(
+                    url="https://assets.ubuntu.com/v1/938d67b4-Distro_Logo_LinuxMint.svg",
+                    alt="",
+                    width="48",
+                    height="48",
+                    hi_def=True
+                ) | safe
+            }}
         </span>
         <span class="p-media-object__details">
           <h4 class="p-media-object__title p-heading--5 u-no-margin--bottom">Linux Mint</h4>
@@ -102,7 +174,15 @@
     <div class="col-3 col-medium-3">
       <a class="p-media-object" href="/install/{{package_name}}/opensuse">
         <span class="p-media-object__image">
-          <img src="https://assets.ubuntu.com/v1/610301c6-Distro_Logo_OpenSUSE.svg" alt="">
+            {{
+                image(
+                    url="https://assets.ubuntu.com/v1/610301c6-Distro_Logo_OpenSUSE.svg",
+                    alt="",
+                    width="48",
+                    height="48",
+                    hi_def=True
+                ) | safe
+            }}
         </span>
         <span class="p-media-object__details">
           <h4 class="p-media-object__title p-heading--5 u-no-margin--bottom">openSUSE</h4>
@@ -112,7 +192,15 @@
     <div class="col-3 col-medium-3">
       <a class="p-media-object" href="/install/{{package_name}}/rhel">
         <span class="p-media-object__image">
-          <img src="https://assets.ubuntu.com/v1/be89e41a-red-hat-2019-primary-stacked.svg" alt="">
+            {{
+                image(
+                    url="https://assets.ubuntu.com/v1/be89e41a-red-hat-2019-primary-stacked.svg",
+                    alt="",
+                    width="48",
+                    height="48",
+                    hi_def=True
+                ) | safe
+            }}
         </span>
         <span class="p-media-object__details">
           <h4 class="p-media-object__title p-heading--5 u-no-margin--bottom">Red Hat Enterprise Linux</h4>
@@ -122,7 +210,15 @@
     <div class="col-3 col-medium-3">
       <a class="p-media-object" href="/install/{{package_name}}/ubuntu">
         <span class="p-media-object__image">
-          <img src="https://assets.ubuntu.com/v1/100386fb-Distro_Logo_Ubuntu.svg" alt="">
+            {{
+                image(
+                    url="https://assets.ubuntu.com/v1/100386fb-Distro_Logo_Ubuntu.svg",
+                    alt="",
+                    width="48",
+                    height="48",
+                    hi_def=True
+                ) | safe
+            }}
         </span>
         <span class="p-media-object__details">
           <h4 class="p-media-object__title p-heading--5 u-no-margin--bottom">Ubuntu</h4>
@@ -133,7 +229,15 @@
     <div class="col-3 col-medium-3">
       <a class="p-media-object" href="/install/{{package_name}}/raspbian">
         <span class="p-media-object__image">
-          <img src="https://assets.ubuntu.com/v1/a8a6238c-RGB+RPi.svg" width="48" height="48" alt="">
+            {{
+                image(
+                    url="https://assets.ubuntu.com/v1/a8a6238c-RGB+RPi.svg",
+                    alt="",
+                    width="48",
+                    height="48",
+                    hi_def=True
+                ) | safe
+            }}
         </span>
         <span class="p-media-object__details">
           <h4 class="p-media-object__title p-heading--5 u-no-margin--bottom">Raspberry Pi</h4>


### PR DESCRIPTION
## Done

- Add distros to cloudinary

## Issue / Card

Fixes https://github.com/canonical-web-and-design/snapcraft.io/issues/3256

## QA

- Pull the branch
- Run the site using the dotrun snap with `$ dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8004/eks
- Make sure images come from cloudiary

