### PR TITLE
Fix settings options indent

### DIFF
--- a/templates/publisher/listing.html
+++ b/templates/publisher/listing.html
@@ -467,30 +467,34 @@ Listing details for {% if display_title %}{{ display_title }}{% else %}{{ snap_t
               <span class="p-tooltip__message">These display relative popularity, not exact numbers.</span>
             </label>
             <div class="p-nested-inputs">
-              <input
-                type="checkbox"
-                name="public_metrics_territories"
-                id="public-metrics-territories"
-                {% if not contains(public_metrics_blacklist, 'installed_base_by_country_percent') %}
-                checked="checked"
-                {% endif %}
-                {% if not public_metrics_enabled %}
-                disabled="disabled"
-                {% endif %}
-                />
-              <label for="public-metrics-territories">World map <span class="p-form-help-text">Displays where your snap is being used by country</span></label>
-              <input
-                type="checkbox"
-                name="public_metrics_distros"
-                id="public-metrics-distros"
-                {% if not contains(public_metrics_blacklist, 'weekly_installed_base_by_operating_system_normalized') %}
-                checked="checked"
-                {% endif %}
-                {% if not public_metrics_enabled %}
-                disabled="disabled"
-                {% endif %}
-                />
-              <label for="public-metrics-distros">Linux distributions <span class="p-form-help-text">Displays where your snap is being used by distro</span></label>
+              <div>
+                <input
+                  type="checkbox"
+                  name="public_metrics_territories"
+                  id="public-metrics-territories"
+                  {% if not contains(public_metrics_blacklist, 'installed_base_by_country_percent') %}
+                  checked="checked"
+                  {% endif %}
+                  {% if not public_metrics_enabled %}
+                  disabled="disabled"
+                  {% endif %}
+                  />
+                <label for="public-metrics-territories">World map <span class="p-form-help-text">Displays where your snap is being used by country</span></label>
+              </div>
+              <div>
+                <input
+                  type="checkbox"
+                  name="public_metrics_distros"
+                  id="public-metrics-distros"
+                  {% if not contains(public_metrics_blacklist, 'weekly_installed_base_by_operating_system_normalized') %}
+                  checked="checked"
+                  {% endif %}
+                  {% if not public_metrics_enabled %}
+                  disabled="disabled"
+                  {% endif %}
+                  />
+                <label for="public-metrics-distros">Linux distributions <span class="p-form-help-text">Displays where your snap is being used by distro</span></label>
+              </div>
               <input
                 type="hidden"
                 name="public_metrics_blacklist"


### PR DESCRIPTION
## Done
Fixed indent in nested options on listings page

## QA
- Go https://snapcraft-io-3914.demos.haus/inkscape/listing
- Scroll to the bottom of the page and check that the nested checkboxes in the metrics section are lined up

## Issue
Fixes #3902

## Screenshot
<img width="1001" alt="Screenshot 2022-03-14 at 09 42 47" src="https://user-images.githubusercontent.com/501889/158146442-745e0e93-6561-451e-9479-00a18a4cca82.png">

