### PR TITLE
Update release date format in release UI history table

### DIFF
--- a/static/js/publisher/release/components/revisionsList.js
+++ b/static/js/publisher/release/components/revisionsList.js
@@ -342,7 +342,7 @@ class RevisionsList extends Component {
                 <th scope="col">Progressive release status</th>
               )}
               {showChannels && <th scope="col">Channels</th>}
-              <th scope="col" width="140px" className="u-align--right">
+              <th scope="col" width="140px">
                 {isReleaseHistory ? "Release date" : "Submission date"}
               </th>
             </tr>

--- a/static/js/publisher/release/components/revisionsListRow.js
+++ b/static/js/publisher/release/components/revisionsListRow.js
@@ -1,8 +1,8 @@
-import React, { Fragment, useState } from "react";
+import React, { useState } from "react";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
 
-import { format, formatDistance } from "date-fns";
+import { format } from "date-fns";
 
 import { canBeReleased } from "../helpers";
 import { getChannelString } from "../../../libs/channels";
@@ -85,7 +85,7 @@ const RevisionsListRow = (props) => {
       <td>{!progressiveBeingCancelled && releasable && <Handle />}</td>
       <td>
         {isSelectable ? (
-          <Fragment>
+          <>
             <input
               type="checkbox"
               checked={isSelected && releasable}
@@ -99,7 +99,7 @@ const RevisionsListRow = (props) => {
             >
               <RevisionLabel revision={revision} showTooltip={true} />
             </label>
-          </Fragment>
+          </>
         ) : (
           <span className="p-revisions-list__revision">
             <RevisionLabel revision={revision} showTooltip={true} />
@@ -107,15 +107,7 @@ const RevisionsListRow = (props) => {
         )}
       </td>
       <td>{revision.version}</td>
-      {showBuildRequest && (
-        <td>
-          {buildRequestId && (
-            <Fragment>
-              <i className="p-icon--lp" /> {buildRequestId}
-            </Fragment>
-          )}
-        </td>
-      )}
+      {showBuildRequest && <td>{buildRequestId && <>{buildRequestId}</>}</td>}
       {canShowProgressiveReleases && (
         <td>
           {revision.release && showProgressive && (
@@ -134,16 +126,14 @@ const RevisionsListRow = (props) => {
         </td>
       )}
       {showChannels && <td>{revision.channels.join(", ")}</td>}
-      <td className="u-align--right">
+      <td>
         {isPending && <em>pending release</em>}
         {!isPending && !progressiveBeingCancelled && (
           <span
             className="p-tooltip p-tooltip--btm-center"
             aria-describedby={`revision-uploaded-${revision.revision}`}
           >
-            {formatDistance(revisionDate, new Date(), {
-              addSuffix: true,
-            })}
+            {format(revisionDate, "dd MMM yyyy")}
             <span
               className="p-tooltip__message u-align--center"
               role="tooltip"


### PR DESCRIPTION
## Done
- Updated the date format in the release history table
- Drive by: Removed the launchpad logo from the build request
- Drive by: Replaced `Fragment` with the up to date syntax

## QA
- Go to https://snapcraft-io-3858.demos.haus/danieltest-snap/releases
- Click the history icon in one of the "Releases available to install" table cells
- Check that the release date is in the following format: "18 Feb 2017"

## Issue
Fixes https://github.com/canonical-web-and-design/marketplace-tribe/issues/2325