### PR TITLE
Fix undefined showing on homepage cards

### DIFF
--- a/static/js/public/hero-tabpanel.js
+++ b/static/js/public/hero-tabpanel.js
@@ -42,9 +42,15 @@ class HeroTabPanels {
   
     `;
 
-      if (!validation) return "";
-      if (validation === "verified") return verifiedAccountBadge;
-      if (validation === "starred") return starDeveloperBadge;
+      if (validation === "verified") {
+        return verifiedAccountBadge;
+      }
+
+      if (validation === "starred") {
+        return starDeveloperBadge;
+      }
+
+      return "";
     };
 
     panel.innerHTML = "";


### PR DESCRIPTION
## Done
Fix `undefined` showing on some homepage cards

## QA
- Go to https://snapcraft-io-4052.demos.haus/
- Click on the "Featured" slide and check that "Jami" doesn't have `undefined` next to "Savoir-faire Linux"

## Issue
Fixes #4051 

## Screenshot
![Image Pasted at 2022-6-27 10-32](https://user-images.githubusercontent.com/501889/175909972-074f6640-5232-4548-bbd8-2b0d16bc83ee.png)
