### PR TITLE
Add some extra information on the set up webook link in settings

### DIFF
--- a/templates/publisher/settings.html
+++ b/templates/publisher/settings.html
@@ -254,20 +254,25 @@ Settings for {% if display_title %}{{ display_title }}{% else %}{{ snap_title }}
       </div>
 
       {% if is_on_lp %}
-      <div class="row p-form__group">
-        <hr class="u-no-margin--bottom" />
-      </div>
-
-      <div class="row p-form__group">
-        <div class="col-2">
-          GitHub Webhook:
+        <div class="row p-form__group">
+          <hr class="u-no-margin--bottom" />
         </div>
-        <div class="col-8">
-          <div class="p-form__control">
-            <a href="/{{snap_name}}/builds/update-webhook">Set up webhook</a>
+
+        <div class="row p-form__group">
+          <div class="col-2">
+            <label class="p-form__label">
+              GitHub Webhook:
+            </label>
+          </div>
+          <div class="col-8">
+            <div class="p-form__control">
+              <p>
+                <a href="/{{snap_name}}/builds/update-webhook">Set up webhook</a>
+              </p>
+            </div>
+            <div class="p-form-help-text">Enables automatic builds from GitHub when you push code to your repository.</div>
           </div>
         </div>
-      </div>
       {% endif %}
     </section>
   </form>


### PR DESCRIPTION
## Done
- Fix styling of webook row
- Add extra help text to explain why you would click the link

## How to QA
- Visit the settings page for a snap that has github set up
- See the help text

## Issue / Card
Fixes #3393 

## Screenshots
![image](https://user-images.githubusercontent.com/479384/173847142-356efe1c-4d43-4f6f-bb81-4140c90e9ffe.png)
