### PR TITLE
Fix name of default_track for publisher API

### DIFF
--- a/static/js/publisher/metrics/graphs/activeDevicesGraph/tooltips.js
+++ b/static/js/publisher/metrics/graphs/activeDevicesGraph/tooltips.js
@@ -23,8 +23,8 @@ export function tooltips() {
 
       if (this.options.graphType && this.options.graphType === "channel") {
         keys = sortChannels(keys, {
-          defaultTrack: this.options.metricsDefaultTrack
-            ? this.options.metricsDefaultTrack
+          defaultTrack: this.options.defaultTrack
+            ? this.options.defaultTrack
             : "latest",
         }).list;
       }

--- a/webapp/publisher/snaps/metrics_views.py
+++ b/webapp/publisher/snaps/metrics_views.py
@@ -178,11 +178,7 @@ def publisher_snap_metrics(snap_name):
 
     annotations = {"name": "annotations", "series": [], "buckets": []}
 
-    default_track = (
-        details.get("default-track")
-        if details.get("default-track")
-        else "latest"
-    )
+    default_track = details.get("default_track", "latest")
 
     for category in details["categories"]["items"]:
         date = category["since"].split("T")[0]


### PR DESCRIPTION
dashboard.snapcraft.io API returns JSON with a "default_track" key, not "default-track".

Metrics graph was incorrectly looking for an option `metricsDefaultTrack` which was never set, `defaultTrack` is.

## Done
1. Fixed name of default_track when looking at the snap info from SCA
2. Fixed name of option in JS tooltip

## How to QA
- Visit the demo in your browser, link commented below
  - Or you can run the project locally using the [dotrun](https://snapcraft.io/dotrun) snap with `$ dotrun` and view it in your web browser at: http://0.0.0.0:8004/
  - If your demo doesn't work, read more about the [demoservice](https://discourse.ubuntu.com/t/demoservice/16862)
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Verify with maas, that 3.1 track is listed first on the by-channel metrics graph at http://0.0.0.0:8004/maas/metrics?active-devices=channel&period=1y

## Issue / Card
Fixes #3851
