### PR TITLE
Redirect status.snapcraft.io to the site without query params

### DIFF
--- a/static/js/base/ga.js
+++ b/static/js/base/ga.js
@@ -89,4 +89,16 @@ if (typeof dataLayer !== "undefined") {
   });
 }
 
+// We want to prevent any query parameters being added to status.snapcraft.io
+// See https://github.com/canonical-web-and-design/snapcraft.io/issues/3789
+// Google analytics does it, but status.snapcraft.io fails to load with any
+// query parameters
+document
+  .querySelector("[href^='https://status.snapcraft.io']")
+  .addEventListener("click", (e) => {
+    e.preventDefault();
+    const origin = e.path.find((path) => path.origin).origin;
+    window.location.href = origin;
+  });
+
 export { triggerEvent, triggerEventReleaseUI };


### PR DESCRIPTION
## Done
- Add click handler for https://status.snapcraft.io to strip query params.

## How to QA
- Pull the code, add a query parameter to the footer link
- Click the link

## Issue / Card
Fixes #3789

## Screenshots
![output](https://user-images.githubusercontent.com/479384/170247259-103329f7-7d02-4665-a661-8df7fc0dd3e9.gif)

