### PR TITLE
Tidy up admin UI

### DIFF
--- a/templates/admin/_navigation.html
+++ b/templates/admin/_navigation.html
@@ -10,9 +10,6 @@
         <a class="p-side-navigation__link {% if current_tab == 'snaps' %}is-active{% endif %}" href="/admin/{{ s.id }}/snaps">Snaps</a>
       </li>
       <li class="p-side-navigation__item">
-        <a class="p-side-navigation__link {% if current_tab == 'models' %}is-active{% endif %}" href="/admin/{{ s.id }}/models">Models</a>
-      </li>
-      <li class="p-side-navigation__item">
         <a class="p-side-navigation__link {% if current_tab == 'members' %}is-active{% endif %}" href="/admin/{{ s.id }}/members">Members</a>
       </li>
       <div class="p-side-navigation__item">

--- a/templates/admin/manage_members.html
+++ b/templates/admin/manage_members.html
@@ -12,7 +12,7 @@
 </div>
 
 <div class="p-modal" id="invite-modal" style="display: none; z-index: 110;">
-  <div class="p-modal__dialog" role="dialog" aria-labelledby="invite-modal-title">
+  <div class="p-modal__dialog" role="dialog" aria-labelledby="invite-modal-title" style="overflow: auto;">
     <header class="p-modal__header">
       <h2 class="p-modal__title" id="invite-modal-title">Invite member</h2>
       <button class="p-modal__close" aria-label="Close active modal" aria-controls="invite-modal">Close</button>

--- a/templates/admin/members.html
+++ b/templates/admin/members.html
@@ -15,7 +15,6 @@
     <tr>
       <th>Name</th>
       <th>Email</th>
-      <th>Snaps in {{ store.name }}</th>
       <th>Access</th>
       <th>Store</th>
     </tr>
@@ -25,7 +24,6 @@
     <tr>
       <td rowspan="1">{{ member.displayname }}</td>
       <td rowspan="1">{{ member.email }}</td>
-      <td><a href="#">-</a></td>
       <td>{% for r in member.roles %}{{ r | capitalize }}{{ ", " if not loop.last }}{% endfor %}</td>
       <td><a href="/admin/{{ store.id }}/snaps">{{ store.name }}</a></td>
     </tr>


### PR DESCRIPTION
## Done

- Removed "Models" from admin navigation
- Removed "Snaps in store" column from members table
- Removed scroll bars from the invite members modal

## Issue / Card

Fixes #3297

## QA

- Go to https://snapcraft-io-3296.demos.haus/admin
- Check that "Models" is not present in the side navigation
- Go to https://snapcraft-io-3296.demos.haus/admin/ahnuP3quahti9vis8aiw/members
- Check that there is no "Snaps in store" column in the table
- Go to https://snapcraft-io-3296.demos.haus/admin/ahnuP3quahti9vis8aiw/members/manage
- Click the "Add" button and check that the modal has no scrollbars