### PR TITLE
Change title on snap details page

### DIFF
--- a/templates/store/snap-details.html
+++ b/templates/store/snap-details.html
@@ -2,7 +2,7 @@
 
 {% block meta_copydoc %}{% endblock %}
 
-{% block meta_title %}Install {{ snap_title }} for Linux using the Snap Store | Snapcraft{% endblock %}
+{% block meta_title %}Install {{ snap_title }} on Linux | Snapcraft{% endblock %}
 {% block meta_description %}Get the latest version of {{ snap_title }} for Linux - {{ summary }}{% endblock %}
 {% block meta_image %}{% if icon_url %}{{ icon_url }}{% else %}https://assets.ubuntu.com/v1/be6eb412-snapcraft-missing-icon.svg{% endif %}{% endblock %}
 


### PR DESCRIPTION
## Done
Changed the title on the snap details page

## QA
- Go to https://snapcraft-io-3554.demos.haus/bitwarden
- Check the the page title in the browser tab is "Install Bitwarden on Linux"

## Issue
Fixes https://github.com/canonical-web-and-design/snap-squad/issues/2073