### PR TITLE
Add icon and links to build summary

### DIFF
--- a/static/js/publisher/build-status.js
+++ b/static/js/publisher/build-status.js
@@ -10,8 +10,23 @@ function addBuildStatus(row, data) {
   const buildStatus = UserFacingStatus[releaseData.status].statusMessage;
   const buildColumn = row.querySelector("[data-js='snap-build-status']");
 
+  const failedStatuses = ["failed_to_build", "release_failed"];
+
+  const errorIcon = document.createElement("i");
+  errorIcon.classList.add("p-icon--error");
+
+  const buildLink = document.createElement("a");
+  buildLink.href = `/${snapName}/builds`;
+
   if (buildColumn && buildStatus && buildStatus.toLowerCase() !== "unknown") {
-    buildColumn.innerText = buildStatus;
+    if (failedStatuses.includes(releaseData.status)) {
+      buildColumn.innerText = "";
+      buildColumn.appendChild(errorIcon);
+      buildLink.innerText = buildStatus;
+      buildColumn.appendChild(buildLink);
+    } else {
+      buildColumn.innerText = buildStatus;
+    }
   } else {
     buildColumn.innerText = buildColumn.dataset.status;
   }

--- a/templates/publisher/account-snaps.html
+++ b/templates/publisher/account-snaps.html
@@ -134,7 +134,7 @@ My published snaps — Linux software in the Snap Store
           <th width="20%">Name</th>
           <th width="10%">Visibility</th>
           <th width="10%">Owner</th>
-          <th width="10%">Status</th>
+          <th width="10%" class="p-table__cell--icon-placeholder u-truncate p-table__cell--icon-placeholder">Status</th>
           <th width="10%">Latest release</th>
           <th width="10%">Version</th>
         </tr>
@@ -187,7 +187,7 @@ My published snaps — Linux software in the Snap Store
             {% endif %}
           </td>
           {% if published %}
-          <td role="gridcell" aria-label="Status" data-js="snap-build-status" data-status="{% if snaps[snap].latest_release.status == 'Published' %}Released{% else %}{{ snaps[snap].latest_release.status }}{% endif %}">
+          <td role="gridcell" aria-label="Status" data-js="snap-build-status" data-status="{% if snaps[snap].latest_release.status == 'Published' %}Released{% else %}{{ snaps[snap].latest_release.status }}{% endif %}" class="p-table__cell--icon-placeholder p-table__cell--icon-placeholder">
             -
           </td>
           <td role="gridcell" aria-label="Latest release">{{ snaps[snap].latest_release.channels[0] }}</td>
@@ -197,7 +197,9 @@ My published snaps — Linux software in the Snap Store
             </a>
           </td>
           {% else %}
-          <td role="gridcell" aria-label="Status" data-js="snap-build-status" data-status="Not released">-</td>
+          <td role="gridcell" aria-label="Status" data-js="snap-build-status" data-status="Not released" class="p-table__cell--icon-placeholder p-table__cell--icon-placeholder">
+            -
+          </td>
           <td role="gridcell" aria-label="Latest release"><a href="/{{snap}}/releases">Not released</a></td>
           <td role="gridcell" aria-label="Version"></td>
           {% endif %}


### PR DESCRIPTION
## Done

Added an icon and linked status to builds tab if status is `failed_to_build` or `release_failed`.

## QA

- Go to https://snapcraft-io-3349.demos.haus/snaps
- Check that any failed statuses have an icon to the left and are linked to the builds tab

## Issue
Fixes #1767