### PR TITLE
Fix release cell padding

### DIFF
--- a/static/sass/_snapcraft_release.scss
+++ b/static/sass/_snapcraft_release.scss
@@ -236,19 +236,11 @@
     right: 0.8rem;
   }
 
-  // release cell
-
   .p-release-data__icon {
     border-radius: 3px;
     cursor: pointer;
     padding: 0 $sph--small;
     transform: rotate(-90deg);
-  }
-
-  .is-pending {
-    .p-release-data__icon {
-      margin-right: 1.25rem;
-    }
   }
 
   .p-release-data__title .has-button,


### PR DESCRIPTION
## Done
Fixed padding when releasing a revision

## QA
- Go to https://snapcraft-io-3915.demos.haus/danieltest2/releases
- Release a revision by dragging it's cell to the releases table
- The padding should stay the same

## Issue
Fixes #3908
