### PR TITLE
Add metadata links to listing page template

### DIFF
--- a/static/sass/_snapcraft_metadata-links.scss
+++ b/static/sass/_snapcraft_metadata-links.scss
@@ -1,0 +1,28 @@
+@mixin snapcraft-metadata-links {
+  .p-links-list__item {
+    position: relative;
+
+    &:not(:last-child) {
+      margin-bottom: 0.25rem;
+      padding-bottom: 0.75rem;
+
+      &::after {
+        background-color: $color-light;
+        bottom: 0;
+        content: "";
+        height: 1px;
+        left: 0;
+        position: absolute;
+        width: 100%;
+      }
+    }
+  }
+
+  .external-link-protocol--positive {
+    color: $color-positive;
+  }
+
+  .external-link-protocol--negative {
+    color: $color-negative;
+  }
+}

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -229,8 +229,14 @@ $color-social-icon-foreground: $color-light;
 @import "snapcraft_p-autocomplete";
 @include snapcraft-autocomplete;
 @include snapcraft-p-icons;
+@import "snapcraft_metadata-links";
+@include snapcraft-metadata-links;
 @include vf-p-form-password-toggle;
 @include vf-p-icon-status-waiting;
+@include vf-p-icon-submit-bug;
+@include vf-p-icon-code;
+@include vf-p-icon-exposed;
+@include vf-p-icon-email;
 
 dl {
   margin-bottom: $spv--x-large;
@@ -380,4 +386,8 @@ code {
   @media (min-width: 1036px) {
     display: none !important;
   }
+}
+
+.u-no-max-width {
+  max-width: 100% !important;
 }

--- a/templates/store/snap-details/_details.html
+++ b/templates/store/snap-details/_details.html
@@ -10,19 +10,219 @@
 
 <hr>
 
+<!-- Once `links` is added to the API we can remove the `request.args` check -->
+{% if links and request.args.get("show_metadata_links") %}
 <h5 class="u-no-margin--bottom">Links</h5>
 <ul class="p-list">
-  {% if website or is_preview %}
-    <li>
-      <a href="{{ website }}" data-live="website">Developer website</a>
-    </li>
+  {% if links["website"] %}
+  <li class="p-links-list__item">
+    {% if links["website"]|length == 1 %}
+      <p class="u-no-margin--bottom">
+        <a class="js-external-link" title="{{ links['website'][0] }}" href="{{ links['website'][0] }}" aria-controls="modal">Website</a>
+      </p>
+    {% else %}
+      <p class="u-no-margin--bottom">Websites</p>
+      <ul class="p-list">
+        {% for link in links["website"] %}
+          <li>
+            <a class="js-external-link" title="{{ link }}" href="{{ link }}" aria-controls="modal">{{ format_link(link) }}</a>
+          </li>
+        {% endfor %}
+      </ul>  
+    {% endif %}
+  </li>
   {% endif %}
-          
-  {% if contact or is_preview %}
-    <li>
-      <a href="{{ contact }}" data-live="contact">Contact {{ publisher }}</a>
-    </li>
+
+  {% if links["contact"] %}
+  <li class="p-links-list__item">
+    {% if links["contact"]|length == 1 %}
+      <p class="u-no-margin--bottom">
+        <a class="js-external-link" title="{{ links['contact'][0] }}" href="{{ links['contact'][0] }}" aria-controls="modal">Contact</a>
+      </p>
+    {% else %}
+      <p class="u-no-margin--bottom">Contact</p>
+      <ul class="p-list">
+        {% for link in links["contact"] %}
+          <li>
+            <a class="js-external-link" title="{{ link }}" href="{{ link }}" aria-controls="modal">{{ format_link(link) }}</a>
+          </li>
+        {% endfor %}
+      </ul>  
+    {% endif %}
+  </li>
+  {% endif %}
+
+  {% if links["donation"] %}
+  <li class="p-links-list__item">
+    {% if links["donation"]|length == 1 %}
+      <p class="u-no-margin--bottom">
+        <a class="js-external-link" title="{{ links['donation'][0] }}" href="{{ links['donation'][0] }}" aria-controls="modal">Donations</a>
+      </p>
+    {% else %}
+      <p class="u-no-margin--bottom">Donations</p>
+      <ul class="p-list">
+        {% for link in links["donation"] %}
+          <li>
+            <a class="js-external-link" title="{{ link }}" href="{{ link }}" aria-controls="modal">{{ format_link(link) }}</a>
+          </li>
+        {% endfor %}
+      </ul>  
+    {% endif %}
+  </li>
+  {% endif %}
+
+  {% if links["source-code"] %}
+  <li class="p-links-list__item">
+    {% if links["source-code"]|length == 1 %}
+      <p class="u-no-margin--bottom">
+        <a class="js-external-link" title="{{ links['source-code'][0] }}" href="{{ links['source-code'][0] }}" aria-controls="modal">Source code</a>
+      </p>
+    {% else %}
+      <p class="u-no-margin--bottom">Source code</p>
+      <ul class="p-list">
+        {% for link in links["source-code"] %}
+          <li>
+            <a class="js-external-link" title="{{ link }}" href="{{ link }}" aria-controls="modal">{{ format_link(link) }}</a>
+          </li>
+        {% endfor %}
+      </ul>  
+    {% endif %}
+  </li>
+  {% endif %}
+
+  {% if links["issues"] %}
+  <li class="p-links-list__item">
+    {% if links["issues"]|length == 1 %}
+      <p class="u-no-margin--bottom">
+        <a class="js-external-link" title="{{ links['issues'][0] }}" href="{{ links['issues'][0] }}" aria-controls="modal">Report a bug</a>
+      </p>
+    {% else %}
+      <p class="u-no-margin--bottom">Report a bug</p>
+      <ul class="p-list">
+        {% for link in links["issues"] %}
+          <li>
+            <a class="js-external-link" title="{{ link }}" href="{{ link }}" aria-controls="modal">{{ format_link(link) }}</a>
+          </li>
+        {% endfor %}
+      </ul>  
+    {% endif %}
+  </li>
   {% endif %}
 </ul>
-
 <hr>
+
+<div class="p-modal js-exeternal-link-modal u-hide" id="modal">
+  <section class="p-modal__dialog" role="dialog" aria-modal="true" aria-labelledby="modal-title" aria-describedby="modal-description">
+    <header class="p-modal__header">
+      <h2 class="p-modal__title" id="modal-title"><i class="p-icon--warning" style="width: 1rem; height: 1rem; position: relative; top: 1px; margin-right: 0.24rem;"></i> External link warning</h2>
+    </header>
+    <p class="u-no-max-width">You are about to open <span class="js-external-link-url"></span></p>
+    <p class="u-no-max-width">Do you wish to proceed?</p>
+    </p>
+    <footer class="p-modal__footer">
+      <button class="u-no-margin--bottom js-close-modal" aria-controls="modal">Go back</button>
+      <a class="p-button--positive u-no-margin--bottom js-open-external-link" href="" target="_blank">Proceed</a>
+    </footer>
+  </section>
+</div>
+
+<script>
+  const externalLinks = document.querySelectorAll(".js-external-link");
+  const externalLinkModal = document.querySelector(".js-exeternal-link-modal");
+  const externalLinkModalCloseButton = externalLinkModal.querySelector(
+    ".js-close-modal"
+  );
+  const externalLinkUrl = externalLinkModal.querySelector(
+    ".js-external-link-url"
+  );
+  const openExternalLinkButton = externalLinkModal.querySelector(
+    ".js-open-external-link"
+  );
+  
+  function openModal() {
+    externalLinkModal.classList.remove("u-hide");
+  }
+  
+  function closeModal() {
+    externalLinkModal.classList.add("u-hide");
+  }
+
+  function setLinkDisplayText(href) {
+    if (href.includes("mailto")) {
+      externalLinkUrl.innerText = href;
+      return;
+    }
+
+    const url = new URL(href);
+
+    const protocolContainer = document.createElement("strong");
+    const hostnameContainer = document.createElement("strong");
+    const pathContainer = document.createElement("span");
+    const searchContainer = document.createElement("span");
+
+    protocolContainer.classList.add(
+      url.protocol === "https:" ? 
+        "external-link-protocol--positive" : "external-link-protocol--negative"
+    );
+
+    pathContainer.classList.add("u-text-muted");
+    searchContainer.classList.add("u-text-muted");
+
+    protocolContainer.innerText = `${url.protocol}//`;
+    hostnameContainer.innerText = url.hostname;
+    
+    if (url.pathname && url.pathname !== "/") {
+      pathContainer.innerText = url.pathname;
+
+    }
+    
+    searchContainer.innerText = url.search;
+
+    externalLinkUrl.innerHTML = "";
+    externalLinkUrl.appendChild(protocolContainer);
+    externalLinkUrl.appendChild(hostnameContainer);
+    externalLinkUrl.appendChild(pathContainer);
+    externalLinkUrl.appendChild(searchContainer);
+  }
+
+  externalLinkModalCloseButton.addEventListener("click", () => {
+    closeModal();
+  });
+
+  externalLinks.forEach((link) => { 
+    
+    link.addEventListener("click", (e) => {
+      e.preventDefault();
+      const href = e.target.href;
+      openExternalLinkButton.href = href;
+      openExternalLinkButton.addEventListener("click", handleOpenExternalLink); 
+      setLinkDisplayText(href);
+      openModal();
+    });
+  });
+
+  function handleOpenExternalLink() {
+    closeModal();
+    openExternalLinkButton.removeEventListener("click", handleOpenExternalLink);
+  }
+</script>
+
+<!-- Once `links` is added to the API we can remove this `else` section -->
+{% else %}
+  <h5 class="u-no-margin--bottom">Links</h5>
+  <ul class="p-list">
+    {% if website or is_preview %}
+      <li>
+        <a href="{{ website }}" data-live="website">Developer website</a>
+      </li>
+    {% endif %}
+            
+    {% if contact or is_preview %}
+      <li>
+        <a href="{{ contact }}" data-live="contact">Contact {{ publisher }}</a>
+      </li>
+    {% endif %}
+  </ul>
+
+  <hr>
+{% endif %}

--- a/tests/tests_templates_utils.py
+++ b/tests/tests_templates_utils.py
@@ -115,3 +115,145 @@ class TemplateUtilsTest(unittest.TestCase):
 
         result = template_utils.format_member_role("access")
         self.assertEquals(result, "publisher")
+
+    def test_format_link(self):
+        result = template_utils.format_link("mailto:hello@example.com")
+        self.assertEquals(result, "hello@example.com")
+
+        result = template_utils.format_link("https://example.com")
+        self.assertEquals(result, "example.com")
+
+        result = template_utils.format_link("http://example.com")
+        self.assertEquals(result, "example.com")
+
+        result = template_utils.format_link("https://example.com/")
+        self.assertEquals(result, "example.com")
+
+        result = template_utils.format_link("http://example.com/")
+        self.assertEquals(result, "example.com")
+
+        result = template_utils.format_link("https://example.com/path")
+        self.assertEquals(result, "example.com")
+
+        result = template_utils.format_link("http://example.com/path")
+        self.assertEquals(result, "example.com")
+
+        result = template_utils.format_link("https://example.com/path/")
+        self.assertEquals(result, "example.com")
+
+        result = template_utils.format_link("http://example.com/path/")
+        self.assertEquals(result, "example.com")
+
+        result = template_utils.format_link("https://example.com/path/path")
+        self.assertEquals(result, "example.com")
+
+        result = template_utils.format_link("http://example.com/path/path")
+        self.assertEquals(result, "example.com")
+
+        result = template_utils.format_link("https://example.com/path/path/")
+        self.assertEquals(result, "example.com")
+
+        result = template_utils.format_link("http://example.com/path/path/")
+        self.assertEquals(result, "example.com")
+
+        result = template_utils.format_link("https://example.com?foo=bar")
+        self.assertEquals(result, "example.com")
+
+        result = template_utils.format_link("http://example.com?foo=bar")
+        self.assertEquals(result, "example.com")
+
+        result = template_utils.format_link("https://example.com/?foo=bar")
+        self.assertEquals(result, "example.com")
+
+        result = template_utils.format_link("http://example.com/?foo=bar")
+        self.assertEquals(result, "example.com")
+
+        result = template_utils.format_link(
+            "https://example.com?foo=bar&bar=foo"
+        )
+        self.assertEquals(result, "example.com")
+
+        result = template_utils.format_link(
+            "http://example.com?foo=bar&bar=foo"
+        )
+        self.assertEquals(result, "example.com")
+
+        result = template_utils.format_link(
+            "https://example.com/?foo=bar&bar=foo"
+        )
+        self.assertEquals(result, "example.com")
+
+        result = template_utils.format_link(
+            "http://example.com/?foo=bar&bar=foo"
+        )
+        self.assertEquals(result, "example.com")
+
+        result = template_utils.format_link("https://example.com/path?foo=bar")
+        self.assertEquals(result, "example.com")
+
+        result = template_utils.format_link("http://example.com/path?foo=bar")
+        self.assertEquals(result, "example.com")
+
+        result = template_utils.format_link(
+            "https://example.com/path/?foo=bar"
+        )
+        self.assertEquals(result, "example.com")
+
+        result = template_utils.format_link("http://example.com/path/?foo=bar")
+        self.assertEquals(result, "example.com")
+
+        result = template_utils.format_link(
+            "https://example.com/path/path?foo=bar"
+        )
+        self.assertEquals(result, "example.com")
+
+        result = template_utils.format_link(
+            "http://example.com/path/path?foo=bar"
+        )
+        self.assertEquals(result, "example.com")
+
+        result = template_utils.format_link(
+            "https://example.com/path/path/?foo=bar"
+        )
+        self.assertEquals(result, "example.com")
+
+        result = template_utils.format_link(
+            "http://example.com/path/path/?foo=bar"
+        )
+        self.assertEquals(result, "example.com")
+
+        result = template_utils.format_link("https://example.com/path?foo=bar")
+        self.assertEquals(result, "example.com")
+
+        result = template_utils.format_link("http://example.com/path?foo=bar")
+        self.assertEquals(result, "example.com")
+
+        result = template_utils.format_link(
+            "https://example.com/path/?foo=bar"
+        )
+        self.assertEquals(result, "example.com")
+
+        result = template_utils.format_link(
+            "http://example.com/path/?foo=bar&bar=foo"
+        )
+        self.assertEquals(result, "example.com")
+
+        result = template_utils.format_link(
+            "https://example.com/path/path?foo=bar&bar=foo"
+        )
+        self.assertEquals(result, "example.com")
+
+        result = template_utils.format_link(
+            "http://example.com/path/path?foo=bar&bar=foo"
+        )
+        self.assertEquals(result, "example.com")
+
+        result = template_utils.format_link(
+            "https://example.com/path/path/?foo=bar&bar=foo"
+        )
+        self.assertEquals(result, "example.com")
+
+        result = template_utils.format_link(
+            "http://example.com/path/path/?foo=bar&bar=foo"
+        )
+        self.assertEquals(result, "example.com")

--- a/webapp/handlers.py
+++ b/webapp/handlers.py
@@ -80,6 +80,7 @@ def set_handlers(app):
             "format_member_role": template_utils.format_member_role,
             "image": image_template,
             "stores": stores,
+            "format_link": template_utils.format_link,
         }
 
     # Error handlers

--- a/webapp/store/snap_details_views.py
+++ b/webapp/store/snap_details_views.py
@@ -276,6 +276,37 @@ def snap_details_views(store, api, handle_errors):
             }
         )
 
+        """
+        This code is purely for testing an upcoming feature
+        It is only available in the view with a query string
+        Once `links` has been added to the API we can remove this
+        """
+        context["links"] = {
+            "donation": [
+                "https://maas.io",
+                "http://juju.is",
+                "https://ubuntu.com/download",
+                "https://charmhub.io?welcome=true",
+                "https://dqlite/docs?hello=true",
+            ],
+            "contact": [
+                "mailto:steve.rydz@canonical.com",
+                "mailto:steve.rydz+test@canonical.com",
+            ],
+            # Wrapping long string to make flake8 happy.
+            # This won't be a problem once `link` is in the API
+            "issues": [
+                "https://github.com/canonical-web-and-design/"
+                "snapcraft.io/issues/new"
+            ],
+            "website": [
+                "https://ubuntu.com",
+            ],
+            "source-code": [
+                "https://github.com/canonical-web-and-design/snapcraft.io"
+            ],
+        }
+
         return (
             flask.render_template("store/snap-details.html", **context),
             status_code,

--- a/webapp/template_utils.py
+++ b/webapp/template_utils.py
@@ -143,3 +143,20 @@ def format_member_role(role):
     }
 
     return roles[role]
+
+
+def format_link(url):
+    """
+    Template function that removes protocol, path and query string from links
+    """
+    url_parts = url.split(":")
+
+    if url_parts[0] == "mailto":
+        return url_parts[1]
+
+    if url_parts[0] == "http" or url_parts[0] == "https":
+        url_parts_no_slashes = url_parts[1].split("//")[1]
+        url_parts_no_query = url_parts_no_slashes.split("?")[0]
+        url_parts_no_path = url_parts_no_query.split("/")[0]
+
+        return url_parts_no_path


### PR DESCRIPTION
## Done
Added metadata links section to the snap details page using dummy data

## QA
- Go to https://snapcraft-io-4020.demos.haus/notion-snap?show_metadata_links=true
- Check that there is a "Links" section in the sidebar
- Check that there is a tooltip/title with the full URL on hover
- Check that clicking on one of the links opens a modal
- Check that clicking the "Go back" button closes the modal and keeps you on the page
- Check that clicking the "Proceed" button opens the link in a new tab and closes the modal
- Remove the query string and check that the new implementation of the "Links" section is no longer there

## Issue
Fixes:
- https://github.com/canonical-web-and-design/marketplace-tribe/issues/2607
- https://github.com/canonical-web-and-design/marketplace-tribe/issues/2608
- https://github.com/canonical-web-and-design/marketplace-tribe/issues/2612