### PR TITLE
Do not return snaps already in store

### DIFF
--- a/static/js/public/manage-snaps.js
+++ b/static/js/public/manage-snaps.js
@@ -47,7 +47,12 @@ function handleSnapsSearch(STATE) {
           `/admin/${STATE.store.id}/snaps/search.json?q=${searchField.value}&allowed_for_inclusion=${STATE.store.id}`
         );
 
-        return await source.json();
+        const data = await source.json();
+
+        return data.filter((d) => {
+          const snap = STATE.snaps.find((s) => s.id === d.id);
+          return !snap;
+        });
       },
       key: ["name"],
       trigger: {


### PR DESCRIPTION
## Done
Remove existing snaps from snap search results

## QA
- Go to https://snapcraft-io-3569.demos.haus/admin/ahnuP3quahti9vis8aiw/snaps
- Click the "Add snap" button
- Search for a snap that isn't in the list
- You should see search suggestions
- Search for a snap that is already in the store
- There should be no search suggestions

## Issue
Fixes #3551