### PR TITLE
Fix word break in code element

### DIFF
--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -365,3 +365,9 @@ dl {
 .p-code-snippet__block.is-wrapped {
   white-space: pre-wrap;
 }
+
+// Vanilla bug: https://github.com/canonical-web-and-design/vanilla-framework/issues/3526
+code {
+  white-space: pre;
+  word-break: normal;
+}


### PR DESCRIPTION
## Done
Fix the word breaking in the `code` element as it makes commands hard to read/understand.

## QA
- Go to https://snapcraft-io-3378.demos.haus/docs/snapcraft-overview
- Find `snapcraft --debug` in the page
- Check that the words and lines are not wrapping

## Issue
Fixes #3377 