### PR TITLE
Remove notification

### DIFF
--- a/templates/publisher/account-snaps.html
+++ b/templates/publisher/account-snaps.html
@@ -118,18 +118,6 @@ My published snaps — Linux software in the Snap Store
   {% endif %}
   {% endfor %}
   {% endif %}
-    <div class="u-fixed-width js-notification-holder">
-      <div class="p-notification--information">
-        <div class="p-notification__content">
-          <div class="p-notification__message">
-            <strong>We are updating the way you build from GitHub</strong> to integrate better within Snapcraft.
-            <a href="/blog/we-are-changing-the-way-you-build-snaps-from-github-repos">Learn more</a>
-          </div>
-        </div>
-        <button class="p-notification__close js-notification-close" data-ispermanent="true" data-name="build-notice-04-2020">Close</button>
-      </div>
-    </div>
-
   <div class="u-fixed-width">
     <table class="p-table--mobile-card" role="grid">
       <thead>


### PR DESCRIPTION
## Done
- Removed outdated notifcation

## How to QA
- Visit the demo in your browser, link commented below
  - Or you can run the project locally using the [dotrun](https://snapcraft.io/dotrun) snap with `$ dotrun` and view it in your web browser at: http://0.0.0.0:8004/
  - If your demo doesn't work, read more about the [demoservice](https://discourse.ubuntu.com/t/demoservice/16862)
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Visit [demo]/snaps and see there is no notification about 'changing the way we build your snaps'

## Issue / Card
Fixes #3909
