### PR TITLE
Link snap name to page if public

### DIFF
--- a/templates/admin/_snaps_section.html
+++ b/templates/admin/_snaps_section.html
@@ -12,7 +12,15 @@
   <tbody>
     <tr>
       <td rowspan="{{ snaps | length }}" aria-label="Published in">{{ store.name }}</td>
-      <td aria-label="Name">{{ snaps[0].name }}</td>
+      <td aria-label="Name">
+        {% if snaps[0].store == 'ubuntu' and not snap.private %}
+          <a href="/{{ snaps[0].name }}">
+        {% endif %}
+        {{ snaps[0].name }}
+        {% if snaps[0].store == 'ubuntu' and not snap.private %}
+          </a>
+        {% endif %}
+      </td>
       <td aria-label="Latest release">
         {% if snaps[0]["latest-release"].channel %}
           <div>
@@ -34,7 +42,15 @@
     {% for snap in snaps %}
       {% if loop.index > 1 %}
         <tr>
-          <td aria-label="Name">{{ snap.name }}</td>
+          <td aria-label="Name">
+            {% if snap.store == 'ubuntu' and not snap.private %}
+              <a href="/{{ snap.name }}">
+            {% endif %}
+            {{ snap.name }}
+            {% if snap.store == 'ubuntu' and not snap.private %}
+              </a>
+            {% endif %}
+          </td>
           <td aria-label="Latest release">
             {% if snap["latest-release"].channel %}
               <div>


### PR DESCRIPTION
## Done
If a snap if public and in the global store, link it to it's detail page

## QA
- Go to https://snapcraft-io-3390.demos.haus/admin
- Check that snaps in the global store are linked to their detail page

## Issue
Fixes #3371 