### PR TITLE
Add build status column

### DIFF
--- a/static/js/publisher/build-status.js
+++ b/static/js/publisher/build-status.js
@@ -1,0 +1,32 @@
+import { UserFacingStatus } from "./builds/helpers";
+
+function getStatuses() {
+  return fetch("/snap-builds.json").then((r) => r.json());
+}
+
+function addBuildStatus(row, data) {
+  const snapName = row.dataset.snapName;
+  const releaseData = data.find((d) => d.name === snapName);
+  const buildStatus = UserFacingStatus[releaseData.status].statusMessage;
+  const buildColumn = row.querySelector("[data-js='snap-build-status']");
+
+  if (buildColumn && buildStatus && buildStatus.toLowerCase() !== "unknown") {
+    buildColumn.innerText = buildStatus;
+  } else {
+    buildColumn.innerText = buildColumn.dataset.status;
+  }
+}
+
+function buildStatus() {
+  getStatuses()
+    .then((data) => {
+      const snapListRows = document.querySelectorAll(
+        "[data-js='snap-list-row']"
+      );
+
+      snapListRows.forEach((row) => addBuildStatus(row, data));
+    })
+    .catch((e) => console.error(e));
+}
+
+export default buildStatus;

--- a/static/js/publisher/publisher.js
+++ b/static/js/publisher/publisher.js
@@ -13,6 +13,7 @@ import submitEnabler from "./submitEnabler";
 import * as tour from "./tour";
 import { initBuilds } from "./builds";
 import { initRepoDisconnect } from "./builds/repoDisconnect";
+import buildStatus from "./build-status";
 
 const settings = { enableInput, changeHandler };
 
@@ -32,4 +33,5 @@ export {
   tour,
   initBuilds,
   initRepoDisconnect,
+  buildStatus,
 };

--- a/templates/publisher/account-snaps.html
+++ b/templates/publisher/account-snaps.html
@@ -131,10 +131,11 @@ My published snaps — Linux software in the Snap Store
     <table class="p-table--mobile-card" role="grid">
       <thead>
         <tr role="row">
-          <th width="30%">Name</th>
+          <th width="20%">Name</th>
           <th width="10%">Visibility</th>
-          <th width="20%">Owner</th>
-          <th width="20%">Latest release</th>
+          <th width="10%">Owner</th>
+          <th width="10%">Status</th>
+          <th width="10%">Latest release</th>
           <th width="10%">Version</th>
         </tr>
       </thead>
@@ -147,7 +148,7 @@ My published snaps — Linux software in the Snap Store
         {% else %}
         {% set published = False %}
         {% endif %}
-        <tr role="row">
+        <tr role="row" data-js="snap-list-row" data-snap-name="{{snap}}">
           <td role="rowheader" class="p-table--mobile-card__header">
             <a href="/{{snap}}/listing" class="p-heading-icon--small">
               <span class="p-heading-icon__header">
@@ -186,6 +187,9 @@ My published snaps — Linux software in the Snap Store
             {% endif %}
           </td>
           {% if published %}
+          <td role="gridcell" aria-label="Status" data-js="snap-build-status" data-status="{% if snaps[snap].latest_release.status == 'Published' %}Released{% else %}{{ snaps[snap].latest_release.status }}{% endif %}">
+            -
+          </td>
           <td role="gridcell" aria-label="Latest release">{{ snaps[snap].latest_release.channels[0] }}</td>
           <td role="gridcell" aria-label="Version">
             <a href="/{{snap}}/releases">
@@ -193,6 +197,7 @@ My published snaps — Linux software in the Snap Store
             </a>
           </td>
           {% else %}
+          <td role="gridcell" aria-label="Status" data-js="snap-build-status" data-status="Not released">-</td>
           <td role="gridcell" aria-label="Latest release"><a href="/{{snap}}/releases">Not released</a></td>
           <td role="gridcell" aria-label="Version"></td>
           {% endif %}
@@ -253,6 +258,7 @@ My published snaps — Linux software in the Snap Store
         token: {{ csrf_token()|tojson }},
       };
       snapcraft.publisher.metrics.renderPublisherMetrics(options);
+      snapcraft.publisher.buildStatus();
     });
   });
 </script>


### PR DESCRIPTION
## Done
Added a build status column to the snaps listing

## How to QA
- Go to https://snapcraft-io-3318.demos.haus/snaps
- Check that the table has a build status column

## Issue / Card
Fixes #3309, #3310