### PR TITLE
Add release date column to snaps table

### DIFF
--- a/templates/admin/snaps.html
+++ b/templates/admin/snaps.html
@@ -43,6 +43,7 @@
       <th style="width: 15%;">Published in</th>
       <th style="width: 25%;">Name</th>
       <th style="width: 20%;">Latest release</th>
+      <th>Release date</th>
       <th>Publisher</th>
       <th style="width: 5%;">&nbsp;</th>
     </tr>
@@ -57,7 +58,9 @@
     <td aria-label="Name" class="u-truncate" data-js-store-name></td>
     <td aria-label="Latest release" class="u-truncate">
       <div data-js-latest-release-version></div>
-      <div><small data-js-latest-release-date></small></div>
+    </td>
+    <td aria-label="Release date">
+      <div data-js-latest-release-date></div>
     </td>
     <td aria-label="Publisher" data-js-collaborators></td>
     <td aria-label="Actions" class="u-align--right" style="overflow: visible;" data-js-actions>


### PR DESCRIPTION
## Done
Moved the release date to it's own table column in the manage snaps table

## QA
- Go to https://snapcraft-io-3623.demos.haus/admin/ahnuP3quahti9vis8aiw/snaps
- Check that there is a "Latest release" and "Release date" column in the table
- Use the "Filter snaps" search and check that those columns are still there

## Issue
Fixes #2169