### PR TITLE
Hide 'Edit details' link

### DIFF
--- a/templates/_header.html
+++ b/templates/_header.html
@@ -83,12 +83,9 @@
               <li>
                 <a href="/account/snaps" class="p-subnav__item">My published snaps</a>
               </li>
-              {# We don't show it for Candid users #}
-              {% if not "macaroons" in session %}
               <li>
                 <a href="/account/details" class="p-subnav__item">Account details</a>
               </li>
-              {% endif %}
               <li>
                 <a href="/logout" class="p-subnav__item">Sign out</a>
               </li>

--- a/templates/publisher/account-details.html
+++ b/templates/publisher/account-details.html
@@ -22,7 +22,10 @@ Account details — Linux software in the Snap Store
   {% endwith %}
   <div class="u-fixed-width u-clearfix">
     <h3 class="u-float-left">Publisher account details</h3>
+    {# We don't show it for Candid users #}
+    {% if not "macaroons" in session %}
     <a href="{{ LOGIN_URL }}" class="p-link--external u-float-right">Edit details</a>
+    {% endif %}
   </div>
   {% if errors %}
   <div class="row">


### PR DESCRIPTION
Hide 'Edit details' link instead of the account link

## QA

No demo, QA locally
Login with candid (`login-beta1`)
Go to `/account/details` and check that the 'Edit details' link doesn't appear.