### PR TITLE
Add width and height attributes to site logo

### DIFF
--- a/templates/_header.html
+++ b/templates/_header.html
@@ -3,7 +3,7 @@
     <div class="p-navigation__banner">
       <div class="p-navigation__logo">
         <a class="p-navigation__link" href="/">
-          <img class="p-navigation__image" src="https://assets.ubuntu.com/v1/7f93bb62-snapcraft-logo--web-white-text.svg" alt="Snapcraft" />
+          <img class="p-navigation__image" src="https://assets.ubuntu.com/v1/7f93bb62-snapcraft-logo--web-white-text.svg" alt="Snapcraft" width="132" height="32" />
         </a>
       </div>
       <a href="#navigation" class="p-navigation__toggle--open" title="menu">Menu</a>


### PR DESCRIPTION
## Done
Added width and height attributes to the snapcraft logo

## QA
- Go to https://snapcraft-io-3420.demos.haus/
- Check that the snapcraft logo looks the same as it does on the live site

## Issue
Fixes #3419