### PR TITLE
Update title and button on snap distribution page

### DIFF
--- a/templates/store/snap-distro-install.html
+++ b/templates/store/snap-distro-install.html
@@ -69,7 +69,7 @@
     <div class="p-strip">
       <div class="row">
         <div class="col-8">
-           <h1 class="p-heading--2 u-no-margin is-light">How to install {{ snap_title }}<br/> on <b>{{ distro_name }}</b></h1>
+           <h1 class="p-heading--2 u-no-margin is-light">Install {{ snap_title }}<br/> on <b>{{ distro_name }}</b></h1>
         </div>
         {% if distro_logo_mono %}
         <div class="col-4 u-hide--small">
@@ -97,8 +97,8 @@
               {% include 'store/snap-details/_snap_heading_data.html' %}
 
               <div class="p-snap-install-buttons">
-                <a class="p-button--neutral p-snap-install-buttons__install js-install" href="#install" data-scroll-to="#install">
-                  Install snap
+                <a class="p-button--positive p-snap-install-buttons__install js-install" href="#install" data-scroll-to="#install">
+                  Install
                 </a>
               </div>
             </div>


### PR DESCRIPTION
## Done
Updated the button style and h1 of snap distribution page

## QA
- Go to https://snapcraft-io-3555.demos.haus/install/bitwarden/kde-neon
- Check that the h1 says "Install Bitwardenon KDE Neon"
- Check that the "Install" button in the top right of the white pane is green

## Issue
Fixes https://github.com/canonical-web-and-design/snap-squad/issues/2074