### PR TITLE
Add stores link to logged in menu

### DIFF
--- a/templates/_header.html
+++ b/templates/_header.html
@@ -84,6 +84,9 @@
                 <a href="/account/snaps" class="p-subnav__item">My published snaps</a>
               </li>
               <li>
+                <a href="/admin" class="p-subnav__item">My stores</a>
+              </li>
+              <li>
                 <a href="/account/details" class="p-subnav__item">Account details</a>
               </li>
               <li>

--- a/templates/_header.html
+++ b/templates/_header.html
@@ -13,84 +13,86 @@
       <span class="u-off-screen">
         <a href="#main-content">Jump to main content</a>
       </span>
-      <ul class="p-navigation__links" role="menu">
+      <ul class="p-navigation__items" role="menu">
         <li
-          class="p-navigation__link {% if page_slug == 'store' %}is-selected{% endif %}"
+          class="p-navigation__item {% if page_slug == 'store' %}is-selected{% endif %}"
           role="menuitem"
         >
-          <a href="/store">
+          <a class="p-navigation__link" href="/store">
             Store
           </a>
         </li>
         <li
-          class="p-navigation__link {% if page_slug == 'about' %}is-selected{% endif %}"
+          class="p-navigation__item {% if page_slug == 'about' %}is-selected{% endif %}"
           role="menuitem"
         >
-          <a href="/about">
+          <a class="p-navigation__link" href="/about">
             About
           </a>
         </li>
         <li
-          class="p-navigation__link {% if page_slug == 'blog' %}is-selected{% endif %}"
+          class="p-navigation__item {% if page_slug == 'blog' %}is-selected{% endif %}"
           role="menuitem"
         >
-          <a href="/blog">
+          <a class="p-navigation__link" href="/blog">
             Blog
           </a>
         </li>
         <li
-          class="p-navigation__link {% if page_slug == 'iot' %}is-selected{% endif %}"
+          class="p-navigation__item {% if page_slug == 'iot' %}is-selected{% endif %}"
           role="menuitem"
         >
-          <a href="/iot">
+          <a class="p-navigation__link" href="/iot">
             IoT
           </a>
         </li>
         <li
-          class="p-navigation__link {% if page_slug == 'build' %}is-selected{% endif %}"
+          class="p-navigation__item {% if page_slug == 'build' %}is-selected{% endif %}"
           role="menuitem"
         >
-          <a href="/build">
+          <a class="p-navigation__link" href="/build">
             Build
           </a>
         </li>
         <li
-          class="p-navigation__link {% if page_slug == 'docs' %}is-selected{% endif %}"
+          class="p-navigation__item {% if page_slug == 'docs' %}is-selected{% endif %}"
           role="menuitem"
         >
-          <a href="{{ url_for('docs.document_view') }}">
+          <a class="p-navigation__link" href="{{ url_for('docs.document_view') }}">
             Docs
           </a>
         </li>
         <li
-          class="p-navigation__link {% if page_slug == 'tutorials' %}is-selected{% endif %}"
+          class="p-navigation__item {% if page_slug == 'tutorials' %}is-selected{% endif %}"
           role="menuitem"
         >
-          <a href="/tutorials">
+          <a class="p-navigation__link" href="/tutorials">
             Tutorials
           </a>
         </li>
-        <li class="p-navigation__link" role="menuitem"><a class="p-link--external" href="https://forum.snapcraft.io/">Forum</a></li>
+        <li class="p-navigation__item" role="menuitem">
+          <a class="p-navigation__link p-link--external" href="https://forum.snapcraft.io/">Forum</a>
+        </li>
       </ul>
 
       <ul class="p-navigation__links" role="menu">
         {% if user_name %}
-          <li class="p-navigation__link p-subnav" role="menuitem" id="link-1">
-            <a class="p-subnav__toggle" aria-controls="account-menu" aria-expanded="false">
+          <li class="p-navigation__item--dropdown-toggle" role="menuitem" id="link-1">
+            <a class="p-subnav__toggle p-navigation__link" aria-controls="account-menu" aria-expanded="false">
               {{ user_name }}
             </a>
-            <ul class="p-subnav__items--right" id="account-menu" aria-hidden="true">
+            <ul class="p-navigation__dropdown--right" id="account-menu" aria-hidden="true">
               <li>
-                <a href="/account/snaps" class="p-subnav__item">My published snaps</a>
+                <a href="/account/snaps" class="p-navigation__dropdown-item">My published snaps</a>
               </li>
               <li>
-                <a href="/admin" class="p-subnav__item">My stores</a>
+                <a href="/admin" class="p-navigation__dropdown-item">My stores</a>
               </li>
               <li>
-                <a href="/account/details" class="p-subnav__item">Account details</a>
+                <a href="/account/details" class="p-navigation__dropdown-item">Account details</a>
               </li>
               <li>
-                <a href="/logout" class="p-subnav__item">Sign out</a>
+                <a href="/logout" class="p-navigation__dropdown-item">Sign out</a>
               </li>
             </ul>
           </li>


### PR DESCRIPTION
## Done
- Added a link to "Stores" in the logged in sub menu
- Drive-by: Fixed the styling of the navigation

## QA
- Go to https://snapcraft-io-3624.demos.haus/
- Click on the logged in menu in the navigation
- Check that there is a link to "My stores" and that it goes to the stores page

## Issue
Fixes #2176