### PR TITLE
Fix search exception

### DIFF
--- a/tests/store/tests_search.py
+++ b/tests/store/tests_search.py
@@ -85,7 +85,6 @@ class GetSearchViewTest(TestCase):
         self.assert_context("featured_snaps", [])
         self.assert_context("total", 0)
         self.assert_context("links", {"next": "/search?q=snap&page=2"})
-        self.assert_context("error_info", {})
 
     @responses.activate
     def test_search_q_with_zero_as_page(self):
@@ -113,7 +112,6 @@ class GetSearchViewTest(TestCase):
         self.assert_context("searched_snaps", {})
         self.assert_context("total", 0)
         self.assert_context("links", {"next": "/search?q=snap&page=2"})
-        self.assert_context("error_info", {})
 
     @responses.activate
     def test_search_q_with_results(self):
@@ -162,8 +160,6 @@ class GetSearchViewTest(TestCase):
         self.assert_context("total", 3)
         self.assert_context("links", {})
 
-        self.assert_context("error_info", {})
-
     @responses.activate
     def test_search_q_with_results_but_no_total(self):
         payload = {
@@ -209,8 +205,6 @@ class GetSearchViewTest(TestCase):
         )
         self.assert_context("total", None)
         self.assert_context("links", {"next": "/search?q=snap&page=2"})
-
-        self.assert_context("error_info", {})
 
     @responses.activate
     def test_search_q_with_category(self):
@@ -266,8 +260,6 @@ class GetSearchViewTest(TestCase):
             },
         )
 
-        self.assert_context("error_info", {})
-
     @responses.activate
     def test_search_q_with_category_page_2(self):
         snap_list = [
@@ -322,8 +314,6 @@ class GetSearchViewTest(TestCase):
             },
         )
 
-        self.assert_context("error_info", {})
-
     @responses.activate
     def test_search_q_with_category_featured(self):
         snap_list = [
@@ -373,5 +363,3 @@ class GetSearchViewTest(TestCase):
         self.assert_context("page", 1)
         self.assert_context("total", 44)
         self.assert_context("links", {})
-
-        self.assert_context("error_info", {})

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -122,7 +122,6 @@ def store_blueprint(store_query=None):
         )
 
     def search_snap():
-        status_code = 200
         snap_searched = flask.request.args.get("q", default="", type=str)
         snap_category = flask.request.args.get(
             "category", default="", type=str
@@ -145,9 +144,6 @@ def store_blueprint(store_query=None):
 
         size = 44
 
-        error_info = {}
-        searched_results = []
-
         try:
             searched_results = api.search(
                 snap_searched,
@@ -157,6 +153,7 @@ def store_blueprint(store_query=None):
             )
         except (StoreApiError, ApiError) as api_error:
             status_code, error_info = _handle_error(api_error)
+            return flask.abort(status_code)
 
         total_pages = None
 
@@ -227,13 +224,9 @@ def store_blueprint(store_query=None):
             "total": total_results_count,
             "links": links,
             "page": page,
-            "error_info": error_info,
         }
 
-        return (
-            flask.render_template("store/search.html", **context),
-            status_code,
-        )
+        return flask.render_template("store/search.html", **context)
 
     def brand_search_snap():
         status_code = 200


### PR DESCRIPTION
## Done
- `searched_results` was a list not a `dict` with the element "results" (fixes https://github.com/canonical-web-and-design/snapcraft.io/issues/3434)
- Previous error handling on this view didn't make sense and `error_info` variable is not being used by the template.

## Issue / Card
Fixes #3434
