### PR TITLE
Fix wrong variables to pop

### DIFF
--- a/webapp/login/views.py
+++ b/webapp/login/views.py
@@ -74,8 +74,6 @@ def login_handler():
 @open_id.after_login
 def after_login(resp):
     flask.session.pop("macaroons", None)
-    flask.session.pop("macaroon_root", None)
-    flask.session.pop("macaroon_discharge", None)
 
     flask.session["macaroon_discharge"] = resp.extensions["macaroon"].discharge
     if not resp.nickname:
@@ -147,7 +145,6 @@ def login_callback():
     code = flask.request.args["code"]
     state = flask.request.args["state"]
 
-    flask.session.pop("macaroons", None)
     flask.session.pop("macaroon_root", None)
     flask.session.pop("macaroon_discharge", None)
 


### PR DESCRIPTION
## Done
- Unfortunatly it's hard to QA without testing on production
- There was a mistake in the session objects to pop
- now rremove the login sessions that are the opposite login on the callbacks
- This is a follow up from this PR https://github.com/canonical-web-and-design/snapcraft.io/pull/3465

## How to QA
- add those variables in `.env.local`
```
LOGIN_URL=https://login.staging.ubuntu.com
SNAPSTORE_API_URL=https://api.staging.snapcraft.io/
SNAPSTORE_DASHBOARD_API_URL=https://dashboard.staging.snapcraft.io/
CANDID_API_URL=https://api.staging.jujucharms.com/identity/
LAUNCHPAD_API_URL=https://api.staging.launchpad.net/devel/
```
- If you don't have a staging at login.staging.ubuntu.com create one :smile: 
- http://localhost:8004/login
- Should login without issues
- http://localhost:8004/login-beta
- should also login with no issues
- http://localhost:8004/logout
- Try again to login with the 2 endpoints
