### PR TITLE
Fix aspect ratio of Raspberry Pi logo

### DIFF
--- a/templates/store/snap-details/_distro-instructions-for-snap-support.html
+++ b/templates/store/snap-details/_distro-instructions-for-snap-support.html
@@ -231,7 +231,7 @@
         <span class="p-media-object__image">
             {{
                 image(
-                    url="https://assets.ubuntu.com/v1/a8a6238c-RGB+RPi.svg",
+                    url="https://assets.ubuntu.com/v1/193cb6ac-logo-raspberry-pi.svg",
                     alt="",
                     width="48",
                     height="48",

--- a/webapp/store/content/distros/raspbian.yaml
+++ b/webapp/store/content/distros/raspbian.yaml
@@ -1,7 +1,7 @@
 name: Raspberry Pi
 color-1: "#c05672"
 color-2: "#a22846"
-logo: https://assets.ubuntu.com/v1/a8a6238c-RGB+RPi.svg
+logo: https://assets.ubuntu.com/v1/193cb6ac-logo-raspberry-pi.svg
 logo-mono: https://assets.ubuntu.com/v1/a31b1451-rpi-b-w.svg
 install:
   - action: |


### PR DESCRIPTION
## Done
Fixed the aspect ratio of the Raspberry Pi logo

## QA
- Go to https://snapcraft-io-3806.demos.haus/cjp256-openvino-samples
- Check that the Raspberry Pi logo towards the bottom of the page in the grid of logos looks correct

## Issue
Fixes #3524 

## Screenshot
![before_and_after](https://user-images.githubusercontent.com/501889/146211308-3db3a966-7b1e-47eb-b58f-0e995525694d.jpg)
