### PR TITLE
Remove release UI actions on mobile

### DIFF
--- a/static/js/publisher/release/components/contextualMenu.js
+++ b/static/js/publisher/release/components/contextualMenu.js
@@ -69,7 +69,7 @@ export default class ContextualMenu extends Component {
       <span
         className={`p-contextual-menu${
           position ? `--${position}` : ""
-        } p-promote-button`}
+        } p-promote-button u-hide--small`}
       >
         <button
           className={className}

--- a/static/js/publisher/release/components/dnd.js
+++ b/static/js/publisher/release/components/dnd.js
@@ -4,7 +4,7 @@ import { useDrag, useDrop } from "react-dnd";
 export const DND_ITEM_REVISIONS = "DND_ITEM_REVISIONS";
 
 export const Handle = () => (
-  <span className="p-drag-handle">
+  <span className="p-drag-handle u-hide--small">
     <i className="p-icon--drag" />
   </span>
 );

--- a/static/js/publisher/release/components/releasesTable/cellViews.js
+++ b/static/js/publisher/release/components/releasesTable/cellViews.js
@@ -54,7 +54,7 @@ export const EmptyInfo = ({ trackingChannel }) => {
         )}
       </span>
 
-      <span className="p-tooltip__message">
+      <span className="p-tooltip__message u-hide--small">
         {trackingChannel
           ? `Tracking ${trackingChannel}`
           : "Nothing currently released"}
@@ -193,7 +193,7 @@ export const RevisionInfo = ({
             }`}
         </span>{" "}
       </span>
-      <span className="p-tooltip__message">
+      <span className="p-tooltip__message u-hide--small">
         {isProgressive ? (
           <ProgressiveTooltip
             revision={revision}

--- a/static/js/publisher/release/components/releasesTable/channelHeading.js
+++ b/static/js/publisher/release/components/releasesTable/channelHeading.js
@@ -306,7 +306,7 @@ const ReleasesTableChannelHeading = (props) => {
           </span>
         </div>
 
-        <span className="p-releases-table__menus">
+        <span className="p-releases-table__menus u-hide--small">
           {(canBePromoted || canBeClosed) && (
             <ChannelMenu
               tooltip={promoteTooltip}

--- a/static/js/publisher/release/releasesController.js
+++ b/static/js/publisher/release/releasesController.js
@@ -67,6 +67,19 @@ const ReleasesController = ({
       {ready && (
         <Fragment>
           {visible && <Notification />}
+          <div className="u-fixed-width u-hide--large u-hide--medium">
+            <div className="p-notification--caution">
+              <div className="p-notification__content">
+                <h5 className="p-notification__title">
+                  This is a read-only view
+                </h5>
+                <p className="p-notification__message">
+                  Some features are not available on this view. Switch to a
+                  tablet or desktop to edit.
+                </p>
+              </div>
+            </div>
+          </div>
           <ReleasesHeading />
           <ReleasesTable />
           {showModal && <Modal />}


### PR DESCRIPTION
## Done
- Removed actions on release UI on mobile
- Added a notification on release UI on mobile to tell user it's read only

## QA
- Go to https://snapcraft-io-3978.demos.haus/notion-snap/releases
- Resize to mobile size
- There should be no drag handles, buttons (except the expand chevron) or tooltips on any of the table cells

## Issue
Fixes #2479, #2480