### PR TITLE
Change wording of manage snaps page heading

### DIFF
--- a/templates/admin/manage_snaps.html
+++ b/templates/admin/manage_snaps.html
@@ -8,7 +8,7 @@
 
 <a class="l-application__back-link" href="/admin/{{ store.id }}/snaps">&lsaquo;&nbsp;Back to snaps</a>
 <div class="l-application__header">
-  <h2 class="l-application__heading p-heading--4">Manage snaps</h2>
+  <h2 class="l-application__heading p-heading--4">Add and remove snaps from the {{ store.name }} store</h2>
 </div>
 
 <table class="p-table--mobile-card" id="snaps-table">


### PR DESCRIPTION
## Done
Changed the heading of the manage snaps page to explain what the page is for

## QA
- Go to https://snapcraft-io-3413.demos.haus/admin/ahnuP3quahti9vis8aiw/snaps/manage
- Check that the heading explains what the page does

## Issue
Fixes #3409 