### PR TITLE
Update link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,7 @@ For more detailed local development instructions, see [HACKING.md](HACKING.md).
 
 This codebase can be modified to setup branded stores that represent specific brand or devices, giving the brand full control over the store content, reviewing process and identity.
 
-- [For companies looking to develop a brand store with Canonical&nbsp;&rsaquo;](https://docs.ubuntu.com/core/en/build-store/create.html
-)
+- [For companies looking to develop a brand store with Canonical&nbsp;&rsaquo;](https://ubuntu.com/core/docs/store-overview)
 - For developers to learn more about developing a brandstore, see [BRANDSTORES.md](BRANDSTORES.md).
 
 # Deploy


### PR DESCRIPTION
It could be made better by linking directly to “§ Brand stores” in that page, but the Discourse shim currently don’t add section anchors.

## Done
- _Updated a broken link in the repo’s README due to successive documentation reshufflings._

## How to QA
- Visit the demo in your browser, link commented below
  - Or you can run the project locally using the [dotrun](https://snapcraft.io/dotrun) snap with `$ dotrun` and view it in your web browser at: http://0.0.0.0:8004/
  - If your demo doesn't work, read more about the [demoservice](https://discourse.ubuntu.com/t/demoservice/16862)
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card
N/A