### PR TITLE
Catch error when continued or new devices do not exist

### DIFF
--- a/static/js/publisher/metrics/metrics.js
+++ b/static/js/publisher/metrics/metrics.js
@@ -107,16 +107,25 @@ function renderPublisherMetrics(options) {
           json.snaps.forEach((snap) => {
             const continuedDevices = snap.series.filter(
               (singleSeries) => singleSeries.name === "continued"
-            )[0].values;
+            )[0];
             const newDevices = snap.series.filter(
               (singleSeries) => singleSeries.name === "new"
-            )[0].values;
+            )[0];
 
-            const totalSeries = continuedDevices.map(
-              (continuedValue, index) => {
-                return continuedValue + newDevices[index];
-              }
-            );
+            let totalSeries = [];
+
+            if (continuedDevices && newDevices) {
+              totalSeries = continuedDevices.values.map(
+                (continuedValue, index) => {
+                  return continuedValue + newDevices.values[index];
+                }
+              );
+            } else {
+              console.log(
+                "There is no information available for continued or new devices.",
+                snap.series
+              );
+            }
 
             snaps.series.push({
               name: snap.name,


### PR DESCRIPTION
## Done
- _Catch error when continued or new devices do not exist._

## How to QA
- Go to https://snapcraft-io-3454.demos.haus/snaps and see the page loads and there are no console errors.
- Hopefully this will fix the [sentry error](https://sentry.is.canonical.com/canonical/snapcraft-io/issues/2757/), but I'll need to check that after we deploy this piece of code.

## Issue / Card
Fixes #3436 

## Screenshots
[if relevant, include a screenshot]
