### PR TITLE
Fix button margins on brand store invites table

### DIFF
--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -471,10 +471,17 @@ code {
   display: block;
   margin: 0 0 0.75rem !important;
 
+  &:last-child {
+    margin-bottom: 0 !important;
+  }
+
   @media (min-width: $breakpoint-medium) {
     display: inline-block;
-    margin-bottom: 0 !important;
     margin-left: 0.75rem !important;
+  }
+
+  @media (min-width: 1353px) {
+    margin-bottom: 0 !important;
   }
 }
 


### PR DESCRIPTION
## Done
Fixed the button margins on the brand store invites table

## How to QA
- Go to https://snapcraft-io-3784.demos.haus/admin/ahnuP3quahti9vis8aiw/members
- Open the "Invites" panel beneath the members table
- Resize the browser and check that the margins around the "Resend" and "Revoke" buttons look correct

## Issue
Fixes #3727