### PR TITLE
Remove my stores link from nav if no stores

### DIFF
--- a/templates/_header.html
+++ b/templates/_header.html
@@ -85,9 +85,11 @@
               <li>
                 <a href="/account/snaps" class="p-navigation__dropdown-item">My published snaps</a>
               </li>
+              {% if stores %}
               <li>
                 <a href="/admin" class="p-navigation__dropdown-item">My stores</a>
               </li>
+              {% endif %}
               <li>
                 <a href="/account/details" class="p-navigation__dropdown-item">Account details</a>
               </li>

--- a/webapp/handlers.py
+++ b/webapp/handlers.py
@@ -40,9 +40,11 @@ def set_handlers(app):
             user_is_canonical = flask.session["publisher"].get(
                 "is_canonical", False
             )
+            stores = flask.session["publisher"].get("stores")
         else:
             user_name = None
             user_is_canonical = False
+            stores = []
 
         page_slug = template_utils.generate_slug(flask.request.path)
 
@@ -77,6 +79,7 @@ def set_handlers(app):
             "format_date": template_utils.format_date,
             "format_member_role": template_utils.format_member_role,
             "image": image_template,
+            "stores": stores,
         }
 
     # Error handlers

--- a/webapp/login/views.py
+++ b/webapp/login/views.py
@@ -93,6 +93,9 @@ def after_login(resp):
         }
         owned, shared = logic.get_snap_names_by_ownership(account)
         flask.session["user_shared_snaps"] = shared
+        flask.session["publisher"]["stores"] = logic.get_stores(
+            account["stores"], roles=["admin", "review", "view"]
+        )
 
     except ApiCircuitBreaker:
         flask.abort(503)
@@ -178,6 +181,7 @@ def login_callback():
 
     try:
         publisher = publisher_api.whoami(flask.session)
+        account = publisher_api.get_account(flask.session)
     except StoreApiResponseErrorList as api_response_error_list:
         return _handle_error_list(api_response_error_list.errors)
     except (StoreApiError, ApiError) as api_error:
@@ -190,6 +194,10 @@ def login_callback():
         "image": None,
         "email": publisher["account"]["email"],
     }
+
+    flask.session["publisher"]["stores"] = logic.get_stores(
+        account["stores"], roles=["admin", "review", "view"]
+    )
 
     response = flask.make_response(
         flask.redirect(

--- a/webapp/publisher/snaps/logic.py
+++ b/webapp/publisher/snaps/logic.py
@@ -51,6 +51,23 @@ def get_snaps_account_info(account_info):
     return user_snaps, registered_snaps
 
 
+def get_stores(stores, roles):
+    """Get list of stores where the user has the specified roles
+
+    :param stores: The account stores
+    :param roles: The requested roles to filter
+
+    :return: A list of stores
+    """
+    user_stores = []
+
+    for store in stores:
+        if not set(roles).isdisjoint(store["roles"]):
+            user_stores.append(store)
+
+    return user_stores
+
+
 def get_snap_names_by_ownership(account_info):
     """Get list of snaps names user is collaborator of
 


### PR DESCRIPTION
## Done
Removed the "My stores" link in the logged in dropdown nav if the user has no stores

## QA
- Go to https://snapcraft-io-3627.demos.haus/
- Login as a user with stores
- Check that there is a "My stores" link in the logged in dropdown nav
- Login as a user with no stores (a test account)
- Check that there is not a "My stores" link in the logged in dropdown nav

## Issue
Fixes #3625 