### PR TITLE
Change font display option to swap

### DIFF
--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -8,6 +8,8 @@ $color-navigation-active-bar: $ubuntu-orange;
 $theme-default-nav: dark;
 $breakpoint-navigation-threshold: 800px;
 
+$font-display-option: swap;
+
 // vanilla patterns
 @import "vanilla-framework/scss/vanilla";
 


### PR DESCRIPTION
## Done
Changed font display option to swap to improve the Largest Contentful Paint metric

## QA
- Go to https://snapcraft-io-3352.demos.haus/code
- Open developer tools and in the network tab, change "Online" to the "Slow 3G" preset
- Reload the page
- Check that the text is always visible

## Issue
Fixes #3344