### PR TITLE
Add metadata links fields

### DIFF
--- a/static/js/publisher/listing/components/App/App.tsx
+++ b/static/js/publisher/listing/components/App/App.tsx
@@ -8,6 +8,8 @@ import {
   Button,
 } from "@canonical/react-components";
 
+import { getChanges, getFormData, getListingData } from "../../utils";
+
 import PageHeader from "../PageHeader";
 import SaveAndPreview from "../SaveAndPreview";
 import ListingDetailsSection from "../../sections/ListingDetailsSection";
@@ -15,84 +17,14 @@ import ContactInformationSection from "../../sections/ContactInformationSection"
 import AdditionalInformationSection from "../../sections/AdditionalInformationSection";
 import PreviewForm from "../PreviewForm";
 
-interface DirtyFields {
-  [key: string]: any;
-}
-
-type License = {
-  key: string;
-  name: string;
-};
-
 function App() {
   const snapId = window?.listingData?.snap_id;
   const publisherName = window?.listingData?.publisher_name;
   const categories = window?.listingData?.categories;
 
-  const licenseSort = (a: License, b: License) => {
-    if (a.name < b.name) {
-      return -1;
-    }
-
-    if (a.name > b.name) {
-      return 1;
-    }
-
-    return 0;
-  };
-
-  const [listingData, setListingData] = useState({
-    snap_name: window?.listingData?.snap_name,
-    title: window?.listingData?.snap_title,
-    summary: window?.listingData?.summary,
-    description: window?.listingData?.description,
-    website: window?.listingData?.website,
-    contact: window?.listingData?.contact,
-    categories: window?.listingData?.categories,
-    images: [],
-    public_metrics_enabled: window?.listingData?.public_metrics_enabled,
-    public_metrics_blacklist: window?.listingData?.public_metrics_blacklist,
-    license: window?.listingData?.license,
-    license_type: window?.listingData?.license_type,
-    licenses: window?.listingData?.licenses.sort(licenseSort),
-    video_urls: window?.listingData?.video_urls[0],
-    "primary-category": window?.listingData?.snap_categories?.categories[0],
-    "secondary-category": window?.listingData?.snap_categories?.categories[1],
-    public_metrics_territories: !window?.listingData?.public_metrics_blacklist.includes(
-      "installed_base_by_country_percent"
-    ),
-    public_metrics_distros: !window?.listingData?.public_metrics_blacklist.includes(
-      "weekly_installed_base_by_operating_system_normalized"
-    ),
-    update_metadata_on_release: window?.listingData?.update_metadata_on_release,
-    contacts: window?.listingData?.links?.contact.map((link: string) => {
-      return {
-        url: link,
-      };
-    }),
-    donations: window?.listingData?.links?.donation.map((link: string) => {
-      return {
-        url: link,
-      };
-    }),
-    issues: window?.listingData?.links?.issues.map((link: string) => {
-      return {
-        url: link,
-      };
-    }),
-    "source-code": window?.listingData?.links?.["source-code"].map(
-      (link: string) => {
-        return {
-          url: link,
-        };
-      }
-    ),
-    websites: window?.listingData?.links?.website.map((link: string) => {
-      return {
-        url: link,
-      };
-    }),
-  });
+  const [listingData, setListingData] = useState(
+    getListingData(window?.listingData)
+  );
 
   const [isSaving, setIsSaving] = useState(false);
   const [hasSaved, setHasSaved] = useState(false);
@@ -118,7 +50,7 @@ function App() {
 
   const isDirty = formState.isDirty;
   const isValid = formState.isValid;
-  const dirtyFields: DirtyFields = formState.dirtyFields;
+  const dirtyFields: { [key: string]: any } = formState.dirtyFields;
 
   const onSubmit = (data: any) => {
     if (listingData?.update_metadata_on_release) {
@@ -130,88 +62,8 @@ function App() {
   };
 
   const submitForm = (data: any) => {
-    const changes: DirtyFields = {};
-    const keys = Object.keys(dirtyFields);
-    const forbiddenKeys = [
-      "primary-category",
-      "secondary-category",
-      "contacts",
-      "donations",
-      "issues",
-      "source-code",
-      "websites",
-      "licenses",
-    ];
-
-    if (
-      dirtyFields.contacts ||
-      dirtyFields.donations ||
-      dirtyFields.issues ||
-      dirtyFields.license ||
-      dirtyFields["source-code"] ||
-      dirtyFields.website
-    ) {
-      changes.links = {
-        contact: data?.contacts,
-        donation: data?.donations,
-        issues: data?.issues,
-        license: data?.license,
-        "source-code": data?.["source-code"],
-        website: data?.websites,
-      };
-    }
-
-    keys.forEach((key) => {
-      if (!forbiddenKeys.includes(key) && dirtyFields[key] === true) {
-        changes[key] = data[key];
-      }
-
-      if (
-        dirtyFields["primary-category"] ||
-        dirtyFields["secondary-category"]
-      ) {
-        changes.categories = [];
-
-        if (data["primary-category"]) {
-          changes.categories.push(data["primary-category"]);
-        }
-
-        if (data["secondary-category"]) {
-          changes.categories.push(data["secondary-category"]);
-        }
-      }
-    });
-
-    const formatLinkFields = (fields: Array<{ url: string }>) => {
-      return fields.map((item) => item.url);
-    };
-
-    const formData = new FormData();
-
-    formData.set("csrf_token", window.CSRF_TOKEN);
-    formData.set("snap_id", snapId);
-    formData.set("title", data?.title);
-    formData.set("summary", data?.summary);
-    formData.set("description", data?.description);
-    formData.set("video_urls", data?.video_urls);
-    formData.set("website", data?.website);
-    formData.set("contact", data?.contact);
-    formData.set("primary-category", data?.["primary-category"]);
-    formData.set("secondary-category", data?.["secondary-category"]);
-    formData.set("public_metrics_enabled", data?.public_metrics_enabled);
-    formData.set("public_metrics_blacklist", data?.public_metrics_blacklist);
-    formData.set("license", data?.license || "unset");
-    formData.set(
-      "links",
-      JSON.stringify({
-        contact: formatLinkFields(data?.contacts),
-        donation: formatLinkFields(data?.donations),
-        issues: formatLinkFields(data?.issues),
-        "source-code": formatLinkFields(data?.["source-code"]),
-        website: formatLinkFields(data?.websites),
-      })
-    );
-    formData.set("changes", JSON.stringify(changes));
+    const changes = getChanges(dirtyFields, data);
+    const formData = getFormData(data, snapId, changes);
 
     setIsSaving(true);
 

--- a/static/js/publisher/listing/components/MultipleInputs/MultipleInputs.tsx
+++ b/static/js/publisher/listing/components/MultipleInputs/MultipleInputs.tsx
@@ -1,0 +1,64 @@
+import React from "react";
+import { useFieldArray } from "react-hook-form";
+import { Row, Col, Button, Icon } from "@canonical/react-components";
+
+type Props = {
+  fieldName: string;
+  label: string;
+  register: Function;
+  control: any;
+};
+
+function MultipleInputs({ fieldName, label, register, control }: Props) {
+  const { fields, append, remove } = useFieldArray({
+    control,
+    name: fieldName,
+  });
+
+  return (
+    <Row className="p-form__group">
+      <Col size={2}>
+        <label className="p-form__label">{label}:</label>
+      </Col>
+      <Col size={8}>
+        {fields.map((field, index) => (
+          <Row key={field.id}>
+            <Col size={5}>
+              <div className="p-form__control">
+                <input
+                  type="text"
+                  {...register(`${fieldName}.${index}.url`, {
+                    required: true,
+                  })}
+                />
+              </div>
+            </Col>
+            <Col size={2}>
+              <Button
+                appearance="base"
+                type="button"
+                onClick={() => {
+                  remove(index);
+                }}
+              >
+                <Icon name="delete">Remove field</Icon>
+              </Button>
+            </Col>
+          </Row>
+        ))}
+
+        <Button
+          type="button"
+          appearance="link"
+          onClick={() => {
+            append({ url: "" });
+          }}
+        >
+          +&nbsp;Add field
+        </Button>
+      </Col>
+    </Row>
+  );
+}
+
+export default MultipleInputs;

--- a/static/js/publisher/listing/components/MultipleInputs/index.ts
+++ b/static/js/publisher/listing/components/MultipleInputs/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./MultipleInputs";

--- a/static/js/publisher/listing/sections/ContactInformationSection/ContactInformationSection.tsx
+++ b/static/js/publisher/listing/sections/ContactInformationSection/ContactInformationSection.tsx
@@ -1,18 +1,24 @@
 import React from "react";
 
 import ListingFormInput from "../../components/ListingFormInput";
+import MultipleInputs from "../../components/MultipleInputs";
 
 type Props = {
   getFieldState: Function;
   register: Function;
   publisherName: string;
+  control: {};
 };
 
 function ContactInformationSection({
   getFieldState,
   register,
   publisherName,
+  control,
 }: Props) {
+  const queryParams = new URLSearchParams(window.location.search);
+  const showMetadataLinks = queryParams.get("show_metadata_links");
+
   return (
     <>
       <div className="u-fixed-width">
@@ -31,6 +37,45 @@ function ContactInformationSection({
           /^https?:\/\/[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_+.~#?&/=]*)$/
         }
       />
+
+      {showMetadataLinks && (
+        <>
+          <MultipleInputs
+            fieldName="websites"
+            label="Websites"
+            register={register}
+            control={control}
+          />
+
+          <MultipleInputs
+            fieldName="contacts"
+            label="Contacts"
+            register={register}
+            control={control}
+          />
+
+          <MultipleInputs
+            fieldName="donations"
+            label="Donations"
+            register={register}
+            control={control}
+          />
+
+          <MultipleInputs
+            fieldName="source-code"
+            label="Source code"
+            register={register}
+            control={control}
+          />
+
+          <MultipleInputs
+            fieldName="issues"
+            label="Issues"
+            register={register}
+            control={control}
+          />
+        </>
+      )}
 
       <ListingFormInput
         type="text"

--- a/static/js/publisher/listing/utils/getChanges.ts
+++ b/static/js/publisher/listing/utils/getChanges.ts
@@ -1,0 +1,57 @@
+function getChanges(
+  dirtyFields: { [key: string]: any },
+  data: { [key: string]: any }
+) {
+  const changes: { [key: string]: any } = {};
+  const keys = Object.keys(dirtyFields);
+  const forbiddenKeys = [
+    "primary-category",
+    "secondary-category",
+    "contacts",
+    "donations",
+    "issues",
+    "source-code",
+    "websites",
+    "licenses",
+  ];
+
+  if (
+    dirtyFields.contacts ||
+    dirtyFields.donations ||
+    dirtyFields.issues ||
+    dirtyFields.license ||
+    dirtyFields["source-code"] ||
+    dirtyFields.website
+  ) {
+    changes.links = {
+      contact: data?.contacts,
+      donation: data?.donations,
+      issues: data?.issues,
+      license: data?.license,
+      "source-code": data?.["source-code"],
+      website: data?.websites,
+    };
+  }
+
+  keys.forEach((key) => {
+    if (!forbiddenKeys.includes(key) && dirtyFields[key] === true) {
+      changes[key] = data[key];
+    }
+
+    if (dirtyFields["primary-category"] || dirtyFields["secondary-category"]) {
+      changes.categories = [];
+
+      if (data["primary-category"]) {
+        changes.categories.push(data["primary-category"]);
+      }
+
+      if (data["secondary-category"]) {
+        changes.categories.push(data["secondary-category"]);
+      }
+    }
+  });
+
+  return changes;
+}
+
+export default getChanges;

--- a/static/js/publisher/listing/utils/getFormData.ts
+++ b/static/js/publisher/listing/utils/getFormData.ts
@@ -1,0 +1,40 @@
+const formatLinkFields = (fields: Array<{ url: string }>) => {
+  return fields.map((item) => item.url);
+};
+
+function getFormData(
+  data: { [key: string]: any },
+  snapId: string,
+  changes: { [key: string]: any }
+) {
+  const formData = new FormData();
+
+  formData.set("csrf_token", window.CSRF_TOKEN);
+  formData.set("snap_id", snapId);
+  formData.set("title", data?.title);
+  formData.set("summary", data?.summary);
+  formData.set("description", data?.description);
+  formData.set("video_urls", data?.video_urls);
+  formData.set("website", data?.website);
+  formData.set("contact", data?.contact);
+  formData.set("primary-category", data?.["primary-category"]);
+  formData.set("secondary-category", data?.["secondary-category"]);
+  formData.set("public_metrics_enabled", data?.public_metrics_enabled);
+  formData.set("public_metrics_blacklist", data?.public_metrics_blacklist);
+  formData.set("license", data?.license || "unset");
+  formData.set(
+    "links",
+    JSON.stringify({
+      contact: formatLinkFields(data?.contacts),
+      donation: formatLinkFields(data?.donations),
+      issues: formatLinkFields(data?.issues),
+      "source-code": formatLinkFields(data?.["source-code"]),
+      website: formatLinkFields(data?.websites),
+    })
+  );
+  formData.set("changes", JSON.stringify(changes));
+
+  return formData;
+}
+
+export default getFormData;

--- a/static/js/publisher/listing/utils/getListingData.ts
+++ b/static/js/publisher/listing/utils/getListingData.ts
@@ -1,0 +1,71 @@
+type License = {
+  key: string;
+  name: string;
+};
+
+const licenseSort = (a: License, b: License) => {
+  if (a.name < b.name) {
+    return -1;
+  }
+
+  if (a.name > b.name) {
+    return 1;
+  }
+
+  return 0;
+};
+
+function getListingData(listingData: { [key: string]: any }) {
+  return {
+    snap_name: listingData?.snap_name,
+    title: listingData?.snap_title,
+    summary: listingData?.summary,
+    description: listingData?.description,
+    website: listingData?.website,
+    contact: listingData?.contact,
+    categories: listingData?.categories,
+    images: [],
+    public_metrics_enabled: listingData?.public_metrics_enabled,
+    public_metrics_blacklist: listingData?.public_metrics_blacklist,
+    license: listingData?.license,
+    license_type: listingData?.license_type,
+    licenses: listingData?.licenses.sort(licenseSort),
+    video_urls: listingData?.video_urls[0],
+    "primary-category": listingData?.snap_categories?.categories[0],
+    "secondary-category": listingData?.snap_categories?.categories[1],
+    public_metrics_territories: !listingData?.public_metrics_blacklist.includes(
+      "installed_base_by_country_percent"
+    ),
+    public_metrics_distros: !listingData?.public_metrics_blacklist.includes(
+      "weekly_installed_base_by_operating_system_normalized"
+    ),
+    update_metadata_on_release: listingData?.update_metadata_on_release,
+    contacts: listingData?.links?.contact.map((link: string) => {
+      return {
+        url: link,
+      };
+    }),
+    donations: listingData?.links?.donation.map((link: string) => {
+      return {
+        url: link,
+      };
+    }),
+    issues: listingData?.links?.issues.map((link: string) => {
+      return {
+        url: link,
+      };
+    }),
+    "source-code": listingData?.links?.["source-code"].map((link: string) => {
+      return {
+        url: link,
+      };
+    }),
+    websites: listingData?.links?.website.map((link: string) => {
+      return {
+        url: link,
+      };
+    }),
+  };
+}
+
+export default getListingData;

--- a/static/js/publisher/listing/utils/index.ts
+++ b/static/js/publisher/listing/utils/index.ts
@@ -1,0 +1,5 @@
+import getChanges from "./getChanges";
+import getFormData from "./getFormData";
+import getListingData from "./getListingData";
+
+export { getChanges, getFormData, getListingData };

--- a/webapp/publisher/snaps/listing_views.py
+++ b/webapp/publisher/snaps/listing_views.py
@@ -134,7 +134,29 @@ def get_listing_snap(snap_name):
         "update_metadata_on_release": snap_details[
             "update_metadata_on_release"
         ],
-        "links": {"websites": []},
+        "links": {
+            "contact": [
+                "mailto:steve.rydz@canonical.com",
+                "mailto:steve.rydz+test@canonical.com",
+            ],
+            "donation": [
+                "https://maas.io",
+                "http://juju.is",
+                "https://ubuntu.com/download",
+                "https://charmhub.io?welcome=true",
+                "https://dqlite/docs?hello=true",
+            ],
+            # Wrapping long string to make flake8 happy.
+            # This won't be a problem once `link` is in the API
+            "issues": [
+                "https://github.com/canonical-web-and-design/"
+                "snapcraft.io/issues/new"
+            ],
+            "source-code": [
+                "https://github.com/canonical-web-and-design/snapcraft.io"
+            ],
+            "website": ["https://ubuntu.com", "https://canonical.com"],
+        },
     }
 
     return flask.render_template(


### PR DESCRIPTION
## Done
Added the metadata links fields to the listing page form

## QA
- Go to https://snapcraft-io-4072.demos.haus/notion-snap/listing?show_react_listing=true&show_metadata_links=true
- Check that there are Websites, Contacts, Donations, Source code and Issues fields
- Check that you can add and remove fields and that the form is enabled/disabled as expected
- **NOTE: THIS IS DUMMY DATA SO WON'T ACTUALLY BE SAVED**
- Remove the `show_metadata_links` query string and check that the metadata links fields are not there

## Issue
Fixes https://github.com/canonical-web-and-design/marketplace-tribe/issues/2650
Fixes https://github.com/canonical-web-and-design/marketplace-tribe/issues/2610