### PR TITLE
Remove unused js from search

### DIFF
--- a/static/js/public/search.js
+++ b/static/js/public/search.js
@@ -1,0 +1,3 @@
+import { getColour } from "../libs/colours";
+
+export { getColour };

--- a/templates/store/search.html
+++ b/templates/store/search.html
@@ -108,7 +108,7 @@
 {% endblock %}
 
 {% block scripts_includes %}
-  <script src="{{ static_url('js/dist/public.js') }}" defer></script>
+  <script src="{{ static_url('js/dist/search.js') }}" defer></script>
 {% endblock %}
 
 {% block scripts %}
@@ -116,7 +116,7 @@
     <script>
       window.addEventListener("DOMContentLoaded", function() {
         Raven.context(function () {
-          snapcraft.public.getColour(
+          snapcraft.public.search.getColour(
             document.querySelector(".js-store-category"),
             ".p-featured-snap__icon img",
             ".p-featured-snap"

--- a/webpack.config.entry.js
+++ b/webpack.config.entry.js
@@ -17,4 +17,5 @@ module.exports = {
   store: "./static/js/public/store.js",
   "store-details": "./static/js/public/store-details.js",
   fsf: "./static/js/public/fsf.js",
+  search: "./static/js/public/search.js",
 };

--- a/webpack.config.rules.js
+++ b/webpack.config.rules.js
@@ -78,4 +78,8 @@ module.exports = [
     test: require.resolve(__dirname + "/static/js/public/fsf.js"),
     use: ["expose-loader?exposes=snapcraft.public.fsf", "babel-loader"],
   },
+  {
+    test: require.resolve(__dirname + "/static/js/public/search.js"),
+    use: ["expose-loader?exposes=snapcraft.public.search", "babel-loader"],
+  },
 ];


### PR DESCRIPTION
## Done

Removed unused JS from search page

## Issue / Card

Fixes #3271 

## QA

- Pull the branch
- Run the site using the dotrun snap with `$ dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8004/search?q=docker