### PR TITLE
Add some basic percy tests for less-QA'd parts of the site

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "watch": "watch -p 'static/sass/**/*.scss' -p 'static/js/**/*.js' -c 'yarn run build'",
     "watch-scss": "watch -p 'static/sass/**/*.scss' -c 'yarn run build-css'",
     "watch-js": "webpack --watch",
-    "clean": "rm -rf node_modules yarn-error.log css static/js/modules static/css *.log *.sqlite _site/ build/ .jekyll-metadata .bundle cache.tmp"
+    "clean": "rm -rf node_modules yarn-error.log css static/js/modules static/css *.log *.sqlite _site/ build/ .jekyll-metadata .bundle cache.tmp",
+    "percy": "node_modules/.bin/percy snapshot snapshots.yml"
   },
   "jest": {
     "testURL": "http://localhost.test",
@@ -95,6 +96,7 @@
     "whatwg-fetch": "3.6.2"
   },
   "devDependencies": {
+    "@percy/cli": "^1.3.1",
     "babel-eslint": "10.1.0",
     "concurrently": "5.3.0",
     "eslint": "7.32.0",

--- a/snapshots.yml
+++ b/snapshots.yml
@@ -1,0 +1,32 @@
+- name: FSF - Python | Install Snapcraft
+  url: https://snapcraft.io/first-snap/python
+  waitForTimeout: 1000
+  execute: "document.querySelector('#cookie-policy-button-accept').click()"
+- name: FSF - Python | Package snap - Choose name
+  url: https://snapcraft.io/first-snap/python/linux/package
+  waitForTimeout: 1000
+  execute: "document.querySelector('#cookie-policy-button-accept').click()"
+- name: FSF - Python | Package snap - Download snapcraft.yaml
+  url: https://snapcraft.io/first-snap/python/linux/package
+  waitForTimeout: 1000
+  execute: "document.querySelector('#cookie-policy-button-accept').click(); document.querySelector('#tab2').click();"
+- name: FSF - Python | Build & Test snap - Build snap
+  url: https://snapcraft.io/first-snap/python/linux/build-and-test
+  waitForTimeout: 1000
+  execute: "document.querySelector('#cookie-policy-button-accept').click();"
+- name: FSF - Python | Build & Test snap - Test snap
+  url: https://snapcraft.io/first-snap/python/linux/build-and-test
+  waitForTimeout: 1000
+  execute: "document.querySelector('#cookie-policy-button-accept').click(); document.querySelector('#tab2').click();"
+- name: FSF - Python | Publish to store
+  url: https://snapcraft.io/first-snap/python/linux/upload
+  waitForTimeout: 1000
+  execute: "document.querySelector('#cookie-policy-button-accept').click();"
+- name: IoT Page
+  url: https://snapcraft.io/iot
+  waitForTimeout: 1000
+  execute: "document.querySelector('#cookie-policy-button-accept').click();"
+- name: Build Page
+  url: https://snapcraft.io/build
+  waitForTimeout: 1000
+  execute: "document.querySelector('#cookie-policy-button-accept').click();"


### PR DESCRIPTION
## Done
- Add percy tests for first snap flow, /iot and /build pages 

## How to QA
- Pull the branch
- Run `export PERCY_TOKEN=[token_here]; node_modules/.bin/percy snapshot snapshots.yml`
- Visit the URL provided when Percy completes
