### PR TITLE
Add new metadata link fields

### DIFF
--- a/templates/publisher/listing.html
+++ b/templates/publisher/listing.html
@@ -141,6 +141,13 @@ Listing details for {% if display_title %}{{ display_title }}{% else %}{{ snap_t
       </div>
 
       {% include "publisher/metadata/_license.html" %}
+
+      {% if request.args.get("show_metadata_links") %}
+        {% include "publisher/metadata/_source-code.html" %}
+        {% include "publisher/metadata/_issues.html" %}
+        {% include "publisher/metadata/_donations.html" %}
+      {% endif %}
+
       {% include "publisher/metadata/_metrics.html" %}
     </section>
   </form>

--- a/templates/publisher/metadata/_donations.html
+++ b/templates/publisher/metadata/_donations.html
@@ -1,0 +1,25 @@
+<div class="row p-form__group p-form-validation {% if field_errors and field_errors['donations'] %}is-error{% endif %}">
+  <div class="col-2" data-tour="listing-donations">
+    <label for="developer-website" class="p-form__label">Donations:</label>
+  </div>
+  <div class="col-8" >
+    <div class="p-form__control" data-tour="listing-donations">
+      <input
+        class="p-form-validation__input"
+        id="donations"
+        type="url"
+        name="donations"
+        value=""
+        maxlength="256"
+        placeholder="https://paypal.me" />
+      {% if field_errors and field_errors['donations'] %}
+      <p class="p-form-validation__message">
+        <strong>Error:</strong> {{ field_errors['donations'] }}
+      </p>
+      {% endif %}
+      <p class="p-form-help-text">
+        Please include a valid http:// or https:// link
+      </p>
+    </div>
+  </div>
+</div>

--- a/templates/publisher/metadata/_issues.html
+++ b/templates/publisher/metadata/_issues.html
@@ -1,0 +1,25 @@
+<div class="row p-form__group p-form-validation {% if field_errors and field_errors['issues'] %}is-error{% endif %}">
+  <div class="col-2" data-tour="listing-issues">
+    <label for="developer-website" class="p-form__label">Issues:</label>
+  </div>
+  <div class="col-8" >
+    <div class="p-form__control" data-tour="listing-issues">
+      <input
+        class="p-form-validation__input"
+        id="issues"
+        type="url"
+        name="issues"
+        value=""
+        maxlength="256"
+        placeholder="https://github.com/username/repo/issues/new" />
+      {% if field_errors and field_errors['issues'] %}
+      <p class="p-form-validation__message">
+        <strong>Error:</strong> {{ field_errors['issues'] }}
+      </p>
+      {% endif %}
+      <p class="p-form-help-text">
+        Please include a valid http:// or https:// link
+      </p>
+    </div>
+  </div>
+</div>

--- a/templates/publisher/metadata/_source-code.html
+++ b/templates/publisher/metadata/_source-code.html
@@ -1,0 +1,25 @@
+<div class="row p-form__group p-form-validation {% if field_errors and field_errors['source-code'] %}is-error{% endif %}">
+  <div class="col-2" data-tour="listing-source-code">
+    <label for="developer-website" class="p-form__label">Source code:</label>
+  </div>
+  <div class="col-8" >
+    <div class="p-form__control" data-tour="listing-source-code">
+      <input
+        class="p-form-validation__input"
+        id="source-code"
+        type="url"
+        name="source-code"
+        value=""
+        maxlength="256"
+        placeholder="https://github.com/username/repo" />
+      {% if field_errors and field_errors['source-code'] %}
+      <p class="p-form-validation__message">
+        <strong>Error:</strong> {{ field_errors['source-code'] }}
+      </p>
+      {% endif %}
+      <p class="p-form-help-text">
+        Please include a valid http:// or https:// link
+      </p>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
## Done
Added metadata link fields to listing page form. **Note**: These fields do not work until the API is ready

## QA
- Go to https://snapcraft-io-4027.demos.haus/notion-snap/listing?show_metadata_links=true
- Check that there are fields for "Donations", "Source code" and "Issues"
- Remove the query string and check that those fields are no longer there

## Issue
Fixes https://github.com/canonical-web-and-design/marketplace-tribe/issues/2609
