### PR TITLE
Add checkbox for uploading metadata for snap

### DIFF
--- a/static/js/publisher/form.js
+++ b/static/js/publisher/form.js
@@ -209,6 +209,10 @@ function initForm(config, initialState, errors) {
     }
   }
 
+  function metadata(field, state) {
+    state["update_metadata_on_release"] = field.checked;
+  }
+
   function updateFormState() {
     // Some extra modifications need to happen for the checkboxes
     if (formEl["public_metrics_enabled"]) {
@@ -222,6 +226,10 @@ function initForm(config, initialState, errors) {
     }
     if (formEl.elements["primary_category"]) {
       categories(formEl, state);
+    }
+
+    if (formEl.elements["update_metadata_on_release"]) {
+      metadata(formEl.elements["update_metadata_on_release"], state);
     }
 
     let formData = new FormData(formEl);

--- a/static/js/publisher/state.js
+++ b/static/js/publisher/state.js
@@ -16,6 +16,7 @@ const allowedKeys = [
   "video_urls",
   "license",
   "categories",
+  "update_metadata_on_release",
 ];
 
 function commaSeperatedStringToArray(str) {

--- a/templates/publisher/listing.html
+++ b/templates/publisher/listing.html
@@ -76,15 +76,13 @@ Listing details for {% if display_title %}{{ display_title }}{% else %}{{ snap_t
       </div>
       {% endif %}
 
-      {% with messages = get_flashed_messages() %}
-        {% if messages %}
-          <div class="u-fixed-width">
-            <div class="p-notification--caution">
-              <p class="p-notification__response">Information here was automatically updated to the latest version of the snapcraft.yaml released to the stable channel. <a class="p-link--external" href="/docs/snapcraft-top-level-metadata">Learn more</a>.</p>
-            </div>
+      {% if update_metadata_on_release %}
+        <div class="u-fixed-width">
+          <div class="p-notification--caution">
+            <p class="p-notification__response">Information here was automatically updated to the latest version of the snapcraft.yaml released to the stable channel. <a class="p-link--external" href="/docs/snapcraft-top-level-metadata">Learn more</a>.</p>
           </div>
-        {% endif %}
-      {% endwith %}
+        </div>
+      {% endif %}
 
       <div class="u-fixed-width">
         <h2 class="p-heading--4">

--- a/templates/publisher/listing.html
+++ b/templates/publisher/listing.html
@@ -76,6 +76,16 @@ Listing details for {% if display_title %}{{ display_title }}{% else %}{{ snap_t
       </div>
       {% endif %}
 
+      {% with messages = get_flashed_messages() %}
+        {% if messages %}
+          <div class="u-fixed-width">
+            <div class="p-notification--caution">
+              <p class="p-notification__response">Information here was automatically updated to the latest version of the snapcraft.yaml released to the stable channel. <a class="p-link--external" href="/docs/snapcraft-top-level-metadata">Learn more</a>.</p>
+            </div>
+          </div>
+        {% endif %}
+      {% endwith %}
+
       <div class="u-fixed-width">
         <h2 class="p-heading--4">
           Listing details

--- a/templates/publisher/settings.html
+++ b/templates/publisher/settings.html
@@ -173,6 +173,29 @@ Settings for {% if display_title %}{{ display_title }}{% else %}{{ snap_title }}
       </div>
 
       <div class="row p-form__group">
+        <hr class="u-no-margin--bottom">
+      </div>
+
+      <div class="row p-form__group">
+        <div class="col-2">
+          <label class="p-form__label">Upload metadata on release:</label>
+        </div>
+        <div class="col-8">
+          <div class="p-form__control">
+            <input
+              type="checkbox"
+              name="update_metadata_on_release"
+              id="update_metadata_on_release"
+              {% if update_metadata_on_release|tojson == "true" %}checked{% endif %}
+            />
+            <label for="update_metadata_on_release">
+              <span class="p-form-help-text">The information on the Listing page of this snap will be automatically updated to the version in snapcraft.yaml of the latest revision pushed to the stable channel. If you manually edit the Listing page, the automatic updates will be turned off. <a class="p-link--external" href="/docs/snapcraft-top-level-metadata">Learn more</a>.</span>
+            </label>
+          </div>
+        </div>
+      </div>
+
+      <div class="row p-form__group">
         <hr class="u-no-margin--bottom" />
       </div>
 
@@ -256,7 +279,8 @@ Settings for {% if display_title %}{{ display_title }}{% else %}{{ snap_title }}
         'private': {{ private|tojson }},
         'unlisted': {{ unlisted|tojson }},
         'whitelist_countries': {{ whitelist_country_codes|tojson }},
-        'blacklist_countries': {{ blacklist_country_codes|tojson }}
+        'blacklist_countries': {{ blacklist_country_codes|tojson }},
+        'update_metadata_on_release': {{ update_metadata_on_release|tojson }},
       },
       {% if error_list %}
         {{ error_list|tojson}}

--- a/templates/publisher/settings.html
+++ b/templates/publisher/settings.html
@@ -192,6 +192,13 @@ Settings for {% if display_title %}{{ display_title }}{% else %}{{ snap_title }}
               <span class="p-form-help-text">The information on the Listing page of this snap will be automatically updated to the version in snapcraft.yaml of the latest revision pushed to the stable channel. If you manually edit the Listing page, the automatic updates will be turned off. <a class="p-link--external" href="/docs/snapcraft-top-level-metadata">Learn more</a>.</span>
             </label>
           </div>
+          {% if update_metadata_on_release %}
+            <div class="p-notification--caution" id="metadata-edit-warning">
+          {% else %}
+            <div class="p-notification--caution u-hide" id="metadata-edit-warning" aria-hidden="true">
+          {% endif %}
+            <p class="p-notification__response">To prevent conflicts, manual edited metadata will be overridden in the next release, even if it differs from the web edited data.</p>
+          </div>
         </div>
       </div>
 
@@ -302,6 +309,21 @@ Settings for {% if display_title %}{{ display_title }}{% else %}{{ snap_title }}
       {% elif blacklist_country_codes %}
         snapcraft.publisher.settings.enableInput('blacklist');
       {% endif %}
+
+      var updateMetadataToggle = document.getElementById("update_metadata_on_release");
+      var updateMetadataWarning = document.getElementById("metadata-edit-warning");
+
+      updateMetadataToggle.addEventListener("click", function(e) {
+        const target = e.currentTarget;
+
+        if (target.checked) {
+          updateMetadataWarning.classList.remove("u-hide");
+          updateMetadataWarning.ariaHidden = false;
+        } else {
+          updateMetadataWarning.classList.add("u-hide");
+          updateMetadataWarning.ariaHidden = true;
+        }
+      });
     });
   });
 </script>

--- a/tests/publisher/snaps/tests_listing.py
+++ b/tests/publisher/snaps/tests_listing.py
@@ -60,6 +60,7 @@ class GetListingPage(BaseTestCases.EndpointLoggedInErrorHandling):
             "video_urls": [],
             "categories": {"items": []},
             "status": "published",
+            "update_metadata_on_release": True,
         }
 
         responses.add(responses.GET, self.api_url, json=payload, status=200)
@@ -117,6 +118,7 @@ class GetListingPage(BaseTestCases.EndpointLoggedInErrorHandling):
             "video_urls": [],
             "categories": {"items": []},
             "status": "published",
+            "update_metadata_on_release": True,
         }
 
         responses.add(responses.GET, self.api_url, json=payload, status=200)
@@ -156,6 +158,7 @@ class GetListingPage(BaseTestCases.EndpointLoggedInErrorHandling):
             "video_urls": [],
             "categories": {"items": []},
             "status": "published",
+            "update_metadata_on_release": True,
         }
 
         responses.add(responses.GET, self.api_url, json=payload, status=200)
@@ -201,6 +204,7 @@ class GetListingPage(BaseTestCases.EndpointLoggedInErrorHandling):
             "video_urls": [],
             "categories": {"items": []},
             "status": "published",
+            "update_metadata_on_release": True,
         }
 
         responses.add(responses.GET, self.api_url, json=payload, status=200)
@@ -240,6 +244,7 @@ class GetListingPage(BaseTestCases.EndpointLoggedInErrorHandling):
             "video_urls": ["https://youtube.com/watch?v=1234"],
             "categories": {"items": []},
             "status": "published",
+            "update_metadata_on_release": True,
         }
 
         responses.add(responses.GET, self.api_url, json=payload, status=200)
@@ -279,6 +284,7 @@ class GetListingPage(BaseTestCases.EndpointLoggedInErrorHandling):
             "video_urls": ["https://youtube.com/watch?v=1234"],
             "categories": {"items": []},
             "status": "published",
+            "update_metadata_on_release": True,
         }
 
         responses.add(responses.GET, self.api_url, json=payload, status=200)

--- a/tests/publisher/snaps/tests_settings.py
+++ b/tests/publisher/snaps/tests_settings.py
@@ -58,6 +58,7 @@ class GetSettingsPage(BaseTestCases.EndpointLoggedInErrorHandling):
             "keywords": [],
             "status": "published",
             "publisher": {"display-name": "test"},
+            "update_metadata_on_release": True,
         }
 
         responses.add(responses.GET, self.api_url, json=payload, status=200)
@@ -96,3 +97,4 @@ class GetSettingsPage(BaseTestCases.EndpointLoggedInErrorHandling):
         self.assert_context("store", "stotore")
         self.assert_context("keywords", [])
         self.assert_context("status", "published")
+        self.assert_context("update_metadata_on_release", True)

--- a/webapp/publisher/snaps/listing_views.py
+++ b/webapp/publisher/snaps/listing_views.py
@@ -130,6 +130,9 @@ def get_listing_snap(snap_name):
         "categories": categories,
         "tour_steps": tour_steps,
         "status": snap_details["status"],
+        "update_metadata_on_release": snap_details[
+            "update_metadata_on_release"
+        ],
     }
 
     return flask.render_template("publisher/listing.html", **context)

--- a/webapp/publisher/snaps/logic.py
+++ b/webapp/publisher/snaps/logic.py
@@ -270,6 +270,7 @@ def filter_changes_data(changes):
         "license",
         "video_urls",
         "categories",
+        "update_metadata_on_release",
     ]
 
     return {key: changes[key] for key in whitelist if key in changes}

--- a/webapp/publisher/snaps/settings_views.py
+++ b/webapp/publisher/snaps/settings_views.py
@@ -75,6 +75,9 @@ def get_settings(snap_name):
         "keywords": snap_details["keywords"],
         "status": snap_details["status"],
         "is_on_lp": is_on_lp,
+        "update_metadata_on_release": snap_details[
+            "update_metadata_on_release"
+        ],
     }
 
     return flask.render_template("publisher/settings.html", **context)
@@ -155,6 +158,13 @@ def post_settings(snap_name):
             else:
                 blacklist_country_codes = []
 
+            update_metadata_on_release = True
+
+            if snap_details["update_metadata_on_release"] == "on":
+                update_metadata_on_release = True
+            else:
+                update_metadata_on_release = False
+
             context = {
                 # read-only values from details API
                 "snap_name": snap_details["snap_name"],
@@ -171,6 +181,7 @@ def post_settings(snap_name):
                 "keywords": snap_details["keywords"],
                 "status": snap_details["status"],
                 "is_on_lp": is_on_lp,
+                "update_metadata_on_release": update_metadata_on_release,
                 # errors
                 "error_list": error_list,
                 "field_errors": field_errors,

--- a/webapp/publisher/snaps/settings_views.py
+++ b/webapp/publisher/snaps/settings_views.py
@@ -160,10 +160,11 @@ def post_settings(snap_name):
 
             update_metadata_on_release = True
 
-            if snap_details["update_metadata_on_release"] == "on":
-                update_metadata_on_release = True
-            else:
-                update_metadata_on_release = False
+            if "update_metadata_on_release" in snap_details:
+                if snap_details["update_metadata_on_release"] == "on":
+                    update_metadata_on_release = True
+                else:
+                    update_metadata_on_release = False
 
             context = {
                 # read-only values from details API


### PR DESCRIPTION
## Done
Added a checkbox to the snap settings page which enables or disables the uploading of metadata

## QA
- You need a snap on staging
- Go to https://snapcraft-io-3527.demos.haus/SNAP_NAME/settings
- Check that there is a checkbox for uploading metadata
- Check the box and save the form
- Check that the box is still checked
- Uncheck the box and save the form
- Check that the box is still unchecked
- Go to https://snapcraft-io-3527.demos.haus/SNAP_NAME/listing
- If the upload metadata box on the settings page is checked you should see a notification
- If the upload metadata box on the settings page is not checked you should not see a notification

## Issue
Fixes #3322