### PR TITLE
Add changes count to members save button

### DIFF
--- a/static/js/public/manage-members.js
+++ b/static/js/public/manage-members.js
@@ -110,9 +110,37 @@ function updateMembers(membersData) {
         member.dirty = false;
       }
 
-      const dirtyState = newData.filter(function (data) {
-        return data.dirty;
+      const dirtyState = newData.filter((data) => data.dirty);
+
+      let changeCount = 0;
+
+      dirtyState.forEach((member) => {
+        const oldMember = membersData.find((data) => data.id === member.id);
+
+        let numberOfChanges = 0;
+
+        if (member.roles.length >= oldMember.roles.length) {
+          numberOfChanges = member.roles.filter((x) => {
+            return oldMember.roles.indexOf(x) === -1;
+          }).length;
+        } else {
+          numberOfChanges = oldMember.roles.filter((x) => {
+            return member.roles.indexOf(x) === -1;
+          }).length;
+        }
+
+        changeCount += numberOfChanges;
       });
+
+      if (dirtyState.length) {
+        if (changeCount === 1) {
+          saveButton.innerText = "Save 1 change";
+        } else {
+          saveButton.innerText = `Save ${changeCount} changes`;
+        }
+      } else {
+        saveButton.innerText = "Save changes";
+      }
 
       saveButton.disabled = !dirtyState.length;
     });


### PR DESCRIPTION
## Done
Added a change count to the save button for the manage members admin page

## QA
- Go to https://snapcraft-io-3412.demos.haus/admin/ahnuP3quahti9vis8aiw/members/manage
- Check and uncheck roles
- If there are no changes from the original state the save button should be disabled and read "Save changes"
- If there is one change from the original state the save button should be enabled and read "Save 1 change"
- If there are more than one changes from the original state the save button should be enabled and read "Save x changes", with x reflecting the number of changes from the original state

## Issue
Fixes #3410