### PR TITLE
Fix non-existing repositories issue

### DIFF
--- a/webapp/publisher/snaps/build_views.py
+++ b/webapp/publisher/snaps/build_views.py
@@ -312,7 +312,8 @@ def post_snap_builds(snap_name):
 
     if not github.check_permissions_over_repo(owner, repo):
         flask.flash(
-            "Your GitHub account doesn't have permissions in the repository",
+            "The repository doesn't exist or you don't have"
+            " enough permissions",
             "negative",
         )
         return flask.redirect(redirect_url)


### PR DESCRIPTION
## Done
- Fix issue when people try to link repositories that don't exist anymore or are private now.

## How to QA
- Go to any of your snaps builds: /<SNAP_NAME>/builds
- Create a GitHub repo
- Search for the repo in the list
- Once selected and before saving make the repo private
- A message should appear with an error and not a 500

## Issue / Card
Fixes #3694
