### PR TITLE
Add delete button on manage snaps page mobile view

### DIFF
--- a/static/js/public/utilities/build-snaps-table-row.js
+++ b/static/js/public/utilities/build-snaps-table-row.js
@@ -8,7 +8,7 @@ function buildSnapsTableRow(snaps, store, currentStore) {
     const clone = tableRowTemplate.content.cloneNode(true);
     const publishedIn = clone.querySelector("[data-js-published-store]");
     const removeSnapForm = clone.querySelector("[data-js-remove-snap-form]");
-    const removeSnapButton = clone.querySelector(
+    const removeSnapButtons = clone.querySelectorAll(
       "[data-js-remove-snap-button]"
     );
 
@@ -31,9 +31,14 @@ function buildSnapsTableRow(snaps, store, currentStore) {
     }
 
     if (store.id !== currentStore.id) {
-      removeSnapButton.disabled = false;
+      removeSnapButtons.forEach((button) => {
+        button.disabled = false;
+      });
 
-      const parent = removeSnapButton.closest("[data-js-remove-snap-tooltip]");
+      const parent = removeSnapButtons[0].closest(
+        "[data-js-remove-snap-tooltip]"
+      );
+
       const child = clone.querySelector(".p-tooltip__message");
       parent.removeChild(child);
 

--- a/templates/admin/snaps.html
+++ b/templates/admin/snaps.html
@@ -65,8 +65,11 @@
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
         <input type="hidden" name="snaps" value="">
         <span class="p-tooltip--left" data-js-remove-snap-tooltip>
-          <button class="p-button--base u-no-margin--bottom u-no-margin--right u-no-padding" data-js-remove-snap-button disabled>
+          <button class="p-button--base u-no-margin--bottom u-no-margin--right u-no-padding u-hide--small" data-js-remove-snap-button disabled>
             <i class="p-icon--delete">Delete</i>
+          </button>
+          <button class="p-button--neutral u-no-margin--bottom u-no-margin--right u-hide--medium u-hide--large" style="display: block; width: 100%;" data-js-remove-snap-button disabled>
+            Delete
           </button>
           <span class="p-tooltip__message" role="tooltip">You can only remove snaps from other stores</span>
         </span>


### PR DESCRIPTION
## Done
Added a delete button on snap cards on mobile

## QA
- Go to https://snapcraft-io-3566.demos.haus/admin/ahnuP3quahti9vis8aiw/snaps
- Resize the browser to mobile view
- Check that the bin icon has turned into a delete button

## Issue
Fixes #3566 