### PR TITLE
Remove trigger new build button from build details page

### DIFF
--- a/static/js/publisher/builds/index.js
+++ b/static/js/publisher/builds/index.js
@@ -204,12 +204,14 @@ class Builds extends React.Component {
 
     return (
       <Fragment>
-        <TriggerBuild
-          hasError={triggerBuildStatus === ERROR ? true : false}
-          errorMessage={triggerBuildErrorMessage}
-          isLoading={triggerBuildLoading}
-          onClick={this.triggerBuildHandler}
-        />
+        {!singleBuild && (
+          <TriggerBuild
+            hasError={triggerBuildStatus === ERROR ? true : false}
+            errorMessage={triggerBuildErrorMessage}
+            isLoading={triggerBuildLoading}
+            onClick={this.triggerBuildHandler}
+          />
+        )}
         <BuildsTable
           builds={builds}
           singleBuild={singleBuild}

--- a/templates/publisher/build.html
+++ b/templates/publisher/build.html
@@ -77,7 +77,6 @@ Builds for
           true
       );
       {% endif %}
-      snapcraft.publisher.stickyListingBar();
     });
   });
 </script>


### PR DESCRIPTION
## Done

- Remove trigger new build button from build details page

## Issue / Card

Fixes #3276

## QA

- Pull the branch
- Run the site using the dotrun snap with `$ dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8004/[snamp-name]/builds/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Go to your builds page see there is a `Trigger new build` button
- Click on one of the builds ID and see there is no `Trigger new builds` button on that page

## Screenshots

[if relevant, include a screenshot]
