### PR TITLE
Add latest release data to snaps admin table

### DIFF
--- a/templates/admin/_snaps_section.html
+++ b/templates/admin/_snaps_section.html
@@ -13,7 +13,16 @@
     <tr>
       <td rowspan="{{ snaps | length }}">{{ store.name }}</td>
       <td>{{ snaps[0].name }}</td>
-      <td>-</td>
+      <td>
+        {% if snaps[0]["latest-release"].channel %}
+          <div>
+            latest/{{ snaps[0]["latest-release"].channel }} {{ snaps[0]["latest-release"].version }}
+          </div>
+          <div>
+            <small>{{ format_date(snaps[0]["latest-release"].timestamp, "%d %B %Y") }}</small>
+          </div>
+        {% endif %}
+      </td>
       <td>
         {% for user in snaps[0].users %}
           {{ user.displayname }}
@@ -24,7 +33,18 @@
       {% if loop.index > 1 %}
         <tr>
           <td>{{ snap.name }}</td>
-          <td>-</td>
+          <td>
+            {% if snap["latest-release"].channel %}
+              <div>
+                latest/{{ snap["latest-release"].channel }} {{ snap["latest-release"].version }}
+              </div>
+              <div>
+                <small>{{ format_date(snap["latest-release"].timestamp, "%d %B %Y") }}</small>
+              </div>
+            {% else %}
+              -
+            {% endif %}
+          </td>
           <td>
             {% for user in snap.users %}
               {{ user.displayname }}{% if not loop.last %},{% endif %}

--- a/tests/tests_templates_utils.py
+++ b/tests/tests_templates_utils.py
@@ -96,3 +96,9 @@ class TemplateUtilsTest(unittest.TestCase):
     def test_static_url(self):
         result = template_utils.static_url("images/rocket.png")
         self.assertEqual(result, "/static/images/rocket.png?v=7d7c26f")
+
+    def test_format_date(self):
+        result = template_utils.format_date(
+            "2019-09-02T09:27:58.930567+00:00", "%d %B %Y"
+        )
+        self.assertEquals(result, "02 September 2019")

--- a/webapp/handlers.py
+++ b/webapp/handlers.py
@@ -68,6 +68,7 @@ def set_handlers(app):
             "format_number": template_utils.format_number,
             "display_name": template_utils.display_name,
             "install_snippet": template_utils.install_snippet,
+            "format_date": template_utils.format_date,
             "image": image_template,
         }
 

--- a/webapp/template_utils.py
+++ b/webapp/template_utils.py
@@ -2,6 +2,8 @@
 import hashlib
 import os
 
+from dateutil import parser
+
 
 # generator functions for templates
 def generate_slug(path):
@@ -118,3 +120,12 @@ def display_name(display_name, username):
         return display_name
     else:
         return f"{display_name} ({username})"
+
+
+def format_date(timestamp, format):
+    """Template function that returns a formatted date
+    based on the given timestamp
+    """
+    datestring = parser.parse(timestamp)
+
+    return datestring.strftime(format)


### PR DESCRIPTION
## Done
Added the latest release data to the snaps admin table

## QA
- Go to https://snapcraft-io-3384.demos.haus/admin
- Check that there is a latest releases column in the snaps table and that it is populated

## Issue
Fixes #3368 