### PR TITLE
Add focus style to custom checkboxes

### DIFF
--- a/static/sass/_snapcraft_custom-checkboxes.scss
+++ b/static/sass/_snapcraft_custom-checkboxes.scss
@@ -105,4 +105,9 @@
       top: -6px;
     }
   }
+
+  .custom-checkbox .custom-checkbox__input:focus + .custom-checkbox__box::before {
+    outline: 0.1875rem solid #2e96ff;
+    outline-offset: -0.1875rem;
+  }
 }


### PR DESCRIPTION
## Done
Added a focus state to the custom checkboxes

## QA
- Go to https://snapcraft-io-3499.demos.haus/admin/ahnuP3quahti9vis8aiw/members
- Tab to the checkboxes and check that there is a focus outline similar to the text field/filter above

## Issue
Fixes https://github.com/canonical-web-and-design/snapcraft.io/issues/3497