### PR TITLE
Refactor some method calls for Release UI performance

### DIFF
--- a/static/js/publisher/release/actions/architectures.js
+++ b/static/js/publisher/release/actions/architectures.js
@@ -1,0 +1,19 @@
+export const UPDATE_ARCHITECTURES = "UPDATE_ARCHITECTURES";
+
+export function updateArchitectures(revisions) {
+  let archs = [];
+
+  revisions.forEach((revision) => {
+    archs = archs.concat(revision.architectures);
+  });
+
+  // make archs unique and sorted
+  archs = archs.filter((item, i, ar) => ar.indexOf(item) === i);
+
+  return {
+    type: UPDATE_ARCHITECTURES,
+    payload: {
+      architectures: archs,
+    },
+  };
+}

--- a/static/js/publisher/release/actions/architectures.test.js
+++ b/static/js/publisher/release/actions/architectures.test.js
@@ -1,0 +1,28 @@
+import { UPDATE_ARCHITECTURES, updateArchitectures } from "./architectures";
+
+describe("architectures actions", () => {
+  describe("updateArchitectures", () => {
+    let revisions = [
+      { revision: 1, architectures: ["amd64", "armhf"] },
+      { revision: 2, architectures: ["test", "test2"] },
+      {
+        revision: 3,
+        channels: ["stable"],
+        architectures: ["amd64", "test2"],
+      },
+    ];
+
+    it("should create an action to update architectures list", () => {
+      expect(updateArchitectures(revisions).type).toBe(UPDATE_ARCHITECTURES);
+    });
+
+    it("should supply a payload with architectures", () => {
+      expect(updateArchitectures(revisions).payload.architectures).toEqual([
+        "amd64",
+        "armhf",
+        "test",
+        "test2",
+      ]);
+    });
+  });
+});

--- a/static/js/publisher/release/actions/availableRevisionsSelect.test.js
+++ b/static/js/publisher/release/actions/availableRevisionsSelect.test.js
@@ -49,6 +49,7 @@ describe("availableRevisionsSelect actions", () => {
         // so this is the value we expect after the actions are dispatched
         availableRevisionsSelect: AVAILABLE_REVISIONS_SELECT_UNRELEASED,
         revisions,
+        architectures: ["abc42", "amd42", "test64"],
       });
 
       store.dispatch(selectAvailableRevisions(value));
@@ -130,6 +131,7 @@ describe("availableRevisionsSelect actions", () => {
             // so this is the value we expect after the actions are dispatched
             availableRevisionsSelect: AVAILABLE_REVISIONS_SELECT_RECENT,
             revisions,
+            architectures: ["arch1", "arch2", "arch3"],
           });
 
           store.dispatch(selectAvailableRevisions(value));
@@ -207,6 +209,7 @@ describe("availableRevisionsSelect actions", () => {
             // so this is the value we expect after the actions are dispatched
             availableRevisionsSelect: AVAILABLE_REVISIONS_SELECT_LAUNCHPAD,
             revisions,
+            architectures: ["arch1", "arch2", "arch3"],
           });
 
           store.dispatch(selectAvailableRevisions(value));

--- a/static/js/publisher/release/actions/index.js
+++ b/static/js/publisher/release/actions/index.js
@@ -1,3 +1,4 @@
+export * from "./architectures";
 export * from "./availableRevisionsSelect";
 export * from "./channelMap";
 export * from "./currentTrack";

--- a/static/js/publisher/release/actions/releases.js
+++ b/static/js/publisher/release/actions/releases.js
@@ -3,6 +3,7 @@ import {
   DEFAULT_ERROR_MESSAGE as ERROR_MESSAGE,
 } from "../constants";
 
+import { updateArchitectures } from "./architectures";
 import { hideNotification, showNotification } from "./globalNotification";
 import { cancelPendingReleases } from "./pendingReleases";
 import { releaseRevisionSuccess, closeChannelSuccess } from "./channelMap";
@@ -26,6 +27,7 @@ function updateReleasesData(releasesData) {
     initReleasesData(revisionsMap, releasesData.releases);
     dispatch(updateRevisions(revisionsMap));
     dispatch(updateReleases(releasesData.releases));
+    dispatch(updateArchitectures(releasesData.revisions));
   };
 }
 

--- a/static/js/publisher/release/actions/releases.test.js
+++ b/static/js/publisher/release/actions/releases.test.js
@@ -324,6 +324,7 @@ describe("releases actions", () => {
         revisions: {
           3: revision,
         },
+        architectures: [],
       });
 
       global.fetch = jest
@@ -382,6 +383,12 @@ describe("releases actions", () => {
               releases: [release],
             },
             type: "UPDATE_RELEASES",
+          },
+          {
+            payload: {
+              architectures: ["amd64"],
+            },
+            type: "UPDATE_ARCHITECTURES",
           },
           {
             type: "CANCEL_PENDING_RELEASES",
@@ -460,6 +467,7 @@ describe("releases actions", () => {
         revisions: {
           3: revision,
         },
+        architectures: [],
       });
 
       global.fetch = jest
@@ -531,6 +539,12 @@ describe("releases actions", () => {
               releases: [release],
             },
             type: "UPDATE_RELEASES",
+          },
+          {
+            payload: {
+              architectures: ["amd64"],
+            },
+            type: "UPDATE_ARCHITECTURES",
           },
           {
             type: "CANCEL_PENDING_RELEASES",

--- a/static/js/publisher/release/components/releasesTable/index.js
+++ b/static/js/publisher/release/components/releasesTable/index.js
@@ -12,7 +12,7 @@ import {
   getArchitectures,
   getBranches,
   getLaunchpadRevisions,
-  getRevisionsFromBuild,
+  getAllRevisions,
 } from "../../selectors";
 import { selectAvailableRevisions, closeHistory } from "../../actions";
 
@@ -119,11 +119,24 @@ class ReleasesTable extends Component {
     const lpRevisions = this.props.launchpadRevisions;
     const { showAllBuilds } = this.state;
 
+    const revisions = this.props.allRevisions;
+    const revisionsMap = revisions.reduce((acc, item) => {
+      const buildId = getBuildId(item);
+      if (buildId) {
+        if (!acc[buildId]) {
+          acc[buildId] = [];
+        }
+
+        acc[buildId].push(item);
+      }
+      return acc;
+    }, {});
+
     const builds = lpRevisions
       .map(getBuildId)
       .filter((item, i, ar) => ar.indexOf(item) === i)
       .map((buildId) => {
-        const revs = this.props.getRevisionsFromBuild(buildId);
+        const revs = revisionsMap[buildId];
 
         const revsMap = {};
 
@@ -182,13 +195,8 @@ class ReleasesTable extends Component {
   }
 
   renderRows() {
-    const {
-      branches,
-      isHistoryOpen,
-      filters,
-      openBranches,
-      currentTrack,
-    } = this.props;
+    const { branches, isHistoryOpen, filters, openBranches, currentTrack } =
+      this.props;
     const { showAllRisksBranches } = this.state;
 
     // rows can consist of a channel row or expanded history panel
@@ -314,7 +322,7 @@ ReleasesTable.propTypes = {
   currentTrack: PropTypes.string.isRequired,
 
   launchpadRevisions: PropTypes.array,
-  getRevisionsFromBuild: PropTypes.func,
+  allRevisions: PropTypes.array,
 
   // actions
   selectAvailableRevisions: PropTypes.func,
@@ -330,7 +338,7 @@ const mapStateToProps = (state) => {
     openBranches: state.branches,
     currentTrack: state.currentTrack,
     launchpadRevisions: getLaunchpadRevisions(state),
-    getRevisionsFromBuild: (buildId) => getRevisionsFromBuild(state, buildId),
+    allRevisions: getAllRevisions(state),
   };
 };
 

--- a/static/js/publisher/release/reducers/architectures.js
+++ b/static/js/publisher/release/reducers/architectures.js
@@ -1,0 +1,10 @@
+import { UPDATE_ARCHITECTURES } from "../actions/architectures";
+
+export default function architectures(state = [], action) {
+  switch (action.type) {
+    case UPDATE_ARCHITECTURES:
+      return [...action.payload.architectures];
+    default:
+      return state;
+  }
+}

--- a/static/js/publisher/release/reducers/architectures.test.js
+++ b/static/js/publisher/release/reducers/architectures.test.js
@@ -1,0 +1,31 @@
+import architectures from "./architectures";
+import { UPDATE_ARCHITECTURES } from "../actions/architectures";
+
+describe("architectures", () => {
+  it("should return the initial state", () => {
+    expect(architectures(undefined, {})).toEqual([]);
+  });
+
+  describe("on UPDATE_ARCHITECTURES action", () => {
+    let updateArchitecturesAction = {
+      type: UPDATE_ARCHITECTURES,
+      payload: {
+        architectures: ["amd64", "armhf", "test", "test2"],
+      },
+    };
+
+    it("should add architectures to state", () => {
+      const result = architectures({}, updateArchitecturesAction);
+
+      expect(result).toEqual(updateArchitecturesAction.payload.architectures);
+    });
+
+    it("should replace existing architectures in state", () => {
+      const initialState = ["testing"];
+
+      const result = architectures(initialState, updateArchitecturesAction);
+
+      expect(result).toEqual(updateArchitecturesAction.payload.architectures);
+    });
+  });
+});

--- a/static/js/publisher/release/reducers/index.js
+++ b/static/js/publisher/release/reducers/index.js
@@ -1,5 +1,6 @@
 import { combineReducers } from "redux";
 
+import architectures from "./architectures";
 import availableRevisionsSelect from "./availableRevisionsSelect";
 import branches from "./branches";
 import channelMap from "./channelMap";
@@ -15,6 +16,7 @@ import releases from "./releases";
 import revisions from "./revisions";
 
 const releasesReducers = combineReducers({
+  architectures,
   availableRevisionsSelect,
   branches,
   channelMap,

--- a/static/js/publisher/release/releasesController.js
+++ b/static/js/publisher/release/releasesController.js
@@ -8,6 +8,7 @@ import ReleasesHeading from "./components/releasesHeading";
 import ReleasesConfirm from "./components/releasesConfirm";
 import Modal from "./components/modal";
 
+import { updateArchitectures } from "./actions/architectures";
 import { updateRevisions } from "./actions/revisions";
 import { updateReleases } from "./actions/releases";
 import { initChannelMap } from "./actions/channelMap";
@@ -22,6 +23,7 @@ const ReleasesController = ({
   snapName,
   releasesData,
   channelMap,
+  updateArchitectures,
   updateReleases,
   updateRevisions,
   initChannelMap,
@@ -40,7 +42,7 @@ const ReleasesController = ({
         initReleasesData(revisionsMap, releasesData.releases);
         updateRevisions(revisionsMap);
         updateReleases(releasesData.releases);
-
+        updateArchitectures(revisionsList);
         initChannelMap(transformedChannelMap);
         setReady(true);
       }
@@ -99,6 +101,7 @@ ReleasesController.propTypes = {
   showModal: PropTypes.bool,
 
   initChannelMap: PropTypes.func,
+  updateArchitectures: PropTypes.func,
   updateReleases: PropTypes.func,
   updateRevisions: PropTypes.func,
 };
@@ -113,6 +116,8 @@ const mapStateToProps = (state) => {
 const mapDispatchToProps = (dispatch) => {
   return {
     initChannelMap: (channelMap) => dispatch(initChannelMap(channelMap)),
+    updateArchitectures: (revisions) =>
+      dispatch(updateArchitectures(revisions)),
     updateRevisions: (revisions) => dispatch(updateRevisions(revisions)),
     updateReleases: (releases) => dispatch(updateReleases(releases)),
   };

--- a/static/js/publisher/release/selectors/index.js
+++ b/static/js/publisher/release/selectors/index.js
@@ -171,16 +171,9 @@ export function getFilteredAvailableRevisionsForArch(state, arch) {
 
 // get list of architectures of uploaded revisions
 export function getArchitectures(state) {
-  let archs = [];
-
-  getAllRevisions(state).forEach((revision) => {
-    archs = archs.concat(revision.architectures);
-  });
-
-  // make archs unique and sorted
-  archs = archs.filter((item, i, ar) => ar.indexOf(item) === i);
-
-  return archs.sort();
+  return state.architectures && state.architectures.length > 0
+    ? state.architectures.sort()
+    : [];
 }
 
 export function getTracks(state) {
@@ -360,9 +353,8 @@ export function getSeparatePendingReleases(state) {
 
       if (isProgressiveEnabled && pendingRelease.replaces) {
         const oldRelease = pendingRelease.replaces;
-        cancelProgressive[
-          `${oldRelease.revision.revision}-${channel}`
-        ] = oldRelease;
+        cancelProgressive[`${oldRelease.revision.revision}-${channel}`] =
+          oldRelease;
       } else if (
         isProgressiveEnabled &&
         pendingRelease.progressive &&

--- a/static/js/publisher/release/selectors/selectors.test.js
+++ b/static/js/publisher/release/selectors/selectors.test.js
@@ -522,17 +522,13 @@ describe("getFilteredAvailableRevisionsByArch", () => {
 
 describe("getArchitectures", () => {
   const initialState = reducers(undefined, {});
-  const stateWithRevisions = {
+  const stateWithArchitectures = {
     ...initialState,
-    revisions: {
-      1: { revision: 1, architectures: ["test64"] },
-      2: { revision: 2, architectures: ["amd42", "abc64"] },
-      3: { revision: 3, architectures: ["test64", "amd42"] },
-    },
+    architectures: ["test64", "amd42", "abc64"],
   };
 
   it("should return alphabetical list of all architectures", () => {
-    expect(getArchitectures(stateWithRevisions)).toEqual([
+    expect(getArchitectures(stateWithArchitectures)).toEqual([
       "abc64",
       "amd42",
       "test64",


### PR DESCRIPTION
## Done
- Refactor code that looped through every single revision (possibly 20k) for each cell that was rendered
- Move architecture calculations from each cell render to immediately after data is fetched - and store them in redux.

## How to QA
- Visit https://snapcraft.io/juju/releases - wait for the page to load
- Visit demo/juju/releases - see how much quicker it loads
- Click around the UI on both and notice the demo is quicker

## Issue / Card
Fixes #

## Screenshots
Before:
![image](https://user-images.githubusercontent.com/479384/176764700-3ec56f6c-b1e4-459d-aba0-89e20bbac9af.png)

After:
![image](https://user-images.githubusercontent.com/479384/176764748-c3366b2e-85ba-4fbd-a8e5-7fb0305a5084.png)

