### PR TITLE
Remove weekly active devices column

### DIFF
--- a/templates/admin/_snaps_section.html
+++ b/templates/admin/_snaps_section.html
@@ -6,7 +6,6 @@
       <th>Published in</th>
       <th>Name</th>
       <th>Latest release</th>
-      <th>Weekly active devices</th>
       <th>Collaborators</th>
     </tr>
   </thead>
@@ -16,13 +15,11 @@
       <td>{{ snaps[0].name }}</td>
       <td>-</td>
       <td>-</td>
-      <td>-</td>
     </tr>
     {% for snap in snaps %}
       {% if loop.index > 1 %}
         <tr>
           <td>{{ snap.name }}</td>
-          <td>-</td>
           <td>-</td>
           <td>-</td>
         </tr>


### PR DESCRIPTION
## Done
Removed the "Weekly active devices" column from the snaps admin table

## QA
- Go to https://snapcraft-io-3314.demos.haus/admin
- Check that the snaps table has no column called "Weekly active devices"

## Issue
Fixes #3315