### PR TITLE
Close member sidepanel when clicking outside of it

### DIFF
--- a/static/js/brand-store/Members/Members.js
+++ b/static/js/brand-store/Members/Members.js
@@ -231,6 +231,12 @@ function Members() {
           </div>
         </div>
       </main>
+      <div
+        className={`l-aside__overlay ${sidePanelOpen ? "" : "u-hide"}`}
+        onClick={() => {
+          setSidePanelOpen(false);
+        }}
+      ></div>
       <aside
         className={`l-aside ${sidePanelOpen ? "" : "is-collapsed"}`}
         id="aside-panel"

--- a/static/sass/_snapcraft_l-application.scss
+++ b/static/sass/_snapcraft_l-application.scss
@@ -120,6 +120,7 @@
   .l-aside {
     height: $layout-height;
     position: relative;
+    z-index: 999;
 
     @media (min-width: $breakpoint-small) {
       width: 22.5rem;
@@ -147,5 +148,15 @@
     padding-top: $spv--large;
     position: relative;
     top: -100%;
+  }
+
+  .l-aside__overlay {
+    background-color: transparent;
+    height: 100%;
+    position: absolute;
+    right: 0;
+    top: 0;
+    width: 100%;
+    z-index: 999;
   }
 }


### PR DESCRIPTION
## Done
Added an overlay behind the side panel so clicking outside of it closes it

## QA
- Go to https://snapcraft-io-3860.demos.haus/admin/test1LaNg1xi6eonae5R/members
- Open the side panel by clicking the "Add new member" button
- Click anywhere outside of the panel and it should close

## Issue
Fixes #3847