### PR TITLE
Change collaborators column name

### DIFF
--- a/templates/admin/snaps.html
+++ b/templates/admin/snaps.html
@@ -35,7 +35,7 @@
       <th style="width: 15%;">Published in</th>
       <th style="width: 25%;">Name</th>
       <th style="width: 20%;">Latest release</th>
-      <th>Collaborators</th>
+      <th>Publisher</th>
       <th style="width: 5%;">&nbsp;</th>
     </tr>
   </thead>
@@ -51,7 +51,7 @@
       <div data-js-latest-release-version></div>
       <div><small data-js-latest-release-date></small></div>
     </td>
-    <td aria-label="Collaborators" data-js-collaborators></td>
+    <td aria-label="Publisher" data-js-collaborators></td>
     <td aria-label="Actions" class="u-align--right" style="overflow: visible;" data-js-actions>
       <span class="p-tooltip--left" aria-describedby="">
         <button class="p-button--base u-no-margin--bottom u-no-margin--right u-no-padding" disabled>


### PR DESCRIPTION
## Done

Changed the "Collaborators" column name to "Publisher"

## QA
- Go to https://snapcraft-io-3532.demos.haus/admin/ahnuP3quahti9vis8aiw/snaps
- Check that the last column in the table is called "Publisher" and not "Collaborators"

## Issue
Fixes #3530 