### PR TITLE
Change highlight colour for release table cells

### DIFF
--- a/static/sass/_snapcraft_release.scss
+++ b/static/sass/_snapcraft_release.scss
@@ -1,7 +1,8 @@
 @import "snapcraft_patterns_icons";
 
 @mixin snapcraft-release {
-  $color-highlighted: #fae6be;
+  $color-highlighted: #e9ffec;
+  $color-highlighted-border: 1px dashed #0e8420;
 
   // RELEASES CONFIRM
 
@@ -113,6 +114,7 @@
     .is-over &,
     &.is-highlighted {
       background-color: $color-highlighted;
+      border: $color-highlighted-border;
     }
   }
 
@@ -383,6 +385,7 @@
     .is-over &,
     &.is-highlighted {
       background: $color-highlighted;
+      border: $color-highlighted-border;
     }
   }
 
@@ -479,6 +482,7 @@
 
       &.is-pending {
         background: $color-highlighted;
+        border: $color-highlighted-border;
       }
 
       &.is-clickable {


### PR DESCRIPTION
## Done
Changed the highlight colour of changed cells in the releases table

## QA
- Go to https://snapcraft-io-3877.demos.haus/danieltest-snap/releases
- Check that any highlighted cells are a light green colour with a dashed border

## Issue
Fixes https://github.com/canonical-web-and-design/marketplace-tribe/issues/2319