### PR TITLE
Highlight members navigation on invites page

### DIFF
--- a/templates/admin/_navigation.html
+++ b/templates/admin/_navigation.html
@@ -10,7 +10,7 @@
         <a class="p-side-navigation__link {% if current_tab == 'snaps' %}is-active{% endif %}" href="/admin/{{ s.id }}/snaps">Snaps</a>
       </li>
       <li class="p-side-navigation__item">
-        <a class="p-side-navigation__link {% if current_tab == 'members' %}is-active{% endif %}" href="/admin/{{ s.id }}/members">Members</a>
+        <a class="p-side-navigation__link {% if current_tab == 'members' or current_tab == 'invites' %}is-active{% endif %}" href="/admin/{{ s.id }}/members">Members</a>
       </li>
       <div class="p-side-navigation__item">
         <a class="p-side-navigation__link {% if current_tab == 'settings' %}is-active{% endif %}" href="/admin/{{ s.id }}/settings">Settings</a>


### PR DESCRIPTION
## Done
Added highlight to members when on the invites page of the admin section

## QA
- Go to https://snapcraft-io-3521.demos.haus/admin/ahnuP3quahti9vis8aiw/members/invites
- Check that "Members" is highlighted in the side navigation

## Issue
Fixes #3519