### PR TITLE
Add manage member invites form

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ canonicalwebteam.discourse==2.1.0
 canonicalwebteam.blog==6.3.1
 canonicalwebteam.search==0.2.1
 canonicalwebteam.image-template==1.3.1
-canonicalwebteam.store-api==3.0.3
+canonicalwebteam.store-api==3.1.1
 canonicalwebteam.launchpad==0.8.2
 django-openid-auth==0.16
 Flask-OpenID-Stateless==1.2.6

--- a/static/js/public/manage-invites.js
+++ b/static/js/public/manage-invites.js
@@ -1,0 +1,278 @@
+import { format } from "date-fns";
+import debounce from "../libs/debounce";
+
+const ACTION_MESSAGES = {
+  open:
+    "Reopening your invite will send a new invite to this email. Do you still want to do it?",
+  resend:
+    "Resending your invite will send a reminder email to this user. Do you still want to do it?",
+  revoke:
+    "Revoking your invite will prevent this user from accepting your invite. Do you still want to do it?",
+};
+
+function updateInvites() {
+  const inviteActionForms = document.querySelectorAll("[data-js-action-form]");
+  const inviteModal = document.querySelector("#invite-modal");
+  const inviteModalHeading = inviteModal.querySelector("#invite-modal-title");
+  const inviteModalSubmitButton = inviteModal.querySelector(
+    "[data-js-submit-invite-action]"
+  );
+
+  inviteActionForms.forEach((actionForm) => {
+    actionForm.addEventListener("submit", (e) => {
+      e.preventDefault();
+
+      const submitButton = actionForm.querySelector("[type='submit']");
+      const inviteEmail = submitButton.dataset.inviteEmail;
+      const inviteAction = submitButton.dataset.inviteAction;
+      const inviteActionLabel = submitButton.dataset.inviteActionLabel;
+      const invitesField = actionForm.querySelector("[name='invites']");
+      const actionConfirmationMessage = document.querySelector(
+        "[data-js-action-confirmation-message]"
+      );
+
+      invitesField.value = JSON.stringify([
+        {
+          email: inviteEmail,
+          action: inviteAction,
+        },
+      ]);
+
+      inviteModalHeading.innerText = `${inviteActionLabel} invite`;
+      inviteModalSubmitButton.innerText = `${inviteActionLabel} invite`;
+      inviteModalSubmitButton.dataset.currentForm = actionForm;
+      actionConfirmationMessage.innerText = ACTION_MESSAGES[inviteAction];
+
+      const handleModalSubmit = () => {
+        inviteModalSubmitButton.disabled = true;
+        actionForm.submit();
+        e.target.removeEventListener("click", handleModalSubmit);
+      };
+
+      inviteModalSubmitButton.addEventListener("click", handleModalSubmit);
+    });
+  });
+}
+
+function filterInvites(
+  pendingInvites,
+  expiredInvites,
+  revokedInvites,
+  storeId,
+  token
+) {
+  pendingInvites = pendingInvites || [];
+  expiredInvites = expiredInvites || [];
+  revokedInvites = revokedInvites || [];
+
+  const invitesTableBody = document.querySelector("#invites-table tbody");
+  const filterInvitesField = document.querySelector("#filter-invites");
+
+  filterInvitesField.addEventListener(
+    "keyup",
+    debounce((e) => {
+      const query = e.target.value.toLowerCase();
+
+      let filteredPendingInvites = pendingInvites.filter((invite) => {
+        return invite.email.toLowerCase().includes(query);
+      });
+
+      let filteredExpiredInvites = expiredInvites.filter((invite) => {
+        return invite.email.toLowerCase().includes(query);
+      });
+
+      let filteredRevokedInvites = revokedInvites.filter((invite) => {
+        return invite.email.toLowerCase().includes(query);
+      });
+
+      if (!query) {
+        filteredPendingInvites = pendingInvites;
+        filteredExpiredInvites = expiredInvites;
+        filteredRevokedInvites = revokedInvites;
+      }
+
+      invitesTableBody.innerHTML = "";
+
+      if (filteredPendingInvites.length > 0) {
+        invitesTableBody.innerHTML += buildTableRows(
+          filteredPendingInvites,
+          "Pending",
+          storeId,
+          token
+        );
+      }
+
+      if (filteredExpiredInvites.length > 0) {
+        invitesTableBody.innerHTML += buildTableRows(
+          filteredExpiredInvites,
+          "Expired",
+          storeId,
+          token
+        );
+      }
+
+      if (filteredRevokedInvites.length > 0) {
+        invitesTableBody.innerHTML += buildTableRows(
+          filteredRevokedInvites,
+          "Revoked",
+          storeId,
+          token
+        );
+      }
+
+      updateInvites();
+    }),
+    100
+  );
+}
+
+function getInviteForm(storeId, token, action) {
+  return `
+    <form action="/admin/${storeId}/members/invite/update" method="post" class="p-action-form" data-js-action-form>
+      <input type="hidden" name="invites" value="">
+      <input type="hidden" name="csrf_token" value="${token}">
+      <button type="submit" class="is-dense u-no-margin--bottom" data-invite-email="${action.email}" data-invite-action="${action.type}" data-invite-action-label="${action.label}" aria-controls="invite-modal">${action.label}</button>
+    </form>
+  `;
+}
+
+function buildTableRows(invites, status, storeId, token) {
+  const ROLES = {
+    admin: "admin",
+    review: "reviewer",
+    view: "viewer",
+    access: "publisher",
+  };
+
+  const formatRoles = (roles) => {
+    let rolesOutput = "";
+
+    roles.forEach((role, index) => {
+      if (index > 0) {
+        rolesOutput += ", ";
+      }
+
+      rolesOutput += ROLES[role];
+    });
+
+    return rolesOutput;
+  };
+
+  let tableRows = "";
+
+  tableRows = `
+    <tr>
+      <td aria-label="Status" rowspan="${invites.length}">${status}</td>
+      <td aria-label="User">${invites[0].email}</td>
+      <td aria-label="Expires">
+        ${format(new Date(invites[0]["expiration-date"]), "dd MMMM yyyy")}
+      </td>
+      <td aria-label="Roles">${formatRoles(invites[0].roles)}</td>
+      <td aria-label="Actions" class="u-align--right">
+        ${
+          status === "Pending"
+            ? getInviteForm(storeId, token, {
+                email: invites[0].email,
+                type: "resend",
+                label: "Resend",
+              })
+            : ""
+        }
+        ${
+          status === "Pending"
+            ? getInviteForm(storeId, token, {
+                email: invites[0].email,
+                type: "revoke",
+                label: "Revoke",
+              })
+            : ""
+        }
+        ${
+          status === "Expired"
+            ? getInviteForm(storeId, token, {
+                email: invites[0].email,
+                type: "open",
+                label: "Reopen",
+              })
+            : ""
+        }
+        ${
+          status === "Revoked"
+            ? getInviteForm(storeId, token, {
+                email: invites[0].email,
+                type: "open",
+                label: "Reopen",
+              })
+            : ""
+        }
+      </td>
+    </tr>
+  `;
+
+  invites.forEach((invite, index) => {
+    if (index > 0) {
+      tableRows += `
+        <tr>
+          <td aria-label="User">${invite.email}</td>
+          <td aria-label="Expires">
+            ${format(new Date(invite["expiration-date"]), "dd MMMM yyyy")}
+          </td>
+          <td aria-label="Roles">${formatRoles(invite.roles)}</td>
+          <td aria-label="Actions" class="u-align--right">
+            ${
+              status === "Pending"
+                ? getInviteForm(storeId, token, {
+                    email: invite.email,
+                    type: "resend",
+                    label: "Resend",
+                  })
+                : ""
+            }
+            ${
+              status === "Pending"
+                ? getInviteForm(storeId, token, {
+                    email: invite.email,
+                    type: "revoke",
+                    label: "Revoke",
+                  })
+                : ""
+            }
+            ${
+              status === "Expired"
+                ? getInviteForm(storeId, token, {
+                    email: invite.email,
+                    type: "open",
+                    label: "Reopen",
+                  })
+                : ""
+            }
+            ${
+              status === "Revoked"
+                ? getInviteForm(storeId, token, {
+                    email: invite.email,
+                    type: "open",
+                    label: "Reopen",
+                  })
+                : ""
+            }
+          </td>
+        </tr>
+      `;
+    }
+  });
+
+  return tableRows;
+}
+
+function initUpdateInvitesTable(
+  pendingInvites,
+  expiredInvites,
+  revokedInvites,
+  storeId,
+  token
+) {
+  updateInvites();
+  filterInvites(pendingInvites, expiredInvites, revokedInvites, storeId, token);
+}
+
+export { initUpdateInvitesTable };

--- a/static/js/public/manage-members.js
+++ b/static/js/public/manage-members.js
@@ -233,4 +233,9 @@ function buildMemberRow(member, roles) {
   return tr;
 }
 
-export { inviteMember, updateMembers, filterMembers };
+function initManageMembersTable(members, roles) {
+  updateMembers(members);
+  filterMembers(members, roles);
+}
+
+export { inviteMember, initManageMembersTable };

--- a/static/sass/_pattern_p-button-group.scss
+++ b/static/sass/_pattern_p-button-group.scss
@@ -1,0 +1,74 @@
+@mixin p-snapcraft-button-group {
+  .p-button-group {
+    align-content: center;
+    column-gap: 1rem;
+    display: flex;
+
+    button:hover {
+      border-color: $color-mid-light;
+    }
+
+    a:visited {
+      color: $color-dark;
+    }
+
+    a:hover {
+      @include vf-animation(#{background-color, border-color}, fast, in);
+
+      background-color: #f2f2f2;
+      text-decoration: none;
+    }
+
+    &__label {
+      margin-right: 0.5rem;
+
+      @media (max-width: 768px) {
+        display: none;
+      }
+    }
+
+    &__buttons {
+      border: 1px solid $color-mid-dark;
+      border-radius: 0.125rem;
+      display: flex;
+      margin-bottom: 1rem;
+      width: auto;
+    }
+
+    &__inner {
+      display: flex;
+      width: 100%;
+    }
+
+    &__button {
+      align-items: center;
+      border: none;
+      border-right: 1px solid $color-mid-dark;
+      color: $color-dark;
+      display: flex;
+      flex: 1;
+      height: 100%;
+      line-height: 1.5;
+      margin: 0 !important; // Required to override Vanilla button:not(:last-of-type):not(:only-of-type)
+      padding: calc(0.4rem - 1px) 1rem;
+      text-align: center;
+      white-space: nowrap;
+
+      &.is-smaller {
+        padding: 0.25rem 0.5rem;
+      }
+
+      &.is-selected {
+        background: $color-mid-x-light;
+      }
+
+      &:last-child {
+        border: 0;
+      }
+
+      [class^="p-icon"] {
+        margin-inline-end: 0.5rem;
+      }
+    }
+  }
+}

--- a/static/sass/_snapcraft_p-action-form.scss
+++ b/static/sass/_snapcraft_p-action-form.scss
@@ -1,0 +1,14 @@
+@mixin snapcraft-action-form {
+  .p-action-form {
+    margin-bottom: $sp-small;
+
+    &:last-child {
+      margin-bottom: 0;
+    }
+
+    @media only screen and (min-width: $breakpoint-medium) {
+      display: inline-block;
+      margin-bottom: 0;
+    }
+  }
+}

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -329,6 +329,14 @@ $color-social-icon-foreground: $color-light;
 
 @include snapcraft-p-videos;
 
+@import "pattern_p-button-group";
+
+@include p-snapcraft-button-group;
+
+@import "snapcraft_p-action-form";
+
+@include snapcraft-action-form;
+
 dl {
   margin-bottom: $spv-outer--scaleable;
 }

--- a/templates/admin/_manage_invites_form.html
+++ b/templates/admin/_manage_invites_form.html
@@ -1,0 +1,5 @@
+<form action="/admin/{{ store.id }}/members/invite/update" method="post" class="p-action-form" data-js-action-form>
+  <input type="hidden" name="invites" value="">
+  <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+  <button type="submit" class="is-dense u-no-margin--bottom" data-invite-email="{{ email }}" data-invite-action="{{ action }}" data-invite-action-label="{{ action_label }}" aria-controls="invite-modal">{{ action_label }}</button>
+</form>

--- a/templates/admin/admin_layout.html
+++ b/templates/admin/admin_layout.html
@@ -4,7 +4,7 @@
 <div class="l-application" role="presentation">
   <div class="l-navigation-bar">
     <div class="u-clearfix">
-      <button class="u-float-right js-menu-open is-dense u-no-margin">Menu</button>
+      <button class="p-button--base is-light u-float-right u-align--right u-no-padding--right js-menu-open is-dense u-no-margin" style="color: #fff;">&lsaquo;&nbsp;Toggle sidebar navigation</button>
     </div>
   </div>
 

--- a/templates/admin/invites.html
+++ b/templates/admin/invites.html
@@ -1,0 +1,198 @@
+{% set current_tab = "invites" %}
+
+{% extends "/admin/admin_layout.html" %}
+
+{% block meta_title %}Manage invites in {{ store.name }} | Snapcraft{% endblock %}
+
+{% block admin_content %}
+
+<ul class="p-inline-list--stretch">
+  <li class="p-inline-list__item u-no-margin--right">
+    <div class="p-button-group">
+      <div class="p-button-group__inner">
+        <div class="p-button-group__buttons">
+          <a href="/admin/{{ store.id }}/members" class="p-button-group__button">Members</a>
+          <a href="/admin/{{ store.id }}/members/invites" class="p-button-group__button is-selected">Invites</a>
+        </div>
+      </div>
+    </div>
+  </li>
+  <li class="p-inline-list__item u-align--right">
+    <label for="filter-invites" class="u-hide">Search for user</label>
+    <input type="text" name="filter-invites" id="filter-invites" placeholder="Search for user" style=" max-width: 320px; min-width: 0;">
+  </li>
+</ul>
+
+<table id="invites-table" class="p-table--mobile-card">
+  <thead>
+    <tr>
+      <th>Status</th>
+      <th>User</th>
+      <th>Expires</th>
+      <th>Roles</th>
+      <th>&nbsp;</th>
+    </tr>
+  </thead>
+  <tbody>
+
+    {% if pending_invites %}
+      <tr>
+        <td aria-label="Status" rowspan="{{ pending_invites|length }}">Pending</td>
+        <td aria-label="User">{{ pending_invites[0]["email"] }}</td>
+        <td aria-label="Expires">{{ format_date(pending_invites[0]["expiration-date"], "%d %B %Y") }}</td>
+        <td aria-label="Roles">
+          <div>
+            {% for role in pending_invites[0]["roles"] %}
+              {{ format_member_role(role) }}{% if not loop.last %},{% endif %}
+            {% endfor %}
+          </div>
+        </td>
+        <td aria-label="Actions" class="u-align--right">
+          <div>
+            {% with email=pending_invites[0]["email"], action="resend", action_label="Resend" %}
+              {% include "admin/_manage_invites_form.html" %}
+            {% endwith %}
+
+            {% with email=pending_invites[0]["email"], action="revoke", action_label="Revoke" %}
+              {% include "admin/_manage_invites_form.html" %}
+            {% endwith %}
+          </div>
+        </td>
+      </tr>
+      {% for invite in pending_invites %}
+        {% if not loop.first %}
+          <tr>
+            <td aria-label="User">{{ invite["email"] }}</td>
+            <td aria-label="Expires">{{ format_date(invite["expiration-date"], "%d %B %Y") }}</td>
+            <td aria-label="Roles">
+              {% for role in invite["roles"] %}
+                {{ format_member_role(role) }}{% if not loop.last %},{% endif %}
+              {% endfor %}
+            </td>
+            <td aria-label="Actions" class="u-align--right">
+              <div>
+                {% with email=invite["email"], action="resend", action_label="Resend" %}
+                  {% include "admin/_manage_invites_form.html" %}
+                {% endwith %}
+
+                {% with email=invite["email"], action="revoke", action_label="Revoke" %}
+                  {% include "admin/_manage_invites_form.html" %}
+                {% endwith %}
+              </div>
+            </td>
+          </tr>
+        {% endif %}
+      {% endfor %}
+    {% endif %}
+
+    {% if expired_invites %}
+      <tr>
+        <td aria-label="Status" rowspan="{{ expired_invites|length }}">Expired</td>
+        <td aria-label="User">{{ expired_invites[0]["email"] }}</td>
+        <td aria-label="Expires">{{ format_date(expired_invites[0]["expiration-date"], "%d %B %Y") }}</td>
+        <td aria-label="Roles">
+          {% for role in expired_invites[0]["roles"] %}
+            {{ format_member_role(role) }}{% if not loop.last %},{% endif %}
+          {% endfor %}
+        </td>
+        <td aria-label="Actions" class="u-align--right">
+          <div>
+            {% with email=expired_invites[0]["email"], action="open", action_label="Reopen" %}
+              {% include "admin/_manage_invites_form.html" %}
+            {% endwith %}
+          </div>
+        </td>
+      </tr>
+      {% for invite in expired_invites %}
+        {% if not loop.first %}
+          <tr>
+            <td aria-label="User">{{ invite["email"] }}</td>
+            <td aria-label="Expires">{{ format_date(invite["expiration-date"], "%d %B %Y") }}</td>
+            <td aria-label="Roles">
+              {% for role in invite["roles"] %}
+                {{ format_member_role(role) }}{% if not loop.last %},{% endif %}
+              {% endfor %}
+            </td>
+            <td aria-label="Actions" class="u-align--right">
+              <div>
+                {% with email=invite["email"], action="open", action_label="Reopen" %}
+                  {% include "admin/_manage_invites_form.html" %}
+                {% endwith %}
+              </div>
+            </td>
+          </tr>
+        {% endif %}
+      {% endfor %}
+    {% endif %}
+
+    {% if revoked_invites %}
+      <tr>
+        <td aria-label="Status" rowspan="{{ revoked_invites|length }}">Revoked</td>
+        <td aria-label="User">{{ revoked_invites[0]["email"] }}</td>
+        <td aria-label="Expires">{{ format_date(revoked_invites[0]["expiration-date"], "%d %B %Y") }}</td>
+        <td aria-label="Roles">
+          {% for role in revoked_invites[0]["roles"] %}
+            {{ format_member_role(role) }}{% if not loop.last %},{% endif %}
+          {% endfor %}
+        </td>
+        <td aria-label="Actions" class="u-align--right">
+          {% with email=revoked_invites[0]["email"], action="open", action_label="Reopen" %}
+            {% include "admin/_manage_invites_form.html" %}
+          {% endwith %}
+        </td>
+      </tr>
+      {% for invite in revoked_invites %}
+        {% if not loop.first %}
+          <tr>
+            <td aria-label="User">{{ invite["email"] }}</td>
+            <td aria-label="Expires">{{ format_date(invite["expiration-date"], "%d %B %Y") }}</td>
+            <td aria-label="Roles">
+              {% for role in invite["roles"] %}
+                {{ format_member_role(role) }}{% if not loop.last %},{% endif %}
+              {% endfor %}
+            </td>
+            <td aria-label="Actions" class="u-align--right">
+              {% with email=invite["email"], action="open", action_label="Reopen" %}
+                {% include "admin/_manage_invites_form.html" %}
+              {% endwith %}
+            </td>
+          </tr>
+        {% endif %}
+      {% endfor %}
+    {% endif %}
+  </tbody>
+</table>
+
+<div class="p-modal" id="invite-modal" style="display: none; z-index: 110;">
+  <div class="p-modal__dialog" role="dialog" aria-labelledby="invite-modal-title" style="max-width: 480px;">
+    <header class="p-modal__header">
+      <h2 class="p-modal__title" id="invite-modal-title">Manage invite</h2>
+      <button class="p-modal__close" aria-label="Close active modal" aria-controls="invite-modal">Close</button>
+    </header>
+    <div>
+      <p data-js-action-confirmation-message>Do you really want to perform this action?</p>
+      <div class="u-align--right">
+        <button aria-controls="invite-modal">Cancel</button>
+        <button class="p-button--positive" data-js-submit-invite-action>Yes</button>
+      </div>
+    </div>
+  </div>
+</div>
+
+{% endblock %}
+
+{% block scripts_includes %}
+<script src="{{ static_url('js/dist/modal.js') }}" defer></script>
+<script src="{{ static_url('js/dist/manage-invites.js') }}" defer></script>
+{% endblock %}
+
+{% block scripts %}
+<script>
+  window.addEventListener("DOMContentLoaded", function () {
+    Raven.context(function () {
+      snapcraft.public.modal.init("invite-modal");
+      snapcraft.public.manageInvites.initUpdateInvitesTable({{ pending_invites | safe }}, {{ expired_invites | safe }}, {{ revoked_invites | safe }}, "{{ store.id }}", "{{ csrf_token() }}");
+    });
+  });
+</script>
+{% endblock %}

--- a/templates/admin/manage_members.html
+++ b/templates/admin/manage_members.html
@@ -6,16 +6,23 @@
 
 {% block admin_content %}
 
-<a class="l-application__back-link" href="/admin/{{ store.id }}/members">&lsaquo;&nbsp;Back to members</a>
-<div class="l-application__header">
-  <h2 class="l-application__heading p-heading--4">Manage members</h2>
-  <button id="show-invite-modal" aria-controls="invite-modal">
-    <i class="p-icon--plus"></i>&nbsp;Invite member
-  </button>
-</div>
+<ul class="p-inline-list--stretch u-no-margin--bottom">
+  <li class="p-inline-list__item u-no-margin--right">
+    <p class="u-no-margin--bottom">
+      <a href="/admin/{{ store.id }}/members">&lsaquo;&nbsp;Back to members</a>
+    </p>
+  </li>
+  <li class="p-inline-list__item u-align--right">
+    <button id="show-invite-modal" style="margin-bottom: 0;" aria-controls="invite-modal">
+      <i class="p-icon--plus"></i>&nbsp;Invite member
+    </button>
+  </li>
+</ul>
+
+<h1 class="p-heading--4">Manage members</h1>
 
 <div class="p-modal" id="invite-modal" style="display: none; z-index: 110;">
-  <div class="p-modal__dialog" role="dialog" aria-labelledby="invite-modal-title" style="overflow: auto;">
+  <div class="p-modal__dialog" role="dialog" aria-labelledby="invite-modal-title">
     <header class="p-modal__header">
       <h2 class="p-modal__title" id="invite-modal-title">Invite member</h2>
       <button class="p-modal__close" aria-label="Close active modal" aria-controls="invite-modal">Close</button>
@@ -56,8 +63,8 @@
     <tr>
       <th style="padding-top: 5px; width: 40%;">
         <div class="u-hide--small">
-          <label for="filter-members" class="u-hide">Filter members</label>
-          <input type="text" name="filter-members" id="filter-members" class="is-dense" placeholder="Filter" style="min-width: 0;">
+          <label for="filter-members" class="u-hide">Search for user</label>
+          <input type="text" name="filter-members" id="filter-members" class="is-dense" placeholder="Search for user" style="min-width: 0;">
         </div>
       </th>
       {% for role in store.roles %}
@@ -98,7 +105,6 @@
     <button type="submit" class="p-button--positive js-save-button" disabled>Save changes</button>
   </div>
 </form>
-
 {% endblock %}
 
 {% block scripts_includes %}
@@ -111,8 +117,7 @@
   window.addEventListener("DOMContentLoaded", function () {
     snapcraft.public.modal.init("invite-modal");
     snapcraft.public.manageMembers.inviteMember();
-    snapcraft.public.manageMembers.updateMembers({{ members | safe }});
-    snapcraft.public.manageMembers.filterMembers({{ members | safe }}, {{ store.roles | safe }});
+    snapcraft.public.manageMembers.initManageMembersTable({{ members | safe }}, {{ store.roles | safe }});
   });
 </script>
 {% endblock %}

--- a/templates/admin/members.html
+++ b/templates/admin/members.html
@@ -6,10 +6,22 @@
 
 {% block admin_content %}
 
-<div class="l-application__header">
-  <h2 class="p-heading--4">Members</h2>
-  <a class="p-button" href="/admin/{{ store.id }}/members/manage">Manage members</a>
-</div>
+<ul class="p-inline-list--stretch">
+  <li class="p-inline-list__item u-no-margin--right">
+    <div class="p-button-group">
+      <div class="p-button-group__inner">
+        <div class="p-button-group__buttons">
+          <a href="/admin/{{ store.id }}/members" class="p-button-group__button is-selected">Members</a>
+          <a href="/admin/{{ store.id }}/members/invites" class="p-button-group__button">Invites</a>
+        </div>
+      </div>
+    </div>
+  </li>
+  <li class="p-inline-list__item u-align--right">
+    <a class="p-button" href="/admin/{{ store.id }}/members/manage">Manage members</a>
+  </li>
+</ul>
+
 <table class="p-table--mobile-card">
   <thead>
     <tr>

--- a/tests/tests_templates_utils.py
+++ b/tests/tests_templates_utils.py
@@ -102,3 +102,16 @@ class TemplateUtilsTest(unittest.TestCase):
             "2019-09-02T09:27:58.930567+00:00", "%d %B %Y"
         )
         self.assertEquals(result, "02 September 2019")
+
+    def test_format_member_role(self):
+        result = template_utils.format_member_role("admin")
+        self.assertEquals(result, "admin")
+
+        result = template_utils.format_member_role("review")
+        self.assertEquals(result, "reviewer")
+
+        result = template_utils.format_member_role("view")
+        self.assertEquals(result, "viewer")
+
+        result = template_utils.format_member_role("access")
+        self.assertEquals(result, "publisher")

--- a/webapp/handlers.py
+++ b/webapp/handlers.py
@@ -75,6 +75,7 @@ def set_handlers(app):
             "display_name": template_utils.display_name,
             "install_snippet": template_utils.install_snippet,
             "format_date": template_utils.format_date,
+            "format_member_role": template_utils.format_member_role,
             "image": image_template,
         }
 

--- a/webapp/template_utils.py
+++ b/webapp/template_utils.py
@@ -129,3 +129,17 @@ def format_date(timestamp, format):
     datestring = parser.parse(timestamp)
 
     return datestring.strftime(format)
+
+
+def format_member_role(role):
+    """Template function that returns the
+    correct label for a members role
+    """
+    roles = {
+        "admin": "admin",
+        "review": "reviewer",
+        "view": "viewer",
+        "access": "publisher",
+    }
+
+    return roles[role]

--- a/webpack.config.entry.js
+++ b/webpack.config.entry.js
@@ -21,4 +21,5 @@ module.exports = {
   "distro-install": "./static/js/public/distro-install.js",
   "publisher-details": "./static/js/public/publisher-details.js",
   "brand-store": "./static/js/public/brand-store.js",
+  "manage-invites": "./static/js/public/manage-invites.js",
 };

--- a/webpack.config.rules.js
+++ b/webpack.config.rules.js
@@ -41,6 +41,13 @@ module.exports = [
     use: ["expose-loader?exposes=snapcraft.public.tabpanel", "babel-loader"],
   },
   {
+    test: require.resolve(__dirname + "/static/js/public/manage-invites.js"),
+    use: [
+      "expose-loader?exposes=snapcraft.public.manageInvites",
+      "babel-loader",
+    ],
+  },
+  {
     test: require.resolve(__dirname + "/static/js/public/manage-members.js"),
     use: [
       "expose-loader?exposes=snapcraft.public.manageMembers",


### PR DESCRIPTION
## Done
Added the ability to resend, reopen and revoke member invites

## QA
- Go to https://snapcraft-io-3404.demos.haus/admin
- Click "Members" on the left navigation
- Click the "Invites" tab above the table
- Use the search box to filter the table by each invites email address
- Check that invites are grouped by status
- Use the action buttons to revoke, resend and reopen invites
- Check that the status changes appropriately

## Issue
Fixes #3375 