### PR TITLE
Extra logging

### DIFF
--- a/konf/site.yaml
+++ b/konf/site.yaml
@@ -100,35 +100,6 @@ production:
     more_set_headers "Link: <https://assets.ubuntu.com>; rel=preconnect; crossorigin, <https://assets.ubuntu.com>; rel=preconnect, <https://res.cloudinary.com>; rel=preconnect, <https://dashboard.snapcraft.io>; rel=preconnect";
 
   routes:
-    - paths: &publisher_paths [
-        '/account(/.*)?$',
-        '/admin(/.*)?$',
-        '/login(/.*)?$',
-        '/logout$',
-        '/github/',
-        '/snaps(/.*)?$',
-        '/[^/]*/listing$',
-        '/[^/]*/publicise$',
-        '/[^/]*/releases$',
-        '/[^/]*/settings$',
-        '/[^/]*/builds$',
-        '/[^/]*/webhook$',
-        '/[^/]*/[^/]*/webhook$',
-        '/[^/]*/preview$',
-        '/[^/]*/metrics$',
-        '/[^/]*/release$',
-        '/register-snap$',
-        '/register-name-dispute$',
-        '/request-reserved-name$',
-        '/snap-builds.json$'
-      ]
-      name: snapcraft-io-publisher
-      app_name: snapcraft.io-publisher
-      image: prod-comms.docker-registry.canonical.com/snapcraft.io
-      replicas: 5
-      memoryLimit: 256Mi
-      env: *env
-
     - paths: [/docs, /tutorials]
       name: snapcraft-io-discourse
       app_name: snapcraft.io-discourse
@@ -156,14 +127,6 @@ staging:
     more_set_headers "Link: <https://assets.ubuntu.com>; rel=preconnect; crossorigin, <https://assets.ubuntu.com>; rel=preconnect, <https://res.cloudinary.com>; rel=preconnect, <https://dashboard.snapcraft.io>; rel=preconnect";
 
   routes:
-    - paths: *publisher_paths
-      name: snapcraft-io-publisher
-      app_name: snapcraft.io-publisher
-      image: prod-comms.docker-registry.canonical.com/snapcraft.io
-      replicas: 3
-      memoryLimit: 256Mi
-      env: *env
-
     - paths: [/docs, /tutorials]
       name: snapcraft-io-discourse
       app_name: snapcraft.io-discourse

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # App dependencies
-canonicalwebteam.flask-base==0.9.2
+canonicalwebteam.flask-base==0.9.3
 canonicalwebteam.candid==0.9.0
 canonicalwebteam.discourse==4.0.7
 canonicalwebteam.blog==6.4.0

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -3,9 +3,12 @@ A Flask application for snapcraft.io.
 
 The web frontend for the snap store.
 """
-
 import talisker.requests
 import webapp.api
+
+from flask import request
+from talisker import logging
+
 from canonicalwebteam.flask_base.app import FlaskBase
 from webapp.blog.views import init_blog
 from webapp.docs.views import init_docs
@@ -21,6 +24,9 @@ from webapp.publisher.views import account
 from webapp.snapcraft.views import snapcraft_blueprint
 from webapp.store.views import store_blueprint
 from webapp.tutorials.views import init_tutorials
+
+
+TALISKER_WSGI_LOGGER = logging.getLogger("talisker.wsgi")
 
 
 def create_app(testing=False):
@@ -70,6 +76,12 @@ def init_snapcraft(app):
     init_docs(app, "/docs")
     init_blog(app, "/blog")
     init_tutorials(app, "/tutorials")
+
+    @app.before_request
+    def before_request_func():
+        TALISKER_WSGI_LOGGER.info(
+            f"START view={request.endpoint} path={request.path}"
+        )
 
 
 def init_extensions(app):


### PR DESCRIPTION
## Done
- Remove previous k8s config
- Added before and after request. This is temporary
- Upgrade Flask-base to v0.9.3 to include PID on logs, https://github.com/canonical-web-and-design/canonicalwebteam.flask-base/pull/53 needs to be merged before this PR

## How to QA
- Check the `dotrun` snap output
- The PID should be present on this kind of logs:
```
2022-01-07 12:55:36.230Z DEBUG gunicorn.error "GET /store/featured-snaps/games" service=snapcraft.io pid=1339778
```
- We should have `START` logs, like:
```
2022-01-07 12:55:36.236Z INFO talisker.wsgi "START view=store.featured_snaps_in_category path=/store/featured-snaps/games" service=snapcraft.io pid=1339778 request_id=1e1f222a-c589-42ee-8019-8368dfbb429e
```
