### PR TITLE
Add verified icon to IoT snaps published by Canonical

### DIFF
--- a/webapp/snapcraft/views.py
+++ b/webapp/snapcraft/views.py
@@ -103,6 +103,7 @@ def snapcraft_blueprint():
                 "title": "edgexfoundry",
                 "origin": "Canonical",
                 "publisher": "Canonical",
+                "developer_validation": "verified",
             },
             {
                 "package_name": "mir-kiosk",
@@ -112,6 +113,7 @@ def snapcraft_blueprint():
                 "title": "mir-kiosk",
                 "origin": "Canonical",
                 "publisher": "Canonical",
+                "developer_validation": "verified",
             },
         ]
 


### PR DESCRIPTION
## Done
- Added verified publisher to all Canonical snaps on the IoT page

## QA
- Go to https://snapcraft-io-3599.demos.haus/iot
- Check that any snaps with Canonical as the publisher have the green verification icon next to them

## Issue
Fixes #3598 