### PR TITLE
Fix ga sentry erros

### DIFF
--- a/static/js/base/ga.js
+++ b/static/js/base/ga.js
@@ -25,7 +25,7 @@ function triggerEvent(category, from, to, label) {
     dataLayer.push({
       event: "GAEvent",
       eventCategory: `${categoryPrefix}${category}`,
-      eventAction: `from:${origin} to:${to}`,
+      eventAction: `from:${from} to:${to}`,
       eventLabel: label,
       eventValue: undefined,
     });

--- a/templates/first-snap/_layout_fsf.html
+++ b/templates/first-snap/_layout_fsf.html
@@ -16,22 +16,6 @@
   {% endif %}
 {% endblock %}
 
-{% block scripts_modules %}
-  <script src="{{ static_url('js/modules/clipboard.min.js') }}" defer></script>
-{% endblock %}
-
 {% block scripts_includes %}
   <script src="{{ static_url('js/dist/fsf.js') }}" defer></script>
-{% endblock %}
-
-{% block scripts %}
-  <script>
-    window.addEventListener("DOMContentLoaded", function() {
-      Raven.context(function() {
-        if (typeof ClipboardJS !== 'undefined') {
-          new ClipboardJS('.js-clipboard-copy');
-        }
-      });
-    });
-  </script>
 {% endblock %}

--- a/templates/partials/_code-snippet.html
+++ b/templates/partials/_code-snippet.html
@@ -1,3 +1,3 @@
 <div class="p-code-snippet">
-  <pre class="p-code-snippet__block--icon is-wrapped"><code>{{ snippet_value }}</code></pre>
+  <pre class="p-code-snippet__block--icon is-wrapped"><code {% if snippet_id %}id="snippet-{{ snippet_id }}"{% endif %}>{{ snippet_value }}</code></pre>
 </div>

--- a/templates/store/snap-distro-install.html
+++ b/templates/store/snap-distro-install.html
@@ -162,6 +162,7 @@
             {% if step.command %}
               <div class="col-5 distro-code-snippet">
                 {% set snippet_value = step.command %}
+                {% set snippet_id = "distro-install-command-" + loop.index|string %}
                 {% include "/partials/_code-snippet.html" %}
               </div>
             {% endif %}
@@ -181,6 +182,7 @@
                   default_track,
                   lowest_risk_available,
                   confinement) %}
+            {% set snippet_id = "snap-install-stable" %}
             {% include "/partials/_code-snippet.html" %}
           </div>
         </div>


### PR DESCRIPTION
## Done
- _Fix GA scroll event sentry errors._

## How to QA
- Visit the demo in your browser, link commented below
  - Or you can run the project locally using the [dotrun](https://snapcraft.io/dotrun) snap with `$ dotrun` and view it in your web browser at: http://0.0.0.0:8004/
  - If your demo doesn't work, read more about the [demoservice](https://discourse.ubuntu.com/t/demoservice/16862)
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- There is no way to QA it on demo

## Issue / Card
Fixes #

## Screenshots
[if relevant, include a screenshot]
