### PR TITLE
Fix navigation highlight color

### DIFF
--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -409,3 +409,9 @@ code {
 .u-text-muted {
   color: $color-mid-dark;
 }
+
+.p-navigation {
+  .p-navigation__link.is-selected > a::before {
+    background-color: $ubuntu-orange;
+  }
+}


### PR DESCRIPTION
## Done
Fixed the navigation highlight color for the current page

## QA
- Go to https://snapcraft-io-3592.demos.haus/
- Click on any of the pages in the top navigation
- Check that there is an orange line underneath the link for the page that you are on

## Issue
Fixes https://github.com/canonical-web-and-design/snap-squad/issues/2115