### PR TITLE
Fix video not displaying on snap detail pages

### DIFF
--- a/templates/store/snap-details.html
+++ b/templates/store/snap-details.html
@@ -149,7 +149,7 @@
     {% include "store/snap-details/_channel_map.html" %}
   {% endif %}
 
-  {% if screenshots or videos or is_preview %}
+  {% if screenshots or video or is_preview %}
     <div class="p-strip--light is-shallow">
       {% include "store/snap-details/_screenshots.html" %}
     </div>


### PR DESCRIPTION
## Done
Fixed videos not showing on snap detail pages

## QA
- Go to https://snapcraft-io-4014.demos.haus/danieltest-snap
- Check that there is a video on the page

## Issue
Fixes #3829