### PR TITLE
Move listing page links to sidebar

### DIFF
--- a/templates/store/snap-details.html
+++ b/templates/store/snap-details.html
@@ -160,19 +160,13 @@
       <div class="col-8 u-text-wrap">
         {% if summary or is_preview %}<h4 data-live="summary">{{ summary }}</h4>{% endif %}
         <div data-live="description">{{ description | safe }}</div>
-        {% if website or is_preview %}<p><a href="{{ website }}" data-live="website">Developer website</a></p>{% endif %}
-        {% if contact or is_preview %}
-          <p>
-            <a href="{{ contact }}" data-live="contact">Contact {{ publisher }}</a>
-          </p>
-        {% endif %}
       </div>
       <div class="col-4">
         {% include "store/snap-details/_details.html" %}
 
         {# EMBEDDABLE CARD SECTION - hidden in preview #}
         {% if not is_preview and not IS_BRAND_STORE %}
-          <h4>Share this snap</h4>
+          <h4 style="margin-top: 1rem;">Share this snap</h4>
           <p>Generate an embeddable card to be shared on external websites.</p>
           <p><button class="p-button js-embedded-card-toggle">Create embeddable card</button></p>
 

--- a/templates/store/snap-details/_details.html
+++ b/templates/store/snap-details/_details.html
@@ -1,7 +1,28 @@
 <h4>Details for {{ snap_title }}</h4>
-<dl>
-  <dt>License</dt>
-  <dd data-live="license">{{ license }}</dd>
-  <dt>Last updated</dt>
-  <dd>{{ last_updated }}</dd>
-</dl>
+
+<h5 class="u-no-margin--bottom">License</h5>
+<p>{{ license }}</p>
+
+<hr>
+
+<h5 class="u-no-margin--bottom">Last updated</h5>
+<p>{{ last_updated }}</p>
+
+<hr>
+
+<h5 class="u-no-margin--bottom">Links</h5>
+<ul class="p-list">
+  {% if website or is_preview %}
+    <li>
+      <a href="{{ website }}" data-live="website">Developer website</a>
+    </li>
+  {% endif %}
+          
+  {% if contact or is_preview %}
+    <li>
+      <a href="{{ contact }}" data-live="contact">Contact {{ publisher }}</a>
+    </li>
+  {% endif %}
+</ul>
+
+<hr>


### PR DESCRIPTION
## Done
Moved the links section on the listing page to the sidebar to bring it closer to the [metadata links design](https://app.zeplin.io/project/60d33b2bc5b9ab16ff7b90a6/screen/6194e2c128de08ab62923837)

## How to QA
- Go to https://snapcraft-io-4018.demos.haus/notion-snap
- Check that the website and contact links are now in the sidebar and not below the description

## Issue / Card
Fixes [#2605](https://github.com/canonical-web-and-design/marketplace-tribe/issues/2605)

## Screenshots
![Screenshot 2022-06-07 at 09 19 04](https://user-images.githubusercontent.com/501889/172332493-43ffeb94-2dcf-4c7f-a464-320bf5d44646.jpg)
