### PR TITLE
Trigger optimize event when user clicks on a language

### DIFF
--- a/static/js/public/fsf-language-select.js
+++ b/static/js/public/fsf-language-select.js
@@ -36,6 +36,12 @@ function initFSFLanguageSelect(rootEl) {
 
   const openDetails = (link) => {
     if (link && link.dataset.flowLink) {
+      // Trigger the first snap flow ABC test. Can be removed once the test is finished
+      const { dataLayer } = window;
+      if (dataLayer) {
+        dataLayer.push({ event: "optimize.activate" });
+      }
+
       // find where the next row of links starts to insert details panel before
       var top = link.offsetTop;
 


### PR DESCRIPTION
## Done
- _Trigger optimize event when user clicks on a language._

## How to QA
- Visit the demo in your browser, link commented below
  - Or you can run the project locally using the [dotrun](https://snapcraft.io/dotrun) snap with `$ dotrun` and view it in your web browser at: http://0.0.0.0:8004/
  - If your demo doesn't work, read more about the [demoservice](https://discourse.ubuntu.com/t/demoservice/16862)
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Click on a language from the FSF
- Check there is an event `optimize.activate` sent to Google Optimize
- To check that you might need to install "GTM/GA Debug" extension

## Issue / Card
Fixes #

## Screenshots
[if relevant, include a screenshot]
