### PR TITLE
Add store ID field to setting page

### DIFF
--- a/static/sass/_patterns_p-password-toggle-input.scss
+++ b/static/sass/_patterns_p-password-toggle-input.scss
@@ -1,0 +1,18 @@
+@mixin p-password-toggle-input {
+  .p-password-toggle-input {
+    position: relative;
+
+    .p-password-toggle-input__button {
+      color: $color-link;
+      padding-left: 0.5rem;
+      padding-right: 0.5rem;
+      position: absolute;
+      right: 0;
+      top: 0;
+
+      &:hover {
+        background-color: inherit;
+      }
+    }
+  }
+}

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -349,6 +349,10 @@ $color-social-icon-foreground: $color-light;
 
 @include snapcraft-p-side-panel;
 
+@import "patterns_p-password-toggle-input";
+
+@include p-password-toggle-input;
+
 dl {
   margin-bottom: $spv-outer--scaleable;
 }

--- a/templates/admin/settings.html
+++ b/templates/admin/settings.html
@@ -8,6 +8,10 @@
 
 {{ form }}
 
+<div class="l-application__header">
+  <h2 class="p-heading--four">Settings</h2>
+</div>
+
 <div class="row">
   <div class="col-7">
     <form action="/admin/{{ store.id }}/settings" method="POST">
@@ -20,6 +24,18 @@
         </label>
         <div class="p-form-help-text--nudge">This store will not be listed in the store dropdowns like the one in the snap name registration form.</div>
       </div>
+      <hr>
+      <h2 class="p-heading--4" id="store-id-label">Store ID</h2>
+      <div class="p-form__group">
+        <div class="p-password-toggle-input">
+          <input type="password" name="store-id" id="store-id" aria-labelledby="store-id-label" value="{{ store.id }}" readonly style="color: inherit;" data-js-store-id-field>
+          <button type="button" class="p-password-toggle-input__button p-button--base" data-js-toggle-store-id-visibility-button>
+            <span class="show-store-id-text">Show</span>
+            <span class="hide-store-id-text u-hide">Hide</span>
+          </button>
+        </div>
+      </div>
+      <hr>
       <h2 class="p-heading--4">Manual review policy</h2>
       <div class="p-form__group">
         <label class="p-radio">
@@ -55,6 +71,36 @@
     </form>
   </div>
 </div>
-
 {% endblock %}
 
+{% block scripts %}
+<script>
+  const storeIdField = document.querySelector(
+    "[data-js-store-id-field]"
+  );
+
+  const toggleStoreIdVisibilityButton = document.querySelector(
+    "[data-js-toggle-store-id-visibility-button]"
+  );
+
+  const showStoreIdText = toggleStoreIdVisibilityButton.querySelector(
+    ".show-store-id-text"
+  );
+
+  const hideStoreIdText = toggleStoreIdVisibilityButton.querySelector(
+    ".hide-store-id-text"
+  );
+
+  toggleStoreIdVisibilityButton.addEventListener("click", function() {
+    if (storeIdField.type === "password") {
+      storeIdField.type = "text";
+      showStoreIdText.classList.add("u-hide");
+      hideStoreIdText.classList.remove("u-hide");
+    } else {
+      storeIdField.type = "password";
+      showStoreIdText.classList.remove("u-hide");
+      hideStoreIdText.classList.add("u-hide");
+    }
+  });
+</script>
+{% endblock %}


### PR DESCRIPTION
## Done
Added the Store ID field to the manage snaps settings page

## QA
- Go to https://snapcraft-io-3550.demos.haus/admin/test1LaNg1xi6eonae5R/settings
- Check that there is a Store ID field
- Click the show/hide button and check that it toggles the Store ID visibility

## Issue
Fixes https://github.com/canonical-web-and-design/snap-squad/issues/2049