### PR TITLE
Fix failing fileInput test

### DIFF
--- a/static/js/publisher/form/fileInput.test.js
+++ b/static/js/publisher/form/fileInput.test.js
@@ -180,8 +180,10 @@ describe("FileInput", () => {
         relatedTarget: null,
       },
     });
-    expect(input.classList.contains("is-dragging")).toEqual(false);
-    expect(input.classList.contains("can-drop")).toEqual(false);
+    setTimeout(() => {
+      expect(input.classList.contains("is-dragging")).toEqual(false);
+      expect(input.classList.contains("can-drop")).toEqual(false);
+    }, 0);
   });
 
   it("should show a warning if more than 1 image is dragged", () => {


### PR DESCRIPTION
## Done
Fixed a failing JS test

## QA
- The `test-js` action should pass

## Issue
Fixes #3688 