### PR TITLE
Make fsf links persistent with the fsf ABC test option

### DIFF
--- a/static/js/public/first-snap-flow.js
+++ b/static/js/public/first-snap-flow.js
@@ -4,7 +4,7 @@ import "whatwg-fetch";
 
 import { toggleAccordion } from "./accordion";
 
-function install(language) {
+function install(language, fsfFlow) {
   const osPickers = Array.from(document.querySelectorAll(".js-os-select"));
   const osWrappers = Array.from(document.querySelectorAll(".js-os-wrapper"));
 
@@ -23,7 +23,7 @@ function install(language) {
       const paginationBtn = document.querySelector(`#js-pagination-next`);
       if (paginationBtn) {
         paginationBtn.classList.remove("is-disabled");
-        paginationBtn.href = `/first-snap/${language}/${selectedOs}/package`;
+        paginationBtn.href = `/${fsfFlow}/${language}/${selectedOs}/package`;
       }
     }
   }
@@ -87,7 +87,7 @@ function install(language) {
     const paginationBtn = document.querySelector(`#js-pagination-next`);
     if (paginationBtn) {
       paginationBtn.classList.remove("is-disabled");
-      paginationBtn.href = `/first-snap/${language}/${type}/package`;
+      paginationBtn.href = `/${fsfFlow}/${language}/${type}/package`;
     }
   }
 

--- a/templates/first-snap/_breadcrumb.html
+++ b/templates/first-snap/_breadcrumb.html
@@ -11,7 +11,7 @@
       {% if path.startswith("/first-snap-2") or path.startswith("/first-snap-3") %}
         <li class="p-breadcrumbs__item">
           {% if fsf_step in ['install', 'package', 'build_and_test', 'push']  %}
-            <a href="/first-snap/{{ language }}/create-account">Create an account</a>
+            <a href="/{{ fsf_flow }}/{{ language }}/create-account">Create an account</a>
           {% else %}
             Create an account
           {% endif %}
@@ -19,7 +19,7 @@
       {% endif %}
       <li class="p-breadcrumbs__item{% if fsf_step in ['language', 'create_account'] %} is-disabled{% endif %}">
         {% if fsf_step in ['package', 'build_and_test', 'push'] %}
-          <a href="/first-snap/{{ language }}">Install Snapcraft</a>
+          <a href="/{{ fsf_flow }}/{{ language }}">Install Snapcraft</a>
         {% else %}
           Install Snapcraft
         {% endif %}
@@ -28,21 +28,21 @@
         {% if fsf_step in ['language', 'create_account', 'install', 'package'] %}
           Package snap
         {% else %}
-          <a href="/first-snap/{{ language }}/{{ os }}/package">Package snap</a>
+          <a href="/{{ fsf_flow }}/{{ language }}/{{ os }}/package">Package snap</a>
         {% endif %}
       </li>
       <li class="p-breadcrumbs__item{% if fsf_step in ['language', 'create_account', 'install'] %} is-disabled{% endif %}">
         {% if fsf_step in ['language', 'create_account', 'install', 'build_and_test'] %}
           Build & test snap
         {% else %}
-          <a href="/first-snap/{{ language }}/{{ os }}/build-and-test">Build & test snap</a>
+          <a href="/{{ fsf_flow }}/{{ language }}/{{ os }}/build-and-test">Build & test snap</a>
         {% endif %}
       </li>
       <li class="p-breadcrumbs__item{% if fsf_step in ['language', 'create_account', 'install'] %} is-disabled{% endif %}">
         {% if fsf_step in ['language', 'create_account', 'install', 'push'] %}
           Publish to store
         {% else %}
-          <a href="/first-snap/{{ language }}/{{ os }}/push">Publish to store</a>
+          <a href="/{{ fsf_flow }}/{{ language }}/{{ os }}/push">Publish to store</a>
         {% endif %}
       </li>
     </ul>

--- a/templates/first-snap/build-and-test.html
+++ b/templates/first-snap/build-and-test.html
@@ -101,11 +101,11 @@
 {% endblock %}
 
 {% block fsf_pagination %}
-  <a class="p-button--neutral" href="/first-snap/{{ language }}/{{ os }}/package">
+  <a class="p-button--neutral" href="/{{ fsf_flow }}/{{ language }}/{{ os }}/package">
     &lsaquo; Previous: Package snap
   </a>
 
-  <a class="p-button--positive u-float-right u-no-margin--right" href="/first-snap/{{ language }}/{{ os }}/push">
+  <a class="p-button--positive u-float-right u-no-margin--right" href="/{{ fsf_flow }}/{{ language }}/{{ os }}/push">
     Next: Publish to store &rsaquo;
   </a>
 {% endblock %}

--- a/templates/first-snap/create-account.html
+++ b/templates/first-snap/create-account.html
@@ -6,7 +6,7 @@
   {% if path.startswith("/first-snap-2") %}
     <h4>Before you start, you'll need an ubuntu One account.</h4>
     <p>Publish snaps to the store, gain access to a host of great features within <a href="/">snapcraft.io</a> such as your very own store listing page, publisher dashboard and snap usage metrics.</p>
-    <p class="u-no-margin--bottom"><a class="p-button--positive" href="/first-snap/{{ language }}/"><span class="p-link--external">Register/Sign in&hellip;</span></a></p>
+    <p class="u-no-margin--bottom"><a class="p-button--positive" href="/{{ fsf_flow }}/{{ language }}/"><span class="p-link--external">Register/Sign in&hellip;</span></a></p>
     <div class="row p-strip is-shallow">
       <div class="col-4">
         {{
@@ -101,7 +101,7 @@
         <p><small>Monitor your snap’s growth</small></p>
       </div>
     </div>
-    <p class="u-no-margin--bottom"><a class="p-button--positive" href="/first-snap/{{ language }}/"><span class="p-link--external">Register/Sign in&hellip;</span></a></p>
+    <p class="u-no-margin--bottom"><a class="p-button--positive" href="/{{ fsf_flow }}/{{ language }}/"><span class="p-link--external">Register/Sign in&hellip;</span></a></p>
   {% endif %}
 </div>
 {% endblock %}

--- a/templates/first-snap/install-snapcraft.html
+++ b/templates/first-snap/install-snapcraft.html
@@ -40,11 +40,11 @@
 
 {% block fsf_pagination %}
   {% if path.startswith("/first-snap-2") or path.startswith("/first-snap-3") %}
-    <a class="p-button--neutral" href="/first-snap/{{ language }}/create-account">
+    <a class="p-button--neutral" href="/{{ fsf_flow }}/{{ language }}/create-account">
       &lsaquo; Previous: Create account
     </a>
   {% else %}
-    <a class="p-button--neutral" href="/first-snap/">
+    <a class="p-button--neutral" href="/{{ fsf_flow }}/">
       &lsaquo; Previous: Select language
     </a>
   {% endif %}
@@ -58,7 +58,7 @@
   <script>
     window.addEventListener("DOMContentLoaded", function() {
       Raven.context(function() {
-        snapcraft.public.fsf.firstSnapFlow.install({{ language|tojson }});
+        snapcraft.public.fsf.firstSnapFlow.install({{ language|tojson }}, "{{ fsf_flow }}");
       });
     });
   </script>

--- a/templates/first-snap/package.html
+++ b/templates/first-snap/package.html
@@ -66,11 +66,11 @@
 {% endblock %}
 
 {% block fsf_pagination %}
-  <a class="p-button--neutral" href="/first-snap/{{ language }}">
+  <a class="p-button--neutral" href="/{{ fsf_flow }}/{{ language }}">
     &lsaquo; Previous: Install Snapcraft
   </a>
 
-  <a class="p-button--positive u-float-right u-no-margin--right" href="/first-snap/{{ language }}/{{ os }}/build-and-test">
+  <a class="p-button--positive u-float-right u-no-margin--right" href="/{{ fsf_flow }}/{{ language }}/{{ os }}/build-and-test">
     Next: Build &amp; test snap &rsaquo;
   </a>
 {% endblock %}

--- a/templates/first-snap/push.html
+++ b/templates/first-snap/push.html
@@ -200,7 +200,7 @@
 {% endblock %}
 
 {% block fsf_pagination %}
-  <a class="p-button--neutral" href="/first-snap/{{ language }}/{{ os }}/build-and-test" aria-label="Previous: Build & test snap">
+  <a class="p-button--neutral" href="/{{ fsf_flow }}/{{ language }}/{{ os }}/build-and-test" aria-label="Previous: Build & test snap">
     &lsaquo; Build &amp; test snap
   </a>
 

--- a/templates/home/_fsf_c.html
+++ b/templates/home/_fsf_c.html
@@ -12,7 +12,7 @@
 
       <div class="p-flow-details__continue">
         <p>In just a few steps, you’ll have an example C/C++ app in the Snap Store.</p>
-        <a class="p-button--positive" href="/first-snap/c/create-account">Continue &rsaquo;</a>
+        <a class="p-button--positive" href="/first-snap/c/">Continue &rsaquo;</a>
       </div>
     </div>
 

--- a/templates/home/_fsf_flutter.html
+++ b/templates/home/_fsf_flutter.html
@@ -12,7 +12,7 @@
 
       <div class="p-flow-details__continue">
         <p>In just a few steps, you’ll have an example Flutter app in the Snap Store.</p>
-        <a class="p-button--positive" href="/first-snap/flutter/create-account">Continue &rsaquo;</a>
+        <a class="p-button--positive" href="/first-snap/flutter/">Continue &rsaquo;</a>
       </div>
     </div>
 

--- a/templates/home/_fsf_go.html
+++ b/templates/home/_fsf_go.html
@@ -15,7 +15,7 @@
 
       <div class="p-flow-details__continue">
         <p>In just a few steps, you’ll have an example Go app in the Snap Store.</p>
-        <a class="p-button--positive" href="/first-snap/golang/create-account">Continue &rsaquo;</a>
+        <a class="p-button--positive" href="/first-snap/golang/">Continue &rsaquo;</a>
       </div>
     </div>
 

--- a/templates/home/_fsf_java.html
+++ b/templates/home/_fsf_java.html
@@ -10,7 +10,7 @@
 
       <div class="p-flow-details__continue">
         <p>In just a few steps, you’ll have an example Java app in the Snap Store.</p>
-        <a class="p-button--positive" href="/first-snap/java/create-account">Continue &rsaquo;</a>
+        <a class="p-button--positive" href="/first-snap/java/">Continue &rsaquo;</a>
       </div>
     </div>
 

--- a/templates/home/_fsf_moos.html
+++ b/templates/home/_fsf_moos.html
@@ -10,7 +10,7 @@
       </ul>
       <div class="p-flow-details__continue">
         <p>In just a few steps, you’ll have an example MOOS app in the Snap Store.</p>
-        <a class="p-button--positive" href="/first-snap/moos/create-account">Continue &rsaquo;</a>
+        <a class="p-button--positive" href="/first-snap/moos/">Continue &rsaquo;</a>
       </div>
     </div>
 

--- a/templates/home/_fsf_node.html
+++ b/templates/home/_fsf_node.html
@@ -10,7 +10,7 @@
       <p>With npm you can distribute apps to other developers, but it’s not tailored to end users. Snaps let you distribute your Node app in an app store experience.</p>
       <div class="p-flow-details__continue">
         <p>In just a few steps, you’ll have an example Node.js app in the Snap Store.</p>
-        <a class="p-button--positive" href="/first-snap/node/create-account">Continue &rsaquo;</a>
+        <a class="p-button--positive" href="/first-snap/node/">Continue &rsaquo;</a>
       </div>
     </div>
 

--- a/templates/home/_fsf_pre-built.html
+++ b/templates/home/_fsf_pre-built.html
@@ -16,7 +16,7 @@
       </p>
       <div class="p-flow-details__continue">
         <p>In just a few steps, you’ll have an example pre-built app in the Snap Store.</p>
-        <a class="p-button--positive" href="/first-snap/pre-built/create-account">Continue &rsaquo;</a>
+        <a class="p-button--positive" href="/first-snap/pre-built/">Continue &rsaquo;</a>
       </div>
     </div>
 

--- a/templates/home/_fsf_python.html
+++ b/templates/home/_fsf_python.html
@@ -16,7 +16,7 @@
       </p>
       <div class="p-flow-details__continue">
         <p>In just a few steps, you’ll have an example Python app in the Snap Store.</p>
-        <a class="p-button--positive" href="/first-snap/python/create-account">Continue &rsaquo;</a>
+        <a class="p-button--positive" href="/first-snap/python/">Continue &rsaquo;</a>
       </div>
     </div>
 

--- a/templates/home/_fsf_ros.html
+++ b/templates/home/_fsf_ros.html
@@ -10,7 +10,7 @@
       </ul>
       <div class="p-flow-details__continue">
         <p>In just a few steps, you’ll have an example ROS app in the Snap Store.</p>
-        <a class="p-button--positive" href="/first-snap/ros/create-account">Continue &rsaquo;</a>
+        <a class="p-button--positive" href="/first-snap/ros/">Continue &rsaquo;</a>
       </div>
     </div>
 

--- a/templates/home/_fsf_ros2.html
+++ b/templates/home/_fsf_ros2.html
@@ -10,7 +10,7 @@
       </ul>
       <div class="p-flow-details__continue">
         <p>In just a few steps, you’ll have an example ROS2 app in the Snap Store.</p>
-        <a class="p-button--positive" href="/first-snap/ros2/create-account">Continue &rsaquo;</a>
+        <a class="p-button--positive" href="/first-snap/ros2/">Continue &rsaquo;</a>
       </div>
     </div>
 

--- a/templates/home/_fsf_ruby.html
+++ b/templates/home/_fsf_ruby.html
@@ -12,7 +12,7 @@
 
       <div class="p-flow-details__continue">
         <p>In just a few steps, you’ll have an example Ruby app in the Snap Store.</p>
-        <a class="p-button--positive" href="/first-snap/ruby/create-account">Continue &rsaquo;</a>
+        <a class="p-button--positive" href="/first-snap/ruby/">Continue &rsaquo;</a>
       </div>
     </div>
 

--- a/templates/home/_fsf_rust.html
+++ b/templates/home/_fsf_rust.html
@@ -11,7 +11,7 @@
 
       <div class="p-flow-details__continue">
         <p>In just a few steps, you’ll have an example Rust app in the Snap Store.</p>
-        <a class="p-button--positive" href="/first-snap/rust/create-account">Continue &rsaquo;</a>
+        <a class="p-button--positive" href="/first-snap/rust/">Continue &rsaquo;</a>
       </div>
     </div>
 

--- a/webapp/first_snap/views.py
+++ b/webapp/first_snap/views.py
@@ -6,6 +6,7 @@ import flask
 from webapp import helpers
 
 YAML_KEY_REGEXP = re.compile(r"([^\s:]*)(:.*)")
+FSF_FLOW = "first-snap"
 
 
 first_snap = flask.Blueprint(
@@ -54,15 +55,10 @@ def get_language(language):
     if not directory_exists(filename):
         return flask.abort(404)
 
-    context = {"language": language}
+    context = {"language": language, "fsf_flow": FSF_FLOW}
     return flask.render_template(
         "first-snap/install-snapcraft.html", **context
     )
-
-
-@first_snap.route("/<language>/create-account")
-def create_account(language):
-    return flask.redirect(f"/first-snap/{language}")
 
 
 @first_snap.route("/<language>/snapcraft.yaml")
@@ -123,6 +119,7 @@ def get_package(language, operating_system):
         "steps": steps,
         "snap_name": snap_name,
         "has_user_chosen_name": has_user_chosen_name,
+        "fsf_flow": FSF_FLOW,
     }
 
     snapcraft_yaml = helpers.get_yaml(
@@ -179,6 +176,7 @@ def get_build(language, operating_system):
         "build_steps": build_steps[operating_system_only][install_type],
         "test_steps": test_steps[operating_system_only],
         "snap_name": snap_name,
+        "fsf_flow": FSF_FLOW,
     }
 
     return flask.render_template("first-snap/build-and-test.html", **context)
@@ -223,6 +221,7 @@ def get_push(language, operating_system):
         "user": user,
         "snap_name": snap_name,
         "has_user_chosen_name": has_user_chosen_name,
+        "fsf_flow": FSF_FLOW,
     }
 
     return flask.render_template("first-snap/push.html", **context)

--- a/webapp/first_snap/views_2.py
+++ b/webapp/first_snap/views_2.py
@@ -7,6 +7,7 @@ from webapp import helpers
 from webapp.decorators import login_required
 
 YAML_KEY_REGEXP = re.compile(r"([^\s:]*)(:.*)")
+FSF_FLOW = "first-snap-2"
 
 
 first_snap_2 = flask.Blueprint(
@@ -50,21 +51,21 @@ def get_pick_language():
 
 
 @first_snap_2.route("/<language>")
+@login_required
 def get_language(language):
     filename = f"first_snap/content/{language}"
     if not directory_exists(filename):
         return flask.abort(404)
 
-    context = {"language": language}
+    context = {"language": language, "fsf_flow": FSF_FLOW}
     return flask.render_template(
         "first-snap/install-snapcraft.html", **context
     )
 
 
 @first_snap_2.route("/<language>/create-account")
-@login_required
 def create_account(language):
-    context = {"language": language}
+    context = {"language": language, "fsf_flow": FSF_FLOW}
     return flask.render_template("first-snap/create-account.html", **context)
 
 
@@ -128,6 +129,7 @@ def get_package(language, operating_system):
         "steps": steps,
         "snap_name": snap_name,
         "has_user_chosen_name": has_user_chosen_name,
+        "fsf_flow": FSF_FLOW,
     }
 
     snapcraft_yaml = helpers.get_yaml(
@@ -185,6 +187,7 @@ def get_build(language, operating_system):
         "build_steps": build_steps[operating_system_only][install_type],
         "test_steps": test_steps[operating_system_only],
         "snap_name": snap_name,
+        "fsf_flow": FSF_FLOW,
     }
 
     return flask.render_template("first-snap/build-and-test.html", **context)
@@ -230,6 +233,7 @@ def get_push(language, operating_system):
         "user": user,
         "snap_name": snap_name,
         "has_user_chosen_name": has_user_chosen_name,
+        "fsf_flow": FSF_FLOW,
     }
 
     return flask.render_template("first-snap/push.html", **context)

--- a/webapp/first_snap/views_3.py
+++ b/webapp/first_snap/views_3.py
@@ -7,6 +7,7 @@ from webapp import helpers
 from webapp.decorators import login_required
 
 YAML_KEY_REGEXP = re.compile(r"([^\s:]*)(:.*)")
+FSF_FLOW = "first-snap-3"
 
 
 first_snap_3 = flask.Blueprint(
@@ -50,21 +51,21 @@ def get_pick_language():
 
 
 @first_snap_3.route("/<language>")
+@login_required
 def get_language(language):
     filename = f"first_snap/content/{language}"
     if not directory_exists(filename):
         return flask.abort(404)
 
-    context = {"language": language}
+    context = {"language": language, "fsf_flow": FSF_FLOW}
     return flask.render_template(
         "first-snap/install-snapcraft.html", **context
     )
 
 
 @first_snap_3.route("/<language>/create-account")
-@login_required
 def create_account(language):
-    context = {"language": language}
+    context = {"language": language, "fsf_flow": FSF_FLOW}
     return flask.render_template("first-snap/create-account.html", **context)
 
 
@@ -128,6 +129,7 @@ def get_package(language, operating_system):
         "steps": steps,
         "snap_name": snap_name,
         "has_user_chosen_name": has_user_chosen_name,
+        "fsf_flow": FSF_FLOW,
     }
 
     snapcraft_yaml = helpers.get_yaml(
@@ -185,6 +187,7 @@ def get_build(language, operating_system):
         "build_steps": build_steps[operating_system_only][install_type],
         "test_steps": test_steps[operating_system_only],
         "snap_name": snap_name,
+        "fsf_flow": FSF_FLOW,
     }
 
     return flask.render_template("first-snap/build-and-test.html", **context)
@@ -230,6 +233,7 @@ def get_push(language, operating_system):
         "user": user,
         "snap_name": snap_name,
         "has_user_chosen_name": has_user_chosen_name,
+        "fsf_flow": FSF_FLOW,
     }
 
     return flask.render_template("first-snap/push.html", **context)


### PR DESCRIPTION
## Done
- _Make all links consistent with the fsf ABC test option._
- _Remove login required from `/first-snap-2/<kanguage>/create-account` and `/first-snap-3/<language>/create-account`._
- _Point fsf links on the homepage to `/first-snap/<kanguage>`._

## How to QA
- Visit the demo in your browser, link commented below
  - Or you can run the project locally using the [dotrun](https://snapcraft.io/dotrun) snap with `$ dotrun` and view it in your web browser at: http://0.0.0.0:8004/
  - If your demo doesn't work, read more about the [demoservice](https://discourse.ubuntu.com/t/demoservice/16862)
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Go to https://snapcraft-io-3385.demos.haus/#python and see that the continue button will take you to https://snapcraft-io-3385.demos.haus/first-snap/python
- Logout from your account and go to https://snapcraft-io-3385.demos.haus/first-snap-2/python/create-account and https://snapcraft-io-3385.demos.haus/first-snap-3/python/create-account and see you can see the pages
- Click on Register/Sign in and see that you have to sign in and you are taken to https://snapcraft-io-3385.demos.haus/first-snap-2/python or https://snapcraft-io-3385.demos.haus/first-snap-3/python

## Issue / Card
Fixes #

## Screenshots
[if relevant, include a screenshot]
