### PR TITLE
Fix clear search on manage snaps page

### DIFF
--- a/templates/admin/snaps.html
+++ b/templates/admin/snaps.html
@@ -10,7 +10,7 @@
   <div style=" align-items: space-between; display: flex;">
     <div style="margin-right: 1rem;">
       <label for="snaps-filter" class="u-off-screen">Filter snaps</label>
-      <input type="search" class="u-no-margin--bottom" name="snaps-filter" placeholder="Search" data-js-snaps-filter>
+      <input type="text" class="u-no-margin--bottom" name="snaps-filter" placeholder="Filter snaps" data-js-snaps-filter autocomplete="off">
     </div>
     <button class="p-button--neutral u-no-margin--bottom" data-js-open-side-panel-btn>
       <i class="p-icon--plus"></i>


### PR DESCRIPTION
## Done
Reset snaps table when search box is cleared

## QA
- Go to https://snapcraft-io-3568.demos.haus/admin/test1LaNg1xi6eonae5R/snaps
- Type "core" in the search box at the top left of the screen
- The table should be filtered
- Clear the search box
- The table should be reset

## Issue
Fixes #2086