### PR TITLE
Defer loading of videos on details page

### DIFF
--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -67,6 +67,7 @@ $color-social-icon-foreground: $color-light;
 @include vf-u-layout;
 @include vf-u-text-muted;
 @include vf-u-truncate;
+@include vf-u-embedded-media;
 
 // vanilla layouts
 @include vf-l-application;

--- a/templates/partials/_snap-details-video-layout.html
+++ b/templates/partials/_snap-details-video-layout.html
@@ -1,13 +1,12 @@
-
 <div class="row p-snap-details__media u-equal-height">
   {# TODO: u-align--center should be u-align-text--center
    see https://github.com/canonical-web-and-design/vanilla-framework/issues/2448 #}
   <div class="col-10 u-align--center">
-    {% for video in videos %}
-      <div class="js-video-slide" data-video-type="{{video.type}}" data-video-url="{{video.url}}" data-video-id="{{video.id}}">
+    {% if video %}
+      <div class="js-video-slide u-embedded-media" data-video-type="{{video.type}}" data-video-url="{{video.url}}" data-video-id="{{video.id}}">
         {% include "partials/_video.html" %}
       </div>
-    {% endfor %}
+    {% endif %}
   </div>
   {% if screenshots %}
     <div class="col-2 p-snap-details__media-items {% if screenshots|length < 5 %}is-small{% endif %}">

--- a/templates/partials/_video.html
+++ b/templates/partials/_video.html
@@ -1,10 +1,35 @@
 {% if video.type == "youtube" %}
   <iframe id="ytplayer" type="text/html" width="818" height="460"
-          src="{{ video.url }}?autoplay=1&mute=1&cc_load_policy=1&modestbranding=1&rel=0" frameborder="0"></iframe>
+          src="" frameborder="0" data-src="{{ video.url }}?autoplay=0&cc_load_policy=1&modestbranding=1&rel=0"></iframe>
 {% elif video.type == "vimeo" %}
   <iframe id="vimeoplayer" width="818" height="460" frameborder="0"
           webkitallowfullscreen mozallowfullscreen allowfullscreen
-          src="{{ video.url }}?title=0&byline=0&portrait=0&transparent=0"></iframe>
+          src="" data-src="{{ video.url }}?title=0&byline=0&portrait=0&transparent=0"></iframe>
 {% elif video.type == "asciinema" %}
-  <script src="{{ video.url }}" id="asciicast-{{ video.id }}" async data-autoplay="1" data-preload="0"></script>
+  <div id="asciicastplayer"></div>
 {% endif %}
+
+<script>
+  document.addEventListener("DOMContentLoaded", function() {
+    const youtubeVideoFrame = document.getElementById("ytplayer");
+    const vimeoplayerFrame = document.getElementById("vimeoplayer");
+    const asciicastplayerFrame = document.getElementById("asciicastplayer");
+
+    if (youtubeVideoFrame) {
+      youtubeVideoFrame.src = youtubeVideoFrame.dataset.src;
+    }
+
+    if (vimeoplayerFrame) {
+      vimeoplayerFrame.src = vimeoplayerFrame.dataset.src;
+    }
+
+    if (asciicastplayerFrame) {
+      const script = document.createElement("script");
+      script.id = "asciicast-{{ video.id }}";
+      script.dataset.autoplay = 0;
+      script.src = "{{ video.url }}";
+
+      asciicastplayerFrame.appendChild(script);
+    }
+  });
+</script>

--- a/templates/store/snap-details/_screenshots.html
+++ b/templates/store/snap-details/_screenshots.html
@@ -1,5 +1,5 @@
 <div class="row" id="js-snap-screenshots" data-live="screenshots">
-  {% if videos %}
+  {% if video %}
     {% include "partials/_snap-details-video-layout.html" %}
   {% elif screenshots %}
     {% include "partials/_snap-details-image-layout.html" %}

--- a/tests/publisher/snaps/test_post_preview.py
+++ b/tests/publisher/snaps/test_post_preview.py
@@ -65,5 +65,5 @@ class PostPreviewPage(BaseTestCases.EndpointLoggedIn):
         self.assertContext("is_preview", True)
         self.assertContext("screenshots", [])
         self.assertContext("icon_url", None)
-        self.assertContext("videos", [])
+        self.assertContext("video", None)
         self.assertContext("package_name", self.snap_name)

--- a/webapp/publisher/snaps/listing_views.py
+++ b/webapp/publisher/snaps/listing_views.py
@@ -25,7 +25,7 @@ from webapp.store.logic import (
     filter_screenshots,
     get_categories,
     get_icon,
-    get_videos,
+    get_video,
 )
 
 store_api = SnapStore(api_publisher_session)
@@ -384,7 +384,7 @@ def post_preview(snap_name):
     icons = get_icon(context["images"])
     context["screenshots"] = filter_screenshots(context["images"])
     context["icon_url"] = icons[0] if icons else None
-    context["videos"] = get_videos(context["images"])
+    context["video"] = get_video(context["images"])
 
     # Channel map
     context["default_track"] = "latest"

--- a/webapp/store/logic.py
+++ b/webapp/store/logic.py
@@ -256,11 +256,9 @@ def get_categories(categories_json):
 
     if "categories" in categories_json:
         for cat in categories_json["categories"]:
-            if (
-                cat["name"] not in categories_list
-                and cat["name"] not in blacklist
-            ):
-                categories_list.append(cat["name"])
+            if cat["name"] not in categories_list:
+                if cat["name"] not in blacklist:
+                    categories_list.append(cat["name"])
 
         for category in categories_list:
             categories.append(
@@ -427,10 +425,13 @@ def get_icon(media):
     return [m["url"] for m in media if m["type"] == "icon"]
 
 
-def get_videos(media):
-    return [
-        get_video_embed_code(m["url"]) for m in media if m["type"] == "video"
-    ]
+def get_video(media):
+    video = None
+    for m in media:
+        if m["type"] == "video":
+            video = get_video_embed_code(m["url"])
+            break
+    return video
 
 
 def promote_snap_with_icon(snaps):

--- a/webapp/store/snap_details_views.py
+++ b/webapp/store/snap_details_views.py
@@ -117,7 +117,7 @@ def snap_details_views(store, api, handle_errors):
                 publisher_snaps["snaps"], 4
             )
 
-        videos = logic.get_videos(details["snap"]["media"])
+        video = logic.get_video(details["snap"]["media"])
 
         is_users_snap = False
         if authentication.is_authenticated(flask.session):
@@ -147,7 +147,7 @@ def snap_details_views(store, api, handle_errors):
             "publisher": details["snap"]["publisher"]["display-name"],
             "username": details["snap"]["publisher"]["username"],
             "screenshots": screenshots,
-            "videos": videos,
+            "video": video,
             "publisher_snaps": publisher_snaps,
             "publisher_featured_snaps": publisher_featured_snaps,
             "has_publisher_page": publisher_info is not None,


### PR DESCRIPTION
## Done

Defer loading of video on snap details page so it isn't render blocking

## Issue / Card

Fixes #3285

## QA

- Go to https://snapcraft-io-3286.demos.haus/code
- Go to https://snapcraft-io-3286.demos.haus/tbmb-bsi-test
- In both cases check that the video loads and the content doesn't jump