### PR TITLE
Remove unused js from distro install

### DIFF
--- a/static/js/public/distro-install.js
+++ b/static/js/public/distro-install.js
@@ -1,0 +1,13 @@
+import screenshots from "./snap-details/screenshots";
+import videos from "./snap-details/videos";
+import initExpandableArea from "./expandable-area";
+import triggerEventWhenVisible from "./ga-scroll-event";
+import { initLinkScroll } from "./scroll-to";
+
+export {
+  screenshots,
+  initExpandableArea,
+  triggerEventWhenVisible,
+  initLinkScroll,
+  videos,
+};

--- a/static/js/public/fsf.js
+++ b/static/js/public/fsf.js
@@ -1,0 +1,11 @@
+import initAccordion from "./accordion";
+import { initFSFLanguageSelect } from "./fsf-language-select";
+import firstSnapFlow from "./first-snap-flow";
+import initExpandableArea from "./expandable-area";
+
+export {
+  initAccordion,
+  initExpandableArea,
+  initFSFLanguageSelect,
+  firstSnapFlow,
+};

--- a/static/js/public/search.js
+++ b/static/js/public/search.js
@@ -1,0 +1,3 @@
+import { getColour } from "../libs/colours";
+
+export { getColour };

--- a/templates/first-snap/_layout_fsf.html
+++ b/templates/first-snap/_layout_fsf.html
@@ -21,7 +21,7 @@
 {% endblock %}
 
 {% block scripts_includes %}
-  <script src="{{ static_url('js/dist/public.js') }}" defer></script>
+  <script src="{{ static_url('js/dist/fsf.js') }}" defer></script>
 {% endblock %}
 
 {% block scripts %}

--- a/templates/first-snap/build-and-test.html
+++ b/templates/first-snap/build-and-test.html
@@ -124,7 +124,7 @@
 <script>
   window.addEventListener("DOMContentLoaded", function () {
     Raven.context(function () {
-      snapcraft.public.initAccordion('.p-accordion__list');
+      snapcraft.public.fsf.initAccordion('.p-accordion__list');
 
       if (typeof ClipboardJS !== 'undefined') {
           new ClipboardJS('.js-clipboard-copy');

--- a/templates/first-snap/install-snapcraft.html
+++ b/templates/first-snap/install-snapcraft.html
@@ -52,7 +52,7 @@
   <script>
     window.addEventListener("DOMContentLoaded", function() {
       Raven.context(function() {
-        snapcraft.public.firstSnapFlow.install({{ language|tojson }});
+        snapcraft.public.fsf.firstSnapFlow.install({{ language|tojson }});
       });
     });
   </script>

--- a/templates/first-snap/language.html
+++ b/templates/first-snap/language.html
@@ -13,8 +13,8 @@
 <script>
   window.addEventListener("DOMContentLoaded", function() {
     Raven.context(function () {
-      snapcraft.public.initFSFLanguageSelect(document.querySelector('.js-fsf-language-select'));
-      snapcraft.public.initExpandableArea();
+      snapcraft.public.fsf.initFSFLanguageSelect(document.querySelector('.js-fsf-language-select'));
+      snapcraft.public.fsf.initExpandableArea();
     });
   });
 </script>

--- a/templates/first-snap/package.html
+++ b/templates/first-snap/package.html
@@ -79,11 +79,11 @@
   <script>
     window.addEventListener("DOMContentLoaded", function() {
       Raven.context(function() {
-        snapcraft.public.firstSnapFlow.initChooseName(
+        snapcraft.public.fsf.firstSnapFlow.initChooseName(
           document.getElementById("choose-name-form"),
            "{{language}}"
         );
-        snapcraft.public.initAccordion('.p-accordion__list');
+        snapcraft.public.fsf.initAccordion('.p-accordion__list');
       });
     });
   </script>

--- a/templates/first-snap/push.html
+++ b/templates/first-snap/push.html
@@ -138,14 +138,14 @@
     window.addEventListener("DOMContentLoaded", function() {
       Raven.context(function() {
         {% if user %}
-          snapcraft.public.firstSnapFlow.initRegisterName(
+          snapcraft.public.fsf.firstSnapFlow.initRegisterName(
             document.getElementById("register-name-form"),
             document.getElementById("register-name-notification"),
             document.getElementById("register-name-success")
           );
-          snapcraft.public.firstSnapFlow.push({{ language|tojson }});
+          snapcraft.public.fsf.firstSnapFlow.push({{ language|tojson }});
         {% endif %}
-        snapcraft.public.initAccordion('.p-accordion__list');
+        snapcraft.public.fsf.initAccordion('.p-accordion__list');
       });
     });
   </script>

--- a/templates/store/search.html
+++ b/templates/store/search.html
@@ -108,7 +108,7 @@
 {% endblock %}
 
 {% block scripts_includes %}
-  <script src="{{ static_url('js/dist/public.js') }}" defer></script>
+  <script src="{{ static_url('js/dist/search.js') }}" defer></script>
 {% endblock %}
 
 {% block scripts %}
@@ -116,7 +116,7 @@
     <script>
       window.addEventListener("DOMContentLoaded", function() {
         Raven.context(function () {
-          snapcraft.public.getColour(
+          snapcraft.public.search.getColour(
             document.querySelector(".js-store-category"),
             ".p-featured-snap__icon img",
             ".p-featured-snap"

--- a/templates/store/snap-distro-install.html
+++ b/templates/store/snap-distro-install.html
@@ -266,26 +266,26 @@
 {% endblock %}
 
 {% block scripts_includes %}
-  <script src="{{ static_url('js/dist/public.js') }}" defer></script>
+  <script src="{{ static_url('js/dist/distro-install.js') }}" defer></script>
 {% endblock %}
 {% block scripts %}
   <script>
     window.addEventListener("DOMContentLoaded", function() {
       Raven.context(function () {
         try {
-          snapcraft.public.initLinkScroll(document.querySelector(".js-install"), { offset: 20 });
+          snapcraft.public.distroInstall.initLinkScroll(document.querySelector(".js-install"), { offset: 20 });
         } catch(e) {
           Raven.captureException(e);
         }
 
         try {
-          snapcraft.public.triggerEventWhenVisible("#snippet-snap-install-stable")
+          snapcraft.public.distroInstall.triggerEventWhenVisible("#snippet-snap-install-stable")
         } catch(e) {
           Raven.captureException(e);
         }
 
         try {
-          snapcraft.public.initExpandableArea(
+          snapcraft.public.distroInstall.initExpandableArea(
             ".js-snap-description-text",
             ".js-snap-description-details"
           );
@@ -294,13 +294,13 @@
         }
 
         try {
-          snapcraft.public.screenshots('#js-snap-screenshots');
+          snapcraft.public.distroInstall.screenshots('#js-snap-screenshots');
         } catch(e) {
           Raven.captureException(e);
         }
 
         try {
-          snapcraft.public.videos('.js-video-slide');
+          snapcraft.public.distroInstall.videos('.js-video-slide');
         } catch(e) {
           Raven.captureException(e);
         }

--- a/webpack.config.entry.js
+++ b/webpack.config.entry.js
@@ -18,4 +18,5 @@ module.exports = {
   "store-details": "./static/js/public/store-details.js",
   fsf: "./static/js/public/fsf.js",
   search: "./static/js/public/search.js",
+  "distro-install": "./static/js/public/distro-install.js",
 };

--- a/webpack.config.entry.js
+++ b/webpack.config.entry.js
@@ -17,4 +17,5 @@ module.exports = {
   store: "./static/js/public/store.js",
   "store-details": "./static/js/public/store-details.js",
   fsf: "./static/js/public/fsf.js",
+  search: "./static/js/public/search.js",
 };

--- a/webpack.config.entry.js
+++ b/webpack.config.entry.js
@@ -16,4 +16,5 @@ module.exports = {
   blog: "./static/js/public/blog.js",
   store: "./static/js/public/store.js",
   "store-details": "./static/js/public/store-details.js",
+  fsf: "./static/js/public/fsf.js",
 };

--- a/webpack.config.rules.js
+++ b/webpack.config.rules.js
@@ -78,4 +78,8 @@ module.exports = [
     test: require.resolve(__dirname + "/static/js/public/fsf.js"),
     use: ["expose-loader?exposes=snapcraft.public.fsf", "babel-loader"],
   },
+  {
+    test: require.resolve(__dirname + "/static/js/public/search.js"),
+    use: ["expose-loader?exposes=snapcraft.public.search", "babel-loader"],
+  },
 ];

--- a/webpack.config.rules.js
+++ b/webpack.config.rules.js
@@ -74,4 +74,8 @@ module.exports = [
       "babel-loader",
     ],
   },
+  {
+    test: require.resolve(__dirname + "/static/js/public/fsf.js"),
+    use: ["expose-loader?exposes=snapcraft.public.fsf", "babel-loader"],
+  },
 ];

--- a/webpack.config.rules.js
+++ b/webpack.config.rules.js
@@ -82,4 +82,11 @@ module.exports = [
     test: require.resolve(__dirname + "/static/js/public/search.js"),
     use: ["expose-loader?exposes=snapcraft.public.search", "babel-loader"],
   },
+  {
+    test: require.resolve(__dirname + "/static/js/public/distro-install.js"),
+    use: [
+      "expose-loader?exposes=snapcraft.public.distroInstall",
+      "babel-loader",
+    ],
+  },
 ];


### PR DESCRIPTION
## Done

Removed unused JS from install distro page

## Issue / Card

Fixes #3272 

## QA

- Pull the branch
- Run the site using the dotrun snap with `$ dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8004/install/docker/ubuntu
- Check that the page works as expected