### PR TITLE
Count accept-encoding instances in prometheus

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,6 +21,7 @@ requests==2.25.1
 responses==0.12.1
 ruamel.yaml==0.16.12
 vcrpy-unittest==0.1.7
+user-agents==2.2.0
 
 # Development dependencies
 Flask-Testing==0.8.1


### PR DESCRIPTION
Here's why:

The cache has to vary by encoding, as in, if a browser requests "gzip" compression of a page, it clearly can't use the same cache as for a browser requesting "br" (brotli) compression. The cache can't actually do this perfectly, because when a request comes in, it doesn't know which compression the app will respond with, so it has to check with the app. This means it uses the distinct value of the "accept-encoding" header instead. So "accept-encoding: gzip, br" will lead to a different cache from "accept-encoding: br, gzip". It does this by setting the header "vary: accept-encoding".

We [are currently looking into](https://github.com/canonical-web-and-design/maas.io/issues/559) how to change our cache-control headers to ensure pages are effectively cached. To understand this, we need to know how many cache variations to expect per page. This in turn requires us to understand how many variations of the "accept-encoding" header we receive, and how many of each. So this is fundamentally what I'm trying to count.

I added in the user-agent, not because I strictly need it, but this will then allow us to see which browsers are sending which accept-encoding strings, which could be useful for a future blog post.

## QA

I don't know how to QA it properly, but if you whack a debugger at the end of the `prometheus_metrics` function, and then run the site and visit it in your browser, you can see that it runs without error.