### PR TITLE
Update staging-api.snapcraft.io.yaml

### DIFF
--- a/konf/staging-api.snapcraft.io.yaml
+++ b/konf/staging-api.snapcraft.io.yaml
@@ -1,6 +1,6 @@
 domain: staging-api.snapcraft.io
 
-image: prod-comms.docker-registry.canonical.com/snapcraft.io
+image: prod-comms.docker-registry.canonical.com/staging-api.snapcraft.io
 
 env:
   - name: DASHBOARD_API


### PR DESCRIPTION
## Done
The image name for staging-api.snapcraft.io is not the correct one. It should be `staging-api.snapcraft.io` like the jenkins job is building.

Fixes https://github.com/canonical-web-and-design/snapcraft.io/issues/3313
