### PR TITLE
Convert release UI history table to cards

### DIFF
--- a/static/js/publisher/release/components/revisionsList.js
+++ b/static/js/publisher/release/components/revisionsList.js
@@ -339,7 +339,7 @@ class RevisionsList extends Component {
             </div>
           </div>
         )}
-        <table className="p-revisions-list">
+        <table className="p-revisions-list p-table--mobile-card">
           <thead>
             <tr>
               <th

--- a/static/js/publisher/release/components/revisionsListRow.js
+++ b/static/js/publisher/release/components/revisionsListRow.js
@@ -85,7 +85,7 @@ const RevisionsListRow = (props) => {
       className={className}
       onClick={isSelectable && releasable ? revisionSelectChange : null}
     >
-      <td>
+      <td data-heading="Revision">
         {isSelectable ? (
           <label className="p-radio">
             <input
@@ -110,11 +110,11 @@ const RevisionsListRow = (props) => {
           </span>
         )}
       </td>
-      <td>{revision.version}</td>
+      <td data-heading="Version">{revision.version}</td>
       {showBuildRequest && <td>{buildRequestId && <>{buildRequestId}</>}</td>}
       {canShowProgressiveReleases &&
         (isProgressive ? (
-          <td>
+          <td data-heading="Release progress">
             <ProgressiveProgressChart
               current={revision?.progressive?.["current-percentage"]}
               target={revision?.progressive?.percentage}
@@ -143,16 +143,13 @@ const RevisionsListRow = (props) => {
             </div>
           </td>
         ) : (
-          <td></td>
+          <td data-heading="Release progress">-</td>
         ))}
 
-      {progressiveBeingCancelled && (
-        <td>
-          <em>Cancel progressive release</em>
-        </td>
+      {showChannels && (
+        <td data-heading="Channels">{revision.channels.join(", ")}</td>
       )}
-      {showChannels && <td>{revision.channels.join(", ")}</td>}
-      <td>
+      <td data-heading="Release date">
         {isPending && <em>pending release</em>}
         {!isPending && !progressiveBeingCancelled && (
           <span

--- a/static/js/publisher/release/releasesController.js
+++ b/static/js/publisher/release/releasesController.js
@@ -81,6 +81,19 @@ const ReleasesController = ({
             </div>
           </div>
           <ReleasesHeading />
+          <div className="u-fixed-width u-hide--large u-hide--medium">
+            <div className="p-notification--caution">
+              <div className="p-notification__content">
+                <h5 className="p-notification__title">
+                  This is a read-only view
+                </h5>
+                <p className="p-notification__message">
+                  Some features are not available on this view. Switch to a
+                  tablet or desktop to edit.
+                </p>
+              </div>
+            </div>
+          </div>
           <ReleasesTable />
           {showModal && <Modal />}
           <ReleasesConfirm />

--- a/static/js/publisher/release/releasesController.js
+++ b/static/js/publisher/release/releasesController.js
@@ -81,19 +81,6 @@ const ReleasesController = ({
             </div>
           </div>
           <ReleasesHeading />
-          <div className="u-fixed-width u-hide--large u-hide--medium">
-            <div className="p-notification--caution">
-              <div className="p-notification__content">
-                <h5 className="p-notification__title">
-                  This is a read-only view
-                </h5>
-                <p className="p-notification__message">
-                  Some features are not available on this view. Switch to a
-                  tablet or desktop to edit.
-                </p>
-              </div>
-            </div>
-          </div>
           <ReleasesTable />
           {showModal && <Modal />}
           <ReleasesConfirm />


### PR DESCRIPTION
## Done
Made the release UI history table use the Vanilla card pattern

## QA
- Go to https://snapcraft-io-3979.demos.haus/notion-snap/releases
- Expand any of the table cells and resize the browser to mobile size
- The history table should display as the Vanilla cards pattern

## Issue
Fixes #2328