### PR TITLE
Use original topic and authenticated API calls

### DIFF
--- a/webapp/docs/views.py
+++ b/webapp/docs/views.py
@@ -1,3 +1,5 @@
+from os import getenv
+
 import talisker
 
 from canonicalwebteam.discourse import (
@@ -7,6 +9,9 @@ from canonicalwebteam.discourse import (
 )
 from canonicalwebteam.search import build_search_view
 
+DISCOURSE_API_KEY = getenv("DISCOURSE_API_KEY")
+DISCOURSE_API_USERNAME = getenv("DISCOURSE_API_USERNAME")
+
 
 def init_docs(app, url_prefix):
     session = talisker.requests.get_session()
@@ -15,9 +20,14 @@ def init_docs(app, url_prefix):
             api=DiscourseAPI(
                 base_url="https://forum.snapcraft.io/",
                 session=session,
+                api_key=DISCOURSE_API_KEY,
+                api_username=DISCOURSE_API_USERNAME,
+                get_topics_query_id=2,
             ),
-            index_topic_id=25750,
+            index_topic_id=11127,
             url_prefix=url_prefix,
+            tutorials_index_topic_id=15409,
+            tutorials_url_prefix="/tutorials",
         ),
         document_template="docs/document.html",
         url_prefix=url_prefix,


### PR DESCRIPTION
## Done
- Use original discourse topic: https://forum.snapcraft.io/t/snap-documentation/11127
- Use authentication for Discourse API calls

## How to QA
- `/docs` and `/tutorials` should work as usual
