### PR TITLE
Add message to no stores page

### DIFF
--- a/static/js/brand-store/NoStores/NoStores.js
+++ b/static/js/brand-store/NoStores/NoStores.js
@@ -7,6 +7,15 @@ function NoStores() {
         <div className="p-panel__content">
           <div className="u-fixed-width">
             <h1>No stores</h1>
+            <p>
+              Currently this section can only show stores if you are a viewer or
+              an admin. If you are a publisher or reviewer you will find your
+              stores{" "}
+              <a href="https://dashboard.snapcraft.io/stores/">
+                on the dashboard
+              </a>
+              .
+            </p>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Done
Added a message to the brand store "No stores" page to explain that publisher and reviewer roles aren't yet available.

## QA
- Go to https://snapcraft-io-3744.demos.haus/admin
- Login with an account which has no stores, e.g. a test account
- Check that you see a "No stores" page which explains that publisher and reviewer pages are available at dashboard.snapcraft.io

## Issue
Fixes #3742 

## Screenshot
<img width="1440" alt="Screenshot 2021-10-27 at 11 23 38" src="https://user-images.githubusercontent.com/501889/139048235-5eae4448-f9b9-415c-ad64-f064539c77e9.png">


