### PR TITLE
Alias publisher names to IDs in store search

### DIFF
--- a/templates/store/search.html
+++ b/templates/store/search.html
@@ -2,7 +2,7 @@
 
 {% block meta_title %}
   {% if query %}
-    Snap search results for '{{ query }}'
+    Snap search results for '{{ display_query }}'
     {% if category_display %}
       in {{ category_display }}
       {% endif %}
@@ -21,7 +21,7 @@
       <div class="p-form__group">
         <label for="search-input" class="u-off-screen">Search</label>
         <div class="p-form__control u-clearfix">
-          <input class="u-no-margin--bottom" id="search-input" type="search" name="q" value="{{ query }}" autofocus />
+          <input class="u-no-margin--bottom" id="search-input" type="search" name="q" value="{{ display_query }}" autofocus />
         </div>
       </div>
       <button type="submit" alt="search" class="p-button--positive">Search</button>

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -147,6 +147,26 @@ def store_blueprint(store_query=None):
 
         size = 44
 
+        publishers = {
+            "jetbrains": "28zEonXNoBLvIB7xneRbltOsp0Nf7DwS",
+            "kde": "2rsYZu6kqYVFsSejExu4YENdXQEO40Xb",
+            "snapcrafters": "eEoV9TnaNkCzfJBu9SRhr2678vzyYV43",
+        }
+
+        display_query = snap_searched
+
+        if "publisher:jetbrains" in snap_searched:
+            snap_searched = f'publisher:{publishers["jetbrains"]}'
+            display_query = "publisher:jetbrains"
+
+        if "publisher:kde" in snap_searched:
+            snap_searched = f'publisher:{publishers["kde"]}'
+            display_query = "publisher:kde"
+
+        if "publisher:snapcrafters" in snap_searched:
+            snap_searched = f'publisher:{publishers["snapcrafters"]}'
+            display_query = "publisher:snapcrafters"
+
         try:
             searched_results = api.search(
                 snap_searched,
@@ -227,6 +247,7 @@ def store_blueprint(store_query=None):
             "total": total_results_count,
             "links": links,
             "page": page,
+            "display_query": display_query,
         }
 
         return flask.render_template("store/search.html", **context)


### PR DESCRIPTION
## Done
Aliased the publisher names to their IDs for the search

## QA
- Go to https://snapcraft-io-3798.demos.haus/
- Search for `publisher:jetbrains`
- Check that the search results are correct
- Search for `publisher:kde`
- Check that the search results are correct
- Search for `publisher:snapcrafters`
- Check that the search results are correct

## Issue
Fixes #3797 