### PR TITLE
Fix misplaced page title on snaps admin page

### DIFF
--- a/templates/admin/snaps.html
+++ b/templates/admin/snaps.html
@@ -1,8 +1,8 @@
 {% set current_tab = "snaps" %}
 
-{% block meta_title %}Manage snaps in {{ store.name }} | Snapcraft{% endblock %}
-
 {% extends "/admin/admin_layout.html" %}
+
+{% block meta_title %}Manage snaps in {{ store.name }} | Snapcraft{% endblock %}
 
 {% block admin_content %}
 {% include "/admin/_snaps_section.html" %}


### PR DESCRIPTION
## Done
Fixed misplaced title on snaps admin page

## QA
- Go to https://snapcraft-io-3363.demos.haus/admin
- Check that there is no page title above the global nav (compare to https://snapcraft.io/admin)

## Issue
Fixes #3362 