### PR TITLE
Change admin navigation colour

### DIFF
--- a/static/sass/_snapcraft_l-application.scss
+++ b/static/sass/_snapcraft_l-application.scss
@@ -2,29 +2,64 @@
   .l-application {
     width: auto;
 
+    .l-navigation.is-collapsed {
+      @media (min-width: $breakpoint-small) and (max-width: $breakpoint-large) {
+        .p-side-navigation__list {
+          display: none;
+        }
+
+        &:hover {
+          .p-side-navigation__list {
+            display: block;
+          }
+        }
+      }
+
+      &:focus-within {
+        box-shadow: none;
+      }
+    }
+
     .l-navigation__drawer {
-      background-color: $color-brand;
-      color: $color-x-light;
+      background-color: $color-light;
+      color: $color-dark;
+      padding: $sp-medium 0 $sp-medium 3px;
     }
 
     .l-navigation__drawer a {
-      color: $color-x-light;
-      opacity: 0.5;
+      color: inherit;
 
       &:hover,
       &:focus,
       &.is-active {
-        opacity: 1;
+        background-color: $color-mid-x-light;
+        color: $color-dark;
+        font-weight: 400;
+        position: relative;
+
+        &::before {
+          background-color: $color-mid-x-light;
+          content: "";
+          display: block;
+          height: 100%;
+          left: -3px;
+          position: absolute;
+          top: 0;
+          width: 3px;
+        }
+      }
+
+      &.is-active::before {
+        background-color: $color-mid-dark;
       }
     }
 
     .l-navigation-bar {
-      background-color: $color-brand;
+      background-color: $color-light;
       padding: $sp-medium;
     }
 
-    .l-main,
-    .l-navigation__drawer {
+    .l-main {
       padding: $sp-medium;
     }
 

--- a/templates/admin/_navigation.html
+++ b/templates/admin/_navigation.html
@@ -4,7 +4,7 @@
   </li>
   {% for s in stores %}
   <li class="p-side-navigation__item">
-    <a class="p-side-navigation__link {% if store.id == s.id %}is-active{% endif %}" href="/admin/{{ s.id }}/snaps">{{ s.name }}</a>
+    <a class="p-side-navigation__link" href="/admin/{{ s.id }}/snaps">{{ s.name }}</a>
     <ul class="p-side-navigation__list {% if store.id != s.id %}u-hide{% endif %}">
       <li class="p-side-navigation__item">
         <a class="p-side-navigation__link {% if current_tab == 'snaps' %}is-active{% endif %}" href="/admin/{{ s.id }}/snaps">Snaps</a>

--- a/templates/admin/admin_layout.html
+++ b/templates/admin/admin_layout.html
@@ -4,14 +4,14 @@
 <div class="l-application" role="presentation">
   <div class="l-navigation-bar">
     <div class="u-clearfix">
-      <button class="p-button--base is-light u-float-right u-align--right u-no-padding--right js-menu-open is-dense u-no-margin" style="color: #fff;">&lsaquo;&nbsp;Toggle sidebar navigation</button>
+      <button class="p-button--base is-light u-float-right u-align--right u-no-padding--right js-menu-open is-dense u-no-margin">&lsaquo;&nbsp;Toggle sidebar navigation</button>
     </div>
   </div>
 
   <header class="l-navigation is-collapsed">
     <div class="l-navigation__drawer">
-      <div class="u-hide--large u-align--right">
-        <button class="js-menu-close is-dense u-no-margin">Close</button>
+      <div class="u-hide--medium u-hide--large u-align--right">
+        <button class="js-menu-close is-dense" style="margin: 0 1rem 1rem; width: auto;">Close</button>
       </div>
       {% include "admin/_navigation.html" %}
     </div>


### PR DESCRIPTION
## Done
Changed the admin pages navigation colours and active state

## QA
- Go to https://snapcraft-io-3491.demos.haus/admin/ahnuP3quahti9vis8aiw/members
- Compare the side navigation to [the design](https://app.zeplin.io/project/5f3170425822f41fc299a330/screen/606c2fda4c199f9300ed9372)

## Issue
Fixes https://github.com/canonical-web-and-design/snap-squad/issues/1995