### PR TITLE
Fix global snaps in brand store

### DIFF
--- a/static/js/brand-store/Snaps/Snaps.js
+++ b/static/js/brand-store/Snaps/Snaps.js
@@ -283,6 +283,7 @@ function Snaps() {
                       snapsToRemove={snapsToRemove}
                       setSnapsToRemove={setSnapsToRemove}
                       nonEssentialSnapIds={nonEssentialSnapIds}
+                      isAdmin={isAdmin}
                     />
                   )}
                 </div>

--- a/static/js/brand-store/Snaps/SnapsTable.js
+++ b/static/js/brand-store/Snaps/SnapsTable.js
@@ -12,9 +12,12 @@ function SnapsTable({
   snapsToRemove,
   setSnapsToRemove,
   nonEssentialSnapIds,
+  isAdmin,
 }) {
   const { id } = useParams();
   const [checkAll, setCheckAll] = useState(false);
+
+  const tableCellClass = isAdmin() ? "table-cell--checkbox" : "";
 
   useEffect(() => {
     setCheckAll(snapsToRemove.length === nonEssentialSnapIds.length);
@@ -29,25 +32,29 @@ function SnapsTable({
         <thead>
           <tr>
             <th>Published in</th>
-            <th className="table-cell-head--checkbox">
-              <CheckboxInput
-                onChange={(e) => {
-                  if (e.target.checked) {
-                    const otherStoresSnaps = otherStores.map(
-                      (item) => item.snaps
-                    );
-                    setSnapsToRemove(
-                      otherStoresSnaps.flat().filter((item) => !item.essential)
-                    );
-                    setCheckAll(true);
-                  } else {
-                    setSnapsToRemove([]);
-                    setCheckAll(false);
-                  }
-                }}
-                checked={checkAll}
-                disabled={!nonEssentialSnapIds.length}
-              />
+            <th className={tableCellClass}>
+              {isAdmin() && (
+                <CheckboxInput
+                  onChange={(e) => {
+                    if (e.target.checked) {
+                      const otherStoresSnaps = otherStores.map(
+                        (item) => item.snaps
+                      );
+                      setSnapsToRemove(
+                        otherStoresSnaps
+                          .flat()
+                          .filter((item) => !item.essential)
+                      );
+                      setCheckAll(true);
+                    } else {
+                      setSnapsToRemove([]);
+                      setCheckAll(false);
+                    }
+                  }}
+                  checked={checkAll}
+                  disabled={!nonEssentialSnapIds.length}
+                />
+              )}
               Name
             </th>
             <th>Latest release</th>
@@ -64,6 +71,7 @@ function SnapsTable({
               snap={snap}
               snapsCount={snaps.length}
               index={index}
+              isAdmin={isAdmin}
             />
           ))}
         </tbody>
@@ -122,6 +130,7 @@ function SnapsTable({
                       index={index}
                       snapsToRemove={snapsToRemove}
                       setSnapsToRemove={setSnapsToRemove}
+                      isAdmin={isAdmin}
                     />
                   ))}
                 </tbody>
@@ -140,6 +149,7 @@ SnapsTable.propTypes = {
   snapsToRemove: PropTypes.array,
   setSnapsToRemove: PropTypes.func,
   nonEssentialSnapIds: PropTypes.array.isRequired,
+  isAdmin: PropTypes.func.isRequired,
 };
 
 export default SnapsTable;

--- a/static/js/brand-store/Snaps/SnapsTableRow.js
+++ b/static/js/brand-store/Snaps/SnapsTableRow.js
@@ -12,8 +12,11 @@ function SnapsTableRow({
   index,
   snapsToRemove,
   setSnapsToRemove,
+  isAdmin,
 }) {
   const { id } = useParams();
+
+  const tableCellClass = isAdmin() ? "table-cell--checkbox" : "";
 
   return (
     <tr>
@@ -26,8 +29,8 @@ function SnapsTableRow({
           {storeName}
         </td>
       ) : null}
-      <td aria-label="Name" className="table-cell--checkbox">
-        {storeId !== id && !snap.essential ? (
+      <td aria-label="Name" className={tableCellClass}>
+        {storeId !== id && !snap.essential && isAdmin() ? (
           <CheckboxInput
             onChange={(e) => {
               if (e.target.checked) {
@@ -66,6 +69,7 @@ SnapsTableRow.propTypes = {
   index: PropTypes.number.isRequired,
   snapsToRemove: PropTypes.array,
   setSnapsToRemove: PropTypes.func,
+  isAdmin: PropTypes.func.isRequired,
 };
 
 export default SnapsTableRow;

--- a/static/js/brand-store/Snaps/SnapsTableRow.js
+++ b/static/js/brand-store/Snaps/SnapsTableRow.js
@@ -41,7 +41,7 @@ function SnapsTableRow({
             checked={snapsToRemove.find((item) => item.id === snap.id)}
           />
         ) : null}
-        {storeId === "ubuntu" && !snap.essential ? (
+        {storeId === "ubuntu" ? (
           <a href={`/${snap.name}`}>{snap.name}</a>
         ) : (
           snap.name


### PR DESCRIPTION
## Done
- Linked all snaps in the global store to their details pages
- Removed checkboxes on snaps table if user is not an admin

## QA
- Go to https://snapcraft-io-3753.demos.haus/admin
- If the global store is part of the store page, all snap titles should be linked to their details pages
- Go to a store where you are not an admin
- There should be no checkboxes in the snaps table

## Issue
Fixes #3745, #3746