### PR TITLE
Add store search filter to brand store

### DIFF
--- a/static/js/public/brand-store-search.js
+++ b/static/js/public/brand-store-search.js
@@ -1,0 +1,46 @@
+import debounce from "../libs/debounce";
+
+function init(stores) {
+  const searchInput = document.querySelector(".js-store-search-input");
+  const storeList = document.querySelector(".js-store-list");
+  const originalStoreList = storeList.cloneNode(true).innerHTML;
+  const storeListItemTemplate = document.querySelector(
+    "#store-list-item-template"
+  );
+
+  searchInput.addEventListener(
+    "keyup",
+    debounce((e) => {
+      const query = e.target.value.toLowerCase();
+      let filteredStores = stores;
+
+      storeList.innerHTML = "";
+
+      filteredStores = stores.filter((store) => {
+        return store.name.toLowerCase().includes(query);
+      });
+
+      if (query) {
+        filteredStores.forEach((store) => {
+          const clone = storeListItemTemplate.content.cloneNode(true);
+          const storeLink = clone.querySelector(".p-side-navigation__link");
+          const storeLinkIcon = clone.querySelector(".p-side-navigation__icon");
+          const storeLinkLabel = clone.querySelector(
+            ".p-side-navigation__label"
+          );
+
+          storeLink.setAttribute("href", `/admin/${store.id}/snaps`);
+          storeLinkIcon.innerText = store.name.charAt(0);
+          storeLinkLabel.innerText = store.name;
+
+          storeList.appendChild(clone);
+        });
+      } else {
+        storeList.innerHTML = originalStoreList;
+      }
+    }),
+    100
+  );
+}
+
+export { init };

--- a/static/sass/_snapcraft_l-application.scss
+++ b/static/sass/_snapcraft_l-application.scss
@@ -153,4 +153,24 @@
       }
     }
   }
+
+  .p-side-navigation--icons .p-search-box {
+    display: block;
+    margin-left: 1rem;
+    margin-right: 1rem;
+
+    .p-search-box__input {
+      background-image: url("data:image/svg+xml,%3Csvg width='16' height='16' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M6.964 1a5.964 5.964 0 014.709 9.623l4.303 4.305-1.06 1.06-4.306-4.305A5.964 5.964 0 116.963 1zm0 1.5a4.464 4.464 0 100 8.927 4.464 4.464 0 000-8.927z' fill='%23666' fill-rule='nonzero'/%3E%3C/svg%3E");
+      background-position: center right 0.5rem;
+      background-repeat: no-repeat;
+      padding-right: 2rem;
+      position: relative;
+    }
+  }
+
+  .p-side-navigation__list {
+    &::after {
+      display: none !important;
+    }
+  }
 }

--- a/templates/admin/_navigation.html
+++ b/templates/admin/_navigation.html
@@ -7,6 +7,16 @@
       </li>
     </ul>
     <ul class="p-side-navigation__list">
+      <li class="p-side-navigation__item--title">
+        <div class="p-side-navigation__icon" style="padding-left: 0.2rem;">
+          <i class="p-icon--search"></i>
+        </div>
+        <div class="p-search-box p-side-navigation__label">
+          <input type="search" class="p-search-box__input js-store-search-input" name="store-search" placeholder="Search stores" title="Search stores" autocomplete="off" aria-label="Search stores">
+        </div>
+      </li>
+    </ul>
+    <ul class="p-side-navigation__list js-store-list">
       {% for s in stores %}
       <li class="p-side-navigation__item">
         <a class="p-side-navigation__link {% if s['id'] == store['id'] %}is-active{% endif %}" href="/admin/{{ s.id }}/snaps">
@@ -31,3 +41,21 @@
     </ul>
   </nav>
 </div>
+
+<template id="store-list-item-template">
+  <li class="p-side-navigation__item">
+    <a class="p-side-navigation__link" href="">
+      <span class="p-side-navigation__icon is-text"></span>
+      <span class="p-side-navigation__label"></span>
+    </a>
+  </li>
+</template>
+
+<script src="{{ static_url('js/dist/brand-store-search.js') }}" defer></script>
+<script>
+  window.addEventListener("DOMContentLoaded", function () {
+    Raven.context(function () {
+      snapcraft.public.brandStoreSearch.init({{ stores | safe}});
+    });
+  });
+</script>

--- a/webpack.config.entry.js
+++ b/webpack.config.entry.js
@@ -24,4 +24,5 @@ module.exports = {
   "manage-invites": "./static/js/public/manage-invites.js",
   "invite-members": "./static/js/public/invite-members.js",
   "manage-member-roles": "./static/js/public/manage-member-roles.js",
+  "brand-store-search": "./static/js/public/brand-store-search.js",
 };

--- a/webpack.config.rules.js
+++ b/webpack.config.rules.js
@@ -123,4 +123,13 @@ module.exports = [
       "babel-loader",
     ],
   },
+  {
+    test: require.resolve(
+      __dirname + "/static/js/public/brand-store-search.js"
+    ),
+    use: [
+      "expose-loader?exposes=snapcraft.public.brandStoreSearch",
+      "babel-loader",
+    ],
+  },
 ];


### PR DESCRIPTION
## Done
Added a search filter to the brand store side navigation

## QA
- Go to https://snapcraft-io-3638.demos.haus/admin/test1LaNg1xi6eonae5R/snaps
- Type in store names in the side navigation search
- Check that the list is filtered correctly
- Clear the search
- Check that the list is as before

## Issue
Fixes #2168