### PR TITLE
Use ID from URL in brand store settings

### DIFF
--- a/static/js/brand-store/Settings/Settings.test.tsx
+++ b/static/js/brand-store/Settings/Settings.test.tsx
@@ -10,7 +10,7 @@ import { RootState } from "./Settings";
 
 jest.mock("react-router-dom", () => ({
   ...jest.requireActual("react-router-dom"),
-  useParams: jest.fn().mockReturnValue({ id: "test" }),
+  useParams: jest.fn().mockReturnValue({ id: "test-id" }),
 }));
 
 function getInitialState(): RootState {

--- a/static/js/brand-store/Settings/Settings.tsx
+++ b/static/js/brand-store/Settings/Settings.tsx
@@ -181,7 +181,7 @@ function Settings() {
                   />
 
                   <PasswordToggle
-                    defaultValue={currentStore.id}
+                    defaultValue={id}
                     readOnly={true}
                     label="Store ID"
                     id="store-id"


### PR DESCRIPTION
## Done
In the brand store settings form, use the store ID from the URL to prevent the wrong ID being used when state has changed

## QA
- Go to https://snapcraft-io-3963.demos.haus/admin
- Go to a number of different stores settings pages e.g. /admin/<store-id>/settings
- Check that the ID in the "Store ID" field always matches the one in the URL

## Issue
Fixes #3959