### PR TITLE
Update content for ABC testing

### DIFF
--- a/templates/first-snap/_breadcrumb.html
+++ b/templates/first-snap/_breadcrumb.html
@@ -2,35 +2,44 @@
   <div class="row">
     <ul class="p-breadcrumbs p-heading--4" style="max-width: 100%;">
       <li class="p-breadcrumbs__item">
-        {% if fsf_step == 'install' or fsf_step == 'package' or fsf_step == 'build_and_test' or fsf_step == 'push' %}
+        {% if fsf_step in ['create_account', 'install', 'package', 'build_and_test', 'push']  %}
           <a href="/first-snap/">Select language</a>
         {% else %}
           Select language
         {% endif %}
       </li>
-      <li class="p-breadcrumbs__item{% if fsf_step == 'language' %} is-disabled{% endif %}">
-        {% if fsf_step == 'package' or fsf_step == 'build_and_test' or fsf_step == 'push' %}
+      {% if path.startswith("/first-snap-2") or path.startswith("/first-snap-3") %}
+        <li class="p-breadcrumbs__item">
+          {% if fsf_step in ['install', 'package', 'build_and_test', 'push']  %}
+            <a href="/first-snap/{{ language }}/create-account">Create an account</a>
+          {% else %}
+            Create an account
+          {% endif %}
+        </li>
+      {% endif %}
+      <li class="p-breadcrumbs__item{% if fsf_step in ['language', 'create_account'] %} is-disabled{% endif %}">
+        {% if fsf_step in ['package', 'build_and_test', 'push'] %}
           <a href="/first-snap/{{ language }}">Install Snapcraft</a>
         {% else %}
           Install Snapcraft
         {% endif %}
       </li>
-      <li class="p-breadcrumbs__item{% if fsf_step == 'language' or fsf_step == 'install' %} is-disabled{% endif %}">
-        {% if fsf_step == 'language' or fsf_step == 'install' or fsf_step == 'package' %}
+      <li class="p-breadcrumbs__item{% if fsf_step in ['language', 'create_account', 'install'] %} is-disabled{% endif %}">
+        {% if fsf_step in ['language', 'create_account', 'install', 'package'] %}
           Package snap
         {% else %}
           <a href="/first-snap/{{ language }}/{{ os }}/package">Package snap</a>
         {% endif %}
       </li>
-      <li class="p-breadcrumbs__item{% if fsf_step == 'language' or fsf_step == 'install' %} is-disabled{% endif %}">
-        {% if fsf_step == 'language' or fsf_step == 'install' or fsf_step == 'build_and_test' %}
+      <li class="p-breadcrumbs__item{% if fsf_step in ['language', 'create_account', 'install'] %} is-disabled{% endif %}">
+        {% if fsf_step in ['language', 'create_account', 'install', 'build_and_test'] %}
           Build & test snap
         {% else %}
           <a href="/first-snap/{{ language }}/{{ os }}/build-and-test">Build & test snap</a>
         {% endif %}
       </li>
-      <li class="p-breadcrumbs__item{% if fsf_step == 'language' or fsf_step == 'install' %} is-disabled{% endif %}">
-        {% if fsf_step == 'language' or fsf_step == 'install' or fsf_step == 'push' %}
+      <li class="p-breadcrumbs__item{% if fsf_step in ['language', 'create_account', 'install'] %} is-disabled{% endif %}">
+        {% if fsf_step in ['language', 'create_account', 'install', 'push'] %}
           Publish to store
         {% else %}
           <a href="/first-snap/{{ language }}/{{ os }}/push">Publish to store</a>

--- a/templates/first-snap/create-account.html
+++ b/templates/first-snap/create-account.html
@@ -1,0 +1,108 @@
+{% set fsf_step = "create_account" %}
+{% extends "first-snap/_layout_fsf.html" %}
+
+{% block fsf_content %}
+<div class="row">
+  {% if path.startswith("/first-snap-2") %}
+    <h4>Before you start, you'll need an ubuntu One account.</h4>
+    <p>Publish snaps to the store, gain access to a host of great features within <a href="/">snapcraft.io</a> such as your very own store listing page, publisher dashboard and snap usage metrics.</p>
+    <p class="u-no-margin--bottom"><a class="p-button--positive" href="/first-snap/{{ language }}/"><span class="p-link--external">Register/Sign in&hellip;</span></a></p>
+    <div class="row p-strip is-shallow">
+      <div class="col-4">
+        {{
+          image(
+            url="https://assets.ubuntu.com/v1/890afaac-2.jpg",
+            alt="",
+            width="257",
+            height="200",
+            hi_def=True,
+            loading="eager"
+          ) | safe
+        }}
+      </div>
+      <div class="col-4">
+        {{
+          image(
+            url="https://assets.ubuntu.com/v1/3220411b-fsf-publisher-dashboard.png",
+            alt="",
+            width="277",
+            height="200",
+            hi_def=True,
+            loading="eager"
+          ) | safe
+        }}
+      </div>
+      <div class="col-4">
+        {{
+          image(
+            url="https://assets.ubuntu.com/v1/f38dc980-3.jpg",
+            alt="",
+            width="284",
+            height="200",
+            hi_def=True,
+            loading="eager"
+          ) | safe
+        }}
+      </div>
+    </div>
+    <p>
+      {{ image (
+          url="https://assets.ubuntu.com/v1/a27e36a1-Screenshot+from+2021-01-26+13-45-29.png",
+          alt="",
+          width="479",
+          height="250",
+          hi_def=True,
+          loading="eager"
+          ) | safe
+      }}
+    </p>
+  {% elif path.startswith("/first-snap-3")%}
+    <h4>Let's build a snap together</h4>
+    <p>The next few steps will guide you to create a snap and publish it to the store. To get started, first create a developer account.</p>
+    <p>Creating a developer account enables you to publish a snap. Your account lets you trigger automatic builds, customize and see the popularity of your snap.</p>
+    <div class="row p-strip is-shallow">
+      <div class="col-4">
+        {{
+        image(
+          url="https://assets.ubuntu.com/v1/88571033-1.jpg",
+          alt="",
+          width="257",
+          height="200",
+          hi_def=True,
+          loading="eager"
+          ) | safe
+        }}
+        <p><small>Craft your snap’s yaml</small></p>
+      </div>
+      <div class="col-4">
+        {{
+          image(
+            url="https://assets.ubuntu.com/v1/890afaac-2.jpg",
+            alt="",
+            width="277",
+            height="200",
+            hi_def=True,
+            loading="eager"
+          ) | safe
+        }}
+        <p><small>Upload it to the store</small></p>
+      </div>
+      <div class="col-4">
+        {{
+          image(
+            url="https://assets.ubuntu.com/v1/f38dc980-3.jpg",
+            alt="",
+            width="284",
+            height="200",
+            hi_def=True,
+            loading="eager"
+          ) | safe
+        }}
+        <p><small>Monitor your snap’s growth</small></p>
+      </div>
+    </div>
+    <p class="u-no-margin--bottom"><a class="p-button--positive" href="/first-snap/{{ language }}/"><span class="p-link--external">Register/Sign in&hellip;</span></a></p>
+  {% endif %}
+</div>
+{% endblock %}
+

--- a/templates/first-snap/install-snapcraft.html
+++ b/templates/first-snap/install-snapcraft.html
@@ -39,9 +39,15 @@
 {% endblock %}
 
 {% block fsf_pagination %}
-  <a class="p-button--neutral" href="/first-snap/">
-    &lsaquo; Previous: Select language
-  </a>
+  {% if path.startswith("/first-snap-2") or path.startswith("/first-snap-3") %}
+    <a class="p-button--neutral" href="/first-snap/{{ language }}/create-account">
+      &lsaquo; Previous: Create account
+    </a>
+  {% else %}
+    <a class="p-button--neutral" href="/first-snap/">
+      &lsaquo; Previous: Select language
+    </a>
+  {% endif %}
 
   <a class="p-button--positive is-disabled u-float-right u-no-margin--right" id="js-pagination-next">
     Next: Package snap &rsaquo;

--- a/templates/first-snap/push.html
+++ b/templates/first-snap/push.html
@@ -2,12 +2,90 @@
 {% extends "first-snap/_layout_fsf.html" %}
 
 {% block fsf_content %}
+  {% if path.startswith("/first-snap-2") or path.startswith("/first-snap-3") %}
+  <div class="row">
+    <div class="p-accordion" role="tablist" aria-multiselect="true">
+      <ol class="p-accordion__list">
+        <li class="p-accordion__group">
+          <button {% if not user %}disabled aria-expanded="false" {% else %}aria-expanded="true" {% endif %} type="button" class="p-accordion__tab--with-title" id="tab2" role="tab" aria-controls="#tab2-section" aria-expanded="false">
+            <h4 class="p-accordion__title">
+              Step 1: Register your snap name
+              <i id="register-name-success" class="p-icon--success u-hide"></i>
+            </h4>
+          </button>
+          <section class="p-accordion__panel" id="tab2-section" role="tabpanel" {% if not user %}aria-hidden="true" {% else %}aria-hidden="false" {% endif %} aria-labelledby="tab2-section">
+            <div class="p-strip is-shallow">
+              <div class="row">
+                <div class="col-8">
+                  <form id="register-name-form">
+                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+                    <label>You must register snap name to be able to push your snap to the store.</label>
+                    <div class="p-form-validation">
+                      <input class="p-form-validation__input" type="text" name="snap-name" value="{{ snap_name }}" />
+                      <p class="p-form-validation__message" id="input-error-message-inline" role="alert">
+                        Name should only have lowercase letters, numbers, and hyphens, must have at least one letter, and cannot start or end with a hyphen.
+                      </p>
+                    </div>
+                    <div id="register-name-notification" class="p-notification--caution u-hide">
+                      <p class="p-notification__response">
+                        <span class="p-notification__status"></span>
+                        Make sure the name matches what has been used previously (i.e <code>{{ snap_name }}</code>)
+                      </p>
+                    </div>
+                    <button class="p-button--positive p-button-spinner" data-js="js-snap-name-register">
+                      <span class="p-button__spinner vanilla-workaround--dark">
+                        <i class="p-icon--spinner u-animation--spin"></i>
+                      </span>
+                      <span class="p-button__text">Register snap name</span>
+                    </button>
+                  </form>
+                </div>
+              </div>
+            </div>
+          </section>
+        </li>
+        <li class="p-accordion__group">
+          <button {% if not user %}disabled{% endif %} type="button" class="p-accordion__tab--with-title" id="tab3" role="tab" aria-controls="#tab3-section" aria-expanded="false">
+            <h4 class="p-accordion__title">
+              Step 2: Push to the Snap store
+            </h4>
+          </button>
+          <section class="p-accordion__panel" id="tab3-section" role="tabpanel" aria-hidden="true" aria-labelledby="tab3-section">
+            <div class="p-strip is-shallow">
+              <div class="row">
+                <div class="col-8">
+                  <p>Log in to snapcraft using your Ubuntu One account credentials:</p>
+                  {% set snippet_value = "snapcraft login" %}
+                  {% set snippet_id = "snapcraft-login" %}
+                  {% include "/partials/_code-snippet.html" %}
+
+                  <p>
+                    Once logged, you can push your snap to the store with following command:
+                  </p>
+                  {% set snippet_value = "snapcraft push --release edge *.snap" %}
+                  {% set snippet_id = "snapcraft-push" %}
+                  {% include "/partials/_code-snippet.html" %}
+
+                  <p>
+                    Once you've pushed to the Snap store, edit your snap public presentation.
+                  </p>
+                  <a class="p-button--neutral js-continue is-disabled">
+                    <i class="p-icon--spinner u-animation--spin"></i>
+                    &nbsp;Waiting for push...</a>
+                </div>
+              </div>
+            </div>
+          </section>
+        </li>
+      </ol>
+    </div>
+  </div>
+  {% else %}
   <div class="p-strip is-shallow u-no-padding--top">
     <div class="row">
       <h4>Before you publish your snap, you'll need an Ubuntu One account</h4>
       <p>Gain access to a host of great features within snapcraft.io such as your very own store listing page, publisher dashboard and snap usage metrics.</p>
     </div>
-
     <div class="row">
       <div class="col-4 col-small-1 col-medium-2">
         <img height="193" width="308" src="https://assets.ubuntu.com/v1/e3eacb56-fsf-publisher-listing.png" />
@@ -20,7 +98,6 @@
       </div>
     </div>
   </div>
-
   <div class="row">
     <div class="p-accordion" role="tablist" aria-multiselect="true">
       <ol class="p-accordion__list">
@@ -121,6 +198,7 @@
       </ol>
     </div>
   </div>
+  {% endif %}
 {% endblock %}
 
 {% block fsf_pagination %}

--- a/templates/home/_fsf_c.html
+++ b/templates/home/_fsf_c.html
@@ -12,7 +12,7 @@
 
       <div class="p-flow-details__continue">
         <p>In just a few steps, you’ll have an example C/C++ app in the Snap Store.</p>
-        <a class="p-button--positive" href="/first-snap/c">Continue &rsaquo;</a>
+        <a class="p-button--positive" href="/first-snap/c/create-account">Continue &rsaquo;</a>
       </div>
     </div>
 

--- a/templates/home/_fsf_flutter.html
+++ b/templates/home/_fsf_flutter.html
@@ -12,7 +12,7 @@
 
       <div class="p-flow-details__continue">
         <p>In just a few steps, you’ll have an example Flutter app in the Snap Store.</p>
-        <a class="p-button--positive" href="/first-snap/flutter">Continue &rsaquo;</a>
+        <a class="p-button--positive" href="/first-snap/flutter/create-account">Continue &rsaquo;</a>
       </div>
     </div>
 

--- a/templates/home/_fsf_go.html
+++ b/templates/home/_fsf_go.html
@@ -15,7 +15,7 @@
 
       <div class="p-flow-details__continue">
         <p>In just a few steps, you’ll have an example Go app in the Snap Store.</p>
-        <a class="p-button--positive" href="/first-snap/golang">Continue &rsaquo;</a>
+        <a class="p-button--positive" href="/first-snap/golang/create-account">Continue &rsaquo;</a>
       </div>
     </div>
 

--- a/templates/home/_fsf_java.html
+++ b/templates/home/_fsf_java.html
@@ -10,7 +10,7 @@
 
       <div class="p-flow-details__continue">
         <p>In just a few steps, you’ll have an example Java app in the Snap Store.</p>
-        <a class="p-button--positive" href="/first-snap/java">Continue &rsaquo;</a>
+        <a class="p-button--positive" href="/first-snap/java/create-account">Continue &rsaquo;</a>
       </div>
     </div>
 

--- a/templates/home/_fsf_moos.html
+++ b/templates/home/_fsf_moos.html
@@ -10,7 +10,7 @@
       </ul>
       <div class="p-flow-details__continue">
         <p>In just a few steps, you’ll have an example MOOS app in the Snap Store.</p>
-        <a class="p-button--positive" href="/first-snap/moos">Continue &rsaquo;</a>
+        <a class="p-button--positive" href="/first-snap/moos/create-account">Continue &rsaquo;</a>
       </div>
     </div>
 

--- a/templates/home/_fsf_node.html
+++ b/templates/home/_fsf_node.html
@@ -10,7 +10,7 @@
       <p>With npm you can distribute apps to other developers, but it’s not tailored to end users. Snaps let you distribute your Node app in an app store experience.</p>
       <div class="p-flow-details__continue">
         <p>In just a few steps, you’ll have an example Node.js app in the Snap Store.</p>
-        <a class="p-button--positive" href="/first-snap/node">Continue &rsaquo;</a>
+        <a class="p-button--positive" href="/first-snap/node/create-account">Continue &rsaquo;</a>
       </div>
     </div>
 

--- a/templates/home/_fsf_pre-built.html
+++ b/templates/home/_fsf_pre-built.html
@@ -16,7 +16,7 @@
       </p>
       <div class="p-flow-details__continue">
         <p>In just a few steps, you’ll have an example pre-built app in the Snap Store.</p>
-        <a class="p-button--positive" href="/first-snap/pre-built">Continue &rsaquo;</a>
+        <a class="p-button--positive" href="/first-snap/pre-built/create-account">Continue &rsaquo;</a>
       </div>
     </div>
 

--- a/templates/home/_fsf_python.html
+++ b/templates/home/_fsf_python.html
@@ -16,7 +16,7 @@
       </p>
       <div class="p-flow-details__continue">
         <p>In just a few steps, you’ll have an example Python app in the Snap Store.</p>
-        <a class="p-button--positive" href="/first-snap/python">Continue &rsaquo;</a>
+        <a class="p-button--positive" href="/first-snap/python/create-account">Continue &rsaquo;</a>
       </div>
     </div>
 

--- a/templates/home/_fsf_ros.html
+++ b/templates/home/_fsf_ros.html
@@ -10,7 +10,7 @@
       </ul>
       <div class="p-flow-details__continue">
         <p>In just a few steps, you’ll have an example ROS app in the Snap Store.</p>
-        <a class="p-button--positive" href="/first-snap/ros">Continue &rsaquo;</a>
+        <a class="p-button--positive" href="/first-snap/ros/create-account">Continue &rsaquo;</a>
       </div>
     </div>
 

--- a/templates/home/_fsf_ros2.html
+++ b/templates/home/_fsf_ros2.html
@@ -10,7 +10,7 @@
       </ul>
       <div class="p-flow-details__continue">
         <p>In just a few steps, you’ll have an example ROS2 app in the Snap Store.</p>
-        <a class="p-button--positive" href="/first-snap/ros2">Continue &rsaquo;</a>
+        <a class="p-button--positive" href="/first-snap/ros2/create-account">Continue &rsaquo;</a>
       </div>
     </div>
 

--- a/templates/home/_fsf_ruby.html
+++ b/templates/home/_fsf_ruby.html
@@ -12,7 +12,7 @@
 
       <div class="p-flow-details__continue">
         <p>In just a few steps, you’ll have an example Ruby app in the Snap Store.</p>
-        <a class="p-button--positive" href="/first-snap/ruby">Continue &rsaquo;</a>
+        <a class="p-button--positive" href="/first-snap/ruby/create-account">Continue &rsaquo;</a>
       </div>
     </div>
 

--- a/templates/home/_fsf_rust.html
+++ b/templates/home/_fsf_rust.html
@@ -11,7 +11,7 @@
 
       <div class="p-flow-details__continue">
         <p>In just a few steps, you’ll have an example Rust app in the Snap Store.</p>
-        <a class="p-button--positive" href="/first-snap/rust">Continue &rsaquo;</a>
+        <a class="p-button--positive" href="/first-snap/rust/create-account">Continue &rsaquo;</a>
       </div>
     </div>
 

--- a/webapp/first_snap/views.py
+++ b/webapp/first_snap/views.py
@@ -60,6 +60,11 @@ def get_language(language):
     )
 
 
+@first_snap.route("/<language>/create-account")
+def create_account(language):
+    return flask.redirect(f"/first-snap/{language}")
+
+
 @first_snap.route("/<language>/snapcraft.yaml")
 def get_language_snapcraft_yaml(language):
     filename = f"first_snap/content/{language}/package.yaml"

--- a/webapp/first_snap/views_2.py
+++ b/webapp/first_snap/views_2.py
@@ -45,13 +45,11 @@ def directory_exists(file):
 
 
 @first_snap_2.route("/")
-@login_required
 def get_pick_language():
     return flask.render_template("first-snap/language.html")
 
 
 @first_snap_2.route("/<language>")
-@login_required
 def get_language(language):
     filename = f"first_snap/content/{language}"
     if not directory_exists(filename):
@@ -61,6 +59,13 @@ def get_language(language):
     return flask.render_template(
         "first-snap/install-snapcraft.html", **context
     )
+
+
+@first_snap_2.route("/<language>/create-account")
+@login_required
+def create_account(language):
+    context = {"language": language}
+    return flask.render_template("first-snap/create-account.html", **context)
 
 
 @first_snap_2.route("/<language>/snapcraft.yaml")

--- a/webapp/first_snap/views_3.py
+++ b/webapp/first_snap/views_3.py
@@ -45,13 +45,11 @@ def directory_exists(file):
 
 
 @first_snap_3.route("/")
-@login_required
 def get_pick_language():
     return flask.render_template("first-snap/language.html")
 
 
 @first_snap_3.route("/<language>")
-@login_required
 def get_language(language):
     filename = f"first_snap/content/{language}"
     if not directory_exists(filename):
@@ -61,6 +59,13 @@ def get_language(language):
     return flask.render_template(
         "first-snap/install-snapcraft.html", **context
     )
+
+
+@first_snap_3.route("/<language>/create-account")
+@login_required
+def create_account(language):
+    context = {"language": language}
+    return flask.render_template("first-snap/create-account.html", **context)
 
 
 @first_snap_3.route("/<language>/snapcraft.yaml")


### PR DESCRIPTION
## Done
- _Update content for ABC testing._
- _Redirect `/first/snap/<language>/create-account` to `/first/snap/<language>`_

## How to QA
- Visit the demo in your browser at https://snapcraft-io-3354.demos.haus
  - Or you can run the project locally using the [dotrun](https://snapcraft.io/dotrun) snap with `$ dotrun` and view it in your web browser at: http://0.0.0.0:8004/
  - If your demo doesn't work, read more about the [demoservice](https://discourse.ubuntu.com/t/demoservice/16862)
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Go to https://snapcraft-io-3354.demos.haus and select "python" from FSF and click continue. It should take you to https://snapcraft-io-3354.demos.haus/first-snap/python
- Go to https://snapcraft-io-3354.demos.haus/first-snap-2/python/create-account and compare to [design](https://app.zeplin.io/project/601000b327cc222b78024e00/screen/601001579046d20e25bec27d)
- Go to https://snapcraft-io-3354.demos.haus/first-snap-3/python/create-account and compare to [design](https://app.zeplin.io/project/601000b327cc222b78024e00/screen/60100157d6838d0b067913d7)
- Log out from your account, go to https://snapcraft-io-3354.demos.haus/first-snap-2/python and see that you will be asked to log in before you get to that page
- Log out from your account, go to https://snapcraft-io-3354.demos.haus/first-snap-3/python and see that you will be asked to log in before you get to that page

## Issue / Card
Fixes https://github.com/canonical-web-and-design/snap-squad/issues/1762

## Screenshots
[if relevant, include a screenshot]
