### PR TITLE
Fix listing preview

### DIFF
--- a/webapp/publisher/snaps/listing_views.py
+++ b/webapp/publisher/snaps/listing_views.py
@@ -379,6 +379,7 @@ def post_preview(snap_name):
     context["is_preview"] = True
     context["package_name"] = context["snap_name"]
     context["snap_title"] = context["title"]
+    context["appliances"] = []
 
     # Images
     icons = get_icon(context["images"])
@@ -387,6 +388,7 @@ def post_preview(snap_name):
     context["video"] = get_video(context["images"])
 
     # Channel map
+    context["channel_map"] = []
     context["default_track"] = "latest"
     context["lowest_risk_available"] = "stable"
     context["version"] = "test"


### PR DESCRIPTION
## Done
- Fix listing preview

## How to QA
- Go to the listing page on any snap as a publisher and click on the preview bottom.

## Issue / Card
Fixes #3553 and #3548
