### PR TITLE
Remove unused JS from store page

### DIFF
--- a/static/js/public/store.js
+++ b/static/js/public/store.js
@@ -1,0 +1,3 @@
+import { storeCategories } from "./store-categories";
+
+export { storeCategories };

--- a/templates/store/store.html
+++ b/templates/store/store.html
@@ -96,14 +96,14 @@
 {% endblock %}
 
 {% block scripts_includes %}
-  <script src="{{ static_url('js/dist/public.js') }}" defer></script>
+  <script src="{{ static_url('js/dist/store.js') }}" defer></script>
 {% endblock %}
 
 {% block scripts %}
   <script>
     window.addEventListener("load", function() {
       Raven.context(function () {
-        snapcraft.public.storeCategories();
+        snapcraft.public.store.storeCategories();
       });
     });
   </script>

--- a/webpack.config.entry.js
+++ b/webpack.config.entry.js
@@ -14,4 +14,5 @@ module.exports = {
   publisher: "./static/js/publisher/publisher.js",
   homepage: "./static/js/public/homepage.js",
   blog: "./static/js/public/blog.js",
+  store: "./static/js/public/store.js",
 };

--- a/webpack.config.rules.js
+++ b/webpack.config.rules.js
@@ -63,4 +63,8 @@ module.exports = [
     test: require.resolve(__dirname + "/static/js/public/blog.js"),
     use: ["expose-loader?exposes=snapcraft.public.blog", "babel-loader"],
   },
+  {
+    test: require.resolve(__dirname + "/static/js/public/store.js"),
+    use: ["expose-loader?exposes=snapcraft.public.store", "babel-loader"],
+  },
 ];


### PR DESCRIPTION
## Done

Removed unused JS from store page

## Issue / Card

Fixes #3266

## QA

- Pull the branch
- Run the site using the dotrun snap with `$ dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8004/store
- Check that the categories still load