### PR TITLE
Add release progress chart for previous revisions

### DIFF
--- a/static/js/publisher/release/components/ProgressiveReleaseProgressChart.tsx
+++ b/static/js/publisher/release/components/ProgressiveReleaseProgressChart.tsx
@@ -38,7 +38,7 @@ function ProgressiveReleaseProgressChart({
             Current
           </span>
         </span>
-        <span>&nbsp;{isPreviousRevision ? "←" : "→"}&nbsp;</span>
+        <span>&nbsp;→&nbsp;</span>
         <span className="u-align--right">
           {Math.round(targetPercentage ? targetPercentage : 0)}%
           <br />

--- a/static/js/publisher/release/components/ProgressiveReleaseProgressChart.tsx
+++ b/static/js/publisher/release/components/ProgressiveReleaseProgressChart.tsx
@@ -38,7 +38,7 @@ function ProgressiveReleaseProgressChart({
             Current
           </span>
         </span>
-        <span>&nbsp;→&nbsp;</span>
+        <span>&nbsp;{isPreviousRevision ? "←" : "→"}&nbsp;</span>
         <span className="u-align--right">
           {Math.round(targetPercentage ? targetPercentage : 0)}%
           <br />

--- a/static/js/publisher/release/components/ProgressiveReleaseProgressChart.tsx
+++ b/static/js/publisher/release/components/ProgressiveReleaseProgressChart.tsx
@@ -1,0 +1,54 @@
+import React from "react";
+
+type ReleaseProgress = {
+  currentPercentage: number;
+  targetPercentage: number;
+  isPreviousRevision: boolean;
+};
+
+function ProgressiveReleaseProgressChart({
+  currentPercentage,
+  targetPercentage,
+  isPreviousRevision,
+}: ReleaseProgress) {
+  return (
+    <div
+      className={
+        isPreviousRevision ? "previous-progressive-progress-chart" : ""
+      }
+    >
+      <div className="progressive-progress-bar u-hide--small">
+        <div
+          className="progressive-progress-bar__inner"
+          style={{ width: `${currentPercentage ? currentPercentage : 0}%` }}
+        ></div>
+        <div
+          className="progressive-progress-bar__marker"
+          style={{
+            left: `${Math.round(targetPercentage ? targetPercentage : 0)}%`,
+          }}
+        ></div>
+      </div>
+      <div className="u-space-between" style={{ maxWidth: "320px" }}>
+        <span>
+          {Math.round(currentPercentage ? currentPercentage : 0)}
+          %
+          <br />
+          <span className="progressive-chart-key--current p-muted-heading u-hide--small">
+            Current
+          </span>
+        </span>
+        <span>&nbsp;→&nbsp;</span>
+        <span className="u-align--right">
+          {Math.round(targetPercentage ? targetPercentage : 0)}%
+          <br />
+          <span className="progressive-chart-key--target p-muted-heading u-hide--small">
+            Target
+          </span>
+        </span>
+      </div>
+    </div>
+  );
+}
+
+export default ProgressiveReleaseProgressChart;

--- a/static/js/publisher/release/components/revisionsList.js
+++ b/static/js/publisher/release/components/revisionsList.js
@@ -42,6 +42,7 @@ class RevisionsList extends Component {
 
   renderRow(
     revision,
+    previousRevision,
     isSelectable,
     showChannels,
     isPending,
@@ -56,6 +57,7 @@ class RevisionsList extends Component {
       <RevisionsListRow
         key={rowKey}
         revision={revision}
+        previousRevision={previousRevision}
         isSelectable={isSelectable}
         showChannels={showChannels}
         isPending={isPending}
@@ -101,8 +103,11 @@ class RevisionsList extends Component {
           ? true
           : false;
 
+      const previousRevision = revisions[index - 1];
+
       return this.renderRow(
         revision,
+        previousRevision,
         isSelectable,
         showChannels,
         false,
@@ -375,6 +380,7 @@ class RevisionsList extends Component {
             {showPendingRelease &&
               this.renderRow(
                 pendingRelease.revision,
+                previousRevision,
                 !isReleaseHistory,
                 showChannels,
                 true,

--- a/static/js/publisher/release/components/revisionsListRow.js
+++ b/static/js/publisher/release/components/revisionsListRow.js
@@ -15,30 +15,12 @@ import {
 } from "../selectors";
 
 import RevisionLabel from "./revisionLabel";
-
-const ProgressiveProgressChart = ({ current, target }) => {
-  return (
-    <div className="progressive-progress-bar u-hide--small">
-      <div
-        className="progressive-progress-bar__inner"
-        style={{ width: `${current}%` }}
-      ></div>
-      <div
-        className="progressive-progress-bar__marker"
-        style={{ left: `${Math.round(target)}%` }}
-      ></div>
-    </div>
-  );
-};
-
-ProgressiveProgressChart.propTypes = {
-  current: PropTypes.number,
-  target: PropTypes.number,
-};
+import ProgressiveReleaseProgressChart from "./ProgressiveReleaseProgressChart";
 
 const RevisionsListRow = (props) => {
   const {
     revision,
+    previousRevision,
     isSelectable,
     showChannels,
     showBuildRequest,
@@ -57,6 +39,9 @@ const RevisionsListRow = (props) => {
   const isSelected = props.selectedRevisions.includes(revision.revision);
 
   const isProgressive = revision?.progressive?.percentage ? true : false;
+  const isPreviousProgressive = previousRevision?.progressive?.percentage
+    ? true
+    : false;
 
   let channel;
   if (revision.release) {
@@ -116,39 +101,26 @@ const RevisionsListRow = (props) => {
           {buildRequestId && <>{buildRequestId}</>}
         </td>
       )}
-      {canShowProgressiveReleases &&
-        (isProgressive ? (
-          <td data-heading="Release progress">
-            <ProgressiveProgressChart
-              current={revision?.progressive?.["current-percentage"]}
-              target={revision?.progressive?.percentage}
-            />
-            <div className="u-space-between" style={{ maxWidth: "320px" }}>
-              <span>
-                {Math.round(
-                  revision?.progressive?.["current-percentage"]
-                    ? revision?.progressive?.["current-percentage"]
-                    : 0
-                )}
-                %
-                <br />
-                <span className="progressive-chart-key--current p-muted-heading u-hide--small">
-                  Current
-                </span>
-              </span>
-              <span>&nbsp;→&nbsp;</span>
-              <span className="u-align--right">
-                {Math.round(revision?.progressive?.percentage)}%
-                <br />
-                <span className="progressive-chart-key--target p-muted-heading u-hide--small">
-                  Target
-                </span>
-              </span>
-            </div>
-          </td>
-        ) : (
-          <td data-heading="Release progress">-</td>
-        ))}
+      {canShowProgressiveReleases && isProgressive ? (
+        <td data-heading="Release progress">
+          <ProgressiveReleaseProgressChart
+            currentPercentage={revision?.progressive?.["current-percentage"]}
+            targetPercentage={revision?.progressive?.percentage}
+          />
+        </td>
+      ) : isPreviousProgressive ? (
+        <td data-heading="Release progress">
+          <ProgressiveReleaseProgressChart
+            currentPercentage={100 - previousRevision?.progressive?.percentage}
+            targetPercentage={
+              100 - previousRevision?.progressive?.["current-percentage"]
+            }
+            isPreviousRevision={true}
+          />
+        </td>
+      ) : (
+        <td data-heading="Release progress">-</td>
+      )}
 
       {showChannels && (
         <td data-heading="Channels">{revision.channels.join(", ")}</td>
@@ -178,6 +150,7 @@ const RevisionsListRow = (props) => {
 RevisionsListRow.propTypes = {
   // props
   revision: PropTypes.object.isRequired,
+  previousRevision: PropTypes.object,
   isSelectable: PropTypes.bool,
   showChannels: PropTypes.bool,
   isPending: PropTypes.bool,

--- a/static/sass/_snapcraft_release.scss
+++ b/static/sass/_snapcraft_release.scss
@@ -777,6 +777,10 @@
     background-color: #652466;
   }
 
+  .previous-progressive-progress-chart .progressive-chart-key--current::after {
+    background-color: #43717e;
+  }
+
   .progressive-chart-key--target::after {
     background-color: #5a5a5a;
   }
@@ -789,6 +793,10 @@
     max-width: 320px;
     position: relative;
     width: 100%;
+
+    .previous-progressive-progress-chart & {
+      background-color: #d7e1e3;
+    }
   }
 
   .progressive-progress-bar__inner {
@@ -796,6 +804,10 @@
     border-bottom-left-radius: 10px;
     border-top-left-radius: 10px;
     height: 10px;
+
+    .previous-progressive-progress-chart & {
+      background-color: #43717e;
+    }
   }
 
   .progressive-progress-bar__marker {


### PR DESCRIPTION
## Done
Added the progressive releases progress chart for previous revisions

## QA
- Go to https://snapcraft-io-4015.demos.haus/notion-snap/releases
- Expand a release row that has a progressive release
- Check that the previous revision has a chart that shows the inverse of the progressive release chart

## Issue
Fixes #3973