### PR TITLE
Update env var names

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -6,10 +6,8 @@
 To use staging APIs locally you can add the following lines to an `.env.local` file:
 
 ```bash
-SNAPCRAFT_IO_API=https://api.staging.snapcraft.io/api/v1/
-SNAPCRAFT_IO_API_V2=https://api.staging.snapcraft.io/v2/
-DASHBOARD_API=https://dashboard.staging.snapcraft.io/dev/api/
-DASHBOARD_API_V2=https://dashboard.staging.snapcraft.io/api/v2/
+SNAPSTORE_API_URL=https://api.staging.snapcraft.io/
+SNAPSTORE_DASHBOARD_API_URL=https://dashboard.staging.snapcraft.io/
 LOGIN_URL=https://login.staging.ubuntu.com
 ```
 

--- a/konf/staging-api.snapcraft.io.yaml
+++ b/konf/staging-api.snapcraft.io.yaml
@@ -3,11 +3,8 @@ domain: staging-api.snapcraft.io
 image: prod-comms.docker-registry.canonical.com/staging-api.snapcraft.io
 
 env:
-  - name: DASHBOARD_API
-    value: https://dashboard.staging.snapcraft.io/dev/api/
-
-  - name: DASHBOARD_API_V2
-    value: https://dashboard.staging.snapcraft.io/api/v2/
+  - name: SNAPSTORE_DASHBOARD_API_URL
+    value: https://dashboard.staging.snapcraft.io/
 
   - name: LOGIN_URL
     value: https://login.staging.ubuntu.com

--- a/webapp/api/sso.py
+++ b/webapp/api/sso.py
@@ -4,8 +4,8 @@ from webapp.api.exceptions import ApiResponseError, ApiResponseDecodeError
 
 api_session = api.requests.Session()
 
-DASHBOARD_API = os.getenv(
-    "DASHBOARD_API", "https://dashboard.snapcraft.io/dev/api/"
+SNAPSTORE_DASHBOARD_API_URL = os.getenv(
+    "SNAPSTORE_DASHBOARD_API_URL", "https://dashboard.snapcraft.io/"
 )
 
 LOGIN_URL = os.getenv("LOGIN_URL", "https://login.ubuntu.com")
@@ -34,7 +34,7 @@ def process_response(response):
 
 
 def post_macaroon(json):
-    url = "".join([DASHBOARD_API, "acl/"])
+    url = "".join([SNAPSTORE_DASHBOARD_API_URL, "dev/api/acl/"])
     response = api_session.post(url=url, headers=HEADERS, json=json)
 
     return process_response(response)


### PR DESCRIPTION
## Done
- Our [store API module](https://github.com/canonical-web-and-design/canonicalwebteam.store-api/) is using different env variables to set the staging APIs, these changes will make snapcraft.io use the same ones and fix the k8s config.

## How to QA
- Check the login is working fine.

## Issue / Card
Fixes https://github.com/canonical-web-and-design/snapcraft.io/issues/3330
