### PR TITLE
Fix docs search pagination buttons

### DIFF
--- a/templates/docs/search.html
+++ b/templates/docs/search.html
@@ -34,18 +34,19 @@
   </div>
   {% endfor %}
   <div class="p-strip">
-    <ul class="p-pagination">
+    <ol class="p-pagination">
       {% if  results.queries and results.queries.previousPage %}
-        <li class="p-pagination__item">
-          <a class="p-pagination__link--previous" href="/docs/search?q={{ query }}&amp;start={{ results.queries.previousPage.0.startIndex }}{% if siteSearch %}&amp;siteSearch={{ siteSearch }}{% endif %}" title="Previous page"><i class="p-icon--contextual-menu">Previous page</i>Previous</a>
-        </li>
+      <li class="p-pagination__item">
+        <a class="p-pagination__link--previous" href="/docs/search?q={{ query }}&amp;start={{ results.queries.previousPage.0.startIndex }}{% if siteSearch %}&amp;siteSearch={{ siteSearch }}{% endif %}" title="Previous page"><i class="p-icon--chevron-down"></i><span>Previous page</span></a>
+      </li>
       {% endif %}
+
       {% if results.queries and results.queries.nextPage %}
-        <li class="p-inline-list__item">
-          <a class="p-pagination__link--next" href="/docs/search?q={{ query }}&amp;start={{ results.queries.nextPage.0.startIndex }}{% if siteSearch %}&amp;siteSearch={{ siteSearch }}{% endif %}" title="Next page">Next<i class="p-icon--contextual-menu">Next page</i></a>
-        </li>
+      <li class="p-pagination__item">
+        <a class="p-pagination__link--next" href="/docs/search?q={{ query }}&amp;start={{ results.queries.nextPage.0.startIndex }}{% if siteSearch %}&amp;siteSearch={{ siteSearch }}{% endif %}" title="Next page"><span>Next page</span><i class="p-icon--chevron-down"></i></a>
+      </li>
       {% endif %}
-    </ul>
+    </ol>
   </div>
   {% else %}
   <div class="p-strip">


### PR DESCRIPTION
## Done
Fixed the pagination buttons on the docs search pages

## How to QA
- Go to https://snapcraft-io-3298.demos.haus/docs/search?q=test
- Check that the prev/next buttons at the bottom of the page look good and work as expected

## Issue / Card
Fixes #2955
