### PR TITLE
Remove unused JS from store details page

### DIFF
--- a/static/js/public/store-details.js
+++ b/static/js/public/store-details.js
@@ -1,0 +1,19 @@
+import map from "./snap-details/map";
+import screenshots from "./snap-details/screenshots";
+import channelMap from "./snap-details/channelMap";
+import videos from "./snap-details/videos";
+import initReportSnap from "./snap-details/reportSnap";
+import initEmbeddedCardModal from "./snap-details/embeddedCard";
+import { snapDetailsPosts } from "./snap-details/blog-posts";
+import initExpandableArea from "./expandable-area";
+
+export {
+  map,
+  screenshots,
+  channelMap,
+  snapDetailsPosts,
+  initEmbeddedCardModal,
+  initExpandableArea,
+  initReportSnap,
+  videos,
+};

--- a/templates/store/publisher-details.html
+++ b/templates/store/publisher-details.html
@@ -14,7 +14,7 @@
 
 
 {% block content %}
-  <div class="p-strip--dark is-shallow" style="background: #262626">
+  <div class="p-strip--dark is-shallow" style="background: #262626;">
     <div class="u-fixed-width">
       <div class="p-snap-heading">
         {% if icon_url %}
@@ -48,7 +48,7 @@
   {% if banner_url %}
   <section
     class="p-strip--image is-deep"
-    style="background-image:url('{{ banner_url }}');">
+    style="background-image: url('{{ banner_url }}');">
   </section>
   {% endif %}
 

--- a/templates/store/snap-details.html
+++ b/templates/store/snap-details.html
@@ -125,7 +125,7 @@
             {% if package_name in appliances %}
             <p class="u-no-margin--bottom">
               Available as an
-              <span class="p-tooltip--btm-center" style="z-index: 2">
+              <span class="p-tooltip--btm-center" style="z-index: 2;">
                 <a href="https://ubuntu.com/appliance/{{appliances[package_name]}}" class="p-link--external">Ubuntu Appliance</a>
                 <span class="p-tooltip__message">Install a ready-made {{snap_title}} image<br />on a Raspberry Pi, an Intel NUC or try<br />it in a VM and get started.</span>
               </span>
@@ -253,7 +253,7 @@
                     {% for distro in normalized_os %}
                       <div
                         class="snapcraft-distro-chart__bar"
-                        style="width: {{ distro.value * 100 }}%"
+                        style="width: {{ distro.value * 100 }}%;"
                       ></div>
                     {% endfor %}
                   </div>
@@ -279,7 +279,7 @@
                 <div class="snapcraft-distro-chart__bars">
                   {% for distro in normalized_os %}
                   <div class="snapcraft-distro-chart__bar"
-                    style="width: {{ distro.value * 100 }}%"></div>
+                    style="width: {{ distro.value * 100 }}%;"></div>
                   {% endfor %}
                 </div>
               </div>
@@ -366,7 +366,7 @@
 {% endblock %}
 
 {% block scripts_includes %}
-  <script src="{{ static_url('js/dist/public.js') }}" defer></script>
+  <script src="{{ static_url('js/dist/store-details.js') }}" defer></script>
   {% if is_preview %}
     <script src="{{ static_url('js/dist/publisher.js') }}" defer></script>
   {% endif %}
@@ -377,34 +377,34 @@
     window.addEventListener("DOMContentLoaded", function() {
       Raven.context(function () {
         try {
-          snapcraft.public.initExpandableArea();
+          snapcraft.public.storeDetails.initExpandableArea();
         } catch (e) {
           Raven.captureException(e);
         }
 
         {% if not is_preview %}
         try {
-          snapcraft.public.screenshots('#js-snap-screenshots');
+          snapcraft.public.storeDetails.screenshots('#js-snap-screenshots');
         } catch(e) {
           Raven.captureException(e);
         }
         {% endif %}
 
         try {
-          snapcraft.public.videos('.js-video-slide');
+          snapcraft.public.storeDetails.videos('.js-video-slide');
         } catch(e) {
           Raven.captureException(e);
         }
 
         try {
-          snapcraft.public.snapDetailsPosts('[data-js="blog-article-list"]', '#blog-article-template', '[data-js="blog-articles"]');
+          snapcraft.public.storeDetails.snapDetailsPosts('[data-js="blog-article-list"]', '#blog-article-template', '[data-js="blog-articles"]');
         } catch(e) {
           Raven.captureException(e);
         }
 
         {% if not is_preview and not IS_BRAND_STORE %}
         try {
-          snapcraft.public.initReportSnap(
+          snapcraft.public.storeDetails.initReportSnap(
             '{{ package_name }}', '.js-modal-open', '#report-snap-modal',
             document.getElementById('report-snap-form').action
           );
@@ -413,7 +413,7 @@
         }
 
         try {
-          snapcraft.public.initEmbeddedCardModal('{{ package_name }}');
+          snapcraft.public.storeDetails.initEmbeddedCardModal('{{ package_name }}');
         } catch(e) {
           Raven.captureException(e);
         }
@@ -421,7 +421,7 @@
 
         {% if countries %}
           try {
-            snapcraft.public.map('#js-snap-map', {{ countries | tojson }});
+            snapcraft.public.storeDetails.map('#js-snap-map', {{ countries | tojson }});
           } catch(e) {
             Raven.captureException(e);
             document.querySelector('.js-snap-map-holder').style.display = 'none';
@@ -430,7 +430,7 @@
 
         {% if not IS_BRAND_STORE and channel_map %}
           try {
-              snapcraft.public.channelMap('#js-channel-map', {{ package_name|tojson }}, {{ channel_map | tojson }}, "{{ default_track }}");
+              snapcraft.public.storeDetails.channelMap('#js-channel-map', {{ package_name|tojson }}, {{ channel_map | tojson }}, "{{ default_track }}");
           } catch(e) {
             Raven.captureException(e);
             document.querySelector('.js-open-channel-map').style.display = 'none';

--- a/templates/store/snap-distro-install.html
+++ b/templates/store/snap-distro-install.html
@@ -219,7 +219,7 @@
     <div class="row">
       <div class="col-6">
         <div class="p-card--highlighted">
-          <a href="/snap-store">            
+          <a href="/snap-store">
             {{
               image(
                 url="https://assets.ubuntu.com/v1/2b48f98d-distro_img_01.svg",

--- a/webpack.config.entry.js
+++ b/webpack.config.entry.js
@@ -15,4 +15,5 @@ module.exports = {
   homepage: "./static/js/public/homepage.js",
   blog: "./static/js/public/blog.js",
   store: "./static/js/public/store.js",
+  "store-details": "./static/js/public/store-details.js",
 };

--- a/webpack.config.rules.js
+++ b/webpack.config.rules.js
@@ -67,4 +67,11 @@ module.exports = [
     test: require.resolve(__dirname + "/static/js/public/store.js"),
     use: ["expose-loader?exposes=snapcraft.public.store", "babel-loader"],
   },
+  {
+    test: require.resolve(__dirname + "/static/js/public/store-details.js"),
+    use: [
+      "expose-loader?exposes=snapcraft.public.storeDetails",
+      "babel-loader",
+    ],
+  },
 ];


### PR DESCRIPTION
## Done

Removed unused JS from store details page

## Issue / Card

Fixes #3265

## QA

- Pull the branch
- Run the site using the dotrun snap with `$ dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8004/<snap_name> (any snap page)
- Click around and make sure it works as expected