### PR TITLE
Empty invites state

### DIFF
--- a/templates/admin/invites.html
+++ b/templates/admin/invites.html
@@ -171,6 +171,12 @@
   </tbody>
 </table>
 
+{% if not pending_invites and not expired_invites and not revoked_invites %}
+  <div class="p-notification--information">
+    <p class="p-notification__response">There are currently no pending, expired or revoked invites.</p>
+  </div>
+{% endif %}
+
 <div class="p-modal" id="invite-modal" style="display: none; z-index: 110;">
   <div class="p-modal__dialog" role="dialog" aria-labelledby="invite-modal-title" style="max-width: 480px;">
     <header class="p-modal__header">


### PR DESCRIPTION
## Done
Added a notification if there are no invites

## QA
- Go to https://snapcraft-io-3529.demos.haus//admin/test1LaNg1xi6eonae5R/members/invites
- Check that there is a notification explaining that there are no invites

## Issue
Fixes #3517