### PR TITLE
Make snaps admin table use card pattern

### DIFF
--- a/templates/admin/_snaps_section.html
+++ b/templates/admin/_snaps_section.html
@@ -1,6 +1,6 @@
 <h2 class="p-heading--four">Snaps in {{ store.name }}</h2>
 
-<table>
+<table class="p-table--mobile-card">
   <thead>
     <tr>
       <th>Published in</th>
@@ -11,19 +11,21 @@
   </thead>
   <tbody>
     <tr>
-      <td rowspan="{{ snaps | length }}">{{ store.name }}</td>
-      <td>{{ snaps[0].name }}</td>
-      <td>
+      <td rowspan="{{ snaps | length }}" aria-label="Published in">{{ store.name }}</td>
+      <td aria-label="Name">{{ snaps[0].name }}</td>
+      <td aria-label="Latest release">
         {% if snaps[0]["latest-release"].channel %}
           <div>
-            latest/{{ snaps[0]["latest-release"].channel }} {{ snaps[0]["latest-release"].version }}
-          </div>
-          <div>
-            <small>{{ format_date(snaps[0]["latest-release"].timestamp, "%d %B %Y") }}</small>
+            <div>
+              latest/{{ snaps[0]["latest-release"].channel }} {{ snaps[0]["latest-release"].version }}
+            </div>
+            <div>
+              <small>{{ format_date(snaps[0]["latest-release"].timestamp, "%d %B %Y") }}</small>
+            </div>
           </div>
         {% endif %}
       </td>
-      <td>
+      <td aria-label="Collaborators">
         {% for user in snaps[0].users %}
           {{ user.displayname }}
         {% endfor %}
@@ -32,20 +34,22 @@
     {% for snap in snaps %}
       {% if loop.index > 1 %}
         <tr>
-          <td>{{ snap.name }}</td>
-          <td>
+          <td aria-label="Name">{{ snap.name }}</td>
+          <td aria-label="Latest release">
             {% if snap["latest-release"].channel %}
               <div>
-                latest/{{ snap["latest-release"].channel }} {{ snap["latest-release"].version }}
-              </div>
-              <div>
-                <small>{{ format_date(snap["latest-release"].timestamp, "%d %B %Y") }}</small>
+                <div>
+                  latest/{{ snap["latest-release"].channel }} {{ snap["latest-release"].version }}
+                </div>
+                <div>
+                  <small>{{ format_date(snap["latest-release"].timestamp, "%d %B %Y") }}</small>
+                </div>
               </div>
             {% else %}
               -
             {% endif %}
           </td>
-          <td>
+          <td aria-label="Collaborators">
             {% for user in snap.users %}
               {{ user.displayname }}{% if not loop.last %},{% endif %}
             {% endfor %}


### PR DESCRIPTION
## Done
Added the table card pattern to the snaps admin table

## QA
- Go to https://snapcraft-io-3387.demos.haus/admin
- Resize to mobile
- Check that the table is using the Vanilla mobile card pattern

## Issue
Fixes #3383