### PR TITLE
Add logic to get YouTube thumbnail URL

### DIFF
--- a/konf/site.yaml
+++ b/konf/site.yaml
@@ -66,6 +66,11 @@ env:
       key: lp-api-token-secret
       name: snapcraft-io
 
+  - name: YOUTUBE_API_KEY
+    secretKeyRef:
+      key: youtube-api-key
+      name: snapcraft-io
+
 memoryLimit: 256Mi
 
 extraHosts:

--- a/static/sass/_snapcraft-p-videos.scss
+++ b/static/sass/_snapcraft-p-videos.scss
@@ -1,12 +1,19 @@
 @mixin snapcraft_p-videos {
-  .youtube-thumbnail {
+  .youtube-thumbnail-button {
+    background-color: $color-x-dark;
     border: none;
+    height: 100%;
     left: 0;
     margin-bottom: 0;
     padding: 0;
     position: absolute;
     top: 0;
+    width: 100%;
     z-index: 1;
+
+    &:hover {
+      background-color: $color-x-dark !important;
+    }
 
     &.fade-out {
       opacity: 0;

--- a/templates/partials/_video.html
+++ b/templates/partials/_video.html
@@ -1,7 +1,7 @@
 {% if video.type == "youtube" %}
-  <iframe id="ytplayer" type="text/html" width="818" height="460" allow="autoplay"></iframe>
-  <button class="youtube-thumbnail" id="youtube-thumbnail">
-    <img src="https://i3.ytimg.com/vi/{{ video.id }}/maxresdefault.jpg" alt="" width="1029" height="588">
+  <iframe id="youtubeplayer" type="text/html" width="818" height="460" allow="autoplay"></iframe>
+  <button class="youtube-thumbnail-button" id="youtube-thumbnail-button">
+    <img src="https://i3.ytimg.com/vi/{{ video.id }}/maxresdefault.jpg" alt="" width="1280" height="720" id="youtube-thumbnail-image">
     <img src="{{ static_url('images/yt_play_btn.svg') }}" alt="" width="68" height="48" class="youtube-play-button">
   </button>
 {% elif video.type == "vimeo" %}
@@ -16,6 +16,7 @@
   document.addEventListener("DOMContentLoaded", function() {
     const vimeoplayerFrame = document.getElementById("vimeoplayer");
     const asciicastplayerFrame = document.getElementById("asciicastplayer");
+    const youtubeFrame = document.getElementById("youtubeplayer");
 
     if (vimeoplayerFrame) {
       vimeoplayerFrame.src = vimeoplayerFrame.dataset.src;
@@ -30,15 +31,55 @@
       asciicastplayerFrame.appendChild(script);
     }
 
-    const youtubeFrame = document.getElementById("ytplayer");
-    const youtubeThumbnail = document.getElementById("youtube-thumbnail");
-    const videoUrl = "{{ video.url }}?autoplay=1&cc_load_policy=1&modestbranding=1&rel=0";
+    if (youtubeFrame) {
+      const videoId = "{{ video.id }}";
+      const thumbnailUrl = `/youtube/${videoId}`;
+      const thumbnailImage = document.querySelector("#youtube-thumbnail-image");
+      const thumbnailButton = document.querySelector("#youtube-thumbnail-button");
+      const videoUrl = "{{ video.url }}?autoplay=1&cc_load_policy=1&modestbranding=1&rel=0";
 
-    youtubeThumbnail.addEventListener("click", function() {
-      youtubeFrame.src = videoUrl;
-      setTimeout(function() {
-        youtubeThumbnail.classList.add("fade-out");
-      }, 300);
-    });
+      fetch(thumbnailUrl)
+        .then(function(r) {
+          if (r.ok === true) {
+            return r.json();
+          }
+        })
+        .then(function(res) {
+          if (!res.items) {
+            return;
+          }
+
+          const thumbnails = res.items[0].snippet.thumbnails;
+
+          if (thumbnails.maxres) {
+            thumbnailImage.src = thumbnails.maxres.url;
+            thumbnailImage.width = thumbnails.maxres.width;
+            thumbnailImage.height = thumbnails.maxres.height;
+          } else if (thumbnails.standard) {
+            thumbnailImage.src = thumbnails.standard.url;
+            thumbnailImage.width = thumbnails.standard.width;
+            thumbnailImage.height = thumbnails.standard.height;
+          } else if (thumbnails.high) {
+            thumbnailImage.src = thumbnails.high.url;
+            thumbnailImage.width = thumbnails.high.width;
+            thumbnailImage.height = thumbnails.high.height;
+          } else if (thumbnails.medium) {
+            thumbnailImage.src = thumbnails.medium.url;
+            thumbnailImage.width = thumbnails.medium.width;
+            thumbnailImage.height = thumbnails.medium.height;
+          } else {
+            thumbnailImage.src = thumbnails.default.url;
+            thumbnailImage.width = thumbnails.default.width;
+            thumbnailImage.height = thumbnails.default.height;
+          }
+        });
+
+      thumbnailButton.addEventListener("click", function() {
+        youtubeFrame.src = videoUrl;
+        setTimeout(function() {
+          thumbnailButton.classList.add("fade-out");
+        }, 300);
+      });
+    }
   });
 </script>

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -18,8 +18,11 @@ from canonicalwebteam.store_api.exceptions import (
 from webapp.api.exceptions import ApiError
 from webapp.snapcraft import logic as snapcraft_logic
 from webapp.store.snap_details_views import snap_details_views
+import os
 
 session = talisker.requests.get_session(requests.Session)
+
+YOUTUBE_API_KEY = os.getenv("YOUTUBE_API_KEY")
 
 
 def store_blueprint(store_query=None):
@@ -273,6 +276,18 @@ def store_blueprint(store_query=None):
             flask.render_template("brand-store/search.html", **context),
             status_code,
         )
+
+    @store.route("/youtube/<video_id>")
+    def get_video_thumbnail_data(video_id):
+        thumbnail_url = "https://www.googleapis.com/youtube/v3/videos"
+        thumbnail_data = session.get(
+            f"{thumbnail_url}?id={video_id}&part=snippet&key={YOUTUBE_API_KEY}"
+        )
+
+        if thumbnail_data:
+            return thumbnail_data.json()
+
+        return {}
 
     @store.route("/publisher/<regex('[a-z0-9-]*[a-z][a-z0-9-]*'):publisher>")
     def publisher_details(publisher):


### PR DESCRIPTION
## Done

## QA
**Note**: If you are running locally you will need an API key which you can get here: https://console.cloud.google.com/apis/credentials?project=snapcraft-youtube-thumbnails&folder=&organizationId=&supportedpurview=project

Add the API to `.env.local` as `YOUTUBE_API_KEY=<KEY>`

---

- Go to https://snapcraft-io-3442.demos.haus/code
- Check that the video thumbnail looks correct
- Go to https://snapcraft-io-3442.demos.haus/wonderwall
- Check that initially a grey image will load, then the correct image (it won't be full screen because it is too small)

## Issue
Fixes https://github.com/canonical-web-and-design/snapcraft.io/issues/3441