### PR TITLE
Add views for publishers and reviewers

### DIFF
--- a/static/js/brand-store/Publisher/Publisher.tsx
+++ b/static/js/brand-store/Publisher/Publisher.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+
+function Publisher() {
+  return (
+    <div className="u-fixed-width">
+      <h1>Publisher</h1>
+      <p>
+        As a publisher you can{" "}
+        <a href="/snaps">register a snap name on the Snap store</a>.
+      </p>
+    </div>
+  );
+}
+
+export default Publisher;

--- a/static/js/brand-store/Publisher/index.ts
+++ b/static/js/brand-store/Publisher/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./Publisher";

--- a/static/js/brand-store/Reviewer/Reviewer.tsx
+++ b/static/js/brand-store/Reviewer/Reviewer.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+
+function Reviewer() {
+  return (
+    <div className="u-fixed-width">
+      <h1>Reviewer</h1>
+      <p>
+        As a reviewer you can{" "}
+        <a href={`${window.API_URL}stores/reviews/`}>
+          manage your snaps on the dashboard
+        </a>
+        .
+      </p>
+    </div>
+  );
+}
+
+export default Reviewer;

--- a/static/js/brand-store/Reviewer/index.ts
+++ b/static/js/brand-store/Reviewer/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./Reviewer";

--- a/static/js/brand-store/ReviewerAndPublisher/ReviewerAndPublisher.tsx
+++ b/static/js/brand-store/ReviewerAndPublisher/ReviewerAndPublisher.tsx
@@ -1,0 +1,22 @@
+import React from "react";
+
+function ReviewerAndPublisher() {
+  return (
+    <div className="u-fixed-width">
+      <h1>Reviewer and publisher</h1>
+      <p>
+        As a reviewer you can{" "}
+        <a href={`${window.API_URL}stores/reviews/`}>
+          manage your snaps on the dashboard
+        </a>
+        .
+      </p>
+      <p>
+        As a publisher you can{" "}
+        <a href="/snaps">register a snap name on the Snap store</a>.
+      </p>
+    </div>
+  );
+}
+
+export default ReviewerAndPublisher;

--- a/static/js/brand-store/ReviewerAndPublisher/index.ts
+++ b/static/js/brand-store/ReviewerAndPublisher/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./ReviewerAndPublisher";

--- a/static/js/brand-store/types/global.d.ts
+++ b/static/js/brand-store/types/global.d.ts
@@ -1,3 +1,4 @@
 declare interface Window {
   CSRF_TOKEN: string;
+  API_URL: string;
 }

--- a/templates/admin/admin.html
+++ b/templates/admin/admin.html
@@ -7,6 +7,7 @@
 <script>
   window.CSRF_TOKEN = "{{ csrf_token() }}";
   window.SENTRY_DSN = "{{ SENTRY_DSN }}";
+  window.API_URL = "{{ api_url }}";
 </script>
 <script src="{{ static_url('js/dist/brand-store.js') }}"></script>
 {% endblock %}

--- a/webapp/admin/views.py
+++ b/webapp/admin/views.py
@@ -1,4 +1,5 @@
 # Packages
+import os
 import json
 import flask
 from canonicalwebteam.store_api.exceptions import (
@@ -20,12 +21,18 @@ admin = flask.Blueprint(
     "admin", __name__, template_folder="/templates", static_folder="/static"
 )
 
+SNAPSTORE_DASHBOARD_API_URL = os.getenv(
+    "SNAPSTORE_DASHBOARD_API_URL", "https://dashboard.snapcraft.io/"
+)
+
+context = {"api_url": SNAPSTORE_DASHBOARD_API_URL}
+
 
 @admin.route("/admin", defaults={"path": ""})
 @admin.route("/admin/<path:path>")
 @login_required
 def get_admin(path):
-    return flask.render_template("admin/admin.html")
+    return flask.render_template("admin/admin.html", **context)
 
 
 @admin.route("/admin/stores")


### PR DESCRIPTION
## Done
Added views for stores where the user is only a reviewer, publisher or both

## QA
- Make sure you are a publisher only in a store, a reviewer only in a store, and a reviewer and publisher in a store
- Go to https://snapcraft-io-3889.demos.haus/admin
- On the stores that you are only a reviewer you should see a reviewer page
- On the stores that you are only a publisher you should see a publisher page
- On the stores that you are a reviewer and publisher you should see a reviewer and publisher page

## Issue
Fixes #3854

## Screenshots
![Publisher](https://user-images.githubusercontent.com/501889/154985938-eb5beaad-5878-47e5-9345-c3c8c1400ba9.jpg)

![Reviewer and publisher](https://user-images.githubusercontent.com/501889/154985946-91600148-1add-4421-a33a-5676416eeecb.jpg)

![Reviewer](https://user-images.githubusercontent.com/501889/154985950-3207ed01-dc11-4741-ac57-5a435978410f.jpg)