### PR TITLE
Disable publicise page if snap has no release

### DIFF
--- a/templates/publisher/publicise/_publisher_publicise_layout.html
+++ b/templates/publisher/publicise/_publisher_publicise_layout.html
@@ -9,21 +9,21 @@ Publicise {% if display_title %}{{ display_title }}{% else %}{{ snap_title }}{% 
   {% set selected_tab='publicise' %}
   {% include "publisher/_header.html" %}
 
-  {% if private %}
+  {% if private or not is_released %}
     <section class="p-strip--light is-shallow">
       <div class="row">
         <div class="col-6">
           <h2 class="p-heading--4">Share and promote your snap</h2>
         </div>
         <div class="col-6">
-          <p>When your snap is public, you'll be able to share it using Store buttons, badges and embeddable cards.</p>
+          <p>When your snap is public and has a release, you'll be able to share it using Store buttons, badges and embeddable cards.</p>
           <p>Make your snap public in <a href="/{{ snap_name }}/settings">its settings page</a>.</p>
         </div>
       </div>
     </section>
   {% endif %}
 
-  <div class="p-strip is-shallow {% if private %}u-disabled{% endif %}">
+  <div class="p-strip is-shallow {% if private or not is_released %}u-disabled{% endif %}">
     <div class="row">
       <div class="col-3">
         <div class="p-navigation--sidebar">

--- a/tests/publisher/snaps/tests_publicise.py
+++ b/tests/publisher/snaps/tests_publicise.py
@@ -47,6 +47,7 @@ class GetPublicisePage(BaseTestCases.EndpointLoggedInErrorHandling):
             "title": "test snap",
             "private": False,
             "snap_name": snap_name,
+            "channel_maps_list": [],
             "keywords": [],
             "publisher": {"display-name": "test"},
         }
@@ -73,6 +74,7 @@ class GetPublicisePage(BaseTestCases.EndpointLoggedInErrorHandling):
             "title": "test snap",
             "private": True,
             "snap_name": snap_name,
+            "channel_maps_list": [],
             "keywords": [],
             "publisher": {"display-name": "test"},
         }

--- a/webapp/publisher/snaps/publicise_views.py
+++ b/webapp/publisher/snaps/publicise_views.py
@@ -32,6 +32,8 @@ def get_publicise(snap_name):
     except (StoreApiError, ApiError) as api_error:
         return _handle_error(api_error)
 
+    is_released = len(snap_details["channel_maps_list"]) > 0
+
     available_languages = {
         "ar": {"title": "العربية", "text": "احصل عليه من Snap Store"},
         "bg": {"title": "български", "text": "Инсталирайте го от Snap Store"},
@@ -58,6 +60,7 @@ def get_publicise(snap_name):
         "snap_title": snap_details["title"],
         "publisher_name": snap_details["publisher"]["display-name"],
         "snap_id": snap_details["snap_id"],
+        "is_release": is_released,
         "available": available_languages,
         "download_version": "v1.4.2",
     }


### PR DESCRIPTION
## Done
- Add check to see if the channel-map has releases
- Update publicise template to disable the page if the snap is private or if there aren't any releases

## How to QA
- Visit the demo
- On a test snap, close all channels on the releases page and ensure the snap is set to "public" on the settings page
- Got to the publicise page and see it's disabled

## Issue / Card
Fixes #3473 

## Screenshots
![image](https://user-images.githubusercontent.com/479384/181553622-9c76ef9e-6e77-40f1-adea-d2f4ec4640f8.png)
