### PR TITLE
Fix navigation brand color for contrast and visibility

### DIFF
--- a/static/sass/styles-embedded.scss
+++ b/static/sass/styles-embedded.scss
@@ -1,5 +1,5 @@
 // colour definitions
-$color-brand: #00302f;
+$color-brand: #fa6340;
 $color-accent: $color-brand;
 $color-navigation-background: #252525;
 

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -1,6 +1,6 @@
 // colour definitions
 $ubuntu-orange: #e95420;
-$color-brand: #00302f;
+$color-brand: #fa6340;
 $color-accent: $color-brand;
 $color-navigation-active-bar: $ubuntu-orange;
 


### PR DESCRIPTION
## Done
- Changed the definition of “brand color” to use a value that is actually from the Snap logo, which makes the site integrate better with that brand (unlike previously, when Ubuntu orange was used, visually tying the product with Ubuntu in detriment of other distros) and adds the benefit that the active tab is actually distinguishable now (the previous color was too dark and too similar to the background of the navigation bar).

## How to QA
- Visit the demo in your browser, link commented below
  - Or you can run the project locally using the [dotrun](https://snapcraft.io/dotrun) snap with `$ dotrun` and view it in your web browser at: http://0.0.0.0:8004/
  - If your demo doesn't work, read more about the [demoservice](https://discourse.ubuntu.com/t/demoservice/16862)
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card
N/A

## Screenshots
Before: 
![before](https://user-images.githubusercontent.com/554953/133002463-3abe878e-9c12-4fc5-bc0c-33552f0faeb7.png)

After: 
![imatge](https://user-images.githubusercontent.com/554953/133335699-5a4e6def-f580-44e6-92d7-2ba4acc4c32b.png)
