### PR TITLE
Don't log BadGateway errors to Sentry

### DIFF
--- a/webapp/handlers.py
+++ b/webapp/handlers.py
@@ -93,7 +93,11 @@ def set_handlers(app):
         error_name = getattr(error, "name", type(error).__name__)
         return_code = getattr(error, "code", 500)
 
-        if not app.testing:
+        supress_sentry = False
+        if type(error).__name__ == 'BadGateway':
+            supress_sentry = True
+
+        if not app.testing and not supress_sentry:
             app.extensions["sentry"].captureException()
 
         return (

--- a/webapp/handlers.py
+++ b/webapp/handlers.py
@@ -94,7 +94,7 @@ def set_handlers(app):
         return_code = getattr(error, "code", 500)
 
         supress_sentry = False
-        if type(error).__name__ == 'BadGateway':
+        if type(error).__name__ == "BadGateway":
             supress_sentry = True
 
         if not app.testing and not supress_sentry:


### PR DESCRIPTION
## Done
- Check for the error type before logging

## How to QA
- Visit the demo in your browser, link commented below
  - Or you can run the project locally using the [dotrun](https://snapcraft.io/dotrun) snap with `$ dotrun` and view it in your web browser at: http://0.0.0.0:8004/
  - If your demo doesn't work, read more about the [demoservice](https://discourse.ubuntu.com/t/demoservice/16862)
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Modify `{virtualenv}/lib/python3.8/site-packages/canonicalwebteam/store_api/store.py` to immediately `raise` the `StoreAPIConnectionError` at the top of `process_response`.
- Load the site

## Issue / Card
Fixes #3970 

