### PR TITLE
Fix promote button hover state in the release UI

### DIFF
--- a/static/sass/_snapcraft_release.scss
+++ b/static/sass/_snapcraft_release.scss
@@ -388,7 +388,10 @@
     &.is-active {
       background-color: $color-light;
       opacity: 1;
+    }
 
+    &:focus,
+    &:hover {
       .p-drag-handle {
         opacity: 1;
         visibility: visible;


### PR DESCRIPTION
## Done
Only show the promote button in the release UI when the cell itself is hovered over

## QA
- Go to https://snapcraft-io-3904.demos.haus/danieltest-snap/releases
- Click on a cell in the releases table to expand it
- If you hover the cell you should see a "Promote" button
- The button should disappear when you are no longer hovering over the cell

## Issue
Fixes #3903