### PR TITLE
Connection close header for API calls

### DIFF
--- a/webapp/api/requests.py
+++ b/webapp/api/requests.py
@@ -24,7 +24,7 @@ class BaseSession:
             commit_hash=os.getenv("COMMIT_ID", "commit_id"),
             environment=os.getenv("ENVIRONMENT", "devel"),
         )
-        headers = {"User-Agent": storefront_header}
+        headers = {"User-Agent": storefront_header, "Connection": "close"}
         self.headers.update(headers)
 
     def request(self, method, url, timeout=12, **kwargs):


### PR DESCRIPTION
## Done
- Connection close header for API calls

I believe this might fix this issue however there is no way to QA, so we will have to see. Explanation:
> HTTP/1.1 by default allows a client to assume that keep-alive is supported unless the server disables it via 'Connection: close'

However, we need to check Sentry, some references:
https://stackoverflow.com/questions/33895739/python-requests-module-error-cant-load-any-url-remote-end-closed-connection/63641442#63641442
https://github.com/vavarachen/splunk_hec_handler/pull/8/files
https://github.com/psf/requests/issues/4784

## Issue / Card
Fixes #3875
