### PR TITLE
Revision cell changes to Release UI

### DIFF
--- a/static/js/publisher/release/components/contextualMenu.js
+++ b/static/js/publisher/release/components/contextualMenu.js
@@ -25,10 +25,20 @@ export default class ContextualMenu extends Component {
   dropdownButtonClick(event) {
     const dropdownEl = event.target.nextSibling;
     const isClosed = dropdownEl.getAttribute("aria-hidden") === "true";
+    const tooltipMessage = dropdownEl.parentNode.previousSibling;
 
     this.closeAllDropdowns();
+
+    if (tooltipMessage) {
+      tooltipMessage.classList.remove("u-hide");
+    }
+
     if (isClosed && dropdownEl) {
       dropdownEl.setAttribute("aria-hidden", false);
+
+      if (tooltipMessage) {
+        tooltipMessage.classList.add("u-hide");
+      }
     }
 
     event.stopPropagation();

--- a/static/js/publisher/release/components/historyIcon.js
+++ b/static/js/publisher/release/components/historyIcon.js
@@ -4,7 +4,7 @@ import PropTypes from "prop-types";
 export default function HistoryIcon({ onClick }) {
   return (
     <span className="p-release-data__icon" onClick={onClick}>
-      <span className="p-icon p-icon--history">History</span>
+      <span className="p-icon--chevron-down">History</span>
     </span>
   );
 }

--- a/static/js/publisher/release/components/historyPanel.js
+++ b/static/js/publisher/release/components/historyPanel.js
@@ -6,9 +6,7 @@ export default class HistoryPanel extends Component {
   render() {
     return (
       <div className="p-history-panel">
-        <div className="p-strip is-shallow">
-          <RevisionsList />
-        </div>
+        <RevisionsList />
       </div>
     );
   }

--- a/static/js/publisher/release/components/releasesTable/cellViews.js
+++ b/static/js/publisher/release/components/releasesTable/cellViews.js
@@ -38,10 +38,21 @@ UnassignedInfo.propTypes = {
 
 // content of empty cell in channel row (nothing released or tracking channel)
 export const EmptyInfo = ({ trackingChannel }) => {
+  const trackingChannelSplit = trackingChannel
+    ? trackingChannel.split("/")
+    : null;
+
   return (
     <Fragment>
       <span className="p-release-data__info--empty">
-        {trackingChannel ? `Tracking ${trackingChannel}` : "–"}
+        {trackingChannel ? (
+          <small>
+            Tracking {trackingChannelSplit[0]}/<br />
+            {trackingChannelSplit[1]}
+          </small>
+        ) : (
+          "-"
+        )}
       </span>
 
       <span className="p-tooltip__message">

--- a/static/js/publisher/release/components/releasesTable/cellViews.js
+++ b/static/js/publisher/release/components/releasesTable/cellViews.js
@@ -41,7 +41,7 @@ export const EmptyInfo = ({ trackingChannel }) => {
   return (
     <Fragment>
       <span className="p-release-data__info--empty">
-        {trackingChannel ? "↑" : "–"}
+        {trackingChannel ? `Tracking channel ${trackingChannel}` : "–"}
       </span>
 
       <span className="p-tooltip__message">
@@ -209,7 +209,7 @@ RevisionInfo.propTypes = {
 
 // generic draggable view of releases table cell
 export const ReleasesTableCellView = (props) => {
-  const { item, canDrag, children, actions, cellType } = props;
+  const { item, canDrag, children, actions, cellType, current } = props;
 
   const [isDragging, isGrabbing, drag] = useDragging({
     item,
@@ -251,6 +251,7 @@ export const ReleasesTableCellView = (props) => {
                       pendingChannelMap={RISKS_WITH_AVAILABLE}
                       item={item}
                       promoteRevision={promoteRevision}
+                      current={current}
                     />
                   );
                 })}
@@ -272,4 +273,5 @@ ReleasesTableCellView.propTypes = {
   children: PropTypes.node,
   actions: PropTypes.node,
   cellType: PropTypes.string,
+  current: PropTypes.string,
 };

--- a/static/js/publisher/release/components/releasesTable/cellViews.js
+++ b/static/js/publisher/release/components/releasesTable/cellViews.js
@@ -41,12 +41,12 @@ export const EmptyInfo = ({ trackingChannel }) => {
   return (
     <Fragment>
       <span className="p-release-data__info--empty">
-        {trackingChannel ? `Tracking channel ${trackingChannel}` : "–"}
+        {trackingChannel ? `Tracking ${trackingChannel}` : "–"}
       </span>
 
       <span className="p-tooltip__message">
         {trackingChannel
-          ? `Tracking channel ${trackingChannel}`
+          ? `Tracking ${trackingChannel}`
           : "Nothing currently released"}
       </span>
     </Fragment>

--- a/static/js/publisher/release/components/releasesTable/channelHeading.js
+++ b/static/js/publisher/release/components/releasesTable/channelHeading.js
@@ -356,8 +356,9 @@ const ReleasesTableChannelHeading = (props) => {
       <div className="p-release-data__meta-container">
         {risk !== AVAILABLE && (
           <span className="p-release-data__meta">
-            {channelVersion} |{" "}
-            {channelBuildDate && format(channelBuildDate, "dd MMM yyyy")}
+            {channelVersion}
+            {channelBuildDate &&
+              ` | ${format(channelBuildDate, "dd MMM yyyy")}`}
           </span>
         )}
         {channelVersion && (

--- a/static/js/publisher/release/components/releasesTable/channelRow.js
+++ b/static/js/publisher/release/components/releasesTable/channelRow.js
@@ -44,6 +44,7 @@ const ReleasesTableChannelRow = (props) => {
         return (
           <ReleasesTableReleaseCell
             key={`${currentTrack}/${risk}/${arch}`}
+            current={`${currentTrack}/${risk}`}
             track={currentTrack}
             risk={risk}
             branch={branch}

--- a/static/js/publisher/release/components/releasesTable/index.js
+++ b/static/js/publisher/release/components/releasesTable/index.js
@@ -1,4 +1,4 @@
-import React, { Component, Fragment } from "react";
+import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
 
@@ -55,7 +55,6 @@ class ReleasesTable extends Component {
 
   handleToggleShowMoreBuilds() {
     const { showAllBuilds } = this.state;
-
     this.setState({
       showAllBuilds: !showAllBuilds,
     });
@@ -96,22 +95,22 @@ class ReleasesTable extends Component {
     const { isHistoryOpen, filters } = this.props;
 
     return (
-      <Fragment>
+      <>
         {this.renderChannelRow(AVAILABLE)}
         {isHistoryOpen &&
           filters.risk === AVAILABLE &&
           this.renderHistoryPanel()}
-      </Fragment>
+      </>
     );
   }
 
   renderAvailableRevisions() {
     return (
-      <Fragment>
+      <>
         <h5>Promote from uploaded revisions</h5>
 
         {this.renderAvailableRevisionsRow()}
-      </Fragment>
+      </>
     );
   }
 
@@ -144,21 +143,37 @@ class ReleasesTable extends Component {
 
     if (builds.length) {
       return (
-        <Fragment>
+        <>
           {buildsToShow.map((revisions) => this.renderBuildRow(revisions))}
           {builds.length > MAX_BUILDS && (
-            <div className="p-releases-table__row--show-all">
-              <a onClick={this.handleToggleShowMoreBuilds.bind(this)}>
-                {!showAllBuilds && (
-                  <Fragment>Show all builds ({builds.length})</Fragment>
-                )}
-                {showAllBuilds && (
-                  <Fragment>Show only {MAX_BUILDS} builds</Fragment>
-                )}
-              </a>
+            <div className="p-releases-table__row--show-all u-align--right">
+              {!showAllBuilds && (
+                <>
+                  <small
+                    className="u-text-muted"
+                    style={{ marginRight: "0.5rem" }}
+                  >
+                    Showing {MAX_BUILDS} of {builds.length} builds
+                  </small>
+                  <button
+                    onClick={this.handleToggleShowMoreBuilds.bind(this)}
+                    className="p-button is-small"
+                  >
+                    Show all builds
+                  </button>
+                </>
+              )}
+              {showAllBuilds && (
+                <button
+                  className="p-button is-small"
+                  onClick={this.handleToggleShowMoreBuilds.bind(this)}
+                >
+                  Show only {MAX_BUILDS} builds
+                </button>
+              )}
             </div>
           )}
-        </Fragment>
+        </>
       );
     }
 
@@ -219,13 +234,9 @@ class ReleasesTable extends Component {
               <div className="p-releases-table__row--show-all">
                 <a onClick={this.handleToggleShowMoreBranches.bind(this, risk)}>
                   {!showAllBranches && (
-                    <Fragment>
-                      Show all branches ({risksBranches.length})
-                    </Fragment>
+                    <>Show all branches ({risksBranches.length})</>
                   )}
-                  {showAllBranches && (
-                    <Fragment>Show only {MAX_BRANCHES} branches</Fragment>
-                  )}
+                  {showAllBranches && <>Show only {MAX_BRANCHES} branches</>}
                 </a>
               </div>
             </div>

--- a/static/js/publisher/release/components/releasesTable/releaseCell.js
+++ b/static/js/publisher/release/components/releasesTable/releaseCell.js
@@ -148,6 +148,8 @@ const ReleasesTableReleaseCell = (props) => {
     );
   }
 
+  const showHistoryIcon = currentRevision || isUnassigned;
+
   return (
     <ReleasesTableCellView
       actions={actionsNode}
@@ -157,7 +159,7 @@ const ReleasesTableReleaseCell = (props) => {
       cellType="release"
       current={current}
     >
-      {currentRevision && (
+      {showHistoryIcon && (
         <HistoryIcon
           onClick={handleHistoryIconClick.bind(
             this,

--- a/static/js/publisher/release/components/releasesTable/releaseCell.js
+++ b/static/js/publisher/release/components/releasesTable/releaseCell.js
@@ -44,6 +44,7 @@ const ReleasesTableReleaseCell = (props) => {
     undoRelease,
     toggleHistoryPanel,
     getProgressiveState,
+    current,
   } = props;
 
   const branchName = branch ? branch.branch : null;
@@ -106,6 +107,7 @@ const ReleasesTableReleaseCell = (props) => {
     isHighlighted ? "is-highlighted" : "",
     isPending ? "is-pending" : "",
     isOverParent ? "is-over" : "",
+    currentRevision?.changed && isUnassigned ? "current-change" : "",
   ].join(" ");
 
   const actionsNode = pendingRelease ? (
@@ -153,16 +155,19 @@ const ReleasesTableReleaseCell = (props) => {
       canDrag={canDrag}
       className={className}
       cellType="release"
+      current={current}
     >
-      <HistoryIcon
-        onClick={handleHistoryIconClick.bind(
-          this,
-          arch,
-          risk,
-          track,
-          branchName
-        )}
-      />
+      {isUnassigned && (
+        <HistoryIcon
+          onClick={handleHistoryIconClick.bind(
+            this,
+            arch,
+            risk,
+            track,
+            branchName
+          )}
+        />
+      )}
       {cellInfoNode}
       {!isChannelPendingClose &&
         pendingProgressiveState &&
@@ -208,6 +213,7 @@ ReleasesTableReleaseCell.propTypes = {
   isOverParent: PropTypes.bool,
 
   revision: PropTypes.object,
+  current: PropTypes.string,
 };
 
 const mapStateToProps = (state) => {

--- a/static/js/publisher/release/components/releasesTable/releaseCell.js
+++ b/static/js/publisher/release/components/releasesTable/releaseCell.js
@@ -1,7 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
-
 import { AVAILABLE } from "../../constants";
 import { getTrackingChannel } from "../../releasesState";
 
@@ -40,7 +39,6 @@ const ReleasesTableReleaseCell = (props) => {
     pendingCloses,
     filters,
     isOverParent,
-    showVersion,
     getAvailableCount,
     hasPendingRelease,
     undoRelease,
@@ -133,7 +131,6 @@ const ReleasesTableReleaseCell = (props) => {
       <RevisionInfo
         revision={currentRevision}
         isPending={pendingRelease ? true : false}
-        showVersion={showVersion}
         progressiveState={progressiveState}
         previousRevision={previousRevision ? previousRevision.revision : null}
         pendingProgressiveState={pendingProgressiveState}
@@ -155,8 +152,8 @@ const ReleasesTableReleaseCell = (props) => {
       item={item}
       canDrag={canDrag}
       className={className}
+      cellType="release"
     >
-      {cellInfoNode}
       <HistoryIcon
         onClick={handleHistoryIconClick.bind(
           this,
@@ -166,6 +163,7 @@ const ReleasesTableReleaseCell = (props) => {
           branchName
         )}
       />
+      {cellInfoNode}
       {!isChannelPendingClose &&
         pendingProgressiveState &&
         pendingProgressiveState.percentage && (
@@ -206,7 +204,6 @@ ReleasesTableReleaseCell.propTypes = {
   track: PropTypes.string,
   risk: PropTypes.string,
   arch: PropTypes.string,
-  showVersion: PropTypes.bool,
   branch: PropTypes.object,
   isOverParent: PropTypes.bool,
 

--- a/static/js/publisher/release/components/releasesTable/releaseCell.js
+++ b/static/js/publisher/release/components/releasesTable/releaseCell.js
@@ -157,7 +157,7 @@ const ReleasesTableReleaseCell = (props) => {
       cellType="release"
       current={current}
     >
-      {isUnassigned && (
+      {currentRevision && (
         <HistoryIcon
           onClick={handleHistoryIconClick.bind(
             this,
@@ -168,6 +168,7 @@ const ReleasesTableReleaseCell = (props) => {
           )}
         />
       )}
+
       {cellInfoNode}
       {!isChannelPendingClose &&
         pendingProgressiveState &&

--- a/static/js/publisher/release/components/releasesTable/releaseMenuItem.js
+++ b/static/js/publisher/release/components/releasesTable/releaseMenuItem.js
@@ -1,0 +1,49 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { connect } from "react-redux";
+
+import { promoteRevision } from "../../actions/pendingReleases";
+import { getPendingChannelMap } from "../../selectors";
+import { canBeReleased } from "../../helpers";
+
+function ReleaseMenuItem(props) {
+  return (
+    <span
+      key={props.risk}
+      className="p-contextual-menu__link"
+      onClick={() => {
+        props.item.revisions.forEach((r) => {
+          return (
+            canBeReleased(r) && props.promoteRevision(r, `latest/${props.risk}`)
+          );
+        });
+      }}
+    >
+      latest/{props.risk}
+    </span>
+  );
+}
+
+ReleaseMenuItem.propTypes = {
+  item: PropTypes.object,
+  currentTrack: PropTypes.string.isRequired,
+  risk: PropTypes.string,
+  pendingChannelMap: PropTypes.object,
+  promoteRevision: PropTypes.func,
+};
+
+const mapStateToProps = (state) => {
+  return {
+    currentTrack: state.currentTrack,
+    pendingChannelMap: getPendingChannelMap(state),
+  };
+};
+
+const mapDispatchToProps = (dispatch) => {
+  return {
+    promoteRevision: (revision, targetChannel) =>
+      dispatch(promoteRevision(revision, targetChannel)),
+  };
+};
+
+export default connect(mapStateToProps, mapDispatchToProps)(ReleaseMenuItem);

--- a/static/js/publisher/release/components/releasesTable/releaseMenuItem.js
+++ b/static/js/publisher/release/components/releasesTable/releaseMenuItem.js
@@ -7,19 +7,21 @@ import { getPendingChannelMap } from "../../selectors";
 import { canBeReleased } from "../../helpers";
 
 function ReleaseMenuItem(props) {
+  const risk = `latest/${props.risk}`;
+
   return (
     <span
       key={props.risk}
-      className="p-contextual-menu__link"
+      className={`p-contextual-menu__link ${
+        props.current === risk ? "is-disabled" : ""
+      }`}
       onClick={() => {
         props.item.revisions.forEach((r) => {
-          return (
-            canBeReleased(r) && props.promoteRevision(r, `latest/${props.risk}`)
-          );
+          return canBeReleased(r) && props.promoteRevision(r, risk);
         });
       }}
     >
-      latest/{props.risk}
+      {risk}
     </span>
   );
 }
@@ -30,6 +32,7 @@ ReleaseMenuItem.propTypes = {
   risk: PropTypes.string,
   pendingChannelMap: PropTypes.object,
   promoteRevision: PropTypes.func,
+  current: PropTypes.string,
 };
 
 const mapStateToProps = (state) => {

--- a/static/js/publisher/release/components/releasesTable/revisionCell.js
+++ b/static/js/publisher/release/components/releasesTable/revisionCell.js
@@ -8,7 +8,7 @@ import { ReleasesTableCellView, RevisionInfo, EmptyInfo } from "./cellViews";
 
 // releases table cell with data for a specific revision (unrelated to channel map)
 const ReleasesTableRevisionCell = (props) => {
-  const { revision, showVersion } = props;
+  const { revision } = props;
 
   const item = {
     revisions: [revision],
@@ -20,12 +20,9 @@ const ReleasesTableRevisionCell = (props) => {
     <ReleasesTableCellView
       item={item}
       canDrag={!!revision && canBeReleased(revision)}
+      cellType="revision"
     >
-      {revision ? (
-        <RevisionInfo revision={revision} showVersion={showVersion} />
-      ) : (
-        <EmptyInfo />
-      )}
+      {revision ? <RevisionInfo revision={revision} /> : <EmptyInfo />}
     </ReleasesTableCellView>
   );
 };

--- a/static/js/publisher/release/components/revisionsList.js
+++ b/static/js/publisher/release/components/revisionsList.js
@@ -66,6 +66,20 @@ class RevisionsList extends Component {
     );
   }
 
+  // Moves the active revision to the top of the list
+  getSortedRevisions(activeRevision, revisions) {
+    const activeRevisionIndex = revisions.findIndex(
+      (revision) =>
+        activeRevision && revision.revision === activeRevision.revision
+    );
+
+    let indexToMove = 1;
+    const item = revisions.splice(activeRevisionIndex, indexToMove)[0];
+    indexToMove = 0;
+    revisions.splice(0, indexToMove, item);
+    return revisions;
+  }
+
   renderRows(
     revisions,
     isSelectable,
@@ -75,7 +89,9 @@ class RevisionsList extends Component {
     hasPendingRelease,
     progressiveReleaseBeingCancelled
   ) {
-    return revisions.map((revision, index) => {
+    const sortedRevisions = this.getSortedRevisions(activeRevision, revisions);
+
+    return sortedRevisions.map((revision, index) => {
       const isActive =
         activeRevision && revision.revision === activeRevision.revision;
 

--- a/static/js/publisher/release/components/revisionsList.js
+++ b/static/js/publisher/release/components/revisionsList.js
@@ -377,10 +377,13 @@ class RevisionsList extends Component {
             )}
             {!showAllRevisions && filteredRevisions.length > 10 && (
               <tr>
-                <td colSpan={4}>
-                  <a onClick={this.showAllRevisions.bind(this, key)}>
+                <td colSpan={5} className="u-align--right">
+                  <button
+                    className="p-button is-small"
+                    onClick={this.showAllRevisions.bind(this, key)}
+                  >
                     Show all {filteredRevisions.length} revisions
-                  </a>
+                  </button>
                 </td>
               </tr>
             )}

--- a/static/js/publisher/release/components/revisionsList.js
+++ b/static/js/publisher/release/components/revisionsList.js
@@ -292,7 +292,9 @@ class RevisionsList extends Component {
     return (
       <Fragment>
         <div className="u-clearfix">
-          <h4 className="u-float-left">{title}</h4>
+          <p role="heading" aria-level="4" className="u-float-left ">
+            {title}
+          </p>
           <a
             style={{ marginTop: "0.5rem" }}
             href="#"

--- a/static/js/publisher/release/components/revisionsList.js
+++ b/static/js/publisher/release/components/revisionsList.js
@@ -379,7 +379,7 @@ class RevisionsList extends Component {
               <tr>
                 <td colSpan={5} className="u-align--right">
                   <button
-                    className="p-button is-small"
+                    className="p-button is-small u-no-margin--bottom"
                     onClick={this.showAllRevisions.bind(this, key)}
                   >
                     Show all {filteredRevisions.length} revisions

--- a/static/js/publisher/release/components/revisionsListRow.js
+++ b/static/js/publisher/release/components/revisionsListRow.js
@@ -69,7 +69,7 @@ const RevisionsListRow = (props) => {
             <input
               type="radio"
               checked={isSelected && releasable}
-              aria-lbelledby={id}
+              aria-labelledby={id}
               onChange={revisionSelectChange}
               disabled={!releasable}
               className="p-radio__input"

--- a/static/js/publisher/release/components/revisionsListRow.js
+++ b/static/js/publisher/release/components/revisionsListRow.js
@@ -43,6 +43,7 @@ const RevisionsListRow = (props) => {
   }
 
   function revisionSelectChange() {
+    revision.changed = true;
     props.toggleRevision(revision);
   }
 

--- a/static/sass/_snapcraft_release.scss
+++ b/static/sass/_snapcraft_release.scss
@@ -82,7 +82,7 @@
     flex-wrap: wrap;
     padding: $spv--small $sph--small;
     position: relative;
-    width: 280px;
+    width: 240px;
 
     .p-promote-button {
       display: none;
@@ -95,6 +95,9 @@
     &:hover {
       .p-promote-button {
         display: inline-block;
+        position: absolute;
+        right: 0.5rem;
+        top: 0.5rem;
       }
 
       .p-releases-channel__name {
@@ -345,6 +348,12 @@
       visibility: visible;
     }
 
+    .p-release-data & {
+      position: absolute;
+      right: 0.5rem;
+      top: 0.5rem;
+    }
+
     .is-draggable & {
       visibility: visible;
     }
@@ -387,6 +396,9 @@
 
       .p-promote-button {
         display: inline-block;
+        position: absolute;
+        right: 1.75rem;
+        top: 0.5rem;
       }
     }
 
@@ -394,7 +406,10 @@
       @include vf-animation(#{background-color, border-color}, fast, in);
 
       background-color: $color-x-light;
-      border-color: $color-mid-dark;
+
+      &:not(.p-releases-table__arch) {
+        border-bottom: 3px solid $color-dark !important;
+      }
 
       .p-release__progressive-percentage,
       .p-release__progressive-pending-percentage {
@@ -408,6 +423,10 @@
       .p-tooltip__message {
         display: none;
       }
+
+      .p-release-data__icon {
+        transform: rotate(0deg);
+      }
     }
 
     &.is-over,
@@ -419,6 +438,11 @@
       &.is-unassigned {
         background-color: $color-light;
         border-color: $color-mid-x-light;
+      }
+
+      .p-promote-button,
+      .p-drag-handle {
+        display: none;
       }
     }
   }
@@ -446,15 +470,10 @@
     padding-left: ($sph--small - 0.1rem);
   }
 
-  .p-releases-table__cell.is-active .p-release-data__icon {
-    transform: rotate(0deg);
-  }
-
   .p-release-data__info--empty {
     display: inline-block;
     overflow: hidden;
     padding-bottom: 0.6em;
-    padding-top: 0.6em;
     text-overflow: ellipsis;
     white-space: nowrap;
   }
@@ -478,6 +497,8 @@
   // REVISIONS LIST
 
   .p-revisions-list {
+    margin-bottom: 0;
+
     td,
     th {
       overflow: visible;
@@ -635,6 +656,11 @@
     margin-top: $sp-x-small;
   }
 
+  .p-history-panel {
+    border: 1px solid $color-mid-x-light;
+    padding: 1.5rem;
+  }
+
   .p-icon--lp {
     @extend %icon;
 
@@ -675,5 +701,10 @@
     @extend %icon;
 
     background-image: url("data:image/svg+xml,%3Csvg width='16' height='16' viewBox='0 0 16 16' fill='none' xmlns='http://www.w3.org/2000/svg'%3E %3Cg%3E %3Cpath d='M14 8L2 14.9282L2 1.0718L14 8Z' fill='%23666'/%3E %3C/g%3E%3C/svg%3E");
+  }
+
+  .current-change {
+    background-color: $color-highlighted !important;
+    border: $color-highlighted-border !important;
   }
 }

--- a/static/sass/_snapcraft_release.scss
+++ b/static/sass/_snapcraft_release.scss
@@ -70,6 +70,10 @@
     }
   }
 
+  .p-promote-button {
+    display: none;
+  }
+
   .p-releases-channel {
     align-items: flex-start;
     border-right: 1px solid $colors--light-theme--border-default;
@@ -234,11 +238,8 @@
   .p-release-data__icon {
     border-radius: 3px;
     cursor: pointer;
-    opacity: 0;
     padding: 0 $sph--small;
-    position: absolute;
-    right: 0.5rem;
-    top: 0.5rem;
+    transform: rotate(-90deg);
   }
 
   .is-pending {
@@ -332,6 +333,23 @@
     }
   }
 
+  .p-drag-handle {
+    margin-left: auto;
+    opacity: 0;
+    visibility: hidden;
+
+    .p-releases-channel__inner & {
+      margin-left: 0;
+      margin-right: 0.5rem;
+      opacity: 1;
+      visibility: visible;
+    }
+
+    .is-draggable & {
+      visibility: visible;
+    }
+  }
+
   .p-releases-table__cell {
     @include vf-animation(#{background-color, border-color}, 0, in);
 
@@ -361,6 +379,15 @@
     &.is-active {
       background-color: $color-light;
       opacity: 1;
+
+      .p-drag-handle {
+        opacity: 1;
+        visibility: visible;
+      }
+
+      .p-promote-button {
+        display: inline-block;
+      }
     }
 
     &.is-active {
@@ -388,6 +415,11 @@
     &.is-highlighted {
       background: $color-highlighted;
       border: $color-highlighted-border;
+
+      &.is-unassigned {
+        background-color: $color-light;
+        border-color: $color-mid-x-light;
+      }
     }
   }
 
@@ -406,6 +438,7 @@
   }
 
   .p-release-data {
+    align-items: start;
     display: flex;
     height: 4rem;
     max-width: 100%;
@@ -414,18 +447,7 @@
   }
 
   .p-releases-table__cell.is-active .p-release-data__icon {
-    opacity: 1;
-  }
-
-  .p-release-data:hover {
-    .p-release-data__icon {
-      opacity: 0.6;
-
-      &:hover {
-        background-color: $color-x-light;
-        opacity: 1;
-      }
-    }
+    transform: rotate(0deg);
   }
 
   .p-release-data__info--empty {
@@ -523,15 +545,6 @@
 
     .is-draggable {
       cursor: move;
-    }
-  }
-
-  .p-drag-handle {
-    margin-right: $sph--small;
-    visibility: hidden;
-
-    .is-draggable & {
-      visibility: visible;
     }
   }
 

--- a/templates/publisher/release-history.html
+++ b/templates/publisher/release-history.html
@@ -9,7 +9,7 @@ Releases and revision history for {% if snap_title %}{{ snap_title }}{% else %}{
   {% set selected_tab='release' %}
   {% include "publisher/_header.html" %}
 
-  <section class="p-strip is-shallow u-no-padding--top">
+  <section class="p-strip is-shallow">
     <div id="release-history">
       {% if release_history["error-list"] %}
         <div class="row">


### PR DESCRIPTION
## Done
- Added visual changes to the revision cells
- Add menus to promote or release revisions on click rather than drag

## QA
- Go to https://snapcraft-io-3892.demos.haus/danieltest-snap/releases
- Hover over a release or revision cell
- Check that there is a "Promote" or "Release" button
- Click the button and select an option from the menu
- Check that the revision/release has been released/promoted

## Issue
Fixes https://github.com/canonical-web-and-design/marketplace-tribe/issues/2316