### PR TITLE
Fix bug that breaks releases page for snapd

### DIFF
--- a/static/js/publisher/release/components/releasesTable/cellViews.js
+++ b/static/js/publisher/release/components/releasesTable/cellViews.js
@@ -79,13 +79,12 @@ const ProgressiveTooltip = ({ revision, previousRevision }) => {
       <br />
       <strong>{previousRevision?.version || "Unknown"}</strong>
       <br />
-      {previousRevision.attributes &&
-        previousRevision.attributes["build-request-id"] && (
-          <>
-            {previousRevision.attributes["build-request-id"]}
-            <br />
-          </>
-        )}
+      {previousRevision?.attributes?.["build-request-id"] && (
+        <>
+          {previousRevision.attributes["build-request-id"]}
+          <br />
+        </>
+      )}
       <strong>{previousRevision?.confinement || "Unknown"}</strong>
     </>
   );
@@ -101,7 +100,7 @@ const ProgressiveTooltip = ({ revision, previousRevision }) => {
       <br />
       <strong>{revision.version}</strong>
       <br />
-      {revision.attributes && revision.attributes["build-request-id"] && (
+      {revision?.attributes?.["build-request-id"] && (
         <>
           {revision.attributes["build-request-id"]}
           <br />
@@ -119,7 +118,7 @@ const ProgressiveTooltip = ({ revision, previousRevision }) => {
       <br />
       Version:
       <br />
-      {revision.attributes && revision.attributes["build-request-id"] && (
+      {revision?.attributes?.["build-request-id"] && (
         <>
           Build:
           <br />
@@ -187,7 +186,7 @@ export const RevisionInfo = ({
             : `
             ${revision.version}
             ${
-              revision.attributes["build-request-id"]
+              revision?.attributes?.["build-request-id"]
                 ? ` | ${revision.attributes["build-request-id"]}`
                 : ""
             }`}
@@ -208,7 +207,7 @@ export const RevisionInfo = ({
               Revision: <b>{revision.revision}</b>
               <br />
               Version: <b>{revision.version}</b>
-              {revision.attributes && revision.attributes["build-request-id"] && (
+              {revision?.attributes?.["build-request-id"] && (
                 <Fragment>
                   <br />
                   Build: {buildIcon}{" "}


### PR DESCRIPTION
## Done
- _A changelist description explaining what the change achieves and why you’re making it._

## How to QA
- Visit the demo in your browser, link commented below
  - Or you can run the project locally using the [dotrun](https://snapcraft.io/dotrun) snap with `$ dotrun` and view it in your web browser at: http://0.0.0.0:8004/
  - If your demo doesn't work, read more about the [demoservice](https://discourse.ubuntu.com/t/demoservice/16862)
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card
Fixes #

## Screenshots
[if relevant, include a screenshot]
