### PR TITLE
Add snaps table

### DIFF
--- a/static/js/brand-store/App/App.js
+++ b/static/js/brand-store/App/App.js
@@ -21,7 +21,6 @@ function App() {
   const isLoading = useSelector((state) => state.brandStores.loading);
   const brandStoresList = useSelector(brandStoresListSelector);
   const dispatch = useDispatch();
-  const globalStoreId = "ubuntu";
 
   useEffect(() => {
     dispatch(fetchStores());
@@ -37,15 +36,7 @@ function App() {
               brandStoresList.length < 1 ? (
                 <NoStores />
               ) : (
-                // The global store has no /snaps view so needs to be
-                // redirected to /settings
-                <Redirect
-                  to={
-                    brandStoresList[0].id === globalStoreId
-                      ? `/admin/${brandStoresList[0].id}/settings`
-                      : `/admin/${brandStoresList[0].id}/snaps`
-                  }
-                />
+                <Redirect to={`/admin/${brandStoresList[0].id}/snaps`} />
               )
             ) : (
               <h1>Loading...</h1>

--- a/static/js/brand-store/Members/Members.js
+++ b/static/js/brand-store/Members/Members.js
@@ -1,7 +1,19 @@
 import React from "react";
 
+import SectionNav from "../SectionNav";
+
 function Members() {
-  return <h1>Members</h1>;
+  return (
+    <main className="l-main">
+      <div className="p-panel">
+        <div className="p-panel__content">
+          <div className="u-fixed-width">
+            <SectionNav sectionName="members" />
+          </div>
+        </div>
+      </div>
+    </main>
+  );
 }
 
 export default Members;

--- a/static/js/brand-store/Navigation/Navigation.js
+++ b/static/js/brand-store/Navigation/Navigation.js
@@ -65,7 +65,7 @@ function Navigation() {
                           <NavLink
                             activeClassName="is-active"
                             className="p-side-navigation__link"
-                            to={`/admin/${item.id}/settings`}
+                            to={`/admin/${item.id}/snaps`}
                             isActive={(match, location) => {
                               return location.pathname.includes(item.id);
                             }}

--- a/static/js/brand-store/SectionNav/SectionNav.js
+++ b/static/js/brand-store/SectionNav/SectionNav.js
@@ -1,0 +1,47 @@
+import React from "react";
+import { Link, useParams } from "react-router-dom";
+import PropTypes from "prop-types";
+
+function SectionNav({ sectionName }) {
+  const { id } = useParams();
+
+  return (
+    <div className="p-tabs">
+      <ul className="p-tabs__list">
+        <li className="p-tabs__item">
+          <Link
+            to={`/admin/${id}/snaps`}
+            className="p-tabs__link"
+            aria-selected={sectionName === "snaps"}
+          >
+            Snaps
+          </Link>
+        </li>
+        <li className="p-tabs__item">
+          <Link
+            to={`/admin/${id}/members`}
+            className="p-tabs__link"
+            aria-selected={sectionName === "members"}
+          >
+            Members
+          </Link>
+        </li>
+        <li className="p-tabs__item">
+          <Link
+            to={`/admin/${id}/settings`}
+            className="p-tabs__link"
+            aria-selected={sectionName === "settings"}
+          >
+            Settings
+          </Link>
+        </li>
+      </ul>
+    </div>
+  );
+}
+
+SectionNav.propTypes = {
+  sectionName: PropTypes.string.isRequired,
+};
+
+export default SectionNav;

--- a/static/js/brand-store/SectionNav/SectionNav.js
+++ b/static/js/brand-store/SectionNav/SectionNav.js
@@ -13,6 +13,7 @@ function SectionNav({ sectionName }) {
             to={`/admin/${id}/snaps`}
             className="p-tabs__link"
             aria-selected={sectionName === "snaps"}
+            role="tab"
           >
             Snaps
           </Link>
@@ -22,6 +23,7 @@ function SectionNav({ sectionName }) {
             to={`/admin/${id}/members`}
             className="p-tabs__link"
             aria-selected={sectionName === "members"}
+            role="tab"
           >
             Members
           </Link>
@@ -31,6 +33,7 @@ function SectionNav({ sectionName }) {
             to={`/admin/${id}/settings`}
             className="p-tabs__link"
             aria-selected={sectionName === "settings"}
+            role="tab"
           >
             Settings
           </Link>

--- a/static/js/brand-store/SectionNav/SectionNav.test.js
+++ b/static/js/brand-store/SectionNav/SectionNav.test.js
@@ -1,0 +1,94 @@
+import React from "react";
+import { BrowserRouter as Router } from "react-router-dom";
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import SectionNav from "./SectionNav";
+
+jest.mock("react-router-dom", () => ({
+  ...jest.requireActual("react-router-dom"),
+  useParams: jest.fn().mockReturnValue({ id: "test" }),
+}));
+
+test("active state is set on snaps when on snaps section", () => {
+  render(
+    <Router>
+      <SectionNav sectionName="snaps" />
+    </Router>
+  );
+
+  expect(screen.getByText("Snaps").getAttribute("aria-selected")).toEqual(
+    "true"
+  );
+});
+
+test("active state is not set on members or settings when on snaps section", () => {
+  render(
+    <Router>
+      <SectionNav sectionName="snaps" />
+    </Router>
+  );
+
+  expect(screen.getByText("Members").getAttribute("aria-selected")).toEqual(
+    "false"
+  );
+
+  expect(screen.getByText("Settings").getAttribute("aria-selected")).toEqual(
+    "false"
+  );
+});
+
+test("active state is set on snaps when on members section", () => {
+  render(
+    <Router>
+      <SectionNav sectionName="members" />
+    </Router>
+  );
+
+  expect(screen.getByText("Members").getAttribute("aria-selected")).toEqual(
+    "true"
+  );
+});
+
+test("active state is not set on snaps or settings when on members section", () => {
+  render(
+    <Router>
+      <SectionNav sectionName="members" />
+    </Router>
+  );
+
+  expect(screen.getByText("Snaps").getAttribute("aria-selected")).toEqual(
+    "false"
+  );
+
+  expect(screen.getByText("Settings").getAttribute("aria-selected")).toEqual(
+    "false"
+  );
+});
+
+test("active state is set on snaps when on settings section", () => {
+  render(
+    <Router>
+      <SectionNav sectionName="settings" />
+    </Router>
+  );
+
+  expect(screen.getByText("Settings").getAttribute("aria-selected")).toEqual(
+    "true"
+  );
+});
+
+test("active state is not set on members or settings when on settings section", () => {
+  render(
+    <Router>
+      <SectionNav sectionName="settings" />
+    </Router>
+  );
+
+  expect(screen.getByText("Snaps").getAttribute("aria-selected")).toEqual(
+    "false"
+  );
+
+  expect(screen.getByText("Members").getAttribute("aria-selected")).toEqual(
+    "false"
+  );
+});

--- a/static/js/brand-store/SectionNav/SectionNav.test.js
+++ b/static/js/brand-store/SectionNav/SectionNav.test.js
@@ -16,9 +16,9 @@ test("active state is set on snaps when on snaps section", () => {
     </Router>
   );
 
-  expect(screen.getByText("Snaps").getAttribute("aria-selected")).toEqual(
-    "true"
-  );
+  expect(
+    screen.getByRole("tab", { name: "Snaps" }).getAttribute("aria-selected")
+  ).toEqual("true");
 });
 
 test("active state is not set on members or settings when on snaps section", () => {
@@ -28,13 +28,13 @@ test("active state is not set on members or settings when on snaps section", () 
     </Router>
   );
 
-  expect(screen.getByText("Members").getAttribute("aria-selected")).toEqual(
-    "false"
-  );
+  expect(
+    screen.getByRole("tab", { name: "Members" }).getAttribute("aria-selected")
+  ).toEqual("false");
 
-  expect(screen.getByText("Settings").getAttribute("aria-selected")).toEqual(
-    "false"
-  );
+  expect(
+    screen.getByRole("tab", { name: "Settings" }).getAttribute("aria-selected")
+  ).toEqual("false");
 });
 
 test("active state is set on snaps when on members section", () => {
@@ -44,9 +44,9 @@ test("active state is set on snaps when on members section", () => {
     </Router>
   );
 
-  expect(screen.getByText("Members").getAttribute("aria-selected")).toEqual(
-    "true"
-  );
+  expect(
+    screen.getByRole("tab", { name: "Members" }).getAttribute("aria-selected")
+  ).toEqual("true");
 });
 
 test("active state is not set on snaps or settings when on members section", () => {
@@ -56,13 +56,13 @@ test("active state is not set on snaps or settings when on members section", () 
     </Router>
   );
 
-  expect(screen.getByText("Snaps").getAttribute("aria-selected")).toEqual(
-    "false"
-  );
+  expect(
+    screen.getByRole("tab", { name: "Snaps" }).getAttribute("aria-selected")
+  ).toEqual("false");
 
-  expect(screen.getByText("Settings").getAttribute("aria-selected")).toEqual(
-    "false"
-  );
+  expect(
+    screen.getByRole("tab", { name: "Settings" }).getAttribute("aria-selected")
+  ).toEqual("false");
 });
 
 test("active state is set on snaps when on settings section", () => {
@@ -72,9 +72,9 @@ test("active state is set on snaps when on settings section", () => {
     </Router>
   );
 
-  expect(screen.getByText("Settings").getAttribute("aria-selected")).toEqual(
-    "true"
-  );
+  expect(
+    screen.getByRole("tab", { name: "Settings" }).getAttribute("aria-selected")
+  ).toEqual("true");
 });
 
 test("active state is not set on members or settings when on settings section", () => {
@@ -84,11 +84,11 @@ test("active state is not set on members or settings when on settings section", 
     </Router>
   );
 
-  expect(screen.getByText("Snaps").getAttribute("aria-selected")).toEqual(
-    "false"
-  );
+  expect(
+    screen.getByRole("tab", { name: "Snaps" }).getAttribute("aria-selected")
+  ).toEqual("false");
 
-  expect(screen.getByText("Members").getAttribute("aria-selected")).toEqual(
-    "false"
-  );
+  expect(
+    screen.getByRole("tab", { name: "Members" }).getAttribute("aria-selected")
+  ).toEqual("false");
 });

--- a/static/js/brand-store/SectionNav/index.js
+++ b/static/js/brand-store/SectionNav/index.js
@@ -1,0 +1,1 @@
+export { default } from "./SectionNav";

--- a/static/js/brand-store/Settings/Settings.js
+++ b/static/js/brand-store/Settings/Settings.js
@@ -15,6 +15,7 @@ import { currentStoreSelector } from "../selectors";
 import { fetchStore } from "../slices/currentStoreSlice";
 
 import PasswordToggle from "../shared/PasswordToggle";
+import SectionNav from "../SectionNav";
 
 function Settings() {
   const currentStore = useSelector(currentStoreSelector);
@@ -101,6 +102,9 @@ function Settings() {
     <main className="l-main">
       <div className="p-panel--settings">
         <div className="p-panel__content">
+          <div className="u-fixed-width">
+            <SectionNav sectionName="settings" />
+          </div>
           <Row>
             <Col size="7">
               {isLoading && !isSaving ? (

--- a/static/js/brand-store/Settings/Settings.test.js
+++ b/static/js/brand-store/Settings/Settings.test.js
@@ -1,9 +1,10 @@
 import React from "react";
+import { BrowserRouter as Router } from "react-router-dom";
 import { Provider, useSelector } from "react-redux";
 import { render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import Settings from "./Settings";
-import store from "../stores/store";
+import store from "../store";
 
 jest.mock("react-redux", () => ({
   ...jest.requireActual("react-redux"),
@@ -40,7 +41,9 @@ test("the 'is public' checkbox should not be checked when the current store is s
 
   render(
     <Provider store={store}>
-      <Settings />
+      <Router>
+        <Settings />
+      </Router>
     </Provider>
   );
 
@@ -55,7 +58,9 @@ test("the 'is public' checkbox should be checked when the current store is not s
 
   render(
     <Provider store={store}>
-      <Settings />
+      <Router>
+        <Settings />
+      </Router>
     </Provider>
   );
 
@@ -69,7 +74,9 @@ test("the correct value is given to the store ID field", () => {
 
   render(
     <Provider store={store}>
-      <Settings />
+      <Router>
+        <Settings />
+      </Router>
     </Provider>
   );
 
@@ -83,7 +90,9 @@ test("the correct radio button is checked by default for manual review policy", 
 
   render(
     <Provider store={store}>
-      <Settings />
+      <Router>
+        <Settings />
+      </Router>
     </Provider>
   );
 
@@ -102,7 +111,9 @@ test("the save button is disabled by default", () => {
 
   render(
     <Provider store={store}>
-      <Settings />
+      <Router>
+        <Settings />
+      </Router>
     </Provider>
   );
 
@@ -114,7 +125,9 @@ test("the save button is enabled when the data changes", () => {
 
   render(
     <Provider store={store}>
-      <Settings />
+      <Router>
+        <Settings />
+      </Router>
     </Provider>
   );
 

--- a/static/js/brand-store/Snaps/Snaps.js
+++ b/static/js/brand-store/Snaps/Snaps.js
@@ -1,16 +1,105 @@
-import React from "react";
+import React, { useState, useEffect } from "react";
 import { useParams } from "react-router-dom";
+import { useSelector, useDispatch } from "react-redux";
+import { Spinner, Row, Col } from "@canonical/react-components";
+
+import { snapsSelector, brandStoresListSelector } from "../selectors";
+import { fetchSnaps } from "../slices/snapsSlice";
+
+import SnapsTable from "./SnapsTable";
+import SnapsFilter from "./SnapsFilter";
+import SectionNav from "../SectionNav";
 
 function Snaps() {
+  const brandStoresList = useSelector(brandStoresListSelector);
+  const snaps = useSelector(snapsSelector);
+  const snapsLoading = useSelector((state) => state.snaps.loading);
+  const storesLoading = useSelector((state) => state.brandStores.loading);
+  const dispatch = useDispatch();
   const { id } = useParams();
+  const [snapsInStore, setSnapsInStore] = useState([]);
+  const [otherStoreIds, setOtherStoreIds] = useState([]);
+  const [otherStores, setOtherStores] = useState([]);
+
+  const getStoreName = (storeId) => {
+    const store = brandStoresList.find((item) => item.id === storeId);
+
+    if (store) {
+      return store.name;
+    } else {
+      return storeId;
+    }
+  };
+
+  useEffect(() => {
+    dispatch(fetchSnaps(id));
+  }, [id]);
+
+  useEffect(() => {
+    setSnapsInStore(snaps.filter((snap) => snap.store === id));
+
+    setOtherStoreIds(
+      new Set(
+        snaps
+          .filter((snap) => snap.store !== id)
+          .map((snap) => {
+            return snap.store;
+          })
+      )
+    );
+  }, [snaps]);
+
+  useEffect(() => {
+    setOtherStores(
+      Array.from(otherStoreIds).map((storeId) => {
+        return {
+          id: storeId,
+          name: getStoreName(storeId),
+          snaps: snaps.filter((snap) => snap.store === storeId),
+        };
+      })
+    );
+  }, [otherStoreIds]);
 
   return (
     <main className="l-main">
       <div className="p-panel">
-        <div className="p-panel__header">
-          <h1>Snaps {id}</h1>
+        <div className="p-panel__content">
+          <div className="u-fixed-width">
+            <SectionNav sectionName="snaps" />
+          </div>
+          {snapsLoading && storesLoading ? (
+            <div className="u-fixed-width">
+              <Spinner text="Loading&hellip;" />
+            </div>
+          ) : (
+            <>
+              <Row>
+                <Col size="6">
+                  <h2 className="p-heading--4">Snaps in {getStoreName(id)}</h2>
+                </Col>
+                <Col size="6">
+                  <SnapsFilter
+                    setSnapsInStore={setSnapsInStore}
+                    snapsInStore={snapsInStore}
+                    setOtherStores={setOtherStores}
+                    otherStoreIds={otherStoreIds}
+                    getStoreName={getStoreName}
+                    snaps={snaps}
+                    id={id}
+                  />
+                </Col>
+              </Row>
+              <div className="u-fixed-width">
+                <SnapsTable
+                  snaps={snapsInStore}
+                  storeName={getStoreName(id)}
+                  otherStores={otherStores}
+                />
+              </div>
+            </>
+          )}
         </div>
-        <div className="p-panel__content">Page content</div>
       </div>
     </main>
   );

--- a/static/js/brand-store/Snaps/SnapsFilter.js
+++ b/static/js/brand-store/Snaps/SnapsFilter.js
@@ -1,0 +1,63 @@
+import React from "react";
+import PropTypes from "prop-types";
+
+function SnapsFilter({
+  setSnapsInStore,
+  snapsInStore,
+  setOtherStores,
+  otherStoreIds,
+  getStoreName,
+  snaps,
+  id,
+}) {
+  return (
+    <input
+      type="text"
+      name="search-snaps"
+      id="search-snaps"
+      placeholder="Search snaps"
+      onKeyUp={(e) => {
+        if (e.target.value) {
+          setSnapsInStore(
+            snapsInStore.filter((snap) => snap.name.includes(e.target.value))
+          );
+          setOtherStores(
+            Array.from(otherStoreIds).map((storeId) => {
+              return {
+                id: storeId,
+                name: getStoreName(storeId),
+                snaps: snaps.filter(
+                  (snap) =>
+                    snap.store === storeId && snap.name.includes(e.target.value)
+                ),
+              };
+            })
+          );
+        } else {
+          setSnapsInStore(snaps.filter((snap) => snap.store === id));
+          setOtherStores(
+            Array.from(otherStoreIds).map((storeId) => {
+              return {
+                id: storeId,
+                name: getStoreName(storeId),
+                snaps: snaps.filter((snap) => snap.store === storeId),
+              };
+            })
+          );
+        }
+      }}
+    />
+  );
+}
+
+SnapsFilter.propTypes = {
+  setSnapsInStore: PropTypes.func.isRequired,
+  snapsInStore: PropTypes.array.isRequired,
+  setOtherStores: PropTypes.func.isRequired,
+  otherStoreIds: PropTypes.array.isRequired,
+  getStoreName: PropTypes.func.isRequired,
+  snaps: PropTypes.array.isRequired,
+  id: PropTypes.string.isRequired,
+};
+
+export default SnapsFilter;

--- a/static/js/brand-store/Snaps/SnapsTable.js
+++ b/static/js/brand-store/Snaps/SnapsTable.js
@@ -1,0 +1,52 @@
+import React from "react";
+import PropTypes from "prop-types";
+
+import SnapsTableRow from "./SnapsTableRow";
+
+function SnapsTable({ storeName, snaps, otherStores }) {
+  return (
+    <table className="p-table--mobile-card">
+      <thead>
+        <tr>
+          <th>Published in</th>
+          <th>Name</th>
+          <th>Latest release</th>
+          <th>Release date</th>
+          <th>Publisher</th>
+        </tr>
+      </thead>
+      <tbody>
+        {snaps.map((snap, index) => (
+          <SnapsTableRow
+            key={snap.id}
+            storeName={storeName}
+            snap={snap}
+            snapsCount={snaps.length}
+            index={index}
+          />
+        ))}
+
+        {otherStores &&
+          otherStores.map((store) => {
+            return store.snaps.map((snap, index) => (
+              <SnapsTableRow
+                key={snap.id}
+                storeName={store.name}
+                snap={snap}
+                snapsCount={store.snaps.length}
+                index={index}
+              />
+            ));
+          })}
+      </tbody>
+    </table>
+  );
+}
+
+SnapsTable.propTypes = {
+  storeName: PropTypes.string.isRequired,
+  snaps: PropTypes.array.isRequired,
+  otherStores: PropTypes.object,
+};
+
+export default SnapsTable;

--- a/static/js/brand-store/Snaps/SnapsTableRow.js
+++ b/static/js/brand-store/Snaps/SnapsTableRow.js
@@ -1,0 +1,32 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { format } from "date-fns";
+
+function SnapsTableRow({ storeName, snap, snapsCount, index }) {
+  return (
+    <tr>
+      {index === 0 ? (
+        <td rowSpan={snapsCount} aria-label="Published in">
+          {storeName}
+        </td>
+      ) : null}
+      <td aria-label="Name">{snap.name}</td>
+      <td aria-label="Latest release">
+        {snap["latest-release"].version ? snap["latest-release"].version : "-"}
+      </td>
+      <td aria-label="Release date">
+        {format(new Date(snap["latest-release"].timestamp), "dd/MM/yyyy")}
+      </td>
+      <td aria-label="Publisher">{snap.users[0].displayname}</td>
+    </tr>
+  );
+}
+
+SnapsTableRow.propTypes = {
+  storeName: PropTypes.string.isRequired,
+  snap: PropTypes.object.isRequired,
+  snapsCount: PropTypes.number.isRequired,
+  index: PropTypes.number.isRequired,
+};
+
+export default SnapsTableRow;

--- a/static/js/brand-store/brand-store.js
+++ b/static/js/brand-store/brand-store.js
@@ -3,7 +3,7 @@ import ReactDOM from "react-dom";
 import * as Sentry from "@sentry/react";
 import { Integrations } from "@sentry/tracing";
 import App from "./App";
-import store from "./stores/store";
+import store from "./store";
 import { Provider } from "react-redux";
 
 Sentry.init({

--- a/static/js/brand-store/selectors/index.js
+++ b/static/js/brand-store/selectors/index.js
@@ -1,3 +1,4 @@
 export const brandStoresListSelector = (state) =>
   state.brandStores.brandStoresList;
 export const currentStoreSelector = (state) => state.currentStore.currentStore;
+export const snapsSelector = (state) => state.snaps.snaps;

--- a/static/js/brand-store/slices/snapsSlice.js
+++ b/static/js/brand-store/slices/snapsSlice.js
@@ -1,0 +1,45 @@
+import { createSlice } from "@reduxjs/toolkit";
+
+export const slice = createSlice({
+  name: "snaps",
+  initialState: {
+    snaps: [],
+    loading: true,
+  },
+  reducers: {
+    getSnapsLoading: (state) => {
+      state.loading = true;
+    },
+    getSnapsSuccess: (state, { payload }) => {
+      state.snaps = payload || [];
+      state.loading = false;
+    },
+    getSnapsError: (state) => {
+      state.loading = false;
+    },
+  },
+});
+
+export const {
+  getSnapsLoading,
+  getSnapsSuccess,
+  getSnapsError,
+} = slice.actions;
+
+export function fetchSnaps(storeId) {
+  return async (dispatch) => {
+    dispatch(getSnapsLoading());
+
+    try {
+      const response = await fetch(`/admin/store/${storeId}/snaps`);
+      const data = await response.json();
+
+      dispatch(getSnapsSuccess(data));
+    } catch (error) {
+      dispatch(getSnapsError());
+      console.log("API fetch failed");
+    }
+  };
+}
+
+export default slice.reducer;

--- a/static/js/brand-store/store/index.js
+++ b/static/js/brand-store/store/index.js
@@ -1,10 +1,12 @@
 import { configureStore } from "@reduxjs/toolkit";
 import brandStoreReducer from "../slices/brandStoreSlice";
 import currentStoreReducer from "../slices/currentStoreSlice";
+import snapsSelector from "../slices/snapsSlice";
 
 export default configureStore({
   reducer: {
     brandStores: brandStoreReducer,
     currentStore: currentStoreReducer,
+    snaps: snapsSelector,
   },
 });

--- a/static/sass/_snapcraft_l-application.scss
+++ b/static/sass/_snapcraft_l-application.scss
@@ -23,6 +23,13 @@
         background: #000;
       }
     }
+
+    .p-tabs__link:active,
+    .p-tabs__link[aria-pressed="true"],
+    .p-tabs__link[aria-selected="true"],
+    .p-tabs__link[aria-expanded="true"] {
+      background-color: $color-x-light;
+    }
   }
 
   .l-navigation-bar {

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -424,3 +424,7 @@ code {
 .p-form-password-toggle + [readonly] {
   color: $color-dark;
 }
+
+.u-top-border {
+  border-top: $border;
+}

--- a/webapp/admin/views.py
+++ b/webapp/admin/views.py
@@ -93,3 +93,16 @@ def get_snaps_search(store_id):
         return _handle_error(api_error)
 
     return jsonify(snaps)
+
+
+@admin.route("/admin/store/<store_id>/snaps")
+@login_required
+def get_store_snaps(store_id):
+    try:
+        snaps = admin_api.get_store_snaps(flask.session, store_id)
+    except StoreApiResponseErrorList as api_response_error_list:
+        return _handle_error_list(api_response_error_list.errors)
+    except (StoreApiError, ApiError) as api_error:
+        return _handle_error(api_error)
+
+    return jsonify(snaps)


### PR DESCRIPTION
## Done
- Added the basic snaps table with a filter
- Added the tabbed navigation to be shared between all views

**Note**: Tests will come in a follow-up PR

## QA
- Go to https://snapcraft-io-3693.demos.haus/admin/ahnuP3quahti9vis8aiw/snaps
- Check that there is a table of snaps on the page
- Check that the search snaps filter filters snaps by name

## Issue
Fixes #3650, #3651