### PR TITLE
Fix tooltip on release page contextual menu

### DIFF
--- a/static/js/publisher/release/components/channelMenu.js
+++ b/static/js/publisher/release/components/channelMenu.js
@@ -29,7 +29,7 @@ export default class ChannelMenu extends Component {
     return (
       <span
         key={`promote-to-${channel}`}
-        className="p-tooltip p-tooltip--btm-center"
+        className="p-tooltip p-tooltip--right"
       >
         <span
           className={className}


### PR DESCRIPTION
## Done
Changed position of tooltip on releases contextual menu so it doesn't overlap actions

## QA
- Go to https://snapcraft-io-3379.demos.haus/<snap-name>/releases
- Click the gear icon on one of the tables
- Hover one of the disabled items within 
- Check that the tooltip is positioned to the right and not covering any of the links in the menu

## Issue
Fixes #3366