### PR TITLE
first_snap(ROS): remove test prefix and update ROS1 snapcraft.yaml

### DIFF
--- a/templates/home/_fsf_ros.html
+++ b/templates/home/_fsf_ros.html
@@ -32,10 +32,9 @@
     <b>source</b>: https://github.com/ros/ros_tutorials.git
     <b>source-branch</b>: melodic-devel
     <b>source-space</b>: roscpp_tutorials/
-    <b>build-packages</b>: [lsb-release]
 
 <b>apps</b>:
-  <b>run</b>:
+  <b>ros-talker-listener</b>:
     <b>command</b>: roslaunch roscpp_tutorials talker_listener.launch</pre>
 
       {% include "home/_fsf_yaml_show_more.html" %}

--- a/webapp/first_snap/content/ros/build.yaml
+++ b/webapp/first_snap/content/ros/build.yaml
@@ -1,4 +1,4 @@
-name: test-ros-talker-listener-{name}
+name: ros-talker-listener-{name}
 linux:
   auto:
     - action: "Create a directory, move the downloaded snapcraft.yaml file into the new directory and navigate there:"

--- a/webapp/first_snap/content/ros/package.yaml
+++ b/webapp/first_snap/content/ros/package.yaml
@@ -1,2 +1,2 @@
-name: test-ros-talker-listener-{name}
+name: ros-talker-listener-{name}
 download: git clone https://github.com/snapcraft-docs/ros-talker-listener

--- a/webapp/first_snap/content/ros/snapcraft.yaml
+++ b/webapp/first_snap/content/ros/snapcraft.yaml
@@ -13,8 +13,7 @@ parts:
     source: https://github.com/ros/ros_tutorials.git
     source-branch: melodic-devel
     source-space: roscpp_tutorials/
-    build-packages: [lsb-release]
 
 apps:
-  run:
+  ${name}:
     command: roslaunch roscpp_tutorials talker_listener.launch

--- a/webapp/first_snap/content/ros/test.yaml
+++ b/webapp/first_snap/content/ros/test.yaml
@@ -1,4 +1,4 @@
-name: test-ros-talker-listener-{name}
+name: ros-talker-listener-{name}
 linux:
   - action: "Install the snap:"
     command: sudo snap install --devmode --dangerous *.snap

--- a/webapp/first_snap/content/ros2/build.yaml
+++ b/webapp/first_snap/content/ros2/build.yaml
@@ -1,4 +1,4 @@
-name: test-ros2-talker-listener-{name}
+name: ros2-talker-listener-{name}
 linux:
   auto:
     - action: "Create a directory, move the downloaded snapcraft.yaml file into the new directory and navigate there:"

--- a/webapp/first_snap/content/ros2/package.yaml
+++ b/webapp/first_snap/content/ros2/package.yaml
@@ -1,2 +1,2 @@
-name: test-ros2-talker-listener-{name}
+name: ros2-talker-listener-{name}
 download: git clone https://github.com/snapcraft-docs/ros2-talker-listener

--- a/webapp/first_snap/content/ros2/test.yaml
+++ b/webapp/first_snap/content/ros2/test.yaml
@@ -1,4 +1,4 @@
-name: test-ros2-talker-listener-{name}
+name: ros2-talker-listener-{name}
 linux:
   - action: "Install the snap:"
     command: sudo snap install --devmode --dangerous *.snap


### PR DESCRIPTION
## Done
- Remove "test" prefix from ROS examples
- Remove lsb-release dependency for ROS1
- Name ROS1 app with the name of the snap