### PR TITLE
Add width and height attributes to verified account icon

### DIFF
--- a/templates/partials/_verified_developer.html
+++ b/templates/partials/_verified_developer.html
@@ -1,4 +1,4 @@
 <span class="p-verified p-tooltip p-tooltip--top-center" aria-describedby="{{ package_name }}-tooltip">
-    <img src="https://assets.ubuntu.com/v1/75654c90-rosette.svg" />
+    <img src="https://assets.ubuntu.com/v1/75654c90-rosette.svg" width="12" height="12" />
     <span class="p-tooltip__message u-align--center" role="tooltip" id="{{ package_name }}-tooltip">Verified account</span>
 </span>


### PR DESCRIPTION
## Done
Added width and height attributes to the verified account icon

## QA
- Go to https://snapcraft-io-3422.demos.haus/code
- Check that the small green tick icon under the snap title looks the same as on the live site

## Issue
Fixes #3421 