### PR TITLE
Check if GitHub app was revoked for snaps that are linked

### DIFF
--- a/templates/publisher/builds.html
+++ b/templates/publisher/builds.html
@@ -63,22 +63,26 @@ Builds for
     </div>
     {% endif %}
 
-    {% if github_repository and (not github_repository_exists or not yaml_file_exists) %}
-    <section class="p-strip is-shallow">
-      <div class="u-fixed-width">
-        <div class="p-notification--negative">
-          <div class="p-notification__content">
-            <p class="p-notification__message">
-              {% if not github_repository_exists %}
-              Your snap is linked to <a href="https://github.com/{{ github_repository }}" >{{ github_repository }}</a>, but this repository doesn&rsquo;t exist. <a href="/{{ snap_name }}/builds" aria-controls="repo-disconnect-modal">Disconnect repo</a>.
-              {% elif not yaml_file_exists %}
-              This repository doesn&rsquo;t contain snapcraft.yaml. More on <a href="https://snapcraft.io/docs/creating-snapcraft-yaml">how to create it</a>.
-              {% endif %}
-            </p>
+    {% if github_repository %}
+      {% if github_app_revoked or not github_repository_exists or not yaml_file_exists %}
+      <section class="p-strip is-shallow">
+        <div class="u-fixed-width">
+          <div class="p-notification--negative">
+            <div class="p-notification__content">
+              <p class="p-notification__message">
+                {% if github_app_revoked %}
+                Access was revoked to your GitHub account. Please check your GitHub OAuth apps or <a href="/github/auth?back=/{{ snap_name }}/builds">click here</a>.
+                {% elif not github_repository_exists %}
+                Your snap is linked to <a href="https://github.com/{{ github_repository }}" >{{ github_repository }}</a>, but this repository doesn&rsquo;t exist. <a href="/{{ snap_name }}/builds" aria-controls="repo-disconnect-modal">Disconnect repo</a>.
+                {% elif not yaml_file_exists %}
+                This repository doesn&rsquo;t contain snapcraft.yaml. More on <a href="https://snapcraft.io/docs/creating-snapcraft-yaml">how to create it</a>.
+                {% endif %}
+              </p>
+            </div>
           </div>
         </div>
-      </div>
-    </section>
+      </section>
+      {% endif %}
     {% endif %}
 
 

--- a/webapp/api/github.py
+++ b/webapp/api/github.py
@@ -267,6 +267,10 @@ class GitHub:
             return False
         elif response.status_code == 200:
             return True
+        elif response.status_code == 401:
+            raise Unauthorized
+
+        response.raise_for_status()
 
     def get_snapcraft_yaml_location(self, owner, repo):
         """
@@ -285,6 +289,8 @@ class GitHub:
                 continue
             elif response.status_code == 200:
                 return loc
+            elif response.status_code == 401:
+                raise Unauthorized
 
             response.raise_for_status()
 

--- a/webapp/publisher/snaps/build_views.py
+++ b/webapp/publisher/snaps/build_views.py
@@ -113,13 +113,15 @@ def get_snap_builds(snap_name):
         context["github_repository"] = lp_snap["git_repository_url"][19:]
         github_owner, github_repo = context["github_repository"].split("/")
 
-        context["github_repository_exists"] = github.check_if_repo_exists(
-            github_owner, github_repo
-        )
-
-        context["yaml_file_exists"] = github.get_snapcraft_yaml_location(
-            github_owner, github_repo
-        )
+        try:
+            context["github_repository_exists"] = github.check_if_repo_exists(
+                github_owner, github_repo
+            )
+            context["yaml_file_exists"] = github.get_snapcraft_yaml_location(
+                github_owner, github_repo
+            )
+        except Unauthorized:
+            context["github_app_revoked"] = True
 
         context.update(get_builds(lp_snap, slice(0, BUILDS_PER_PAGE)))
 


### PR DESCRIPTION
## Done
- Check if the GitHub app was revoked for snaps that are linked

## How to QA
- Locally connect your snap to the snapcraft.io GitHub OAuth app
- After that go to your GitHub setting and revoke the app
- Check that you get the following notification:
![image](https://user-images.githubusercontent.com/6353928/161148543-c52df896-5583-49f9-9edc-995c65698198.png)
- And check that the notification goes away after clicking on the link.

## Issue / Card
Fixes https://github.com/canonical-web-and-design/snapcraft.io/issues/3918
