### PR TITLE
[Sentry] Ignore AbortError messages

### DIFF
--- a/templates/_base-layout.html
+++ b/templates/_base-layout.html
@@ -30,6 +30,7 @@
         Raven.config('{{ SENTRY_DSN }}', {
           whitelistUrls: ['staging.snapcraft.io/static/js', 'snapcraft.io/static/js/'],
           ignoreUrls: ['staging.snapcraft.io/static/js/modules', 'snapcraft.io/static/js/modules'],
+          ignoreErrors: ['AbortError'],
           release: '{{ COMMIT_ID }}',
           environment: '{{ ENVIRONMENT }}'
         }).install();


### PR DESCRIPTION
## Done
- Add `AbortError` to the list of `ignoreErrors` for Sentry - these are triggered when the user aborts a request by either stopping the page loading or navigating away. They're not errors in the sense of something went wrong, but they manifest as 'the network request failed - because of the abort'.

## How to QA
- Visit the demo in your browser, link commented below
  - Or you can run the project locally using the [dotrun](https://snapcraft.io/dotrun) snap with `$ dotrun` and view it in your web browser at: http://0.0.0.0:8004/
  - If your demo doesn't work, read more about the [demoservice](https://discourse.ubuntu.com/t/demoservice/16862)
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- :shrug: 

## Issue / Card
Fixes #3933

