### PR TITLE
Use Vanilla fix for app navigation pattern

### DIFF
--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -371,8 +371,3 @@ code {
   white-space: pre;
   word-break: normal;
 }
-
-// Vanilla bug: https://github.com/canonical-web-and-design/vanilla-framework/issues/3530
-.l-navigation.is-collapsed:focus-within {
-  transform: translateX(-100%);
-}

--- a/templates/admin/admin_layout.html
+++ b/templates/admin/admin_layout.html
@@ -43,6 +43,7 @@
 
   document.querySelector(".js-menu-close").addEventListener("click", function(e) {
     document.querySelector(".l-navigation").classList.add("is-collapsed");
+    document.activeElement.blur();
   });
 </script>
 {% endblock %}


### PR DESCRIPTION
## Done
Replace `:focus-within` override with recommended fix from Vanilla for closing the application layout navigation on mobile

## QA
- Go to https://snapcraft-io-3389.demos.haus/admin
- Resize to mobile
- Open and close the side navigation
- Check that it works

## Issue
Fixes #3388