### PR TITLE
Update page titles for brand store admin pages

### DIFF
--- a/templates/admin/members.html
+++ b/templates/admin/members.html
@@ -2,7 +2,7 @@
 
 {% extends "/admin/admin_layout.html" %}
 
-{% block meta_title %}Admin | Snapcraft{% endblock %}
+{% block meta_title %}Members in {{ store.name }} | Snapcraft{% endblock %}
 
 {% block admin_content %}
 

--- a/templates/admin/snaps.html
+++ b/templates/admin/snaps.html
@@ -1,8 +1,8 @@
 {% set current_tab = "snaps" %}
 
-{% extends "/admin/admin_layout.html" %}
+{% block meta_title %}Manage snaps in {{ store.name }} | Snapcraft{% endblock %}
 
-{% block meta_title %}Admin | Snapcraft{% endblock %}
+{% extends "/admin/admin_layout.html" %}
 
 {% block admin_content %}
 {% include "/admin/_snaps_section.html" %}


### PR DESCRIPTION
## Done

Updated page titles for the admin snaps and members pages

## QA

- Pull the branch
- Run the site using the dotrun snap with `$ dotrun`
- Go to http://localhost:8004/admin/ahnuP3quahti9vis8aiw/snaps
- Check that the page title in the browser tab makes sense
- Go to http://localhost:8004/admin/ahnuP3quahti9vis8aiw/members
- Check that the page title in the browser tab makes sense
