### PR TITLE
Update macOS install instructions

### DIFF
--- a/templates/first-snap/_install-macos.html
+++ b/templates/first-snap/_install-macos.html
@@ -35,7 +35,7 @@
             </span>
           </h4>
           <span class="p-stepped-list__content">
-            {% set snippet_value = "brew cask install multipass" %}
+            {% set snippet_value = "brew install --cask multipass" %}
             {% include "/partials/_code-snippet.html" %}
           </span>
         </li>


### PR DESCRIPTION
`brew cask` commands were deprecated in 2.6.0 in favour of using the `--cask` flag: https://github.com/Homebrew/brew/pull/8899

## Done
- Replaced deprecated `brew cask install multipass` command with `brew install --cask multipass`

