### PR TITLE
Empty macaroons in session on login

### DIFF
--- a/webapp/login/views.py
+++ b/webapp/login/views.py
@@ -73,6 +73,10 @@ def login_handler():
 
 @open_id.after_login
 def after_login(resp):
+    flask.session.pop("macaroons", None)
+    flask.session.pop("macaroon_root", None)
+    flask.session.pop("macaroon_discharge", None)
+
     flask.session["macaroon_discharge"] = resp.extensions["macaroon"].discharge
     if not resp.nickname:
         return flask.redirect(LOGIN_URL)
@@ -142,6 +146,10 @@ def login_candid():
 def login_callback():
     code = flask.request.args["code"]
     state = flask.request.args["state"]
+
+    flask.session.pop("macaroons", None)
+    flask.session.pop("macaroon_root", None)
+    flask.session.pop("macaroon_discharge", None)
 
     # Avoid CSRF attacks
     validate_csrf(state)


### PR DESCRIPTION
## Done
- We are managing 2 identity providers: candid and login, there was a conflict between them
- The pr emptys the macaroon session on login to avoid the conflic

## How to QA
- add those variables in `.env.local`
```
LOGIN_URL=https://login.staging.ubuntu.com
SNAPSTORE_API_URL=https://api.staging.snapcraft.io/
SNAPSTORE_DASHBOARD_API_URL=https://dashboard.staging.snapcraft.io/
CANDID_API_URL=https://api.staging.jujucharms.com/identity/
LAUNCHPAD_API_URL=https://api.staging.launchpad.net/devel/
```
- If you don't have a staging at login.staging.ubuntu.com create one :smile: 
- http://localhost:8004/login
- Should login without issues
- http://localhost:8004/login-beta
- should also login with no issues
- http://localhost:8004/logout
- Try again to login with the 2 endpoints