### PR TITLE
Update raspian install steps

### DIFF
--- a/webapp/store/content/distros/raspbian.yaml
+++ b/webapp/store/content/distros/raspbian.yaml
@@ -13,3 +13,7 @@ install:
       You will also need to reboot your device:
     command: |
       sudo reboot
+  - action: |
+      After this, install the core snap in order to get the latest snapd:
+    command: |
+      sudo snap install core


### PR DESCRIPTION
## Done
- Update the raspian instructions to install the core snap
- See: https://snapcraft.io/docs/installing-snap-on-debian

## How to QA
- `dotrun`
- http://0.0.0.0:8004/install/hugo/raspbian
- The install section should have a section that explains how to install the core snap after the device is restarted

![image](https://user-images.githubusercontent.com/2707508/118958315-38bbed00-b959-11eb-860b-4a68ededc062.png)


## Issue / Card
Fixes #3544 


