### PR TITLE
Add progressive release tooltip

### DIFF
--- a/static/js/publisher/release/components/releasesTable/releaseCell.js
+++ b/static/js/publisher/release/components/releasesTable/releaseCell.js
@@ -58,16 +58,15 @@ const ReleasesTableReleaseCell = (props) => {
   // check if there is a pending release in this cell
   const pendingRelease = hasPendingRelease(channel, arch);
 
-  let progressiveState;
   let previousRevision;
   let pendingProgressiveState;
 
   if (currentRevision) {
-    [
-      progressiveState,
-      previousRevision,
-      pendingProgressiveState,
-    ] = getProgressiveState(channel, arch, pendingRelease);
+    [previousRevision, pendingProgressiveState] = getProgressiveState(
+      channel,
+      arch,
+      pendingRelease
+    );
   }
 
   const isChannelPendingClose = pendingCloses.includes(channel);
@@ -133,9 +132,7 @@ const ReleasesTableReleaseCell = (props) => {
       <RevisionInfo
         revision={currentRevision}
         isPending={pendingRelease ? true : false}
-        progressiveState={progressiveState}
         previousRevision={previousRevision ? previousRevision : null}
-        pendingProgressiveState={pendingProgressiveState}
       />
     );
   } else if (isUnassigned) {
@@ -172,24 +169,6 @@ const ReleasesTableReleaseCell = (props) => {
       )}
 
       {cellInfoNode}
-      {!isChannelPendingClose &&
-        pendingProgressiveState &&
-        pendingProgressiveState.percentage && (
-          <span
-            className="p-release__progressive-pending-percentage"
-            style={{
-              width: `${pendingProgressiveState.percentage}%`,
-            }}
-          />
-        )}
-      {!isChannelPendingClose &&
-        progressiveState &&
-        progressiveState.percentage && (
-          <span
-            className="p-release__progressive-percentage"
-            style={{ width: `${progressiveState.percentage}%` }}
-          />
-        )}
     </ReleasesTableCellView>
   );
 };

--- a/static/js/publisher/release/components/revisionLabel.js
+++ b/static/js/publisher/release/components/revisionLabel.js
@@ -12,7 +12,9 @@ export default function RevisionLabel({
   let revisionLabel = revision.revision;
 
   if (isProgressive) {
-    revisionLabel = `${previousRevision} → ${revisionLabel}`;
+    revisionLabel = `${
+      previousRevision ? previousRevision : "?"
+    } → ${revisionLabel}`;
   }
 
   if (isInDevmode(revision)) {

--- a/static/js/publisher/release/selectors/index.js
+++ b/static/js/publisher/release/selectors/index.js
@@ -270,9 +270,8 @@ export function getRevisionsFromBuild(state, buildId) {
   );
 }
 
-// return an array of 3 items:
+// return an array of 2 items:
 // [
-//    current progressive release status,
 //    the previous revision number,
 //    the progressive release status of a pending release of the same release
 // ]
@@ -283,7 +282,6 @@ export function getProgressiveState(state, channel, arch, isPending) {
 
   const { releases, pendingReleases, revisions } = state;
 
-  let progressiveStatus = null;
   let previousRevision = null;
   let pendingProgressiveStatus = null;
 
@@ -297,8 +295,6 @@ export function getProgressiveState(state, channel, arch, isPending) {
     // If the release is pending we don't want to look up the previous state, as it will be
     // for an outdated release
     if (!isPending && release && release.progressive) {
-      progressiveStatus = jsonClone(release.progressive);
-
       previousRevision = allReleases[1];
 
       if (previousRevision && previousRevision.revision) {
@@ -328,7 +324,7 @@ export function getProgressiveState(state, channel, arch, isPending) {
     }
   }
 
-  return [progressiveStatus, previousRevision, pendingProgressiveStatus];
+  return [previousRevision, pendingProgressiveStatus];
 }
 
 // Is the latest release for a channel & architecture a valid revision?

--- a/static/js/publisher/release/selectors/selectors.test.js
+++ b/static/js/publisher/release/selectors/selectors.test.js
@@ -913,15 +913,7 @@ describe("getProgressiveState", () => {
   it("should return the progressive release state of a channel and arch", () => {
     expect(
       getProgressiveState(stateWithProgressiveEnabled, "latest/stable", "arch2")
-    ).toEqual([
-      {
-        key: "test",
-        paused: false,
-        percentage: 60,
-      },
-      "revision2",
-      null,
-    ]);
+    ).toEqual(["revision2", null]);
   });
 
   it("should return the progressiveState and pendingProgressiveStatus", () => {
@@ -932,7 +924,6 @@ describe("getProgressiveState", () => {
         "arch2"
       )
     ).toEqual([
-      { key: "test", paused: false, percentage: 60 },
       "revision2",
       { key: "progressive-test", paused: false, percentage: 40 },
     ]);

--- a/static/sass/_snapcraft_release.scss
+++ b/static/sass/_snapcraft_release.scss
@@ -251,42 +251,6 @@
     white-space: nowrap;
   }
 
-  .p-release__progressive-percentage,
-  .p-release__progressive-pending-percentage {
-    @include vf-animation(#{transform}, fast, in);
-
-    border-radius: 0 4px 4px 0;
-    bottom: 0;
-    height: 3px;
-    left: 0;
-    position: absolute;
-    transform: scaleX(1);
-    transform-origin: left;
-  }
-
-  .p-release__progressive-percentage {
-    background: $color-link;
-  }
-
-  .p-release__progressive-pending-percentage {
-    background: scale-color($color-link, $lightness: -20%);
-  }
-
-  .is-highlighted {
-    .p-release__progressive-percentage,
-    .p-release__progressive-pending-percentage {
-      height: 5px;
-    }
-  }
-
-  // stylelint-disable
-  .p-release__progressive-pending-percentage
-    + .p-release__progressive-percentage {
-    border-radius: 0;
-    border-right: 1px solid $color-x-light;
-  }
-  // stylelint-enable
-
   .p-contextual-menu__dropdown {
     overflow: visible; // allow tooltips inside menu
     z-index: 2; // workaround for https://github.com/canonical-web-and-design/vanilla-framework/issues/2577
@@ -406,11 +370,6 @@
 
       &:not(.p-releases-table__arch) {
         border-bottom: 3px solid $color-dark !important;
-      }
-
-      .p-release__progressive-percentage,
-      .p-release__progressive-pending-percentage {
-        transform: scaleX(0);
       }
 
       .p-release-data__title {


### PR DESCRIPTION
## Done
Added progressive release tooltip to releases table

## QA
- Go to https://snapcraft-io-3954.demos.haus/steve-test-snap/releases
- Check that there is a tooltip showing the progressive release status

## Issue
Fixes https://github.com/canonical-web-and-design/marketplace-tribe/issues/2332