### PR TITLE
Add rss metatag for blog

### DIFF
--- a/templates/blog/index.html
+++ b/templates/blog/index.html
@@ -2,6 +2,9 @@
 
 {% block meta_title %}Blog | Snapcraft{% endblock %}
 {% block meta_copydoc %}https://docs.google.com/document/d/1YWhw_DlbXrq9CBUtMgjzlzZds0_m8xr-MZlXpXkMvIQ/edit{% endblock %}
+{% block extra_meta %}
+<link rel="alternate" type="application/rss+xml"  href="/blog/feed" title="Snapcraft.io's Blog RSS feed">
+{% endblock %}
 
 {% block content %}
 


### PR DESCRIPTION
## Done

- Add rss metatag for blog

## Issue / Card

Fixes #3294 

## QA

- Pull the branch
- Run the site using the dotrun snap with `$ dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8004/blog
- Make sure the metatag for rss is here
