### PR TITLE
Fix release table for non-default tracks

### DIFF
--- a/static/js/publisher/release/actions/releases.js
+++ b/static/js/publisher/release/actions/releases.js
@@ -70,13 +70,7 @@ export function getErrorMessage(error) {
   return message;
 }
 
-export function handleReleaseResponse(
-  dispatch,
-  json,
-  release,
-  revisions,
-  defaultTrack
-) {
+export function handleReleaseResponse(dispatch, json, release, revisions) {
   if (json.success) {
     // Update channel map based on the response
     // We need to use channel_map_tree to get branches
@@ -103,11 +97,7 @@ export function handleReleaseResponse(
                 };
               }
 
-              let channel = map.channel;
-              if (RISKS.indexOf(channel.split("/")[0]) > -1) {
-                channel = `${defaultTrack}/${channel}`;
-              }
-
+              let channel = `${trackKey}/${map.channel}`;
               dispatch(releaseRevisionSuccess(revision, channel));
             }
           });


### PR DESCRIPTION
## Done
- Fix release table for non-default tracks

## How to QA
- Visit as a publisher any snap with multiple tracks, like https://snapcraft-io-3734.demos.haus/fran-snap/releases
- Do a release in a different channel than `latest`
- Click on save and the table should be updated

## Issue / Card
Fixes #3571 
