### PR TITLE
Admin: Fix missing snaps from the Global store

### DIFF
--- a/static/js/brand-store/Snaps/Snaps.js
+++ b/static/js/brand-store/Snaps/Snaps.js
@@ -224,9 +224,7 @@ function Snaps() {
     setGlobalStore({
       id: "ubuntu",
       name: "Global",
-      snaps: snaps.filter(
-        (snap) => snap.store === "ubuntu" && !snap["other-stores"].length
-      ),
+      snaps: snaps.filter((snap) => snap.store === "ubuntu"),
     });
 
     setOtherStores(


### PR DESCRIPTION
## Done
- Fix missing snaps from the Global store

## How to QA
- Visit the web and design store: https://snapcraft-io-4013.demos.haus//admin/ahnuP3quahti9vis8aiw/snaps
- Check that the global store has a long list of snaps:
![image](https://user-images.githubusercontent.com/6353928/170967293-7d3f17d7-60f3-4eea-91ee-20895add0bd6.png)


## Issue / Card
Fixes #4012
