### PR TITLE
Fix metrics

### DIFF
--- a/webapp/publisher/snaps/metrics_views.py
+++ b/webapp/publisher/snaps/metrics_views.py
@@ -123,6 +123,9 @@ def publisher_snap_metrics(snap_name):
 
     series = active_metrics["series"]
 
+    # Temp fix (https://forum.snapcraft.io/t/metrics-by-channel-broken/26188/3)
+    series = [s for s in series if s["name"] != "latest/stable"]
+
     if installed_base_metric == "os":
         capitalized_series = active_metrics["series"]
         for item in capitalized_series:


### PR DESCRIPTION
## Done
- Get are getting from the API `latest/stable` and `stable`, the metrics that we want to show are for `stable` not `latest/stable`

## How to QA
- Visit any snap metrics page: http://0.0.0.0:8004/gimp/metrics?active-devices=channel
- Check that when you hover over the graph, there is a high value on the `stable` channel and `latest/stable` is not mentioned.

## Issue / Card
Fixes https://github.com/canonical-web-and-design/snapcraft.io/issues/3639
