### PR TITLE
Remove unused JS from fsf

### DIFF
--- a/static/js/public/fsf.js
+++ b/static/js/public/fsf.js
@@ -1,0 +1,11 @@
+import initAccordion from "./accordion";
+import { initFSFLanguageSelect } from "./fsf-language-select";
+import firstSnapFlow from "./first-snap-flow";
+import initExpandableArea from "./expandable-area";
+
+export {
+  initAccordion,
+  initExpandableArea,
+  initFSFLanguageSelect,
+  firstSnapFlow,
+};

--- a/templates/first-snap/_layout_fsf.html
+++ b/templates/first-snap/_layout_fsf.html
@@ -21,7 +21,7 @@
 {% endblock %}
 
 {% block scripts_includes %}
-  <script src="{{ static_url('js/dist/public.js') }}" defer></script>
+  <script src="{{ static_url('js/dist/fsf.js') }}" defer></script>
 {% endblock %}
 
 {% block scripts %}

--- a/templates/first-snap/build-and-test.html
+++ b/templates/first-snap/build-and-test.html
@@ -124,7 +124,7 @@
 <script>
   window.addEventListener("DOMContentLoaded", function () {
     Raven.context(function () {
-      snapcraft.public.initAccordion('.p-accordion__list');
+      snapcraft.public.fsf.initAccordion('.p-accordion__list');
 
       if (typeof ClipboardJS !== 'undefined') {
           new ClipboardJS('.js-clipboard-copy');

--- a/templates/first-snap/install-snapcraft.html
+++ b/templates/first-snap/install-snapcraft.html
@@ -52,7 +52,7 @@
   <script>
     window.addEventListener("DOMContentLoaded", function() {
       Raven.context(function() {
-        snapcraft.public.firstSnapFlow.install({{ language|tojson }});
+        snapcraft.public.fsf.firstSnapFlow.install({{ language|tojson }});
       });
     });
   </script>

--- a/templates/first-snap/language.html
+++ b/templates/first-snap/language.html
@@ -13,8 +13,8 @@
 <script>
   window.addEventListener("DOMContentLoaded", function() {
     Raven.context(function () {
-      snapcraft.public.initFSFLanguageSelect(document.querySelector('.js-fsf-language-select'));
-      snapcraft.public.initExpandableArea();
+      snapcraft.public.fsf.initFSFLanguageSelect(document.querySelector('.js-fsf-language-select'));
+      snapcraft.public.fsf.initExpandableArea();
     });
   });
 </script>

--- a/templates/first-snap/package.html
+++ b/templates/first-snap/package.html
@@ -79,11 +79,11 @@
   <script>
     window.addEventListener("DOMContentLoaded", function() {
       Raven.context(function() {
-        snapcraft.public.firstSnapFlow.initChooseName(
+        snapcraft.public.fsf.firstSnapFlow.initChooseName(
           document.getElementById("choose-name-form"),
            "{{language}}"
         );
-        snapcraft.public.initAccordion('.p-accordion__list');
+        snapcraft.public.fsf.initAccordion('.p-accordion__list');
       });
     });
   </script>

--- a/templates/first-snap/push.html
+++ b/templates/first-snap/push.html
@@ -138,14 +138,14 @@
     window.addEventListener("DOMContentLoaded", function() {
       Raven.context(function() {
         {% if user %}
-          snapcraft.public.firstSnapFlow.initRegisterName(
+          snapcraft.public.fsf.firstSnapFlow.initRegisterName(
             document.getElementById("register-name-form"),
             document.getElementById("register-name-notification"),
             document.getElementById("register-name-success")
           );
-          snapcraft.public.firstSnapFlow.push({{ language|tojson }});
+          snapcraft.public.fsf.firstSnapFlow.push({{ language|tojson }});
         {% endif %}
-        snapcraft.public.initAccordion('.p-accordion__list');
+        snapcraft.public.fsf.initAccordion('.p-accordion__list');
       });
     });
   </script>

--- a/webpack.config.entry.js
+++ b/webpack.config.entry.js
@@ -16,4 +16,5 @@ module.exports = {
   blog: "./static/js/public/blog.js",
   store: "./static/js/public/store.js",
   "store-details": "./static/js/public/store-details.js",
+  fsf: "./static/js/public/fsf.js",
 };

--- a/webpack.config.rules.js
+++ b/webpack.config.rules.js
@@ -74,4 +74,8 @@ module.exports = [
       "babel-loader",
     ],
   },
+  {
+    test: require.resolve(__dirname + "/static/js/public/fsf.js"),
+    use: ["expose-loader?exposes=snapcraft.public.fsf", "babel-loader"],
+  },
 ];


### PR DESCRIPTION
## Done

Removed unused JS from first snap flow

## Issue / Card

Fixes #3267

## QA

- Pull the branch
- Run the site using the dotrun snap with `$ dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8004/first-snap
- Go through the process and check that it works as expected