### PR TITLE
Update copy for update metadata on release

### DIFF
--- a/templates/publisher/settings.html
+++ b/templates/publisher/settings.html
@@ -180,7 +180,7 @@ Settings for {% if display_title %}{{ display_title }}{% else %}{{ snap_title }}
 
       <div class="row p-form__group" style="align-items: flex-start;">
         <div class="col-2">
-          <label class="p-form__label" for="update_metadata_on_release">Upload metadata on release:</label>
+          <label class="p-form__label" for="update_metadata_on_release">Update metadata on release:</label>
         </div>
         <div class="col-8">
           <div class="p-form__control">


### PR DESCRIPTION
## Done
Changed the label of the update metadata field on snap settings pages

## QA
- Go to https://snapcraft-io-3878.demos.haus/danieltest-snap/settings
- Check that the label for the update metadata field is "Update metadata on release"

## Issue
Fixes #3879