### PR TITLE
JSON endpoint to summarize snap builds

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ canonicalwebteam.blog==6.3.1
 canonicalwebteam.search==0.2.1
 canonicalwebteam.image-template==1.3.1
 canonicalwebteam.store-api==3.0.1
-canonicalwebteam.launchpad==0.7.9
+canonicalwebteam.launchpad==0.8.0
 django-openid-auth==0.16
 Flask-OpenID-Stateless==1.2.6
 Flask-WTF==0.14.3

--- a/webapp/helpers.py
+++ b/webapp/helpers.py
@@ -2,13 +2,21 @@ import json
 import os
 
 import flask
+from canonicalwebteam.launchpad import Launchpad
 from ruamel.yaml import YAML
-from webapp.api.requests import Session, PublisherSession
+from webapp.api.requests import PublisherSession, Session
 
 _yaml = YAML(typ="rt")
 _yaml_safe = YAML(typ="safe")
 api_session = Session()
 api_publisher_session = PublisherSession()
+
+launchpad = Launchpad(
+    username=os.getenv("LP_API_USERNAME"),
+    token=os.getenv("LP_API_TOKEN"),
+    secret=os.getenv("LP_API_TOKEN_SECRET"),
+    session=api_publisher_session,
+)
 
 
 def get_yaml_loader(typ="safe"):

--- a/webapp/publisher/snaps/build_views.py
+++ b/webapp/publisher/snaps/build_views.py
@@ -4,7 +4,6 @@ from hashlib import md5
 
 # Packages
 import flask
-from canonicalwebteam.launchpad import Launchpad
 from canonicalwebteam.store_api.stores.snapstore import SnapPublisher
 from canonicalwebteam.store_api.exceptions import (
     StoreApiError,
@@ -13,7 +12,7 @@ from canonicalwebteam.store_api.exceptions import (
 from requests.exceptions import HTTPError
 
 # Local
-from webapp.helpers import api_publisher_session
+from webapp.helpers import api_publisher_session, launchpad
 from webapp.api.github import GitHub, InvalidYAML
 from webapp.api.exceptions import ApiError
 from webapp.decorators import login_required
@@ -25,12 +24,6 @@ from werkzeug.exceptions import Unauthorized
 GITHUB_SNAPCRAFT_USER_TOKEN = os.getenv("GITHUB_SNAPCRAFT_USER_TOKEN")
 GITHUB_WEBHOOK_HOST_URL = os.getenv("GITHUB_WEBHOOK_HOST_URL")
 BUILDS_PER_PAGE = 15
-launchpad = Launchpad(
-    username=os.getenv("LP_API_USERNAME"),
-    token=os.getenv("LP_API_TOKEN"),
-    secret=os.getenv("LP_API_TOKEN_SECRET"),
-    session=api_publisher_session,
-)
 publisher_api = SnapPublisher(api_publisher_session)
 
 

--- a/webapp/publisher/snaps/settings_views.py
+++ b/webapp/publisher/snaps/settings_views.py
@@ -1,11 +1,9 @@
 # Standard library
-import os
 from json import loads
 
 # Packages
 import flask
 import pycountry
-from canonicalwebteam.launchpad import Launchpad
 from canonicalwebteam.store_api.stores.snapstore import SnapPublisher
 from canonicalwebteam.store_api.exceptions import (
     StoreApiError,
@@ -13,18 +11,12 @@ from canonicalwebteam.store_api.exceptions import (
 )
 
 # Local
-from webapp.helpers import api_publisher_session
+from webapp.helpers import api_publisher_session, launchpad
 from webapp.api.exceptions import ApiError
 from webapp.decorators import login_required
 from webapp.publisher.snaps import logic
 from webapp.publisher.views import _handle_error, _handle_error_list
 
-launchpad = Launchpad(
-    username=os.getenv("LP_API_USERNAME"),
-    token=os.getenv("LP_API_TOKEN"),
-    secret=os.getenv("LP_API_TOKEN_SECRET"),
-    session=api_publisher_session,
-)
 publisher_api = SnapPublisher(api_publisher_session)
 
 


### PR DESCRIPTION
## Done

- JSON endpoint to summarize snap builds

## How to QA
- Visit the demo in your browser, link commented below
  - Or you can run the project locally using the [dotrun](https://snapcraft.io/dotrun) snap with `$ dotrun` and view it in your web browser at: http://0.0.0.0:8004/
  - If your demo doesn't work, read more about the [demoservice](https://discourse.ubuntu.com/t/demoservice/16862)
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Having snaps using automated builds on snapcraft.io and being authenticated request:
- http://0.0.0.0:8004/snap-builds.json

## Issue / Card
Fixes #3308 
