### PR TITLE
Add changes summary to bottom of releases UI

### DIFF
--- a/static/js/publisher/release/components/releasesConfirm.js
+++ b/static/js/publisher/release/components/releasesConfirm.js
@@ -84,13 +84,35 @@ class ReleasesConfirm extends Component {
 
     return (
       <Fragment>
-        <div className="p-releases-confirm">
-          <div className="row u-vertically-center">
+        <div
+          className={`p-releases-confirm ${updatesCount > 0 ? "" : "u-hide"}`}
+        >
+          <div
+            className="row u-vertically-center"
+            style={{ marginBottom: "0.5rem" }}
+          >
             <div className="col-6">
               {updatesCount > 0 && (
                 <Fragment>
-                  {updatesCount} update
-                  {updatesCount > 1 ? "s" : ""}
+                  <button
+                    type="button"
+                    className="p-button--base u-no-margin--bottom has-icon"
+                    onClick={this.toggleDetails.bind(this)}
+                  >
+                    <i
+                      className={`${
+                        showDetails
+                          ? "p-icon--chevron-down"
+                          : "p-icon--chevron-up"
+                      }`}
+                    >
+                      {showDetails ? "Hide" : "Show"} details
+                    </i>
+                    <span>
+                      {updatesCount} update
+                      {updatesCount > 1 ? "s" : ""}
+                    </span>
+                  </button>
                 </Fragment>
               )}
             </div>
@@ -100,14 +122,7 @@ class ReleasesConfirm extends Component {
                   className={`p-releases-confirm__details-toggle ${
                     showDetails ? "is-open" : ""
                   }`}
-                >
-                  <p className="u-no-margin--bottom">
-                    <span onClick={this.toggleDetails.bind(this)}>
-                      {showDetails ? "Hide" : "Show"} details{" "}
-                      <i className="p-icon--contextual-menu" />
-                    </span>
-                  </p>
-                </div>
+                ></div>
               )}
               <ReleasesConfirmActions
                 isCancelEnabled={isCancelEnabled}
@@ -118,8 +133,10 @@ class ReleasesConfirm extends Component {
               />
             </div>
           </div>
+          <div className="row">
+            {showDetails && <ReleasesConfirmDetails updates={updates} />}
+          </div>
         </div>
-        {showDetails && <ReleasesConfirmDetails updates={updates} />}
       </Fragment>
     );
   }

--- a/static/js/publisher/release/components/releasesConfirmActions.js
+++ b/static/js/publisher/release/components/releasesConfirmActions.js
@@ -10,7 +10,7 @@ const ReleasesConfirmActions = ({
 }) => (
   <div className="p-releases-confirm__buttons">
     <button
-      className="p-button u-no-margin--bottom"
+      className="u-no-margin--bottom u-no-margin--right"
       disabled={!isCancelEnabled}
       onClick={cancelPendingReleases}
     >

--- a/static/js/publisher/release/releasesController.js
+++ b/static/js/publisher/release/releasesController.js
@@ -66,13 +66,11 @@ const ReleasesController = ({
       )}
       {ready && (
         <Fragment>
-          <div className="row">
-            <ReleasesConfirm />
-            {visible && <Notification />}
-          </div>
+          {visible && <Notification />}
           <ReleasesHeading />
           <ReleasesTable />
           {showModal && <Modal />}
+          <ReleasesConfirm />
         </Fragment>
       )}
     </Fragment>

--- a/static/sass/_snapcraft_p-release-details-row.scss
+++ b/static/sass/_snapcraft_p-release-details-row.scss
@@ -5,7 +5,7 @@
     font-size: 0.875rem;
     grid-column-gap: 1rem;
     grid-template-columns: 4rem 15rem 2rem auto 16rem;
-    padding: 0.25rem;
+    padding: 0.25rem 0;
 
     @media screen and (max-width: $breakpoint-large) {
       grid-column-gap: 0.5rem;

--- a/static/sass/_snapcraft_release.scss
+++ b/static/sass/_snapcraft_release.scss
@@ -7,10 +7,14 @@
   // RELEASES CONFIRM
 
   .p-releases-confirm {
-    border-bottom: 1px solid $color-mid-light;
-    margin-bottom: 1rem;
-    padding: 0.5em 0;
-    position: relative;
+    background-color: $color-x-light;
+    bottom: 0;
+    box-shadow: 0 1px 7px rgba(0, 0, 0, 0.3);
+    left: 0;
+    padding: 0.5em 0 0;
+    position: fixed;
+    right: 0;
+    z-index: 20;
   }
 
   .p-releases-confirm__buttons {
@@ -42,11 +46,9 @@
   }
 
   .p-releases-confirm__details {
-    border-bottom: 1px solid $color-mid-light;
-    margin: 0.5rem 0 1rem;
-    padding-bottom: 0.5rem;
-    position: relative;
-    top: -1rem;
+    border-top: 1px solid $color-mid-light;
+    margin-bottom: 1rem;
+    padding-top: 0.25rem;
   }
 
   // RELEASES TABLE


### PR DESCRIPTION
## Done
Added the changes summary of the release UI

## QA
- Go to https://snapcraft-io-3890.demos.haus/danieltest-snap/releases
- Make a change
- Check that a bar appears at the bottom of the screen with the number of changes and save/revert buttons
- Click on the changes count and check that the bar expands and shows the list of changes

## Issue
Fixes https://github.com/canonical-web-and-design/marketplace-tribe/issues/2320