### PR TITLE
Fix bug with manage snaps save button

### DIFF
--- a/static/js/public/manage-snaps.js
+++ b/static/js/public/manage-snaps.js
@@ -19,12 +19,16 @@ function updateSnaps() {
   );
 
   const originalSnapState = formatSelectedSnapData(snapCheckboxes);
-  let currentSnaps = formatSelectedSnapData(originalSnapState);
+  let currentSnaps = originalSnapState;
   let dirtyData = false;
 
   snapCheckboxes.forEach((snap) => {
     snap.addEventListener("change", () => {
-      currentSnaps = formatSelectedSnapData(snapCheckboxes);
+      const currentSnapCheckboxes = Array.prototype.slice.call(
+        snapsTable.querySelectorAll(":checked")
+      );
+
+      currentSnaps = formatSelectedSnapData(currentSnapCheckboxes);
 
       if (
         JSON.stringify(originalSnapState.sort()) !==


### PR DESCRIPTION
## Done
Fixed a bug with the manage snaps save button state

## QA
- Go to https://snapcraft-io-3430.demos.haus/admin/ahnuP3quahti9vis8aiw/snaps/manage
- Uncheck any of the snaps
- The "Save changes" button should not be disabled (do not actually click the button)
- Check the snaps to return the page to it's original state
- The "Save changes" button should be disabled

## Issue
Fixes #3429 