### PR TITLE
Change fileinput test timeout for waitfor

### DIFF
--- a/static/js/publisher/form/fileInput.test.js
+++ b/static/js/publisher/form/fileInput.test.js
@@ -1,6 +1,6 @@
 import FileInput from "./fileInput";
 import React from "react";
-import { render, fireEvent } from "@testing-library/react";
+import { render, fireEvent, waitFor } from "@testing-library/react";
 import * as fileValidation from "../../libs/fileValidation";
 
 describe("FileInput", () => {
@@ -180,10 +180,10 @@ describe("FileInput", () => {
         relatedTarget: null,
       },
     });
-    setTimeout(() => {
+    waitFor(() => {
       expect(input.classList.contains("is-dragging")).toEqual(false);
       expect(input.classList.contains("can-drop")).toEqual(false);
-    }, 0);
+    });
   });
 
   it("should show a warning if more than 1 image is dragged", () => {


### PR DESCRIPTION
## Done
Swapped the timeout in the fileinput test to use `waitFor` from testing library

## QA
Check that the `test-js` test passes