### PR TITLE
Fix brand store sentry error

### DIFF
--- a/static/js/brand-store/Snaps/SnapsFilter.js
+++ b/static/js/brand-store/Snaps/SnapsFilter.js
@@ -22,7 +22,9 @@ function SnapsFilter({
         onKeyUp={(e) => {
           if (e.target.value) {
             setSnapsInStore(
-              snapsInStore.filter((snap) => snap.name.includes(e.target.value))
+              snapsInStore.filter((snap) =>
+                snap?.name?.includes(e.target.value)
+              )
             );
             setOtherStores(
               otherStoreIds.map((storeId) => {


### PR DESCRIPTION
## Done
Fixed a [Sentry error](https://sentry.is.canonical.com/canonical/snapcraft-io/issues/24375/) in the brand store

## QA
- Go to https://snapcraft-io-3967.demos.haus/admin/ahnuP3quahti9vis8aiw/snaps
- Use the search field to filter snaps and check that it works as expected

## Issue
Fixes #3965 