### PR TITLE
Add no script message to publisher pages

### DIFF
--- a/templates/publisher/_header.html
+++ b/templates/publisher/_header.html
@@ -1,3 +1,5 @@
+{% include "publisher/_noscript.html" %}
+
 <section class="p-strip is-shallow u-no-padding--bottom">
   {% if from in ["first-snap", "first-snap-unpublished"] %}
   <div class="row">

--- a/templates/publisher/_noscript.html
+++ b/templates/publisher/_noscript.html
@@ -1,0 +1,11 @@
+<noscript>
+  <section class="p-strip is-shallow u-no-padding--bottom">
+    <div class="u-fixed-width">
+      <div class="p-notification--information">
+        <p class="p-notification__response" role="status">
+          It seems like you've got JavaScript turned off, so everything seems blank. Please enable JavaScript to use all the available features.
+        </p>
+      </div>
+    </div>
+  </section>
+</noscript>

--- a/templates/publisher/account-snaps.html
+++ b/templates/publisher/account-snaps.html
@@ -21,6 +21,8 @@ My published snaps — Linux software in the Snap Store
 {% endif %}
 {% endwith %}
 
+{% include "publisher/_noscript.html" %}
+
 {% if snaps %}
 <section class="p-strip is-shallow" data-js="dashboard-metrics">
   <div class="u-fixed-width">


### PR DESCRIPTION
## Done
Added a message for users with JS disabled

## How to QA
- Disable JS in your browser
- Go to https://snapcraft-io-3299.demos.haus/snaps
- Check that there is a message about having JS disabled
- Click through to a snap page
- Check that there is a message about having JS disabled

## Issue / Card
Fixes #2850