### PR TITLE
Fix listing page tour buttons

### DIFF
--- a/static/js/publisher/tour/tourStepCard.js
+++ b/static/js/publisher/tour/tourStepCard.js
@@ -70,16 +70,16 @@ export default function TourStepCard({
           </span>
         )}
 
+        <small className="p-tour-controls__step">
+          {currentStepIndex + 1}/{steps.length}
+        </small>
         <span className="p-tour-controls__buttons">
-          <small className="p-tour-controls__step">
-            {currentStepIndex + 1}/{steps.length}
-          </small>
           <button
             disabled={currentStepIndex === 0}
             onClick={onPrevClick}
             className="p-button has-icon u-no-margin--bottom"
           >
-            <i className="p-icon--contextual-menu is-prev">Previous step</i>
+            <i className="p-icon--chevron-up is-prev">Previous step</i>
           </button>
           <button
             onClick={isLastStep ? onFinishClick : onNextClick}
@@ -88,9 +88,7 @@ export default function TourStepCard({
             {isLastStep ? (
               "Finish tour"
             ) : (
-              <i className="p-icon--contextual-menu is-light is-next">
-                Next step
-              </i>
+              <i className="p-icon--chevron-up is-light is-next">Next step</i>
             )}
           </button>
         </span>

--- a/static/sass/_snapcraft_tour.scss
+++ b/static/sass/_snapcraft_tour.scss
@@ -263,6 +263,7 @@
   }
 
   .p-tour-controls {
+    align-items: center;
     display: flex;
     justify-content: space-between;
     margin-top: $spv--large;
@@ -270,21 +271,23 @@
     // based on pagination pattern from Vanilla this turns contextual menu
     // chevron icon into < > arrows
     // let's hope Vanilla doesn't change this icon to something else ;)
-    .p-icon--contextual-menu.is-next {
+    .p-icon--chevron-up.is-next {
       transform: rotate(-90deg);
     }
 
-    .p-icon--contextual-menu.is-prev {
+    .p-icon--chevron-up.is-prev {
       transform: rotate(90deg);
     }
   }
 
   .p-tour-controls__buttons {
     display: flex;
-    margin-left: auto; // align right in flex parent
+    margin-left: $sph--small;
   }
 
   .p-tour-controls__step {
+    margin-bottom: 0;
+    margin-left: auto; // align right in flex parent
     margin-right: $sph--large;
   }
 }


### PR DESCRIPTION
## Done
- Updated `p-icon--contextual-menu` to `p-icon--chevron-up`
- Moved `p-tour-controls__step` outside of the button holder
- Aligned text vertically centre

## How to QA
- Visit the demo in your browser, link commented below
  - Or you can run the project locally using the [dotrun](https://snapcraft.io/dotrun) snap with `$ dotrun` and view it in your web browser at: http://0.0.0.0:8004/
  - If your demo doesn't work, read more about the [demoservice](https://discourse.ubuntu.com/t/demoservice/16862)
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Visit a snap and click the (?) in the bottom right
- Ensure the bottom of the tour looks ok

## Issue / Card
Fixes #3921

## Screenshots
![image](https://user-images.githubusercontent.com/479384/161729886-bdafc45e-1e59-4e42-8e7d-740f32d38d85.png)
