### PR TITLE
Release UI - compact dates

### DIFF
--- a/static/js/publisher/release/components/releasesTable/channelHeading.js
+++ b/static/js/publisher/release/components/releasesTable/channelHeading.js
@@ -384,7 +384,7 @@ const ReleasesTableChannelHeading = (props) => {
 };
 
 ReleasesTableChannelHeading.propTypes = {
-  // props]
+  // props
   drag: PropTypes.func,
   risk: PropTypes.string.isRequired,
   branch: PropTypes.object,

--- a/static/js/publisher/release/components/releasesTable/channelHeading.js
+++ b/static/js/publisher/release/components/releasesTable/channelHeading.js
@@ -70,7 +70,6 @@ const ReleasesTableChannelHeading = (props) => {
     risk,
     branch,
     numberOfBranches,
-    archs,
     pendingChannelMap,
     openBranches,
     availableBranches,

--- a/static/js/publisher/release/components/releasesTable/channelHeading.js
+++ b/static/js/publisher/release/components/releasesTable/channelHeading.js
@@ -357,12 +357,8 @@ const ReleasesTableChannelHeading = (props) => {
         {risk !== AVAILABLE && (
           <span className="p-release-data__meta">
             {channelVersion}
-            {channelBuildDate &&
-              ` | ${format(channelBuildDate, "dd MMM yyyy")}`}
+            {channelBuildDate && ` | ${format(channelBuildDate, "dd MMM yy")}`}
           </span>
-        )}
-        {channelVersion && (
-          <span className="p-tooltip__message">{channelVersionTooltip}</span>
         )}
       </div>
 
@@ -388,7 +384,7 @@ const ReleasesTableChannelHeading = (props) => {
 };
 
 ReleasesTableChannelHeading.propTypes = {
-  // props
+  // props]
   drag: PropTypes.func,
   risk: PropTypes.string.isRequired,
   branch: PropTypes.object,

--- a/static/js/publisher/release/components/releasesTable/channelHeading.js
+++ b/static/js/publisher/release/components/releasesTable/channelHeading.js
@@ -251,35 +251,6 @@ const ReleasesTableChannelHeading = (props) => {
     }
   }
 
-  const channelVersionTooltip = (
-    <Fragment>
-      {Object.keys(versionsMap).map((version) => {
-        return (
-          <span key={`tooltip-${channel}-${version}`}>
-            {version}:{" "}
-            <b>
-              {versionsMap[version].length === archs.length
-                ? "All architectures"
-                : versionsMap[version].join(", ")}
-            </b>
-            <br />
-            {isLaunchpadBuild && (
-              <Fragment>
-                Build: <i className="p-icon--lp" /> <b>{channelBuild}</b>
-                <br />
-                Built at:{" "}
-                <b>
-                  {channelBuildDate &&
-                    format(channelBuildDate, "yyyy-MM-dd HH:mm")}
-                </b>
-              </Fragment>
-            )}
-          </span>
-        );
-      })}
-    </Fragment>
-  );
-
   let rowTitle = risk === AVAILABLE ? channelVersion : channel;
 
   if (risk === BUILD) {

--- a/static/sass/_snapcraft_release.scss
+++ b/static/sass/_snapcraft_release.scss
@@ -248,6 +248,7 @@
     display: block;
     overflow: hidden;
     text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   .p-release__progressive-percentage,


### PR DESCRIPTION
## Done
- Reduce year representation to the final two digits (I don't think anyone will expect snaps to have been built before 2000 or after 2100 at this point)
- Ensure if the version + date is too long for the cell, don't wrap text, hide it
- Removed tooltip that wasn't being used

## How to QA
- Visit the demo in your browser, link commented below
  - Or you can run the project locally using the [dotrun](https://snapcraft.io/dotrun) snap with `$ dotrun` and view it in your web browser at: http://0.0.0.0:8004/
  - If your demo doesn't work, read more about the [demoservice](https://discourse.ubuntu.com/t/demoservice/16862)
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Visit a snaps with many architectures and releases and long version numbers/names
- https://snapcraft-io-3946.demos.haus

## Issue / Card
Fixes #3923

## Screenshots
![image](https://user-images.githubusercontent.com/479384/161576933-393d8172-5495-4f6a-ad87-149efa968c61.png)

