### PR TITLE
Add snap to IoT page

### DIFF
--- a/webapp/snapcraft/views.py
+++ b/webapp/snapcraft/views.py
@@ -170,6 +170,15 @@ def snapcraft_blueprint():
                 "origin": "ixot",
                 "publisher": "Michael Hathaway",
             },
+            {
+                "package_name": "anyvizcloudadapter",
+                "icon_url": "/".join(
+                    [icon_host, "2020/06/LogoAnyViz_Wolke512.svg.png"]
+                ),
+                "title": "anyvizcloudadapter",
+                "origin": "mirasoft",
+                "publisher": "Mirasoft GmbH & Co KG",
+            },
         ]
 
         networking = [


### PR DESCRIPTION
## Done
- Add snap to IoT page

## How to QA
- Visit /iot
- Check the snap `anyvizcloudadapter` is listed

## Issue / Card
Fixes #3741
