### PR TITLE
Remove store column from tables

### DIFF
--- a/static/js/public/manage-members.js
+++ b/static/js/public/manage-members.js
@@ -144,13 +144,6 @@ function filterMembers(members, roles) {
   members = members || [];
   roles = roles || [];
 
-  const ROLES = {
-    admin: "admin",
-    reviewer: "review",
-    viewer: "view",
-    publisher: "access",
-  };
-
   const membersTableBody = document.querySelector("#members-table tbody");
   const filterMembersField = document.querySelector("#filter-members");
 
@@ -162,8 +155,7 @@ function filterMembers(members, roles) {
         return (
           member.displayname.toLowerCase().includes(query) ||
           member.email.toLowerCase().includes(query) ||
-          member.username.toLowerCase().includes(query) ||
-          member.roles.includes(ROLES[query])
+          member.username.toLowerCase().includes(query)
         );
       });
 

--- a/templates/admin/_snaps_section.html
+++ b/templates/admin/_snaps_section.html
@@ -6,7 +6,6 @@
 <table class="p-table--mobile-card">
   <thead>
     <tr>
-      <th>Published in</th>
       <th>Name</th>
       <th>Latest release</th>
       <th>Collaborators</th>
@@ -14,7 +13,6 @@
   </thead>
   <tbody>
     <tr>
-      <td rowspan="{{ snaps | length }}" aria-label="Published in">{{ store.name }}</td>
       <td aria-label="Name">
         {% if snaps[0].store == 'ubuntu' and not snap.private %}
           <a href="/{{ snaps[0].name }}">

--- a/templates/admin/manage_members.html
+++ b/templates/admin/manage_members.html
@@ -54,7 +54,7 @@
 <table id="members-table" class="p-table--mobile-card">
   <thead>
     <tr>
-      <th style="padding-top: 5px;">
+      <th style="padding-top: 5px; width: 40%;">
         <div class="u-hide--small">
           <label for="filter-members" class="u-hide">Filter members</label>
           <input type="text" name="filter-members" id="filter-members" class="is-dense" placeholder="Filter" style="min-width: 0;">

--- a/templates/admin/manage_snaps.html
+++ b/templates/admin/manage_snaps.html
@@ -14,7 +14,6 @@
 <table class="p-table--mobile-card" id="snaps-table">
   <thead>
     <tr>
-      <th>Published in</th>
       <th width="34">&nbsp;</th>
       <th>Name</th>
       <th>Latest release</th>
@@ -23,7 +22,6 @@
   </thead>
   <tbody>
     <tr>
-      <td rowspan="{{ snaps | length }}" aria-label="Published in">{{ store.name }}</td>
       <td aria-label="Add or remove">
         <label class="p-checkbox">
           <input type="checkbox" aria-labelledby="add-or-remove" class="p-checkbox__input u-no-margin--top" data-snap-name="{{ snaps[0].name }}" checked>

--- a/templates/admin/members.html
+++ b/templates/admin/members.html
@@ -10,22 +10,20 @@
   <h2 class="p-heading--4">Members</h2>
   <a class="p-button" href="/admin/{{ store.id }}/members/manage">Manage members</a>
 </div>
-<table>
+<table class="p-table--mobile-card">
   <thead>
     <tr>
       <th>Name</th>
       <th>Email</th>
       <th>Access</th>
-      <th>Store</th>
     </tr>
   </thead>
   <tbody>
     {% for member in members %}
     <tr>
-      <td rowspan="1">{{ member.displayname }}</td>
-      <td rowspan="1">{{ member.email }}</td>
-      <td>{% for r in member.roles %}{{ r | capitalize }}{{ ", " if not loop.last }}{% endfor %}</td>
-      <td><a href="/admin/{{ store.id }}/snaps">{{ store.name }}</a></td>
+      <td aria-label="Name" rowspan="1">{{ member.displayname }}</td>
+      <td aria-label="Email" rowspan="1">{{ member.email }}</td>
+      <td aria-label="Access">{% for r in member.roles %}{{ r | capitalize }}{{ ", " if not loop.last }}{% endfor %}</td>
     </tr>
     {% endfor %}
   </tbody>


### PR DESCRIPTION
## Done
- Removed "Store" and "Published in" columns from the "Snaps", "Manage snaps" and "Members" tables as it is redundant
- Updated the width of the "Name" column on the "Manage members" table to 40%
- Updated the "Manage members" filter to only filter via display name, username or email address

## QA
- Go to https://snapcraft-io-3405.demos.haus/admin
- Check that the "Snaps" table has no "Published in" column
- Click "Manage snaps" and check that the table has no "Published in" column
- Go to https://snapcraft-io-3405.demos.haus/admin/ahnuP3quahti9vis8aiw/members
- Check that the table has no is no "Store" column
- Click "Manage members" and check that the name column of the table is 40% width
- Use the filter to search by display name, username or email address (e.g. Steve Rydz, steverydz, steve.rydz@canonical.com)

## Issue
Fixes #3407 