### PR TITLE
Run Percy snapshot tool at 3am tues, wed, thurs, fri and sat

### DIFF
--- a/.github/workflows/run-percy.yml
+++ b/.github/workflows/run-percy.yml
@@ -1,0 +1,17 @@
+name: Run percy
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 3 * * tue,wed,thu,fri,sat'
+
+jobs:
+  snapshots:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install deps
+        run: yarn install
+
+      - name: Run Percy
+        run: export PERCY_TOKEN=${{ secrets.PERCY_TOKEN }}; ./node_modules/.bin/percy snapshot snapshots.yml


### PR DESCRIPTION
## Done
- Create a workflow that runs percy snapshots at 3am tuesday, wednesday, thursday, friday and saturday.
- Why those days? I don't expect anyone to make changes on Sunday, so why bother running it on Monday? Same with Saturday, why run it on Sunday?

