### PR TITLE
Add a template for no stores

### DIFF
--- a/templates/admin/no-stores.html
+++ b/templates/admin/no-stores.html
@@ -1,0 +1,10 @@
+{% extends "_base-layout.html" %}
+{% block content %}
+<section class="p-strip">
+  <div class="u-fixed-width">
+    <h1 class="p-heading--3">No stores</h1>
+    <p>You do not own or belong to any stores</p>
+    <p><a href="/snaps">Go back to your snaps</a></p>
+  </div>
+</section>
+{% endblock %}

--- a/webapp/admin/views.py
+++ b/webapp/admin/views.py
@@ -35,7 +35,7 @@ def get_stores():
         return _handle_error(api_error)
 
     if not stores:
-        flask.abort(403)
+        return flask.render_template("admin/no-stores.html")
 
     # We redirect to the first store snap list
     return flask.redirect(


### PR DESCRIPTION
## Done
- Add a page template when a user with no stores visits the admin page

## QA
- Login as a user with no stores (a test account)
- Go to https://snapcraft-io-3628.demos.haus/admin
- Check that you see a page that tells you that there are no stores

## Issue
Fixes #3626 

## Screenshot
<img width="1162" alt="Screenshot 2021-08-17 at 15 06 07" src="https://user-images.githubusercontent.com/501889/129740871-8c03a381-5f95-4046-8ad5-90ad2ae84b96.png">
