### PR TITLE
Update flask-base and use exclude_xframe_options_header

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # App dependencies
-canonicalwebteam.flask_base==0.7.1
+canonicalwebteam.flask-base==0.7.3
 canonicalwebteam.discourse==2.1.0
 canonicalwebteam.blog==6.3.1
 canonicalwebteam.search==0.2.1

--- a/webapp/store/snap_details_views.py
+++ b/webapp/store/snap_details_views.py
@@ -1,11 +1,17 @@
 import flask
 import humanize
+
 import webapp.helpers as helpers
 import webapp.metrics.helper as metrics_helper
 import webapp.metrics.metrics as metrics
 import webapp.store.logic as logic
-from pybadges import badge
 from webapp import authentication
+from webapp.api.exceptions import ApiError
+from webapp.markdown import parse_markdown_description
+
+from canonicalwebteam.flask_base.decorators import (
+    exclude_xframe_options_header,
+)
 from canonicalwebteam.store_api.exceptions import (
     StoreApiCircuitBreaker,
     StoreApiError,
@@ -14,8 +20,7 @@ from canonicalwebteam.store_api.exceptions import (
     StoreApiResponseErrorList,
     StoreApiTimeoutError,
 )
-from webapp.api.exceptions import ApiError
-from webapp.markdown import parse_markdown_description
+from pybadges import badge
 
 
 def snap_details_views(store, api, handle_errors):
@@ -277,6 +282,7 @@ def snap_details_views(store, api, handle_errors):
         )
 
     @store.route('/<regex("' + snap_regex + '"):snap_name>/embedded')
+    @exclude_xframe_options_header
     def snap_details_embedded(snap_name):
         """
         A view to display the snap embedded card for specific snaps.


### PR DESCRIPTION
## Done
- Update flask-base to 0.7.3
- Exclude `/<snap_name>/embedded` route from using this header.

## How to QA
- Do `curl -I http://0.0.0.0:8004/toto-fran/embedded` and `X-Frame-Options: SAMEORIGIN` shouldn't be there
- Do `curl -I http://0.0.0.0:8004/` and `X-Frame-Options: SAMEORIGIN` should be present

## Issue / Card
Fixes https://github.com/canonical-web-and-design/snapcraft.io/issues/3336
