### PR TITLE
Test with gevent.Timeout

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,6 @@ bleach==3.3.0
 humanize==3.2.0
 mistune==0.8.4
 pybadges==2.2.1
-pybreaker==0.6.0
 pycountry==20.7.3
 pymacaroons==0.13.0
 python-dateutil==2.8.1

--- a/webapp/api/exceptions.py
+++ b/webapp/api/exceptions.py
@@ -49,7 +49,3 @@ class ApiResponseErrorList(ApiResponseError):
     def __init__(self, message, status_code, errors):
         self.errors = errors
         return super().__init__(message, status_code)
-
-
-class ApiCircuitBreaker(ApiError):
-    pass

--- a/webapp/login/views.py
+++ b/webapp/login/views.py
@@ -14,7 +14,7 @@ from flask_wtf.csrf import generate_csrf, validate_csrf
 
 from webapp import authentication
 from webapp.helpers import api_publisher_session
-from webapp.api.exceptions import ApiCircuitBreaker, ApiError, ApiResponseError
+from webapp.api.exceptions import ApiError, ApiResponseError
 from webapp.extensions import csrf
 from webapp.login.macaroon import MacaroonRequest, MacaroonResponse
 from webapp.publisher.snaps import logic
@@ -52,8 +52,6 @@ def login_handler():
             return flask.redirect(flask.url_for(".logout"))
         else:
             return flask.abort(502, str(api_response_error))
-    except ApiCircuitBreaker:
-        flask.abort(503)
     except ApiError as api_error:
         return flask.abort(502, str(api_error))
 
@@ -96,9 +94,6 @@ def after_login(resp):
         flask.session["publisher"]["stores"] = logic.get_stores(
             account["stores"], roles=["admin", "review", "view"]
         )
-
-    except ApiCircuitBreaker:
-        flask.abort(503)
     except Exception:
         flask.session["publisher"] = {
             "identity_url": resp.identity_url,

--- a/webapp/publisher/views.py
+++ b/webapp/publisher/views.py
@@ -4,7 +4,6 @@ from canonicalwebteam.store_api.exceptions import (
     PublisherAgreementNotSigned,
     PublisherMacaroonRefreshRequired,
     PublisherMissingUsername,
-    StoreApiCircuitBreaker,
     StoreApiTimeoutError,
 )
 from canonicalwebteam.store_api.stores.snapstore import SnapPublisher
@@ -19,7 +18,6 @@ import webapp.api.marketo as marketo_api
 from webapp import authentication
 from webapp.helpers import api_publisher_session
 from webapp.api.exceptions import (
-    ApiCircuitBreaker,
     ApiError,
     ApiResponseError,
     ApiTimeoutError,
@@ -60,8 +58,6 @@ def _handle_error(api_error: ApiError):
         return flask.redirect(flask.url_for("account.get_agreement"))
     elif type(api_error) is PublisherMacaroonRefreshRequired:
         return refresh_redirect(flask.request.path)
-    elif type(api_error) in [ApiCircuitBreaker, StoreApiCircuitBreaker]:
-        return flask.abort(503)
     else:
         return flask.abort(502, str(api_error))
 

--- a/webapp/store/snap_details_views.py
+++ b/webapp/store/snap_details_views.py
@@ -13,7 +13,6 @@ from canonicalwebteam.flask_base.decorators import (
     exclude_xframe_options_header,
 )
 from canonicalwebteam.store_api.exceptions import (
-    StoreApiCircuitBreaker,
     StoreApiError,
     StoreApiResponseDecodeError,
     StoreApiResponseError,
@@ -48,8 +47,6 @@ def snap_details_views(store, api, handle_errors):
                 flask.abort(502, error_messages)
         except StoreApiResponseError as api_response_error:
             flask.abort(502, str(api_response_error))
-        except StoreApiCircuitBreaker:
-            flask.abort(503)
         except (StoreApiError, ApiError) as api_error:
             flask.abort(502, str(api_error))
 

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -7,7 +7,6 @@ import webapp.store.logic as logic
 from webapp.api import requests
 from canonicalwebteam.store_api.stores.snapstore import SnapStore
 from canonicalwebteam.store_api.exceptions import (
-    StoreApiCircuitBreaker,
     StoreApiConnectionError,
     StoreApiError,
     StoreApiResponseDecodeError,
@@ -50,10 +49,6 @@ def store_blueprint(store_query=None):
             status_code = 502
         elif type(api_error) is StoreApiConnectionError:
             status_code = 502
-        elif type(api_error) is StoreApiCircuitBreaker:
-            # Special case for this one, because it is the only case where we
-            # don't want the user to be able to access the page.
-            return flask.abort(503)
 
         return status_code, error
 


### PR DESCRIPTION
## Done
- Remove pybreaker, since it is not being useful.
- Added `gevent.Timeout` for HTTP requests with a limit close to the gunicorn timeout limit. This should avoid the restarts of the gunicorn worker and we should get the `GeventGreenletTimeout` exception on Sentry every time one was about to happen.

## QA
- Demo should work as usual

**This is a temporary change until we analyze the results**