### PR TITLE
remove general use of sudo from snap install commands

### DIFF
--- a/static/js/publisher/release/actions/defaultTrack.js
+++ b/static/js/publisher/release/actions/defaultTrack.js
@@ -38,7 +38,7 @@ export function clearDefaultTrack() {
         showNotification({
           status: "success",
           appearance: "positive",
-          content: `The default track for ${snapName} has been removed. All new installations without a specified track (e.g. \`sudo snap install ${snapName}\`) will receive updates from latest track.`,
+          content: `The default track for ${snapName} has been removed. All new installations without a specified track (e.g. \`snap install ${snapName}\`) will receive updates from latest track.`,
           canDismiss: true,
         })
       );
@@ -63,7 +63,7 @@ export function setDefaultTrack() {
         showNotification({
           status: "success",
           appearance: "positive",
-          content: `The default track for ${snapName} has been set to ${currentTrack}. All new installations without a specified track (e.g. \`sudo snap install ${snapName}\`) will receive updates from the newly defined default track.`,
+          content: `The default track for ${snapName} has been set to ${currentTrack}. All new installations without a specified track (e.g. \`snap install ${snapName}\`) will receive updates from the newly defined default track.`,
           canDismiss: true,
         })
       );

--- a/templates/store/snap-details.html
+++ b/templates/store/snap-details.html
@@ -135,7 +135,7 @@
       {% else %}
         <div class="p-snap-install-buttons">
           <div class="p-code-snippet">
-            <pre class="p-code-snippet__block--icon"><code>sudo snap install {{ package_name }}</code></pre>
+            <pre class="p-code-snippet__block--icon"><code>snap install {{ package_name }}</code></pre>
           </div>
         </div>
       {% endif %}

--- a/templates/store/snap-details/_channel_map.html
+++ b/templates/store/snap-details/_channel_map.html
@@ -128,7 +128,7 @@
   <div class="u-fixed-width">
     <p><b>Install using the command line</b></p>
     <div class="p-code-snippet">
-      <pre class="p-code-snippet__block--icon is-wrapped"><code id="snap-install-alt">sudo snap install {{ package_name }}${paramString}</code></pre>
+      <pre class="p-code-snippet__block--icon is-wrapped"><code id="snap-install-alt">snap install {{ package_name }}${paramString}</code></pre>
     </div>
     <p class="p-form-help-text">
       Don't have snapd? <a href="/docs/installing-snapd">Get set up for snaps</a>.

--- a/tests/tests_templates_utils.py
+++ b/tests/tests_templates_utils.py
@@ -66,17 +66,17 @@ class TemplateUtilsTest(unittest.TestCase):
         result = template_utils.install_snippet(
             "spotify", "latest", "stable", ""
         )
-        self.assertTrue(result, "sudo snap install spotify")
+        self.assertTrue(result, "snap install spotify")
 
     def test_install_snippet_with_classic(self):
         result = template_utils.install_snippet(
             "skype", "latest", "stable", "classic"
         )
-        self.assertTrue(result, "sudo snap install skype --classic")
+        self.assertTrue(result, "snap install skype --classic")
 
     def test_install_snippet_with_non_stable_risk_level(self):
         result = template_utils.install_snippet("test", "latest", "edge", "")
-        self.assertTrue(result, "sudo snap install test --edge")
+        self.assertTrue(result, "snap install test --edge")
 
     def test_display_name(self):
         result = template_utils.display_name("Toto", "toto")

--- a/webapp/first_snap/content/c/build.yaml
+++ b/webapp/first_snap/content/c/build.yaml
@@ -11,7 +11,7 @@ linux:
     - action: "Return to the root directory of the project containing your snapcraft.yaml and run the snapcraft Docker image:"
       command: docker run -v $PWD:$PWD -w $PWD snapcore/snapcraft snapcraft
     - action: "Install the snap:"
-      command: sudo snap install --devmode --dangerous *.snap
+      command: snap install --devmode --dangerous *.snap
     - action: "List your installed snaps to confirm:"
       command: snap list
     - action: "Run the snap:"

--- a/webapp/first_snap/content/c/test.yaml
+++ b/webapp/first_snap/content/c/test.yaml
@@ -1,7 +1,7 @@
 name: test-dosbox-{name}
 linux:
   - action: "Install the snap:"
-    command: sudo snap install --devmode --dangerous *.snap
+    command: snap install --devmode --dangerous *.snap
   - action: "List your installed snaps to confirm:"
     command: snap list
   - action: "Run the snap:"
@@ -14,7 +14,7 @@ macos:
   - action: "Connect to the virtual machine:"
     command: multipass shell testvm
   - action: "Install the snap inside the virtual machine:"
-    command: sudo snap install --devmode --dangerous ${name}*.snap
+    command: snap install --devmode --dangerous ${name}*.snap
   - action: "Confirm the snap is installed by listing your installed snaps:"
     command: snap list
   - action: "Run the snap inside the virtual machine:"

--- a/webapp/first_snap/content/flutter/build.yaml
+++ b/webapp/first_snap/content/flutter/build.yaml
@@ -11,7 +11,7 @@ linux:
     - action: "Return to the root directory of the project containing your snapcraft.yaml and run the snapcraft Docker image:"
       command: docker run -v $PWD:$PWD -w $PWD snapcore/snapcraft snapcraft
     - action: "Install the snap:"
-      command: sudo snap install --dangerous *.snap
+      command: snap install --dangerous *.snap
     - action: "List your installed snaps to confirm:"
       command: snap list
     - action: "Run the snap:"

--- a/webapp/first_snap/content/flutter/test.yaml
+++ b/webapp/first_snap/content/flutter/test.yaml
@@ -1,7 +1,7 @@
 name: test-super-cool-app-{name}
 linux:
   - action: "Install the snap:"
-    command: sudo snap install --dangerous *.snap
+    command: snap install --dangerous *.snap
   - action: "List your installed snaps to confirm:"
     command: snap list
   - action: "Run the snap:"
@@ -14,7 +14,7 @@ macos:
   - action: "Connect to the virtual machine:"
     command: multipass shell testvm
   - action: "Install the snap inside the virtual machine:"
-    command: sudo snap install --dangerous ${name}*.snap
+    command: snap install --dangerous ${name}*.snap
   - action: "Confirm the snap is installed by listing your installed snaps:"
     command: snap list
   - action: "Run the snap inside the virtual machine:"

--- a/webapp/first_snap/content/golang/build.yaml
+++ b/webapp/first_snap/content/golang/build.yaml
@@ -11,7 +11,7 @@ linux:
     - action: "Return to the root directory of the project containing your snapcraft.yaml and run the snapcraft Docker image:"
       command: docker run -v $PWD:$PWD -w $PWD snapcore/snapcraft snapcraft
     - action: "Install the snap:"
-      command: sudo snap install --devmode --dangerous *.snap
+      command: snap install --devmode --dangerous *.snap
     - action: "List your installed snaps to confirm:"
       command: snap list
     - action: "Run the snap:"

--- a/webapp/first_snap/content/golang/test.yaml
+++ b/webapp/first_snap/content/golang/test.yaml
@@ -1,7 +1,7 @@
 name: test-httplab-{name}
 linux:
   - action: "Install the snap:"
-    command: sudo snap install --devmode --dangerous *.snap
+    command: snap install --devmode --dangerous *.snap
   - action: "List your installed snaps to confirm:"
     command: snap list
   - action: "Run the snap:"
@@ -14,7 +14,7 @@ macos:
   - action: "Connect to the virtual machine:"
     command: multipass shell testvm
   - action: "Install the snap inside the virtual machine:"
-    command: sudo snap install --devmode --dangerous ${name}*.snap
+    command: snap install --devmode --dangerous ${name}*.snap
   - action: "Confirm the snap is installed by listing your installed snaps:"
     command: snap list
   - action: "Run the snap inside the virtual machine:"

--- a/webapp/first_snap/content/java/build.yaml
+++ b/webapp/first_snap/content/java/build.yaml
@@ -11,7 +11,7 @@ linux:
     - action: Return to the root directory of the project containing your snapcraft.yaml and run the snapcraft Docker image
       command: docker run -v $PWD:$PWD -w $PWD snapcore/snapcraft snapcraft
     - action: Install the snap
-      command: sudo snap install --devmode --dangerous *.snap
+      command: snap install --devmode --dangerous *.snap
     - action: List your installed snaps to confirm
       command: snap list
     - action: Run the snap

--- a/webapp/first_snap/content/java/test.yaml
+++ b/webapp/first_snap/content/java/test.yaml
@@ -1,7 +1,7 @@
 name: test-freeplane-{name}
 linux:
   - action: "Install the snap:"
-    command: sudo snap install --devmode --dangerous *.snap
+    command: snap install --devmode --dangerous *.snap
   - action: "List your installed snaps to confirm:"
     command: snap list
   - action: "Run the snap:"
@@ -14,7 +14,7 @@ macos:
   - action: "Connect to the virtual machine:"
     command: multipass shell testvm
   - action: "Install the snap inside the virtual machine:"
-    command: sudo snap install --devmode --dangerous ${name}*.snap
+    command: snap install --devmode --dangerous ${name}*.snap
   - action: "Confirm the snap is installed by listing your installed snaps:"
     command: snap list
   - action: "Run the snap inside the virtual machine:"

--- a/webapp/first_snap/content/moos/build.yaml
+++ b/webapp/first_snap/content/moos/build.yaml
@@ -11,7 +11,7 @@ linux:
     - action: "Return to the root directory of the project containing your snapcraft.yaml and run the snapcraft Docker image:"
       command: docker run -v $PWD:$PWD -w $PWD snapcore/snapcraft snapcraft
     - action: "Install the snap:"
-      command: sudo snap install --devmode --dangerous *.snap
+      command: snap install --devmode --dangerous *.snap
     - action: "List your installed snaps to confirm:"
       command: snap list
     - action: "Run the snap:"

--- a/webapp/first_snap/content/moos/test.yaml
+++ b/webapp/first_snap/content/moos/test.yaml
@@ -1,7 +1,7 @@
 name: test-moos-{name}
 linux:
   - action: "Install the snap:"
-    command: sudo snap install --devmode --dangerous *.snap
+    command: snap install --devmode --dangerous *.snap
   - action: "List your installed snaps to confirm:"
     command: snap list
   - action: "Run the snap:"
@@ -14,7 +14,7 @@ macos:
   - action: "Connect to the virtual machine:"
     command: multipass shell testvm
   - action: "Install the snap inside the virtual machine:"
-    command: sudo snap install --devmode --dangerous ${name}*.snap
+    command: snap install --devmode --dangerous ${name}*.snap
   - action: "Confirm the snap is installed by listing your installed snaps:"
     command: snap list
   - action: "Run the snap inside the virtual machine:"

--- a/webapp/first_snap/content/node/build.yaml
+++ b/webapp/first_snap/content/node/build.yaml
@@ -11,7 +11,7 @@ linux:
     - action: "Return to the root directory of the project containing your snapcraft.yaml and run the snapcraft Docker image:"
       command: docker run -v $PWD:$PWD -w $PWD snapcore/snapcraft snapcraft
     - action: "Install the snap:"
-      command: sudo snap install --devmode --dangerous *.snap
+      command: snap install --devmode --dangerous *.snap
     - action: "List your installed snaps to confirm:"
       command: snap list
     - action: "Run the snap:"

--- a/webapp/first_snap/content/node/test.yaml
+++ b/webapp/first_snap/content/node/test.yaml
@@ -1,7 +1,7 @@
 name: test-wethr-{name}
 linux:
   - action: "Install the snap:"
-    command: sudo snap install --devmode --dangerous *.snap
+    command: snap install --devmode --dangerous *.snap
   - action: "List your installed snaps to confirm:"
     command: snap list
   - action: "Run the snap:"
@@ -14,7 +14,7 @@ macos:
   - action: "Connect to the virtual machine:"
     command: multipass shell testvm
   - action: "Install the snap inside the virtual machine:"
-    command: sudo snap install --devmode --dangerous ${name}*.snap
+    command: snap install --devmode --dangerous ${name}*.snap
   - action: "Confirm the snap is installed by listing your installed snaps:"
     command: snap list
   - action: "Run the snap inside the virtual machine:"

--- a/webapp/first_snap/content/pre-built/build.yaml
+++ b/webapp/first_snap/content/pre-built/build.yaml
@@ -11,7 +11,7 @@ linux:
     - action: "Return to the root directory of the project containing your snapcraft.yaml and run the snapcraft Docker image:"
       command: docker run -v $PWD:$PWD -w $PWD snapcore/snapcraft snapcraft
     - action: "Install the snap:"
-      command: sudo snap install --devmode --dangerous *.snap
+      command: snap install --devmode --dangerous *.snap
     - action: "List your installed snaps to confirm:"
       command: snap list
     - action: "Run the snap:"

--- a/webapp/first_snap/content/pre-built/test.yaml
+++ b/webapp/first_snap/content/pre-built/test.yaml
@@ -1,7 +1,7 @@
 name: test-geekbench4-{name}
 linux:
   - action: "Install the snap:"
-    command: sudo snap install --devmode --dangerous *.snap
+    command: snap install --devmode --dangerous *.snap
   - action: "List your installed snaps to confirm:"
     command: snap list
   - action: "Run the snap:"
@@ -14,7 +14,7 @@ macos:
   - action: "Connect to the virtual machine using Multipass:"
     command: multipass shell testvm
   - action: "Install the snap inside the virtual machine:"
-    command: sudo snap install --devmode --dangerous
+    command: snap install --devmode --dangerous
   - action: "Confirm the snap is installed by listing your installed snaps:"
     command: snap list
   - action: "Run the snap inside the virtual machine:"

--- a/webapp/first_snap/content/python/build.yaml
+++ b/webapp/first_snap/content/python/build.yaml
@@ -11,7 +11,7 @@ linux:
     - action: "Return to the root directory of the project containing your snapcraft.yaml and run the snapcraft Docker image:"
       command: docker run -v $PWD:$PWD -w $PWD snapcore/snapcraft snapcraft
     - action: "Install the snap:"
-      command: sudo snap install --devmode --dangerous *.snap
+      command: snap install --devmode --dangerous *.snap
     - action: "List your installed snaps to confirm:"
       command: snap list
     - action: "Run the snap:"

--- a/webapp/first_snap/content/python/test.yaml
+++ b/webapp/first_snap/content/python/test.yaml
@@ -1,7 +1,7 @@
 name: test-offlineimap-{name}
 linux:
   - action: "Install the snap:"
-    command: sudo snap install --devmode --dangerous *.snap
+    command: snap install --devmode --dangerous *.snap
   - action: "List your installed snaps to confirm:"
     command: snap list
   - action: "Run the snap:"
@@ -14,7 +14,7 @@ macos:
   - action: "Connect to the virtual machine:"
     command: multipass shell testvm
   - action: "Install the snap inside the virtual machine:"
-    command: sudo snap install --devmode --dangerous ${name}*.snap
+    command: snap install --devmode --dangerous ${name}*.snap
   - action: "Confirm the snap is installed by listing your installed snaps:"
     command: snap list
   - action: "Run the snap inside the virtual machine:"

--- a/webapp/first_snap/content/ros/test.yaml
+++ b/webapp/first_snap/content/ros/test.yaml
@@ -1,7 +1,7 @@
 name: test-ros-talker-listener-{name}
 linux:
   - action: "Install the snap:"
-    command: sudo snap install --devmode --dangerous *.snap
+    command: snap install --devmode --dangerous *.snap
   - action: "List your installed snaps to confirm:"
     command: snap list
   - action: "Run the snap:"
@@ -16,7 +16,7 @@ macos:
   - action: "Connect to the virtual machine:"
     command: multipass shell testvm
   - action: "Install the snap inside the virtual machine:"
-    command: sudo snap install --devmode --dangerous ${name}*.snap
+    command: snap install --devmode --dangerous ${name}*.snap
   - action: "Confirm the snap is installed by listing your installed snaps:"
     command: snap list
   - action: "Run the snap inside the virtual machine:"

--- a/webapp/first_snap/content/ros2/test.yaml
+++ b/webapp/first_snap/content/ros2/test.yaml
@@ -1,7 +1,7 @@
 name: test-ros2-talker-listener-{name}
 linux:
   - action: "Install the snap:"
-    command: sudo snap install --devmode --dangerous *.snap
+    command: snap install --devmode --dangerous *.snap
   - action: "List your installed snaps to confirm:"
     command: snap list
   - action: "Run the snap:"
@@ -16,7 +16,7 @@ macos:
   - action: "Connect to the virtual machine:"
     command: multipass shell testvm
   - action: "Install the snap inside the virtual machine:"
-    command: sudo snap install --devmode --dangerous ${name}*.snap
+    command: snap install --devmode --dangerous ${name}*.snap
   - action: "Confirm the snap is installed by listing your installed snaps:"
     command: snap list
   - action: "Run the snap inside the virtual machine:"

--- a/webapp/first_snap/content/ruby/build.yaml
+++ b/webapp/first_snap/content/ruby/build.yaml
@@ -11,7 +11,7 @@ linux:
     - action: "Return to the root directory of the project containing your snapcraft.yaml and run the snapcraft Docker image:"
       command: docker run -v $PWD:$PWD -w $PWD snapcore/snapcraft snapcraft
     - action: "Install the snap:"
-      command: sudo snap install --devmode --dangerous *.snap
+      command: snap install --devmode --dangerous *.snap
     - action: "List your installed snaps to confirm:"
       command: snap list
     - action: "Run the snap:"

--- a/webapp/first_snap/content/ruby/test.yaml
+++ b/webapp/first_snap/content/ruby/test.yaml
@@ -1,7 +1,7 @@
 name: test-mdl-{name}
 linux:
   - action: "Install the snap:"
-    command: sudo snap install --devmode --dangerous *.snap
+    command: snap install --devmode --dangerous *.snap
   - action: "List your installed snaps to confirm:"
     command: snap list
   - action: "Run the snap:"
@@ -14,7 +14,7 @@ macos:
   - action: Connect to the virtual machine
     command: multipass shell testvm
   - action: Install the snap inside the virtual machine
-    command: sudo snap install --devmode --dangerous ${name}*.snap
+    command: snap install --devmode --dangerous ${name}*.snap
   - action: Confirm the snap is installed by listing your installed snaps
     command: snap list
   - action: Run the snap inside the virtual machine

--- a/webapp/first_snap/content/rust/build.yaml
+++ b/webapp/first_snap/content/rust/build.yaml
@@ -11,7 +11,7 @@ linux:
     - action: "Return to the root directory of the project containing your snapcraft.yaml and run the snapcraft Docker image:"
       command: docker run -v $PWD:$PWD -w $PWD snapcore/snapcraft snapcraft
     - action: "Install the snap:"
-      command: sudo snap install --devmode --dangerous *.snap
+      command: snap install --devmode --dangerous *.snap
     - action: "List your installed snaps to confirm:"
       command: snap list
     - action: "Run the snap:"

--- a/webapp/first_snap/content/rust/test.yaml
+++ b/webapp/first_snap/content/rust/test.yaml
@@ -1,7 +1,7 @@
 name: test-xsv-{name}
 linux:
   - action: "Install the snap:"
-    command: sudo snap install --devmode --dangerous *.snap
+    command: snap install --devmode --dangerous *.snap
   - action: "List your installed snaps to confirm:"
     command: snap list
   - action: "Run the snap:"
@@ -14,7 +14,7 @@ macos:
   - action: "Connect to the virtual machine:"
     command: multipass shell testvm
   - action: "Install the snap inside the virtual machine:"
-    command: sudo snap install --devmode --dangerous ${name}*.snap
+    command: snap install --devmode --dangerous ${name}*.snap
   - action: "Confirm the snap is installed by listing your installed snaps:"
     command: snap list
   - action: "Run the snap inside the virtual machine:"

--- a/webapp/store/content/distros/debian.yaml
+++ b/webapp/store/content/distros/debian.yaml
@@ -10,4 +10,4 @@ install:
     command: |
       sudo apt update
       sudo apt install snapd
-      sudo snap install core
+      snap install core

--- a/webapp/store/content/distros/raspbian.yaml
+++ b/webapp/store/content/distros/raspbian.yaml
@@ -16,4 +16,4 @@ install:
   - action: |
       After this, install the core snap in order to get the latest snapd:
     command: |
-      sudo snap install core
+      snap install core

--- a/webapp/template_utils.py
+++ b/webapp/template_utils.py
@@ -93,7 +93,7 @@ def install_snippet(
     detail pages
     """
 
-    snippet_value = "sudo snap install " + package_name
+    snippet_value = "snap install " + package_name
 
     if lowest_risk_available != "stable":
         snippet_value += f" --{lowest_risk_available}"


### PR DESCRIPTION
## Removed sudo from install instructions
- This should just replace all calls to `sudo snap` with just `snap` in order to let snap elevate privileges where necessary and to stop encouraging universal unnecessary use of `sudo`

- I have changed the calls under `./webapp` but not those under `.gitub/workflows/`
