### PR TITLE
Add missing as attribute to preloaded image

### DIFF
--- a/templates/_layout.html
+++ b/templates/_layout.html
@@ -11,7 +11,7 @@
     <link rel="preconnect" href="https://assets.ubuntu.com">
     <link rel="preconnect" href="https://munchkin.marketo.net">
 
-    <link rel="preload" href="https://assets.ubuntu.com/v1/9689339a-snapcraft-hero-background--light.png">
+    <link rel="preload" href="https://assets.ubuntu.com/v1/9689339a-snapcraft-hero-background--light.png" as="image">
 
     <!-- Google Tag Manager -->
     <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':


### PR DESCRIPTION
## Done
Added a valid `as` attribute to the pre-loaded hero image

## QA
- Go to https://snapcraft-io-3426.demos.haus/code
- Check that there is no warning in the console about a missing `as` attribute for `preload`

## Issue
Fixes #3425
