### PR TITLE
Added Candid login

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -9,6 +9,7 @@ To use staging APIs locally you can add the following lines to an `.env.local` f
 SNAPSTORE_API_URL=https://api.staging.snapcraft.io/
 SNAPSTORE_DASHBOARD_API_URL=https://dashboard.staging.snapcraft.io/
 LOGIN_URL=https://login.staging.ubuntu.com
+CANDID_API_URL=https://api.staging.jujucharms.com/identity/
 ```
 
 ## Snap automated builds

--- a/konf/staging-api.snapcraft.io.yaml
+++ b/konf/staging-api.snapcraft.io.yaml
@@ -12,6 +12,9 @@ env:
   - name: SNAPSTORE_API_URL
     value: https://api.staging.snapcraft.io/
 
+  - name: CANDID_API_URL
+    value: https://api.staging.jujucharms.com/identity/
+
   - name: SENTRY_DSN
     value: https://1e82fd54e08142c9978f623cb746b965@sentry.is.canonical.com//3
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,11 @@
 # App dependencies
 canonicalwebteam.flask-base==0.7.3
+canonicalwebteam.candid==0.9.0
 canonicalwebteam.discourse==2.1.0
 canonicalwebteam.blog==6.3.1
 canonicalwebteam.search==0.2.1
 canonicalwebteam.image-template==1.3.1
-canonicalwebteam.store-api==3.1.1
+canonicalwebteam.store-api==3.1.5
 canonicalwebteam.launchpad==0.8.2
 django-openid-auth==0.16
 Flask-OpenID-Stateless==1.2.6

--- a/tests/first_snap/tests_views.py
+++ b/tests/first_snap/tests_views.py
@@ -148,7 +148,7 @@ class FirstSnap(TestCase):
             "email": "testing@testing.com",
         }
         with self.client.session_transaction() as s:
-            s["openid"] = {
+            s["publisher"] = {
                 "image": None,
                 "nickname": "Toto",
                 "fullname": "El Toto",

--- a/tests/login/tests_login_handler.py
+++ b/tests/login/tests_login_handler.py
@@ -23,7 +23,7 @@ class LoginHandlerTest(TestCase):
 
     def test_redirect_user_logged_in(self):
         with self.client.session_transaction() as s:
-            s["openid"] = "openid"
+            s["publisher"] = "openid"
             s["macaroon_root"] = "macaroon_root"
             s["macaroon_discharge"] = "macaroon_discharge"
 
@@ -33,7 +33,7 @@ class LoginHandlerTest(TestCase):
 
     def test_redirect_user_logged_in_next_url(self):
         with self.client.session_transaction() as s:
-            s["openid"] = "openid"
+            s["publisher"] = "openid"
             s["macaroon_root"] = "macaroon_root"
             s["macaroon_discharge"] = "macaroon_discharge"
 

--- a/tests/publisher/endpoint_testing.py
+++ b/tests/publisher/endpoint_testing.py
@@ -54,7 +54,7 @@ class BaseTestCases:
             discharge = pymacaroons.Macaroon("3rd", "a_ident", "a_caveat_key")
 
             with client.session_transaction() as s:
-                s["openid"] = {
+                s["publisher"] = {
                     "image": None,
                     "nickname": "Toto",
                     "fullname": "El Toto",

--- a/tests/publisher/tests_publisher.py
+++ b/tests/publisher/tests_publisher.py
@@ -76,7 +76,7 @@ class PublisherPage(TestCase):
         discharge = pymacaroons.Macaroon("3rd", "a_ident", "a_caveat_key")
 
         with client.session_transaction() as s:
-            s["openid"] = {
+            s["publisher"] = {
                 "image": None,
                 "nickname": "Toto",
                 "fullname": "El Toto",

--- a/tests/store/tests_details.py
+++ b/tests/store/tests_details.py
@@ -186,7 +186,7 @@ class GetDetailsPageTest(TestCase):
 
         with self.client.session_transaction() as s:
             # make test session 'authenticated'
-            s["openid"] = {"nickname": "toto", "fullname": "Totinio"}
+            s["publisher"] = {"nickname": "toto", "fullname": "Totinio"}
             s["macaroon_root"] = "test"
             s["macaroon_discharge"] = "test"
             # mock test user snaps list
@@ -307,7 +307,7 @@ class GetDetailsPageTest(TestCase):
         )
 
         with self.client.session_transaction() as s:
-            s["openid"] = {"nickname": "greg"}
+            s["publisher"] = {"nickname": "greg"}
 
         response = self.client.get(self.endpoint_url)
 

--- a/tests/store/tests_github_badge.py
+++ b/tests/store/tests_github_badge.py
@@ -229,7 +229,7 @@ class GetGitHubBadgeTest(TestCase):
 
         with self.client.session_transaction() as s:
             # make test session 'authenticated'
-            s["openid"] = {"nickname": "toto", "fullname": "Totinio"}
+            s["publisher"] = {"nickname": "toto", "fullname": "Totinio"}
             s["macaroon_root"] = "test"
             s["macaroon_discharge"] = "test"
             # mock test user snaps list

--- a/webapp/authentication.py
+++ b/webapp/authentication.py
@@ -6,6 +6,17 @@ from webapp.api import sso
 
 LOGIN_URL = os.getenv("LOGIN_URL", "https://login.ubuntu.com")
 
+PERMISSIONS = [
+    "edit_account",
+    "package_access",
+    "package_metrics",
+    "package_register",
+    "package_release",
+    "package_update",
+    "package_upload_request",
+    "store_admin",
+]
+
 
 def get_authorization_header(root, discharge):
     """
@@ -25,19 +36,20 @@ def is_authenticated(session):
     Returns True if the user is authenticated
     """
     return (
-        "openid" in session
+        "publisher" in session
         and "macaroon_discharge" in session
         and "macaroon_root" in session
-    )
+    ) or ("publisher" in session and "macaroons" in session)
 
 
 def empty_session(session):
     """
     Empty the session, used to logout.
     """
+    session.pop("macaroons", None)
     session.pop("macaroon_root", None)
     session.pop("macaroon_discharge", None)
-    session.pop("openid", None)
+    session.pop("publisher", None)
     session.pop("user_shared_snaps", None)
     session.pop("github_auth_secret", None)
 
@@ -61,20 +73,7 @@ def request_macaroon():
     Request a macaroon from dashboard.
     Returns the macaroon.
     """
-    response = sso.post_macaroon(
-        {
-            "permissions": [
-                "edit_account",
-                "package_access",
-                "package_metrics",
-                "package_register",
-                "package_release",
-                "package_update",
-                "package_upload_request",
-                "store_admin",
-            ]
-        }
-    )
+    response = sso.post_macaroon({"permissions": PERMISSIONS})
 
     return response["macaroon"]
 

--- a/webapp/first_snap/views.py
+++ b/webapp/first_snap/views.py
@@ -105,8 +105,8 @@ def get_package(language, operating_system):
     snap_name = steps["name"]
     has_user_chosen_name = False
 
-    if flask.session.get("openid"):
-        user_name = flask.session["openid"]["nickname"]
+    if "publisher" in flask.session:
+        user_name = flask.session["publisher"]["nickname"]
         snap_name = snap_name.replace("{name}", user_name)
 
     if snap_name_cookie in flask.request.cookies:
@@ -163,8 +163,8 @@ def get_build(language, operating_system):
 
     snap_name = build_steps["name"]
 
-    if flask.session.get("openid"):
-        user_name = flask.session["openid"]["nickname"]
+    if "publisher" in flask.session:
+        user_name = flask.session["publisher"]["nickname"]
         snap_name = snap_name.replace("{name}", user_name)
 
     if snap_name_cookie in flask.request.cookies:
@@ -195,15 +195,15 @@ def get_push(language, operating_system):
     snap_name = data["name"]
     has_user_chosen_name = False
 
-    if flask.session.get("openid"):
-        user_name = flask.session["openid"]["nickname"]
+    if "publisher" in flask.session:
+        user_name = flask.session["publisher"]["nickname"]
         snap_name = snap_name.replace("{name}", user_name)
 
     if snap_name_cookie in flask.request.cookies:
         snap_name = flask.request.cookies.get(snap_name_cookie)
         has_user_chosen_name = True
 
-    flask_user = flask.session.get("openid", {})
+    flask_user = flask.session.get("publisher", {})
 
     if "nickname" in flask_user:
         user = {

--- a/webapp/first_snap/views_2.py
+++ b/webapp/first_snap/views_2.py
@@ -115,8 +115,8 @@ def get_package(language, operating_system):
     snap_name = steps["name"]
     has_user_chosen_name = False
 
-    if flask.session.get("openid"):
-        user_name = flask.session["openid"]["nickname"]
+    if "publisher" in flask.session:
+        user_name = flask.session["publisher"]["nickname"]
         snap_name = snap_name.replace("{name}", user_name)
 
     if snap_name_cookie in flask.request.cookies:
@@ -174,8 +174,8 @@ def get_build(language, operating_system):
 
     snap_name = build_steps["name"]
 
-    if flask.session.get("openid"):
-        user_name = flask.session["openid"]["nickname"]
+    if "publisher" in flask.session:
+        user_name = flask.session["publisher"]["nickname"]
         snap_name = snap_name.replace("{name}", user_name)
 
     if snap_name_cookie in flask.request.cookies:
@@ -207,15 +207,15 @@ def get_push(language, operating_system):
     snap_name = data["name"]
     has_user_chosen_name = False
 
-    if flask.session.get("openid"):
-        user_name = flask.session["openid"]["nickname"]
+    if "publisher" in flask.session:
+        user_name = flask.session["publisher"]["nickname"]
         snap_name = snap_name.replace("{name}", user_name)
 
     if snap_name_cookie in flask.request.cookies:
         snap_name = flask.request.cookies.get(snap_name_cookie)
         has_user_chosen_name = True
 
-    flask_user = flask.session.get("openid", {})
+    flask_user = flask.session.get("publisher", {})
 
     if "nickname" in flask_user:
         user = {

--- a/webapp/first_snap/views_3.py
+++ b/webapp/first_snap/views_3.py
@@ -115,8 +115,8 @@ def get_package(language, operating_system):
     snap_name = steps["name"]
     has_user_chosen_name = False
 
-    if flask.session.get("openid"):
-        user_name = flask.session["openid"]["nickname"]
+    if "publisher" in flask.session:
+        user_name = flask.session["publisher"]["nickname"]
         snap_name = snap_name.replace("{name}", user_name)
 
     if snap_name_cookie in flask.request.cookies:
@@ -174,8 +174,8 @@ def get_build(language, operating_system):
 
     snap_name = build_steps["name"]
 
-    if flask.session.get("openid"):
-        user_name = flask.session["openid"]["nickname"]
+    if "publisher" in flask.session:
+        user_name = flask.session["publisher"]["nickname"]
         snap_name = snap_name.replace("{name}", user_name)
 
     if snap_name_cookie in flask.request.cookies:
@@ -207,15 +207,15 @@ def get_push(language, operating_system):
     snap_name = data["name"]
     has_user_chosen_name = False
 
-    if flask.session.get("openid"):
-        user_name = flask.session["openid"]["nickname"]
+    if "publisher" in flask.session:
+        user_name = flask.session["publisher"]["nickname"]
         snap_name = snap_name.replace("{name}", user_name)
 
     if snap_name_cookie in flask.request.cookies:
         snap_name = flask.request.cookies.get(snap_name_cookie)
         has_user_chosen_name = True
 
-    flask_user = flask.session.get("openid", {})
+    flask_user = flask.session.get("publisher", {})
 
     if "nickname" in flask_user:
         user = {

--- a/webapp/handlers.py
+++ b/webapp/handlers.py
@@ -36,8 +36,8 @@ def set_handlers(app):
         """
 
         if authentication.is_authenticated(flask.session):
-            user_name = flask.session["openid"]["fullname"]
-            user_is_canonical = flask.session["openid"].get(
+            user_name = flask.session["publisher"]["fullname"]
+            user_is_canonical = flask.session["publisher"].get(
                 "is_canonical", False
             )
         else:

--- a/webapp/login/views.py
+++ b/webapp/login/views.py
@@ -105,7 +105,7 @@ def after_login(resp):
     return flask.redirect(open_id.get_next_url())
 
 
-@login.route("/login-candid", methods=["GET"])
+@login.route("/login-beta", methods=["GET"])
 @csrf.exempt
 def login_candid():
     # Get a bakery v2 macaroon from the publisher API to be discharged

--- a/webapp/login/views.py
+++ b/webapp/login/views.py
@@ -1,15 +1,23 @@
 import os
 
 import flask
+from canonicalwebteam.candid import CandidClient
 from canonicalwebteam.store_api.stores.snapstore import SnapPublisher
+from canonicalwebteam.store_api.exceptions import (
+    StoreApiError,
+    StoreApiResponseErrorList,
+)
 from django_openid_auth.teams import TeamsRequest, TeamsResponse
 from flask_openid import OpenID
+from flask_wtf.csrf import generate_csrf, validate_csrf
+
 from webapp import authentication
 from webapp.helpers import api_publisher_session
 from webapp.api.exceptions import ApiCircuitBreaker, ApiError, ApiResponseError
 from webapp.extensions import csrf
 from webapp.login.macaroon import MacaroonRequest, MacaroonResponse
 from webapp.publisher.snaps import logic
+from webapp.publisher.views import _handle_error, _handle_error_list
 
 login = flask.Blueprint(
     "login", __name__, template_folder="/templates", static_folder="/static"
@@ -26,6 +34,7 @@ open_id = OpenID(
 )
 
 publisher_api = SnapPublisher(api_publisher_session)
+candid = CandidClient(api_publisher_session)
 
 
 @login.route("/login", methods=["GET", "POST"])
@@ -70,7 +79,7 @@ def after_login(resp):
 
     try:
         account = publisher_api.get_account(flask.session)
-        flask.session["openid"] = {
+        flask.session["publisher"] = {
             "identity_url": resp.identity_url,
             "nickname": account["username"],
             "fullname": account["displayname"],
@@ -85,7 +94,7 @@ def after_login(resp):
     except ApiCircuitBreaker:
         flask.abort(503)
     except Exception:
-        flask.session["openid"] = {
+        flask.session["publisher"] = {
             "identity_url": resp.identity_url,
             "nickname": resp.nickname,
             "fullname": resp.fullname,
@@ -94,6 +103,72 @@ def after_login(resp):
         }
 
     return flask.redirect(open_id.get_next_url())
+
+
+@login.route("/login-candid", methods=["GET"])
+@csrf.exempt
+def login_candid():
+    # Get a bakery v2 macaroon from the publisher API to be discharged
+    # and save it in the session
+    flask.session["publisher-macaroon"] = publisher_api.get_macaroon(
+        authentication.PERMISSIONS
+    )
+
+    login_url = candid.get_login_url(
+        macaroon=flask.session["publisher-macaroon"],
+        callback_url=flask.url_for("login.login_callback", _external=True),
+        state=generate_csrf(),
+    )
+
+    # Next URL to redirect the user after the login
+    next_url = flask.request.args.get("next")
+
+    if next_url:
+        if not next_url.startswith(
+            flask.request.url_root
+        ) or next_url.startswith("/"):
+            return flask.abort(400)
+        flask.session["next_url"] = next_url
+
+    return flask.redirect(login_url, 302)
+
+
+@login.route("/login/callback")
+def login_callback():
+    code = flask.request.args["code"]
+    state = flask.request.args["state"]
+
+    # Avoid CSRF attacks
+    validate_csrf(state)
+
+    discharged_token = candid.discharge_token(code)
+    candid_macaroon = candid.discharge_macaroon(
+        flask.session["publisher-macaroon"], discharged_token
+    )
+
+    # Store bakery authentication
+    flask.session["macaroons"] = candid.get_serialized_bakery_macaroon(
+        flask.session["publisher-macaroon"], candid_macaroon
+    )
+
+    try:
+        publisher = publisher_api.whoami(flask.session)
+    except StoreApiResponseErrorList as api_response_error_list:
+        return _handle_error_list(api_response_error_list.errors)
+    except (StoreApiError, ApiError) as api_error:
+        return _handle_error(api_error)
+
+    # whoami is the only Dashboard API endpoint
+    # that support Candid.
+    return publisher
+
+    # return flask.redirect(
+    #     flask.session.pop(
+    #         "next_url",
+    #         flask.url_for("publisher_snaps.get_account_snaps"),
+    #     ),
+    #     302,
+    # )
 
 
 @login.route("/logout")

--- a/webapp/publisher/snaps/views.py
+++ b/webapp/publisher/snaps/views.py
@@ -233,7 +233,7 @@ def get_account_snaps():
 
     user_snaps, registered_snaps = logic.get_snaps_account_info(account_info)
 
-    flask_user = flask.session["openid"]
+    flask_user = flask.session["publisher"]
 
     context = {
         "snaps": user_snaps,

--- a/webapp/publisher/views.py
+++ b/webapp/publisher/views.py
@@ -102,7 +102,7 @@ def get_account_details():
     except (StoreApiError, ApiError) as api_error:
         return _handle_error(api_error)
 
-    flask_user = flask.session["openid"]
+    flask_user = flask.session["publisher"]
 
     subscriptions = None
 

--- a/webapp/store/snap_details_views.py
+++ b/webapp/store/snap_details_views.py
@@ -127,7 +127,7 @@ def snap_details_views(store, api, handle_errors):
         is_users_snap = False
         if authentication.is_authenticated(flask.session):
             if (
-                flask.session.get("openid").get("nickname")
+                flask.session.get("publisher").get("nickname")
                 == details["snap"]["publisher"]["username"]
             ) or (
                 "user_shared_snaps" in flask.session
@@ -379,7 +379,7 @@ def snap_details_views(store, api, handle_errors):
         show_as_preview = False
         if is_preview and authentication.is_authenticated(flask.session):
             if (
-                flask.session.get("openid").get("nickname")
+                flask.session.get("publisher").get("nickname")
                 == context["username"]
             ) or (
                 "user_shared_snaps" in flask.session


### PR DESCRIPTION
## Done
- Added Candid login

## How to QA

**Demo link will not work with Candid**

Set up all the staging APIs in the `.env.local`:
```
LOGIN_URL=https://login.staging.ubuntu.com
SNAPSTORE_API_URL=https://api.staging.snapcraft.io/
SNAPSTORE_DASHBOARD_API_URL=https://dashboard.staging.snapcraft.io/
CANDID_API_URL=https://api.staging.jujucharms.com/identity/
```

- `dotrun`
- Visit `localhost:8004/login-candid`
- Please use your SSO staging account
- After you are logged you will see a JSON response will information about your user.
- That's all.

## Issue / Card
Fixes https://github.com/canonical-web-and-design/snap-squad/issues/1835
