### PR TITLE
Update copy for release UI track switcher

### DIFF
--- a/static/js/publisher/release/components/releasesHeading.js
+++ b/static/js/publisher/release/components/releasesHeading.js
@@ -1,4 +1,4 @@
-import React, { Component, Fragment } from "react";
+import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
 
@@ -43,13 +43,13 @@ class ReleasesHeading extends Component {
         <div className="col-6">
           <h4>
             <Wrap htmlFor="track-dropdown">
-              Releases available to install
-              {tracks.length > 1 && (
-                <Fragment>
-                  {" "}
-                  in &nbsp;
+              {tracks.length > 1 ? (
+                <>
+                  Track &nbsp;
                   {this.renderTrackDropdown(tracks)}
-                </Fragment>
+                </>
+              ) : (
+                <>Releases available to install</>
               )}
             </Wrap>
           </h4>


### PR DESCRIPTION
## Done
Updated the copy on the release UI track switcher

## QA
- Go to https://snapcraft-io-3844.demos.haus/fran-snap/releases
- Check that there is a dropdown with a "Track" label
- Go to https://snapcraft-io-3844.demos.haus/danieltest-snap/releases
- Check that there is a heading "Releases available to install" instead of the dropdown

## Issue
Fixes https://github.com/canonical-web-and-design/marketplace-tribe/issues/2329