### PR TITLE
Candid re-auth

### DIFF
--- a/webapp/decorators.py
+++ b/webapp/decorators.py
@@ -14,8 +14,11 @@ def login_required(func):
 
     @functools.wraps(func)
     def is_user_logged_in(*args, **kwargs):
+        last_login_method = flask.request.cookies.get("last_login_method")
+        login_path = "login-beta" if last_login_method == "candid" else "login"
+
         if not authentication.is_authenticated(flask.session):
-            return flask.redirect("/login?next=" + flask.request.path)
+            return flask.redirect(f"/{login_path}?next={flask.request.path}")
 
         return func(*args, **kwargs)
 

--- a/webapp/publisher/views.py
+++ b/webapp/publisher/views.py
@@ -71,8 +71,10 @@ def _handle_error_list(errors):
         "macaroon-permission-required",
         "macaroon-authorization-required",
     ]:
+        last_login_method = flask.request.cookies.get("last_login_method")
+        login_path = "login-beta" if last_login_method == "candid" else "login"
         authentication.empty_session(flask.session)
-        return flask.redirect("/login?next=" + flask.request.path)
+        return flask.redirect(f"/{login_path}?next={flask.request.path}")
 
     codes = [
         f"{error['code']}: {error.get('message', 'No message')}"


### PR DESCRIPTION
## Done
- Store the last auth method in a cookie

## How to QA

**Demo will not work with Candid authentication**
- http://localhost:8004/login-beta
- Finish the auth flow and check your cookies: `last_login_method:"candid"`
- http://localhost:8004/logout
- Go directly to http://localhost:8004/snaps, it should redirect you to Candid
- Check that the cookie is being set with SSO (/login) and works properly

## Issue / Card
Fixes #3492
