### PR TITLE
Disable account details for Candid users

### DIFF
--- a/templates/_header.html
+++ b/templates/_header.html
@@ -83,9 +83,12 @@
               <li>
                 <a href="/account/snaps" class="p-subnav__item">My published snaps</a>
               </li>
+              {# We don't show it for Candid users #}
+              {% if not "macaroons" in session %}
               <li>
                 <a href="/account/details" class="p-subnav__item">Account details</a>
               </li>
+              {% endif %}
               <li>
                 <a href="/logout" class="p-subnav__item">Sign out</a>
               </li>


### PR DESCRIPTION
## Done
Remove edit your account details from the navigation for Candid users

## How to QA
- Authenticate with candid /login-beta
- Check don't see this option in the dropdown
![image](https://user-images.githubusercontent.com/6353928/116551240-a2635100-a8ef-11eb-9614-043e9ecb4e2f.png)

## Issue / Card
Fixes #3504
