### PR TITLE
Fix brand store mobile

### DIFF
--- a/static/js/brand-store/Snaps/Snaps.js
+++ b/static/js/brand-store/Snaps/Snaps.js
@@ -201,9 +201,12 @@ function Snaps() {
   }, [otherStoreIds]);
 
   useEffect(() => {
-    setSnapsInStore([]);
-    setOtherStores([]);
-    setIsReloading(true);
+    // protect against hash changes e.g. mobile navigation
+    if (location.pathname !== `/admin/${id}/snaps`) {
+      setSnapsInStore([]);
+      setOtherStores([]);
+      setIsReloading(true);
+    }
   }, [location]);
 
   useEffect(() => {

--- a/static/js/brand-store/Snaps/Snaps.js
+++ b/static/js/brand-store/Snaps/Snaps.js
@@ -166,12 +166,14 @@ function Snaps() {
     setSnapsInStore(snaps.filter((snap) => snap.store === id));
 
     setOtherStoreIds(
-      new Set(
-        snaps
-          .filter((snap) => snap.store !== id)
-          .map((snap) => {
-            return snap.store;
-          })
+      Array.from(
+        new Set(
+          snaps
+            .filter((snap) => snap.store !== id)
+            .map((snap) => {
+              return snap.store;
+            })
+        )
       )
     );
 
@@ -188,7 +190,7 @@ function Snaps() {
 
   useEffect(() => {
     setOtherStores(
-      Array.from(otherStoreIds).map((storeId) => {
+      otherStoreIds.map((storeId) => {
         return {
           id: storeId,
           name: getStoreName(storeId),

--- a/static/js/brand-store/Snaps/SnapsFilter.js
+++ b/static/js/brand-store/Snaps/SnapsFilter.js
@@ -25,7 +25,7 @@ function SnapsFilter({
               snapsInStore.filter((snap) => snap.name.includes(e.target.value))
             );
             setOtherStores(
-              Array.from(otherStoreIds).map((storeId) => {
+              otherStoreIds.map((storeId) => {
                 return {
                   id: storeId,
                   name: getStoreName(storeId),
@@ -40,7 +40,7 @@ function SnapsFilter({
           } else {
             setSnapsInStore(snaps.filter((snap) => snap.store === id));
             setOtherStores(
-              Array.from(otherStoreIds).map((storeId) => {
+              otherStoreIds.map((storeId) => {
                 return {
                   id: storeId,
                   name: getStoreName(storeId),


### PR DESCRIPTION
## Done
- Fix the snaps view being cleared by a location change triggered by the main navigation hash
- Drive by: Refactored `otherStoreIds` so it doesn't need to be converted to an array every time it's referenced

## QA
- Go to https://snapcraft-io-3752.demos.haus/admin on a small/mobile screen
- Open the main site navigation
- The main content should still be there

## Issue
Fixes #3748