### PR TITLE
Homepage a11y fixes (#3761)

### DIFF
--- a/static/js/public/hero-tabpanel.js
+++ b/static/js/public/hero-tabpanel.js
@@ -29,7 +29,7 @@ class HeroTabPanels {
     );
     const verifiedAccountBadge = `
       <span class="p-verified" title="Verified account">
-        <img src="https://assets.ubuntu.com/v1/75654c90-rosette.svg">
+        <img src="https://assets.ubuntu.com/v1/75654c90-rosette.svg" alt="">
       </span>
     `;
     panel.innerHTML = "";
@@ -57,9 +57,9 @@ class HeroTabPanels {
             height="48">
 
           <div class="p-media-object__details">
-            <h4 class="p-media-object__title p-heading--5 u-no-margin--bottom">
+            <h3 class="p-media-object__title p-heading--5 u-no-margin--bottom">
               ${snap.title}
-            </h4>
+            </h3>
             <div class="p-media-object__content">
               <p>
                 <span class="u-off-screen">Publisher: </span>${snap.publisher}

--- a/templates/_footer.html
+++ b/templates/_footer.html
@@ -48,19 +48,19 @@
   <div class="u-fixed-width">
     <ul class="p-inline-list--middot u-no-margin--bottom">
       <li class="p-inline-list__item">
-        <a class="p-link--soft" accesskey="6" href="https://ubuntu.com/legal/terms-and-policies/snap-store-terms"><small>Terms of Service</small></a>
+        <a class="p-link--soft" href="https://ubuntu.com/legal/terms-and-policies/snap-store-terms"><small>Terms of Service</small></a>
       </li>
       <li class="p-inline-list__item">
-        <a class="p-link--soft" accesskey="7" href="https://www.ubuntu.com/legal/data-privacy"><small>Data privacy</small></a>
+        <a class="p-link--soft" href="https://www.ubuntu.com/legal/data-privacy"><small>Data privacy</small></a>
       </li>
       <li class="p-inline-list__item">
         <a class="p-link--soft js-revoke-cookie-manager" href=""><small>Manage your tracker settings</small></a>
       </li>
       <li class="p-inline-list__item">
-        <a class="p-link--soft" accesskey="8" href="https://status.snapcraft.io/"><small>Service status</small></a>
+        <a class="p-link--soft" href="https://status.snapcraft.io/"><small>Service status</small></a>
       </li>
       <li class="p-inline-list__item">
-        <a class="p-link--soft" accesskey="9" href="https://dashboard.snapcraft.io/"><small>Other functions</small></a>
+        <a class="p-link--soft" href="https://dashboard.snapcraft.io/"><small>Other functions</small></a>
       </li>
     </ul>
   </div>

--- a/templates/_header-brandstore.html
+++ b/templates/_header-brandstore.html
@@ -20,9 +20,6 @@
       <a href="#navigation-closed" class="p-navigation__toggle--close" title="close menu">Close menu</a>
     </div>
     <nav class="p-navigation__nav">
-      <span class="u-off-screen">
-        <a href="#main-content">Jump to main content</a>
-      </span>
       {% if webapp_config['STORE_LINKS'] %}
         <ul class="p-navigation__links" role="menu">
           {% for link in webapp_config['STORE_LINKS'] %}

--- a/templates/_header.html
+++ b/templates/_header.html
@@ -10,9 +10,6 @@
       <a href="#navigation-closed" class="p-navigation__toggle--close" title="close menu">Close menu</a>
     </div>
     <nav class="p-navigation__nav">
-      <span class="u-off-screen">
-        <a href="#main-content">Jump to main content</a>
-      </span>
       <ul class="p-navigation__items" role="menu">
         <li
           class="p-navigation__item {% if page_slug == 'store' %}is-selected{% endif %}"

--- a/templates/home/_fsf_c.html
+++ b/templates/home/_fsf_c.html
@@ -1,7 +1,7 @@
 <div class="col-{{ columns }} u-hide" data-flow-details="c">
   <div class="row">
     <div class="col-{{ (columns/2) | int }}">
-      <h4>Why are snaps good for C/C++ projects?</h4>
+      <h3 class="p-heading--4">Why are snaps good for C/C++ projects?</h3>
       <ul>
         <li>Snaps are easy to discover and install. Millions of users can browse and install snaps graphically in the Snap Store or from the command-line.</li>
         <li>Snaps install and run the same across Linux. They bundle the exact versions of your app’s dependencies.</li>
@@ -17,7 +17,7 @@
     </div>
 
     <div class="col-{{ (columns/2) | int }}">
-      <h4>Here's how <a href="https://snapcraft.io/dosbox-x">dosbox</a> defines snapcraft.yaml:</h4>
+      <h3 class="p-heading--4">Here's how <a href="https://snapcraft.io/dosbox-x">dosbox</a> defines snapcraft.yaml:</h3>
       <div class ="p-show-more is-collapsed" data-js="js-show-more">
         <pre class="p-code-yaml"><b>name</b>: dosbox
 <b>version</b>: "0.74-svn"

--- a/templates/home/_fsf_electron.html
+++ b/templates/home/_fsf_electron.html
@@ -1,7 +1,7 @@
 <div class="col-{{ columns }} u-hide" data-flow-details="electron">
   <div class="row">
     <div class="col-{{ (columns/2) | int }}">
-      <h4>Why are snaps good for Electron projects?</h4>
+      <h3 class="p-heading--4">Why are snaps good for Electron projects?</h3>
       <ul>
         <li>Snaps are easy to discover and install. Millions of users can browse and install snaps graphically in the Snap Store or from the command-line.</li>
         <li>Snaps install and run the same across Linux. They bundle Electron and all of your app’s dependencies, be they Node modules or system libraries.</li>
@@ -17,7 +17,7 @@
     </div>
 
     <div class="col-{{ (columns/2) | int }}">
-      <h4>Here's how to use it with electron-quick-start:</h4>
+      <h3 class="p-heading--4">Here's how to use it with electron-quick-start:</h3>
       <div class ="p-show-more is-collapsed" data-js="js-show-more">
         <pre class="p-code-yaml">{
   <b>"name"</b>: "electron-quick-start",

--- a/templates/home/_fsf_flutter.html
+++ b/templates/home/_fsf_flutter.html
@@ -1,7 +1,7 @@
 <div class="col-{{ columns }} u-hide" data-flow-details="flutter">
   <div class="row">
     <div class="col-{{ (columns/2) | int }}">
-      <h4>Why are snaps good for Flutter projects?</h4>
+      <h3 class="p-heading--4">Why are snaps good for Flutter projects?</h3>
       <ul>
         <li>Snaps are easy to discover and install. Millions of users can browse and install snaps graphically in the Snap Store or from the command-line.</li>
         <li>Snaps install and run the same across Linux. They bundle the exact versions of your app’s dependencies.</li>
@@ -17,7 +17,7 @@
     </div>
 
     <div class="col-{{ (columns/2) | int }}">
-      <h4>Here's how <a href="https://snapcraft.io/super-cool-app">super-cool-app</a> defines snapcraft.yaml:</h4>
+      <h3 class="p-heading--4">Here's how <a href="https://snapcraft.io/super-cool-app">super-cool-app</a> defines snapcraft.yaml:</h3>
       <div class ="p-show-more is-collapsed" data-js="js-show-more">
         <pre class="p-code-yaml"><b>name</b>: super-cool-app
 <b>version</b>: "1.0"

--- a/templates/home/_fsf_go.html
+++ b/templates/home/_fsf_go.html
@@ -1,7 +1,7 @@
 <div class="col-{{ columns }} u-hide" data-flow-details="go">
   <div class="row">
     <div class="col-{{ (columns/2) | int }}">
-      <h4>Why are snaps good for Go projects?</h4>
+      <h3 class="p-heading--4">Why are snaps good for Go projects?</h3>
       <ul>
         <li>Easy to discover and install by millions using the Snap Store or command-line every day</li>
         <li>Automatically updated to the latest stable version of your app</li>
@@ -20,7 +20,7 @@
     </div>
 
     <div class="col-{{ (columns/2) | int }}">
-      <h4>Here’s how httplab defines snapcraft.yaml:</h4>
+      <h3 class="p-heading--4">Here’s how httplab defines snapcraft.yaml:</h3>
       <div class ="p-show-more is-collapsed" data-js="js-show-more">
         <pre class="p-code-yaml"><b>name</b>: httplab
 <b>version</b>: '1.0'

--- a/templates/home/_fsf_java.html
+++ b/templates/home/_fsf_java.html
@@ -1,7 +1,7 @@
 <div class="col-{{ columns }} u-hide" data-flow-details="java">
   <div class="row">
     <div class="col-{{ (columns/2) | int }}">
-      <h4>Why are snaps good for Java projects?</h4>
+      <h3 class="p-heading--4">Why are snaps good for Java projects?</h3>
       <ul>
         <li>Simplify installation instructions, regardless of distribution, to snap install myjavaapp.</li>
         <li>Directly control the delivery of automatic application updates.</li>
@@ -15,7 +15,7 @@
     </div>
 
     <div class="col-{{ (columns/2) | int }}">
-      <h4>Here's how <a href="https://snapcraft.io/freeplane-mindmapping">freeplane</a> defines snapcraft.yaml:</h4>
+      <h3 class="p-heading--4">Here's how <a href="https://snapcraft.io/freeplane-mindmapping">freeplane</a> defines snapcraft.yaml:</h3>
       <div class ="p-show-more is-collapsed" data-js="js-show-more">
         <pre class="p-code-yaml"><b>name</b>: freeplane
 <b>version</b>: '1.8.1'

--- a/templates/home/_fsf_moos.html
+++ b/templates/home/_fsf_moos.html
@@ -1,7 +1,7 @@
 <div class="col-{{ columns }} u-hide" data-flow-details="moos">
   <div class="row">
     <div class="col-{{ (columns/2) | int }}">
-      <h4>Why are snaps good for MOOS projects?</h4>
+      <h3 class="p-heading--4">Why are snaps good for MOOS projects?</h3>
       <ul>
         <li>Bundle all the runtime requirements, including the exact version of MOOS/MOOS-IvP and system libraries you need.</li>
         <li>Directly and reliably control the delivery of application updates using existing infrastructure.</li>
@@ -15,7 +15,7 @@
     </div>
 
     <div class="col-{{ (columns/2) | int }}">
-      <h4>Here's an example snapcraft.yaml that uses MOOS:</h4>
+      <h3 class="p-heading--4">Here's an example snapcraft.yaml that uses MOOS:</h3>
       <div class ="p-show-more is-collapsed" data-js="js-show-more">
         <pre class="p-code-yaml"><b>name</b>: moos
 <b>version</b>: '0.1'

--- a/templates/home/_fsf_node.html
+++ b/templates/home/_fsf_node.html
@@ -1,7 +1,7 @@
 <div class="col-{{ columns }} u-hide" data-flow-details="node">
   <div class="row">
     <div class="col-{{ (columns/2) | int }}">
-      <h4>Why are snaps good for Node.js projects?</h4>
+      <h3 class="p-heading--4">Why are snaps good for Node.js projects?</h3>
       <ul>
         <li>Easy to discover and install by millions using the Snap Store or command-line every day.</li>
         <li>Automatically updated to the latest stable version of your app.</li>
@@ -15,7 +15,7 @@
     </div>
 
     <div class="col-{{ (columns/2) | int }}">
-      <h4>Here's how <a href="https://snapcraft.io/wethr">wethr</a> defines snapcraft.yaml:</h4>
+      <h3 class="p-heading--4">Here's how <a href="https://snapcraft.io/wethr">wethr</a> defines snapcraft.yaml:</h3>
       <div class ="p-show-more is-collapsed" data-js="js-show-more">
         <pre class="p-code-yaml"><b>name</b>: wethr
 <b>version</b>: '1.0'

--- a/templates/home/_fsf_pre-built.html
+++ b/templates/home/_fsf_pre-built.html
@@ -1,7 +1,7 @@
 <div class="col-{{ columns }} u-hide" data-flow-details="pre-built">
   <div class="row">
     <div class="col-{{ (columns/2) | int }}">
-      <h4>Why are snaps good for pre-built apps?</h4>
+      <h3 class="p-heading--4">Why are snaps good for pre-built apps?</h3>
       <ul>
         <li>Easy to discover and install by millions using the Snap Store or command-line every day</li>
         <li>Automatically updated to the latest stable version of your app</li>
@@ -21,7 +21,7 @@
     </div>
 
     <div class="col-{{ (columns/2) | int }}">
-      <h4>How <a href="https://www.geekbench.com/">geekbench4</a> defines snapcraft.yaml</h4>
+      <h3 class="p-heading--4">How <a href="https://www.geekbench.com/">geekbench4</a> defines snapcraft.yaml</h3>
       <div class ="p-show-more is-collapsed" data-js="js-show-more">
         <pre class="p-code-yaml"><b>name</b>: geekbench4
 <b>version</b>: 4.2.0

--- a/templates/home/_fsf_python.html
+++ b/templates/home/_fsf_python.html
@@ -1,7 +1,7 @@
 <div class="col-{{ columns }} u-hide" data-flow-details="python">
   <div class="row">
     <div class="col-{{ (columns/2) | int }}">
-      <h4>Why are snaps good for Python projects?</h4>
+      <h3 class="p-heading--3">Why are snaps good for Python projects?</h3>
       <ul>
         <li>Easy to discover and install by millions using the Snap Store or command-line every day</li>
         <li>Automatically updated to the latest stable version of your app</li>
@@ -21,7 +21,7 @@
     </div>
 
     <div class="col-{{ (columns/2) | int }}">
-      <h4>Here's how <a href="https://snapcraft.io/offlineimap">offlineimap</a> defines snapcraft.yaml:</h4>
+      <h3 class="p-heading--3">Here's how <a href="https://snapcraft.io/offlineimap">offlineimap</a> defines snapcraft.yaml:</h3>
       <div class ="p-show-more is-collapsed" data-js="js-show-more">
         <pre class="p-code-yaml"><b>name</b>: offlineimap
 <b>version</b>: '1.0'

--- a/templates/home/_fsf_ros.html
+++ b/templates/home/_fsf_ros.html
@@ -1,7 +1,7 @@
 <div class="col-{{ columns }} u-hide" data-flow-details="ros">
   <div class="row">
     <div class="col-{{ (columns/2) | int }}">
-      <h4>Why are snaps good for ROS projects?</h4>
+      <h3 class="p-heading--4">Why are snaps good for ROS projects?</h3>
       <ul>
         <li>Bundle all the runtime requirements, including the exact version of ROS and system libraries you need.</li>
         <li>Expand the distributions supported beyond just Ubuntu.</li>
@@ -15,7 +15,7 @@
     </div>
 
     <div class="col-{{ (columns/2) | int }}">
-      <h4>Here's an example snapcraft.yaml that uses ROS:</h4>
+      <h3 class="p-heading--4">Here's an example snapcraft.yaml that uses ROS:</h3>
       <div class ="p-show-more is-collapsed" data-js="js-show-more">
         <pre class="p-code-yaml"><b>name</b>: ros-talker-listener
 <b>version</b>: '0.1'

--- a/templates/home/_fsf_ros2.html
+++ b/templates/home/_fsf_ros2.html
@@ -1,7 +1,7 @@
 <div class="col-{{ columns }} u-hide" data-flow-details="ros2">
   <div class="row">
     <div class="col-{{ (columns/2) | int }}">
-      <h4>Why are snaps good for ROS2 projects?</h4>
+      <h3 class="p-heading--4">Why are snaps good for ROS2 projects?</h3>
       <ul>
         <li>Bundle all the runtime requirements, including the exact version of ROS and system libraries you need.</li>
         <li>Expand the distributions supported beyond just Ubuntu.</li>
@@ -15,7 +15,7 @@
     </div>
 
     <div class="col-{{ (columns/2) | int }}">
-      <h4>Here's an example snapcraft.yaml that uses ROS2:</h4>
+      <h3 class="p-heading--4">Here's an example snapcraft.yaml that uses ROS2:</h3>
       <div class="p-show-more is-collapsed" data-js="js-show-more">
         <pre class="p-code-yaml"><b>name</b>: ros2-talker-listener
 <b>version</b>: '0.1'

--- a/templates/home/_fsf_ruby.html
+++ b/templates/home/_fsf_ruby.html
@@ -1,7 +1,7 @@
 <div class="col-{{ columns }} u-hide" data-flow-details="ruby">
   <div class="row">
     <div class="col-{{ (columns/2) | int }}">
-      <h4>Why are snaps good for Ruby projects?</h4>
+      <h3 class="p-heading--4">Why are snaps good for Ruby projects?</h3>
       <ul>
         <li>Bundle all the runtime requirements.</li>
         <li>Simplify installation instructions, regardless of distribution, to snap install myrubyapp.</li>
@@ -17,7 +17,7 @@
     </div>
 
     <div class="col-{{ (columns/2) | int }}">
-      <h4>Here’s how mdl uses it:</h4>
+      <h3 class="p-heading--4">Here’s how mdl uses it:</h3>
       <div class="p-show-more is-collapsed" data-js="js-show-more">
         <pre class="p-code-yaml"><b>name</b>: mdl
 <b>version</b>: "0.5.0"

--- a/templates/home/_fsf_rust.html
+++ b/templates/home/_fsf_rust.html
@@ -1,7 +1,7 @@
 <div class="col-{{ columns }} u-hide" data-flow-details="rust">
   <div class="row">
     <div class="col-{{ (columns/2) | int }}">
-      <h4>Why are snaps good for Rust projects?</h4>
+      <h3 class="p-heading--3">Why are snaps good for Rust projects?</h3>
       <ul>
         <li>Easy to discover and install by millions using the Snap Store or command-line every day.</li>
         <li>Automatically updated to the latest stable version of your app.</li>
@@ -16,7 +16,7 @@
     </div>
 
     <div class="col-{{ (columns/2) | int }}">
-      <h4>Here's how xsv defines snapcraft.yaml:</h4>
+      <h3 class="p-heading--3">Here's how xsv defines snapcraft.yaml:</h3>
       <div class="p-show-more is-collapsed" data-js="js-show-more">
         <pre class="p-code-yaml"><b>name</b>: xsv
 <b>version</b>: '1.0'

--- a/templates/index.html
+++ b/templates/index.html
@@ -105,7 +105,7 @@
 
 <section class="p-strip">
   <div class="row">
-    <h3 class="p-muted-heading">Official snaps from major publishers</h3>
+    <h2 class="p-muted-heading">Official snaps from major publishers</h2>
   </div>
   <div class="row">
     <div class="col-small-2 col-medium-3 col-2 col-logo u-align--center">
@@ -201,7 +201,7 @@
 
 <section class="p-strip" data-js="latest-news">
   <div class="u-fixed-width">
-    <h3 class="p-heading--2">Latest  news from <a href="/blog">our blog&nbsp;&rsaquo;</a></h3>
+    <h2>Latest  news from <a href="/blog">our blog&nbsp;&rsaquo;</a></h2>
   </div>
   <div id="horizontal-latest-articles" class="row" style="min-height: 84px;">
     <div class="u-align--center" style="min-height: 9.1rem;"><i class="p-icon--spinner u-animation--spin">Loading...</i></div>
@@ -233,7 +233,7 @@
 
 <div class="p-strip">
   <div class="u-fixed-width">
-    <h3 class="p-heading--2">Learn how to snap an app <br class="u-hide--large" /> in 30 minutes</h3>
+    <h2>Learn how to snap an app <br class="u-hide--large" /> in 30 minutes</h2>
     <p>What language or framework does your app use?</p>
   </div>
   {% include "partials/fsf_language.html" %}
@@ -244,6 +244,9 @@
 </div>
 
 <div class="p-strip">
+  <div class="u-fixed-width">
+    <h2>Testimonials</h2>
+  </div>
   <div class="row">
     <div class="col-4">
       <blockquote class="p-testimonial">
@@ -260,7 +263,7 @@
             }}
           </a>
         </div>
-        <h4 class="p-testimonial__title">“The auto-updating feature is huge”</h4>
+        <h3 class="p-testimonial__title">“The auto-updating feature is huge”</h3>
         <p class="p-testimonial__content">Due to the nature of our platform, we release updates more than daily which admittedly can be annoying for our users to constantly update.</p>
         <p class="p-testimonial__content">Therefore, having them done seamlessly in the background makes life for our users so much easier. It’s great to see snaps as the first serious attempt to try and unify the community.</p>
         <cite class="p-testimonial__citation">
@@ -283,7 +286,7 @@
             }}
           </a>
         </div>
-        <h4 class="p-testimonial__title">“Starting with snaps is easy”</h4>
+        <h3 class="p-testimonial__title">“Starting with snaps is easy”</h3>
         <p class="p-testimonial__content">We definitely find Snapcraft easier as it is yaml based and provides details of what artifacts are needed. Debian packaging has things that need to be followed which can be distribution specific, which creates complication.
         <p class="p-testimonial__content">The modular containment is what appealed about snaps and [we] can see it will be a lot more flexible. Starting with snaps is easy and the resources that are provided are clean and structured which aids adoption.</p>
         <cite class="p-testimonial__citation">
@@ -306,7 +309,7 @@
             }}
           </a>
         </div>
-        <h4 class="p-testimonial__title">“A major software discovery tool”</h4>
+        <h3 class="p-testimonial__title">“A major software discovery tool”</h3>
         <p class="p-testimonial__content">The Snap store provides additional exposure to our tools for many of our existing and potential users. The decision to use it came quite naturally. We believe the store will be a major software discovery tool on Linux, so the more people find out about our tools naturally and install them more easily, the better for everyone.</p>
         <cite class="p-testimonial__citation">
           Aleksey Rostovskiy<br /> Engineer, <a href="https://www.jetbrains.com/" class="p-link--external">JetBrains</a>
@@ -323,7 +326,7 @@
 <div class="p-strip">
   <div class="row">
     <div class="col-6">
-      <h3 class="p-heading--2"> One build <br>for all Linux and IoT</h3>
+      <h2> One build <br>for all Linux and IoT</h2>
     </div>
     <div class="col-6">
       <p>Snaps work across Linux on any distribution or version. Bundle your dependencies and assets, simplifying installs to a single standard command.</p>
@@ -419,7 +422,7 @@
 <section class="p-strip">
   <div class="row">
     <div class="col-6">
-      <h3 class="p-heading--2">Showcase to millions</h3>
+      <h2>Showcase to millions</h2>
       <p>Reach beyond your existing audience with a listing on the Snap Store, the front page for app discovery on Ubuntu and other popular distros.</p>
       <p><a class="p-button--neutral" href="/store">Browse the Snap Store</a></p>
     </div>
@@ -444,7 +447,7 @@
 <section class="p-strip">
   <div class="row">
     <div class="col-6">
-      <h3 class="p-heading--2">Measure user growth</h3>
+      <h2>Measure user growth</h2>
       <p>Make data-driven decisions with active install metrics. Watch as automatic updates migrate users to your latest release. Understand your audience with geographic and version breakdowns.</p>
     </div>
     <div class="col-6">


### PR DESCRIPTION
Co-authored with @bethcollins92 
Co-authored with @sowasred2012 

## Done

- Resolved a number of quick a11y related issues, including:
  - Fixed up the heading heirarchy
  - Added blank alt text to "verified" badges
  - Added a heading for the testimonials section
  - Removed redundant skip link

## How to QA
- Visit the demo in your browser, link commented below
  - Or you can run the project locally using the [dotrun](https://snapcraft.io/dotrun) snap with `$ dotrun` and view it in your web browser at: http://0.0.0.0:8004/
  - If your demo doesn't work, read more about the [demoservice](https://discourse.ubuntu.com/t/demoservice/16862)
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Open the wave extension, see that there are no errors or contrast errors

## Screenshots
Before:
![Screenshot from 2021-11-17 16-02-15](https://user-images.githubusercontent.com/2376968/142243832-30c6d3a3-4366-4f1e-9e19-f49d3dabecf7.png)

After:
![Screenshot from 2021-11-17 16-44-13](https://user-images.githubusercontent.com/2376968/142243852-b4ac7fc9-fd81-4029-bb23-226aac7863ba.png)

