### PR TITLE
Fix double publisher in header

### DIFF
--- a/templates/store/snap-details/_snap_heading_data.html
+++ b/templates/store/snap-details/_snap_heading_data.html
@@ -15,7 +15,7 @@
 {% endif %}
 <div class="p-snap-heading__title">
   <h1 class="p-heading--2 p-snap-heading__name" data-live="title">{{ snap_title }}</h1>
-  <div class="u-hide u-show--small">
+  <div class="u-hide--medium u-hide--large">
     {% if developer %}
     {% include 'store/_snap-header-developer-information.html' %}
     {% endif %}


### PR DESCRIPTION
## Done
- _A changelist description explaining what the change achieves and why you’re making it._

## How to QA
- Visit the demo in your browser, link commented below
  - Or you can run the project locally using the [dotrun](https://snapcraft.io/dotrun) snap with `$ dotrun` and view it in your web browser at: http://0.0.0.0:8004/
  - If your demo doesn't work, read more about the [demoservice](https://discourse.ubuntu.com/t/demoservice/16862)
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Visit https://charmhub-io-3955.demos.haus/microk8s and resize the browser - The canonical publisher should only ever be displayed once

## Issue / Card
Fixes #3953

## Screenshots
![image](https://user-images.githubusercontent.com/479384/162977570-24c7e3e0-e8f9-4738-b130-1b9f4b4c4b2b.png)
![image](https://user-images.githubusercontent.com/479384/162977655-b33017fb-73d1-4b89-b45e-b83e60b171f5.png)

