### PR TITLE
Fix heading size on details page

### DIFF
--- a/templates/store/snap-details/_distro-instructions-for-snap-support.html
+++ b/templates/store/snap-details/_distro-instructions-for-snap-support.html
@@ -3,7 +3,7 @@
 </div>
 <div class="p-strip is-shallow">
   <div class="u-fixed-width">
-    <h3 class="p-heading--2">Install {{snap_title}} on your Linux distribution</h3>
+    <h3 class="p-heading--4">Install {{snap_title}} on your Linux distribution</h3>
     <p>Choose your Linux distribution to get detailed installation instructions. If yours is not shown, get more details on the <a href="/docs/installing-snapd" target="_blank">installing snapd documentation</a>.</p>
     </div>
 </div>


### PR DESCRIPTION
## Done
Fixed the heading size on the "Install <snap> on your Linux distribution" heading

## QA
- Go to https://snapcraft-io-3537.demos.haus/boa
- Scroll down to the "Install Wolfenstein | Blade of Agony on your Linux distribution" heading
- Check that it is the same size as the "Where people are using Wolfenstein | Blade of Agony" heading

## Issue
Fixes https://github.com/canonical-web-and-design/snapcraft.io/issues/3535