### PR TITLE
Fix hidden tooltip on IoT page

### DIFF
--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -415,3 +415,7 @@ code {
     background-color: $ubuntu-orange;
   }
 }
+
+.u-overflow-visible {
+  overflow: visible !important;
+}

--- a/templates/partials/_verified_developer.html
+++ b/templates/partials/_verified_developer.html
@@ -1,4 +1,4 @@
-<span class="p-verified p-tooltip p-tooltip--top-center" aria-describedby="{{ package_name }}-tooltip">
-    <img src="https://assets.ubuntu.com/v1/75654c90-rosette.svg" width="12" height="12" />
+<span class="p-verified p-tooltip p-tooltip--top-center">
+    <img src="https://assets.ubuntu.com/v1/75654c90-rosette.svg" width="12" height="12" alt="Verified account" />
     <span class="p-tooltip__message u-align--center" role="tooltip" id="{{ package_name }}-tooltip">Verified account</span>
 </span>

--- a/templates/store/_media-object-snap-partial.html
+++ b/templates/store/_media-object-snap-partial.html
@@ -23,13 +23,13 @@
       attrs={"class": "p-media-object__image", style: style}
     ) | safe
   }}
-  <div class="p-media-object__details">
+  <div class="p-media-object__details u-overflow-visible" style="width: calc(100% - 48px);">
     <h4 class="p-media-object__title p-heading--5 u-no-margin--bottom">
       {{ snap.title }}
     </h4>
     <div class="p-media-object__content">
       {% if not hide_publisher %}
-        <p>
+        <p class="u-overflow-visible">
           <span class="u-off-screen">Publisher: </span>{{ snap.publisher}}
           {% if snap.developer_validation and snap.developer_validation == VERIFIED_PUBLISHER %}
             {% set package_name = snap.package_name %}

--- a/templates/store/categories/iot.html
+++ b/templates/store/categories/iot.html
@@ -19,8 +19,17 @@ Transactional updates, airtight security, and compatibility across architectures
         <p><a class="p-button--positive" href="https://ubuntu.com/internet-of-things">Getting started with IoT</a></p>
         <p><a class="p-button--neutral" href="/docs/creating-a-snap">Publish IoT applications with Snapcraft &rsaquo;</a></p>
       </div>
-      <div class="col-5">
-        <img src="https://assets.ubuntu.com/v1/2c5e93c5-fast-easy-safe-illustration.svg" />
+      <div class="col-5 u-align--center">
+        {{
+          image(
+            url="https://assets.ubuntu.com/v1/2c5e93c5-fast-easy-safe-illustration.svg",
+            alt="",
+            height="244",
+            width="243",
+            hi_def=True,
+            loading="auto",
+          ) | safe
+        }}
       </div>
     </div>
   </section>


### PR DESCRIPTION
## Done
Fixed the hidden tooltip on the verified badge on the IoT page

## QA
- Go to https://snapcraft-io-3597.demos.haus/iot
- Hover over any of the ticks in the green circles in the "IoT tools and server" section
- Check that you see the tooltip

## Issue
Fixes #3596 