### PR TITLE
Disable talisker context logger

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,3 @@
+import logging
+
+logging.getLogger("talisker.context").disabled = True


### PR DESCRIPTION
## Done
- Disable talisker context logger for tests (Fixes https://github.com/canonical-web-and-design/snapcraft.io/issues/3122)

## How to QA
- `dotrun test-python`

## Issue / Card
Fixes #3122
