### PR TITLE
Show error message for non-collaborators on releases

### DIFF
--- a/static/js/publisher/release/actions/releases.js
+++ b/static/js/publisher/release/actions/releases.js
@@ -114,6 +114,10 @@ export function handleReleaseResponse(
         });
       });
     });
+  } else {
+    if (json.errors) {
+      throw new Error(json.errors[0]);
+    }
   }
 }
 


### PR DESCRIPTION
## Done
- Show error message for non-collaborators

## How to QA
- Try to release a snap you don't own: /<snap_name>/releases
- An error message should appear

## Issue / Card
Fixes #3571
