### PR TITLE
Add header to listing page

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "react-dnd": "11.1.3",
     "react-dnd-html5-backend": "11.1.3",
     "react-dom": "17.0.2",
+    "react-hook-form": "7.32.2",
     "react-redux": "7.2.6",
     "react-router-dom": "5.3.0",
     "react-sortable-hoc": "1.11.0",

--- a/static/js/publisher/listing/components/App/App.test.tsx
+++ b/static/js/publisher/listing/components/App/App.test.tsx
@@ -1,11 +1,5 @@
-import React from "react";
-import { render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom";
-import App from "./App";
 
-test("the page should have the correct title", () => {
-  render(<App />);
-  expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent(
-    "Snap listing page"
-  );
+test("placeholder test", () => {
+  expect(true).toBe(true);
 });

--- a/static/js/publisher/listing/components/App/App.tsx
+++ b/static/js/publisher/listing/components/App/App.tsx
@@ -1,14 +1,48 @@
 import React, { useState } from "react";
+import { useForm } from "react-hook-form";
+import { Form } from "@canonical/react-components";
+
+import PageHeader from "../PageHeader";
+import SaveAndPreview from "../SaveAndPreview";
 
 function App() {
   const [listingData, setListingData] = useState(window.listingData);
 
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { isDirty },
+  } = useForm({ defaultValues: listingData });
+
+  const onSubmit = (data: any) => {
+    console.log({ data });
+  };
+
   return (
-    <section className="p-strip">
-      <div className="u-fixed-width">
-        <h1>Snap listing page</h1>
-      </div>
-    </section>
+    <>
+      <PageHeader snapName={listingData?.snap_name} />
+      <Form onSubmit={handleSubmit(onSubmit)} className="p-form--stacked">
+        <SaveAndPreview
+          snapName={listingData?.snap_name}
+          isDirty={isDirty}
+          reset={reset}
+        />
+        <div className="row">
+          <hr className="u-no-margin--bottom" />
+        </div>
+
+        {/* Only here to test the buttons */}
+        <section className="p-strip">
+          <div className="u-fixed-width">
+            <input
+              defaultValue={listingData?.snap_name}
+              {...register("snap_name")}
+            />
+          </div>
+        </section>
+      </Form>
+    </>
   );
 }
 

--- a/static/js/publisher/listing/components/NavTabs/NavTabs.test.tsx
+++ b/static/js/publisher/listing/components/NavTabs/NavTabs.test.tsx
@@ -1,0 +1,49 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+import NavTabs from "./NavTabs";
+
+const snapName = "test-snap-name";
+
+test("the 'Listing' tab has the correct path", () => {
+  render(<NavTabs snapName={snapName} />);
+  expect(
+    screen.getByRole("tab", { name: "Listing" }).getAttribute("href")
+  ).toBe(`/${snapName}/listing`);
+});
+
+test("the 'Builds' tab has the correct path", () => {
+  render(<NavTabs snapName={snapName} />);
+  expect(screen.getByRole("tab", { name: "Builds" }).getAttribute("href")).toBe(
+    `/${snapName}/builds`
+  );
+});
+
+test("the 'Releases' tab has the correct path", () => {
+  render(<NavTabs snapName={snapName} />);
+  expect(
+    screen.getByRole("tab", { name: "Releases" }).getAttribute("href")
+  ).toBe(`/${snapName}/releases`);
+});
+
+test("the 'Metrics' tab has the correct path", () => {
+  render(<NavTabs snapName={snapName} />);
+  expect(
+    screen.getByRole("tab", { name: "Metrics" }).getAttribute("href")
+  ).toBe(`/${snapName}/metrics`);
+});
+
+test("the 'Publicise' tab has the correct path", () => {
+  render(<NavTabs snapName={snapName} />);
+  expect(
+    screen.getByRole("tab", { name: "Publicise" }).getAttribute("href")
+  ).toBe(`/${snapName}/publicise`);
+});
+
+test("the 'Settings' tab has the correct path", () => {
+  render(<NavTabs snapName={snapName} />);
+  expect(
+    screen.getByRole("tab", { name: "Settings" }).getAttribute("href")
+  ).toBe(`/${snapName}/settings`);
+});

--- a/static/js/publisher/listing/components/NavTabs/NavTabs.tsx
+++ b/static/js/publisher/listing/components/NavTabs/NavTabs.tsx
@@ -1,0 +1,81 @@
+import React from "react";
+
+type Props = {
+  snapName: string;
+};
+
+function NavTabs({ snapName }: Props) {
+  return (
+    <nav className="p-tabs">
+      <ul
+        className="p-tabs__list u-float-right u-no-margin--bottom"
+        role="tablist"
+      >
+        <li className="p-tabs__item" role="presentation">
+          <a
+            data-tour="listing-intro"
+            href={`/${snapName}/listing`}
+            className="p-tabs__link"
+            tabIndex={0}
+            role="tab"
+            aria-selected="true"
+          >
+            Listing
+          </a>
+        </li>
+        <li className="p-tabs__item" role="presentation">
+          <a
+            href={`/${snapName}/builds`}
+            className="p-tabs__link"
+            tabIndex={0}
+            role="tab"
+          >
+            Builds
+          </a>
+        </li>
+        <li className="p-tabs__item" role="presentation">
+          <a
+            href={`/${snapName}/releases`}
+            className="p-tabs__link"
+            tabIndex={0}
+            role="tab"
+          >
+            Releases
+          </a>
+        </li>
+        <li className="p-tabs__item" role="presentation">
+          <a
+            href={`/${snapName}/metrics`}
+            className="p-tabs__link"
+            tabIndex={0}
+            role="tab"
+          >
+            Metrics
+          </a>
+        </li>
+        <li className="p-tabs__item" role="presentation">
+          <a
+            href={`/${snapName}/publicise`}
+            className="p-tabs__link"
+            tabIndex={0}
+            role="tab"
+          >
+            Publicise
+          </a>
+        </li>
+        <li className="p-tabs__item" role="presentation">
+          <a
+            href={`/${snapName}/settings`}
+            className="p-tabs__link"
+            tabIndex={0}
+            role="tab"
+          >
+            Settings
+          </a>
+        </li>
+      </ul>
+    </nav>
+  );
+}
+
+export default NavTabs;

--- a/static/js/publisher/listing/components/NavTabs/index.ts
+++ b/static/js/publisher/listing/components/NavTabs/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./NavTabs";

--- a/static/js/publisher/listing/components/PageHeader/PageHeader.test.tsx
+++ b/static/js/publisher/listing/components/PageHeader/PageHeader.test.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+import PageHeader from "./PageHeader";
+
+test("the page displays the correct name for the snap", () => {
+  render(<PageHeader snapName="test-snap-name" />);
+  expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent(
+    "test-snap-name"
+  );
+});

--- a/static/js/publisher/listing/components/PageHeader/PageHeader.tsx
+++ b/static/js/publisher/listing/components/PageHeader/PageHeader.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+
+import NavTabs from "../NavTabs";
+
+type Props = {
+  snapName: string;
+};
+
+function PageHeader({ snapName }: Props) {
+  return (
+    <section className="p-strip is-shallow u-no-padding--bottom">
+      <div className="u-fixed-width">
+        <a href="/snaps">&lsaquo;&nbsp;My snaps</a>
+        <h1 className="p-heading--3">{snapName}</h1>
+        <NavTabs snapName={snapName} />
+      </div>
+    </section>
+  );
+}
+
+export default PageHeader;

--- a/static/js/publisher/listing/components/PageHeader/index.ts
+++ b/static/js/publisher/listing/components/PageHeader/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./PageHeader";

--- a/static/js/publisher/listing/components/SaveAndPreview/SaveAndPreview.test.tsx
+++ b/static/js/publisher/listing/components/SaveAndPreview/SaveAndPreview.test.tsx
@@ -1,0 +1,49 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+import SaveAndPreview from "./SaveAndPreview";
+
+test("the 'Revert' button is disabled by default", () => {
+  render(
+    <SaveAndPreview
+      snapName="test-snap-name"
+      isDirty={false}
+      reset={jest.fn()}
+    />
+  );
+  expect(screen.getByRole("button", { name: "Revert" })).toBeDisabled();
+});
+
+test("the 'Revert' button is enabled is data is dirty", () => {
+  render(
+    <SaveAndPreview
+      snapName="test-snap-name"
+      isDirty={true}
+      reset={jest.fn()}
+    />
+  );
+  expect(screen.getByRole("button", { name: "Revert" })).not.toBeDisabled();
+});
+
+test("the 'Save' button is disabled by default", () => {
+  render(
+    <SaveAndPreview
+      snapName="test-snap-name"
+      isDirty={false}
+      reset={jest.fn()}
+    />
+  );
+  expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
+});
+
+test("the 'Save' button is enabled is data is dirty", () => {
+  render(
+    <SaveAndPreview
+      snapName="test-snap-name"
+      isDirty={true}
+      reset={jest.fn()}
+    />
+  );
+  expect(screen.getByRole("button", { name: "Save" })).not.toBeDisabled();
+});

--- a/static/js/publisher/listing/components/SaveAndPreview/SaveAndPreview.tsx
+++ b/static/js/publisher/listing/components/SaveAndPreview/SaveAndPreview.tsx
@@ -1,0 +1,56 @@
+import React from "react";
+import { Button } from "@canonical/react-components";
+
+type Props = {
+  snapName: string;
+  isDirty: boolean;
+  reset: Function;
+};
+
+function SaveAndPreview({ snapName, isDirty, reset }: Props) {
+  return (
+    <div className="snapcraft-p-sticky">
+      <div className="row">
+        <div className="col-7">
+          <p className="u-no-margin--bottom">
+            Updates to this information will appear immediately on the{" "}
+            <a href={`/${snapName}`}>snap listing page</a>.
+          </p>
+        </div>
+        <div className="col-5">
+          <div className="u-align--right">
+            <Button
+              type="button"
+              className="p-tooltip--btm-center"
+              aria-describedby="preview-tooltip"
+            >
+              Preview
+              <span
+                className="p-tooltip__message"
+                role="tooltip"
+                id="preview-tooltip"
+              >
+                Previews will only work in the same browser, locally
+              </span>
+            </Button>
+            <Button
+              appearance="default"
+              disabled={!isDirty}
+              type="reset"
+              onClick={() => {
+                reset();
+              }}
+            >
+              Revert
+            </Button>
+            <Button appearance="positive" disabled={!isDirty} type="submit">
+              Save
+            </Button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default SaveAndPreview;

--- a/static/js/publisher/listing/components/SaveAndPreview/index.ts
+++ b/static/js/publisher/listing/components/SaveAndPreview/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./SaveAndPreview";

--- a/yarn.lock
+++ b/yarn.lock
@@ -6364,6 +6364,11 @@ react-dom@17.0.2:
     object-assign "^4.1.1"
     scheduler "^0.20.2"
 
+react-hook-form@7.32.2:
+  version "7.32.2"
+  resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-7.32.2.tgz#58ec2ab0239ce97969baa2faa03ced13fae913ac"
+  integrity sha512-F1A6n762xaRhvtQH5SkQQhMr19cCkHZYesTcKJJeNmrphiZp/cYFTIzC05FnQry0SspM54oPJ9tXFXlzya8VNQ==
+
 react-is@^16.13.1, react-is@^16.6.0, react-is@^16.7.0:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"


### PR DESCRIPTION
## Done
Added the header, navigation and save/preview bar to the new listing page

## QA
- Go to https://snapcraft-io-4037.demos.haus/notion-snap/listing?show_react_listing=true (or any other snap)
- Check that the "Revert" and "Save" buttons are disabled
- Change the text in the field
- Check that the "Revert" and "Save" buttons are no longer disabled
- Undo any changes you made to the text in the field
- Check that the "Revert" and "Save" buttons are disabled
- Change the text in the field
- Check that the "Revert" and "Save" buttons are no longer disabled
- Click the "Revert" button
- Check that the "Revert" and "Save" buttons are disabled
- Check that the "My snaps" link goes to `/snaps`
- Check that the "snap listing page" link goes to the right listing page
- Check that the tabbed navigation go to the right place

## Issue
Fixes https://github.com/canonical-web-and-design/marketplace-tribe/issues/2641