### PR TITLE
Replace some bad gateway to 404s

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 # Sub dependencies pinned to avoid issues
 ruamel.yaml.clib==0.2.2
+click==8.0.3
 
 # App dependencies
 canonicalwebteam.flask-base==1.0.2
@@ -8,7 +9,7 @@ canonicalwebteam.discourse==4.0.8
 canonicalwebteam.blog==6.4.0
 canonicalwebteam.search==1.0.0
 canonicalwebteam.image-template==1.3.1
-canonicalwebteam.store-api==3.2.8
+canonicalwebteam.store-api==3.2.9
 canonicalwebteam.launchpad==0.8.3
 django-openid-auth==0.16
 Flask-OpenID==1.3.0

--- a/tests/store/tests_details.py
+++ b/tests/store/tests_details.py
@@ -52,7 +52,7 @@ class GetDetailsPageTest(TestCase):
 
     @responses.activate
     def test_api_404(self):
-        payload = {"error-list": []}
+        payload = {"error-list": [{"code": "resource-not-found"}]}
         responses.add(
             responses.Response(
                 method="GET", url=self.api_url, json=payload, status=404

--- a/webapp/publisher/views.py
+++ b/webapp/publisher/views.py
@@ -5,6 +5,7 @@ from canonicalwebteam.store_api.exceptions import (
     PublisherMacaroonRefreshRequired,
     PublisherMissingUsername,
     StoreApiTimeoutError,
+    StoreApiResourceNotFound,
 )
 from canonicalwebteam.store_api.stores.snapstore import SnapPublisher
 from canonicalwebteam.store_api.exceptions import (
@@ -58,6 +59,8 @@ def _handle_error(api_error: ApiError):
         return flask.redirect(flask.url_for("account.get_agreement"))
     elif type(api_error) is PublisherMacaroonRefreshRequired:
         return refresh_redirect(flask.request.path)
+    elif type(api_error) is StoreApiResourceNotFound:
+        return flask.abort(404, str(api_error))
     else:
         return flask.abort(502, str(api_error))
 

--- a/webapp/store/snap_details_views.py
+++ b/webapp/store/snap_details_views.py
@@ -14,6 +14,7 @@ from canonicalwebteam.flask_base.decorators import (
 )
 from canonicalwebteam.store_api.exceptions import (
     StoreApiError,
+    StoreApiResourceNotFound,
     StoreApiResponseDecodeError,
     StoreApiResponseError,
     StoreApiResponseErrorList,
@@ -30,6 +31,8 @@ def snap_details_views(store, api, handle_errors):
     def _get_context_snap_details(snap_name):
         try:
             details = api.get_item_details(snap_name, api_version=2)
+        except StoreApiResourceNotFound:
+            flask.abort(404, "No snap named {}".format(snap_name))
         except StoreApiTimeoutError as api_timeout_error:
             flask.abort(504, str(api_timeout_error))
         except StoreApiResponseDecodeError as api_response_decode_error:

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -9,6 +9,7 @@ from canonicalwebteam.store_api.stores.snapstore import SnapStore
 from canonicalwebteam.store_api.exceptions import (
     StoreApiConnectionError,
     StoreApiError,
+    StoreApiResourceNotFound,
     StoreApiResponseDecodeError,
     StoreApiResponseError,
     StoreApiResponseErrorList,
@@ -49,6 +50,8 @@ def store_blueprint(store_query=None):
             status_code = 502
         elif type(api_error) is StoreApiConnectionError:
             status_code = 502
+        elif type(api_error) is StoreApiResourceNotFound:
+            status_code = 404
 
         return status_code, error
 


### PR DESCRIPTION
## Done
- Replace some bad gateway to 404s

## How to QA
- Run `dotrun`
- Visit URLs for snaps that should return 404 on the publisher parts (listing, metrics, releases, etc...)

## Issue / Card
Fixes #3922
