### PR TITLE
Show built at time for launchpad builds

### DIFF
--- a/static/js/publisher/release/components/releasesTable/channelHeading.js
+++ b/static/js/publisher/release/components/releasesTable/channelHeading.js
@@ -240,7 +240,7 @@ const ReleasesTableChannelHeading = (props) => {
       channelVersion = "Multiple versions";
     }
 
-    isLaunchpadBuild = Object.keys(buildMap).length === 1;
+    isLaunchpadBuild = Object.keys(buildMap).length > 0;
     if (isLaunchpadBuild) {
       channelBuild = Object.keys(buildMap)[0];
       channelBuildDate =


### PR DESCRIPTION
## Done
Show "Built at" time for launchpad builds

## QA
- Go to https://snapcraft-io-3360.demos.haus/toto-fran/releases
- Click the launchpad tab under the "Revisions available to release" heading
- Click the gear icon and promote to one of the channels
- Hover over the first cell for the updated channel and check that you can see a "Built at" time

## Issue
Fixes #2985 