### PR TITLE
Use original Flask-OpenID instead of FlaskOpenID-Stateless

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ canonicalwebteam.image-template==1.3.1
 canonicalwebteam.store-api==3.2.6
 canonicalwebteam.launchpad==0.8.2
 django-openid-auth==0.16
-Flask-OpenID-Stateless==1.2.6
+Flask-OpenID==1.3.0
 Flask-WTF==0.14.3
 bleach==3.3.0
 humanize==3.2.0

--- a/webapp/login/views.py
+++ b/webapp/login/views.py
@@ -29,7 +29,7 @@ LOGIN_URL = os.getenv("LOGIN_URL", "https://login.ubuntu.com")
 LP_CANONICAL_TEAM = "canonical"
 
 open_id = OpenID(
-    stateless=True,
+    store_factory=lambda: None,
     safe_roots=[],
     extension_responses=[MacaroonResponse, TeamsResponse],
 )


### PR DESCRIPTION
We are having trouble building our own stateless fork and using the original
library with the changes in this commit should achieve the same result.
