### PR TITLE
Fix brand store snaps side panel and notifications

### DIFF
--- a/static/js/brand-store/Snaps/Snaps.js
+++ b/static/js/brand-store/Snaps/Snaps.js
@@ -100,16 +100,28 @@ function Snaps() {
 
           if (data.success) {
             setShowAddSuccessNotification(true);
+
+            setTimeout(() => {
+              setShowAddSuccessNotification(false);
+            }, 5000);
           }
 
           if (data.error) {
             setShowErrorNotification(true);
+
+            setTimeout(() => {
+              setShowErrorNotification(false);
+            }, 5000);
           }
         }, 1500);
       })
       .catch(() => {
         setIsSaving(false);
         setShowErrorNotification(true);
+
+        setTimeout(() => {
+          setShowErrorNotification(false);
+        }, 5000);
       });
   };
 
@@ -148,6 +160,10 @@ function Snaps() {
           setRemoveSnapSaving(false);
           setSnapsToRemove([]);
           setShowRemoveSuccessNotification(true);
+
+          setTimeout(() => {
+            setShowRemoveSuccessNotification(false);
+          }, 5000);
         }, 1500);
       })
       .catch(() => {
@@ -303,6 +319,12 @@ function Snaps() {
           </div>
         </div>
       </main>
+      <div
+        className={`l-aside__overlay ${sidePanelOpen ? "" : "u-hide"}`}
+        onClick={() => {
+          setSidePanelOpen(false);
+        }}
+      ></div>
       <aside
         className={`l-aside ${sidePanelOpen ? "" : "is-collapsed"}`}
         id="aside-panel"


### PR DESCRIPTION
## Done
- Close brand store snaps side panel when clicking outside of it
- Remove notifications after 5 seconds

## QA
- Go to https://snapcraft-io-3863.demos.haus/admin/test1LaNg1xi6eonae5R/snaps
- Click the "Include snap" button to open the side panel
- Click anywhere outside the side panel and it should close
- Include a snap to the store
- The notification should disappear after 5 seconds