### PR TITLE
Remove unused JS from homepage

### DIFF
--- a/static/js/public/homepage.js
+++ b/static/js/public/homepage.js
@@ -1,0 +1,5 @@
+import { initFSFLanguageSelect } from "./fsf-language-select";
+import nps from "./nps";
+import initExpandableArea from "./expandable-area";
+
+export { initExpandableArea, initFSFLanguageSelect, nps };

--- a/templates/index.html
+++ b/templates/index.html
@@ -432,7 +432,7 @@
 {% endblock %}
 
 {% block scripts_includes %}
-<script src="{{ static_url('js/dist/public.js') }}" defer></script>
+<script src="{{ static_url('js/dist/homepage.js') }}" defer></script>
 <script src="{{ static_url('js/dist/tabpanel.js') }}" defer></script>
 {% if nps %}
 <script src="//app-sjg.marketo.com/js/forms2/js/forms2.min.js" defer></script>
@@ -443,12 +443,12 @@
 <script>
   window.addEventListener("DOMContentLoaded", function () {
     Raven.context(function () {
-      snapcraft.public.initFSFLanguageSelect(document.querySelector('.js-fsf-language-select'));
-      snapcraft.public.initExpandableArea();
+      snapcraft.public.homepage.initFSFLanguageSelect(document.querySelector('.js-fsf-language-select'));
+      snapcraft.public.homepage.initExpandableArea();
       snapcraft.public.tabpanel.init("[data-js='hero-snaps-container']", {{ hero_categories| safe }});
 
   {% if nps %}
-  snapcraft.public.nps();
+  snapcraft.public.homepage.nps();
   {% endif %}
     });
   });

--- a/webpack.config.entry.js
+++ b/webpack.config.entry.js
@@ -12,4 +12,5 @@ module.exports = {
   // publisher bundle is big (webpack warning) - try to chunk it down
   // https://github.com/canonical-web-and-design/snapcraft.io/issues/1246
   publisher: "./static/js/publisher/publisher.js",
+  homepage: "./static/js/public/homepage.js",
 };

--- a/webpack.config.rules.js
+++ b/webpack.config.rules.js
@@ -55,4 +55,8 @@ module.exports = [
     test: require.resolve(__dirname + "/static/js/public/modal.js"),
     use: ["expose-loader?exposes=snapcraft.public.modal", "babel-loader"],
   },
+  {
+    test: require.resolve(__dirname + "/static/js/public/homepage.js"),
+    use: ["expose-loader?exposes=snapcraft.public.homepage", "babel-loader"],
+  },
 ];


### PR DESCRIPTION
## Done

Removed unused JS from homepage bringing it down from 1.7mb to 47.9kb

## QA

- Pull the branch
- Run the site using the dotrun snap with `$ dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8004/
- Check that the homepage still works as expected