### PR TITLE
Remove getRevisionsFromBuilds from releaseCell.js

### DIFF
--- a/static/js/publisher/release/components/releasesTable/releaseCell.js
+++ b/static/js/publisher/release/components/releasesTable/releaseCell.js
@@ -14,7 +14,6 @@ import { undoRelease } from "../../actions/pendingReleases";
 import {
   getPendingChannelMap,
   getFilteredAvailableRevisionsForArch,
-  getRevisionsFromBuild,
   getProgressiveState,
   hasPendingRelease,
 } from "../../selectors";
@@ -185,7 +184,6 @@ ReleasesTableReleaseCell.propTypes = {
   // compute state
   getAvailableCount: PropTypes.func,
   hasPendingRelease: PropTypes.func,
-  getRevisionsFromBuild: PropTypes.func,
   getProgressiveState: PropTypes.func,
   // actions
   toggleHistoryPanel: PropTypes.func.isRequired,
@@ -209,7 +207,6 @@ const mapStateToProps = (state) => {
     pendingChannelMap: getPendingChannelMap(state),
     getAvailableCount: (arch) =>
       getFilteredAvailableRevisionsForArch(state, arch).length,
-    getRevisionsFromBuild: (buildId) => getRevisionsFromBuild(state, buildId),
     getProgressiveState: (channel, arch, isPending) =>
       getProgressiveState(state, channel, arch, isPending),
     hasPendingRelease: (channel, arch) =>


### PR DESCRIPTION
## Done
- `getRevisionsFromBuilds` wasn't being using in the component, so remove it
This should hopefully reduce the overhead of displaying a cell.

## How to QA
- Visit https://snapcraft-io-4055.demos.haus//juju/releases
- Hopefully it loads quicker
