### PR TITLE
Disallow markdown links in preview

### DIFF
--- a/static/js/publisher/preview.js
+++ b/static/js/publisher/preview.js
@@ -25,6 +25,7 @@ const md = new MarkdownIt({
   "image",
   "html_inline",
   "fence",
+  "link",
 ]);
 
 // For the different elements we might need to change different properties


### PR DESCRIPTION
## Done
Disallow links in snap previews

## How to QA
- Go to a snap listing page on https://snapcraft-io-4036.demos.haus/
- Put a markdown link in the description e.g. `[This is a link](https://example.com)`
- Use the preview and check that it isn't rendered as a text link, only the URL is linked

## Issue / Card
Fixes #4035
