### PR TITLE
Add collaborators col to snaps table

### DIFF
--- a/templates/admin/_snaps_section.html
+++ b/templates/admin/_snaps_section.html
@@ -14,14 +14,22 @@
       <td rowspan="{{ snaps | length }}">{{ store.name }}</td>
       <td>{{ snaps[0].name }}</td>
       <td>-</td>
-      <td>-</td>
+      <td>
+        {% for user in snaps[0].users %}
+          {{ user.displayname }}
+        {% endfor %}
+      </td>
     </tr>
     {% for snap in snaps %}
       {% if loop.index > 1 %}
         <tr>
           <td>{{ snap.name }}</td>
           <td>-</td>
-          <td>-</td>
+          <td>
+            {% for user in snap.users %}
+              {{ user.displayname }}{% if not loop.last %},{% endif %}
+            {% endfor %}
+          </td>
         </tr>
       {% endif %}
     {% endfor %}


### PR DESCRIPTION
## Done
Added collaborators column to the snaps table in the admin pages

## QA
- Go to https://snapcraft-io-3381.demos.haus/admin
- Check that the snaps table has a collaborators column which has a comma delimited list of users

## Issue
Fixes #3370 