### PR TITLE
Default store to settings page

### DIFF
--- a/webapp/admin/views.py
+++ b/webapp/admin/views.py
@@ -38,7 +38,7 @@ def get_stores():
 
     # We redirect to the first store snap list
     return flask.redirect(
-        flask.url_for(".get_store_snaps", store_id=stores[0]["id"])
+        flask.url_for(".get_settings", store_id=stores[0]["id"])
     )
 
 


### PR DESCRIPTION
## Done
Default store in admin to settings page

## QA
- Go to https://snapcraft-io-3514.demos.haus/admin
- Check you are taken to the settings page of the first store

## Issue
Fixes https://github.com/canonical-web-and-design/snapcraft.io/issues/3513