### PR TITLE
Remove unused js from publisher details

### DIFF
--- a/static/js/public/distro-install.js
+++ b/static/js/public/distro-install.js
@@ -1,0 +1,13 @@
+import screenshots from "./snap-details/screenshots";
+import videos from "./snap-details/videos";
+import initExpandableArea from "./expandable-area";
+import triggerEventWhenVisible from "./ga-scroll-event";
+import { initLinkScroll } from "./scroll-to";
+
+export {
+  screenshots,
+  initExpandableArea,
+  triggerEventWhenVisible,
+  initLinkScroll,
+  videos,
+};

--- a/static/js/public/publisher-details.js
+++ b/static/js/public/publisher-details.js
@@ -1,0 +1,3 @@
+import { snapDetailsPosts } from "./snap-details/blog-posts";
+
+export { snapDetailsPosts };

--- a/static/js/public/search.js
+++ b/static/js/public/search.js
@@ -1,0 +1,3 @@
+import { getColour } from "../libs/colours";
+
+export { getColour };

--- a/templates/store/publisher-details.html
+++ b/templates/store/publisher-details.html
@@ -139,7 +139,7 @@
 
 {% block scripts_includes %}
   {% if blog_slug %}
-    <script src="{{ static_url('js/dist/public.js') }}" defer></script>
+    <script src="{{ static_url('js/dist/publisher-details.js') }}" defer></script>
   {% endif %}
 {% endblock %}
 
@@ -149,7 +149,7 @@
       window.addEventListener("DOMContentLoaded", function() {
         Raven.context(function () {
           try {
-            snapcraft.public.snapDetailsPosts('[data-js="blog-article-list"]', '#blog-article-template', '[data-js="blog-articles"]');
+            snapcraft.public.publisherDetails.snapDetailsPosts('[data-js="blog-article-list"]', '#blog-article-template', '[data-js="blog-articles"]');
           } catch(e) {
             Raven.captureException(e);
           }

--- a/templates/store/search.html
+++ b/templates/store/search.html
@@ -108,7 +108,7 @@
 {% endblock %}
 
 {% block scripts_includes %}
-  <script src="{{ static_url('js/dist/public.js') }}" defer></script>
+  <script src="{{ static_url('js/dist/search.js') }}" defer></script>
 {% endblock %}
 
 {% block scripts %}
@@ -116,7 +116,7 @@
     <script>
       window.addEventListener("DOMContentLoaded", function() {
         Raven.context(function () {
-          snapcraft.public.getColour(
+          snapcraft.public.search.getColour(
             document.querySelector(".js-store-category"),
             ".p-featured-snap__icon img",
             ".p-featured-snap"

--- a/templates/store/snap-distro-install.html
+++ b/templates/store/snap-distro-install.html
@@ -266,26 +266,26 @@
 {% endblock %}
 
 {% block scripts_includes %}
-  <script src="{{ static_url('js/dist/public.js') }}" defer></script>
+  <script src="{{ static_url('js/dist/distro-install.js') }}" defer></script>
 {% endblock %}
 {% block scripts %}
   <script>
     window.addEventListener("DOMContentLoaded", function() {
       Raven.context(function () {
         try {
-          snapcraft.public.initLinkScroll(document.querySelector(".js-install"), { offset: 20 });
+          snapcraft.public.distroInstall.initLinkScroll(document.querySelector(".js-install"), { offset: 20 });
         } catch(e) {
           Raven.captureException(e);
         }
 
         try {
-          snapcraft.public.triggerEventWhenVisible("#snippet-snap-install-stable")
+          snapcraft.public.distroInstall.triggerEventWhenVisible("#snippet-snap-install-stable")
         } catch(e) {
           Raven.captureException(e);
         }
 
         try {
-          snapcraft.public.initExpandableArea(
+          snapcraft.public.distroInstall.initExpandableArea(
             ".js-snap-description-text",
             ".js-snap-description-details"
           );
@@ -294,13 +294,13 @@
         }
 
         try {
-          snapcraft.public.screenshots('#js-snap-screenshots');
+          snapcraft.public.distroInstall.screenshots('#js-snap-screenshots');
         } catch(e) {
           Raven.captureException(e);
         }
 
         try {
-          snapcraft.public.videos('.js-video-slide');
+          snapcraft.public.distroInstall.videos('.js-video-slide');
         } catch(e) {
           Raven.captureException(e);
         }

--- a/webpack.config.entry.js
+++ b/webpack.config.entry.js
@@ -18,4 +18,5 @@ module.exports = {
   "store-details": "./static/js/public/store-details.js",
   fsf: "./static/js/public/fsf.js",
   search: "./static/js/public/search.js",
+  "distro-install": "./static/js/public/distro-install.js",
 };

--- a/webpack.config.entry.js
+++ b/webpack.config.entry.js
@@ -17,4 +17,5 @@ module.exports = {
   store: "./static/js/public/store.js",
   "store-details": "./static/js/public/store-details.js",
   fsf: "./static/js/public/fsf.js",
+  search: "./static/js/public/search.js",
 };

--- a/webpack.config.entry.js
+++ b/webpack.config.entry.js
@@ -19,4 +19,5 @@ module.exports = {
   fsf: "./static/js/public/fsf.js",
   search: "./static/js/public/search.js",
   "distro-install": "./static/js/public/distro-install.js",
+  "publisher-details": "./static/js/public/publisher-details.js",
 };

--- a/webpack.config.rules.js
+++ b/webpack.config.rules.js
@@ -78,4 +78,8 @@ module.exports = [
     test: require.resolve(__dirname + "/static/js/public/fsf.js"),
     use: ["expose-loader?exposes=snapcraft.public.fsf", "babel-loader"],
   },
+  {
+    test: require.resolve(__dirname + "/static/js/public/search.js"),
+    use: ["expose-loader?exposes=snapcraft.public.search", "babel-loader"],
+  },
 ];

--- a/webpack.config.rules.js
+++ b/webpack.config.rules.js
@@ -82,4 +82,11 @@ module.exports = [
     test: require.resolve(__dirname + "/static/js/public/search.js"),
     use: ["expose-loader?exposes=snapcraft.public.search", "babel-loader"],
   },
+  {
+    test: require.resolve(__dirname + "/static/js/public/distro-install.js"),
+    use: [
+      "expose-loader?exposes=snapcraft.public.distroInstall",
+      "babel-loader",
+    ],
+  },
 ];

--- a/webpack.config.rules.js
+++ b/webpack.config.rules.js
@@ -89,4 +89,11 @@ module.exports = [
       "babel-loader",
     ],
   },
+  {
+    test: require.resolve(__dirname + "/static/js/public/publisher-details.js"),
+    use: [
+      "expose-loader?exposes=snapcraft.public.publisherDetails",
+      "babel-loader",
+    ],
+  },
 ];


### PR DESCRIPTION
## Done

Removed unused JS from publisher detail pages

## Issue / Card

Fixes #3275

## QA

- Pull the branch
- Run the site using the dotrun snap with `$ dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8004/publisher/kde