### PR TITLE
Only show pipe if build-request-id is available

### DIFF
--- a/static/js/publisher/release/components/releasesTable/cellViews.js
+++ b/static/js/publisher/release/components/releasesTable/cellViews.js
@@ -155,8 +155,11 @@ export const RevisionInfo = ({
           />
         </span>
         <span className="p-release-data__meta">
-          {revision.version} | {revision.attributes["build-request-id"]}
-        </span>
+          {revision.version}
+          {revision.attributes["build-request-id"]
+            ? ` | ${revision.attributes["build-request-id"]}`
+            : ""}
+        </span>{" "}
       </span>
       <span className="p-tooltip__message">
         {isPending && "Pending release of:"}


### PR DESCRIPTION
## Done
- Added the pipe into a check if a build-request-id is available

## How to QA
- Visit the demo in your browser, link commented below
  - Or you can run the project locally using the [dotrun](https://snapcraft.io/dotrun) snap with `$ dotrun` and view it in your web browser at: http://0.0.0.0:8004/
  - If your demo doesn't work, read more about the [demoservice](https://discourse.ubuntu.com/t/demoservice/16862)
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Visit a couple of snaps release pages, if they were built with launchpad a pipe + build id should appear, if not no pipe should appear (just the version number)
- https://snapcraft-io-3945.demos.haus/deno/releases has examples of both

## Issue / Card
Fixes #3932

## Screenshots
![image](https://user-images.githubusercontent.com/479384/161563919-2adaeb8a-9908-4fd0-bcfb-81b714ed1ce2.png)

