### PR TITLE
Preload hero background image

### DIFF
--- a/templates/_layout.html
+++ b/templates/_layout.html
@@ -11,6 +11,8 @@
     <link rel="preconnect" href="https://assets.ubuntu.com">
     <link rel="preconnect" href="https://munchkin.marketo.net">
 
+    <link rel="preload" href="https://assets.ubuntu.com/v1/9689339a-snapcraft-hero-background--light.png">
+
     <!-- Google Tag Manager -->
     <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
     new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],


### PR DESCRIPTION
## Done
Pre-load the hero background image to improve first contentful paint

## QA
- Go to https://snapcraft-io-3424.demos.haus/code
- Check that the pale green suru image still loads

## Issue
Fixes #3423