### PR TITLE
Clear new member roles when closing panel

### DIFF
--- a/static/js/brand-store/Members/InviteModal.js
+++ b/static/js/brand-store/Members/InviteModal.js
@@ -82,7 +82,7 @@ InviteModal.propTypes = {
   inviteActionData: PropTypes.object.isRequired,
   inviteModalOpen: PropTypes.bool.isRequired,
   setInviteModalOpen: PropTypes.func.isRequired,
-  updateInvite: PropTypes.func.updateInvite,
+  updateInvite: PropTypes.func.isRequired,
   inviteModalIsSaving: PropTypes.bool.isRequired,
 };
 

--- a/static/js/brand-store/Members/InvitesTable.js
+++ b/static/js/brand-store/Members/InvitesTable.js
@@ -20,7 +20,7 @@ function InvitesTable({
   const [expiredInvites, setExpiredInvites] = useState([]);
   const [revokedInvites, setRevokedInvites] = useState([]);
   const [inviteModalOpen, setInviteModalOpen] = useState(false);
-  const [inviteActionData, setInviteActionData] = useState(null);
+  const [inviteActionData, setInviteActionData] = useState({});
   const [inviteModalIsSaving, setInviteModalIsSaving] = useState(false);
   const { id } = useParams();
   const dispatch = useDispatch();
@@ -55,7 +55,7 @@ function InvitesTable({
         setTimeout(() => {
           setInviteModalOpen(false);
           setInviteModalIsSaving(false);
-          setInviteActionData(null);
+          setInviteActionData({});
           setNotificationText("The invite status has been updated");
           setShowSuccessNotification(true);
         }, 1500);
@@ -63,7 +63,7 @@ function InvitesTable({
       .catch(() => {
         setInviteModalOpen(false);
         setInviteModalIsSaving(false);
-        setInviteActionData(null);
+        setInviteActionData({});
         setShowErrorNotification(true);
       });
   };

--- a/static/js/brand-store/Members/InvitesTable.js
+++ b/static/js/brand-store/Members/InvitesTable.js
@@ -173,7 +173,7 @@ function InvitesTable({
             {
               "aria-label": "Status",
               content: getInviteStatusText(invite.status),
-              rowspan: invitesGroup.length,
+              rowSpan: invitesGroup.length,
             },
           ].concat(buildTableCols(invite)),
         };

--- a/static/js/brand-store/Members/Members.js
+++ b/static/js/brand-store/Members/Members.js
@@ -292,6 +292,7 @@ function Members() {
                     label={ROLES[role].name}
                     help={ROLES[role].description}
                     onChange={handleRoleChange}
+                    checked={newMemberRoles.includes(role)}
                   />
                 ))}
               </div>

--- a/static/js/brand-store/Members/Members.js
+++ b/static/js/brand-store/Members/Members.js
@@ -93,12 +93,20 @@ function Members() {
             setShowSuccessNotification(true);
             setNotificationText("Member has been added to the store");
             setShowInviteForm(false);
+
+            setTimeout(() => {
+              setShowSuccessNotification(false);
+            }, 5000);
           }
         }, 1500);
       })
       .catch(() => {
         setIsSaving(false);
         setShowErrorNotification(true);
+
+        setTimeout(() => {
+          setShowErrorNotification(false);
+        }, 5000);
       });
   };
 
@@ -399,11 +407,19 @@ function Members() {
                       setIsSaving(false);
                       setShowSuccessNotification(true);
                       setNotificationText("Member roles have been changed");
+
+                      setTimeout(() => {
+                        setShowSuccessNotification(false);
+                      }, 5000);
                     }, 1500);
                   })
                   .catch(() => {
                     setIsSaving(false);
                     setShowErrorNotification(true);
+
+                    setTimeout(() => {
+                      setShowErrorNotification(false);
+                    }, 5000);
                   });
               }}
             >

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -304,10 +304,11 @@ code {
 
   .p-checkbox {
     margin-bottom: 0;
-    margin-left: -2rem;
+    margin-left: -1.5rem;
+    margin-right: 0.25rem;
     padding-top: 0;
     position: relative;
-    top: 4px;
+    top: 2px;
 
     .p-checkbox__input {
       margin-top: 0;
@@ -317,7 +318,7 @@ code {
 
 .table-cell-head--checkbox {
   .p-checkbox {
-    top: -2px;
+    top: 0;
   }
 }
 


### PR DESCRIPTION
## Done
- Fixed bug where invite roles weren't cleared when the panel was closed and then reopened
- Add timeout to notifications so they disappear after 5 seconds
- Drive by: Fixed some minor JS errors

## QA
- Go to https://snapcraft-io-3859.demos.haus/admin/test1LaNg1xi6eonae5R/members
- Click the "Add new member" button
- Select some roles in the panel
- Close the panel
- Reopen the panel
- No roles should be checked
- Invite someone to the store
- The success (or error) notification should disappear after 5 seconds

## Issue
Fixes #3850, #3848