### PR TITLE
Throw error when ga-scroll element does not exist

### DIFF
--- a/static/js/public/ga-scroll-event.js
+++ b/static/js/public/ga-scroll-event.js
@@ -17,28 +17,32 @@ export default function triggerEventWhenVisible(selector) {
   const el = document.querySelector(selector);
   const origin = window.location.href;
 
-  if (isInViewport(el)) {
-    triggerEvent(
-      "element-visible",
-      origin,
-      selector,
-      `Element visible on screen: ${selector}`
-    );
+  if (el) {
+    if (isInViewport(el)) {
+      triggerEvent(
+        "element-visible",
+        origin,
+        selector,
+        `Element visible on screen: ${selector}`
+      );
+    } else {
+      let triggered = false;
+      window.addEventListener(
+        "scroll",
+        debounce(() => {
+          if (!triggered && isInViewport(el)) {
+            triggerEvent(
+              "element-visible",
+              origin,
+              selector,
+              `Element visible on screen: ${selector}`
+            );
+            triggered = true;
+          }
+        }, 500)
+      );
+    }
   } else {
-    let triggered = false;
-    window.addEventListener(
-      "scroll",
-      debounce(() => {
-        if (!triggered && isInViewport(el)) {
-          triggerEvent(
-            "element-visible",
-            origin,
-            selector,
-            `Element visible on screen: ${selector}`
-          );
-          triggered = true;
-        }
-      }, 500)
-    );
+    throw new Error(`${selector} does not exist`);
   }
 }


### PR DESCRIPTION
## Done
- _Fix https://sentry.is.canonical.com/canonical/snapcraft-io/issues/15743/_
- _Throw error console if the ga-scroll element does not exist._

## How to QA
- Visit the demo in your browser, link commented below
  - Or you can run the project locally using the [dotrun](https://snapcraft.io/dotrun) snap with `$ dotrun` and view it in your web browser at: http://0.0.0.0:8004/install/dbeaver-ce/manjaro
  - If your demo doesn't work, read more about the [demoservice](https://discourse.ubuntu.com/t/demoservice/16862)
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Open the console and see there is no error

## Issue / Card
Fixes #3356 

## Screenshots
[if relevant, include a screenshot]
