### PR TITLE
Remove delete icon overrides

### DIFF
--- a/static/sass/_snapcraft_market.scss
+++ b/static/sass/_snapcraft_market.scss
@@ -1,4 +1,4 @@
-@import 'snapcraft_patterns_icons';
+@import "snapcraft_patterns_icons";
 
 @mixin snapcraft-market {
   $white-overlay-color: rgba(255, 255, 255, 0.5);
@@ -141,14 +141,6 @@
     }
   }
 
-  .p-icon--delete {
-    @include snapcraft-icon-delete($color-mid-dark);
-
-    &:hover {
-      @include snapcraft-icon-delete($color-negative);
-    }
-  }
-
   .p-market-banner {
     .p-market-banner__image-holder {
       cursor: pointer;
@@ -248,10 +240,6 @@
 
     &:hover {
       opacity: 1;
-
-      .p-icon--delete {
-        @include snapcraft-icon-delete($color-negative);
-      }
     }
   }
 }

--- a/static/sass/_snapcraft_patterns_icons.scss
+++ b/static/sass/_snapcraft_patterns_icons.scss
@@ -1,10 +1,6 @@
 // This file is here until https://github.com/vanilla-framework/vanilla-framework/issues/2221
 // is fixed
 
-@mixin snapcraft-icon-delete($color) {
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='14' height='16'%3E%3Cg fill='none'%3E%3Cpath d='M-1 0h16v16H-1z'/%3E%3Cpath fill='#{vf-url-friendly-color($color)}' d='M1.5 4.998h-1v-1.5C.5 2.678 1.178 2 2 2h2.5V0h5v2H12c.822 0 1.5.677 1.5 1.499v1.5H.5v-1h2v1h-1zm10 8.503V5.998h2V14.5c0 .822-.678 1.499-1.5 1.499H2c-.822 0-1.5-.677-1.5-1.5V5.999h2V13.5c0 .285.214.5.5.5h8c.286 0 .5-.215.5-.5zm-3-11.502V1h-3v1h3zm-5 3.999h1v5.998h-1V5.998zm3 0h1v5.998h-1V5.998zm3 0h1v5.998h-1V5.998z'/%3E%3C/g%3E%3C/svg%3E");
-}
-
 @mixin snapcraft-icon-branch($color, $width, $height) {
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='$width' height='$height'%3E%3Cpath fill='#{vf-url-friendly-color($color)}' fill-rule='nonzero' d='M3 6h1.268a2 2 0 1 1 0 2H3v2a1 1 0 0 1-2 0V3.732a2 2 0 1 1 2 0V6zM2 3a1 1 0 1 0 0-2 1 1 0 0 0 0 2zm4 5a1 1 0 1 0 0-2 1 1 0 0 0 0 2z'/%3E%3C/svg%3E");
 }
@@ -17,7 +13,7 @@
   .p-icon--top {
     @extend %icon;
 
-    background-image: url('#{$assets-path}9ec2c354-icon-arrow-up.svg');
+    background-image: url("#{$assets-path}9ec2c354-icon-arrow-up.svg");
     background-size: 0.75rem 0.75rem;
     margin-left: $sp-x-small;
   }

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -409,7 +409,3 @@ code {
 .u-text-muted {
   color: $color-mid-dark;
 }
-
-[disabled]:hover .p-icon--delete {
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='14' height='16'%3E%3Cg fill='none'%3E%3Cpath d='M-1 0h16v16H-1z'/%3E%3Cpath fill='%23666' d='M1.5 4.998h-1v-1.5C.5 2.678 1.178 2 2 2h2.5V0h5v2H12c.822 0 1.5.677 1.5 1.499v1.5H.5v-1h2v1h-1zm10 8.503V5.998h2V14.5c0 .822-.678 1.499-1.5 1.499H2c-.822 0-1.5-.677-1.5-1.5V5.999h2V13.5c0 .285.214.5.5.5h8c.286 0 .5-.215.5-.5zm-3-11.502V1h-3v1h3zm-5 3.999h1v5.998h-1V5.998zm3 0h1v5.998h-1V5.998zm3 0h1v5.998h-1V5.998z'/%3E%3C/g%3E%3C/svg%3E");
-}


### PR DESCRIPTION
## Done
Removed overrides for the delete icon

## QA
- Go to https://snapcraft-io-3562.demos.haus/admin/ahnuP3quahti9vis8aiw/snaps
- Compare the delete icons to `p-icon--delete` from Vanilla: https://vanillaframework.io/docs/patterns/icons

# Issue
Fixes https://github.com/canonical-web-and-design/snap-squad/issues/2076