### PR TITLE
Fix potential error where swiper container doesn't exist

### DIFF
--- a/static/js/config/swiper.config.js
+++ b/static/js/config/swiper.config.js
@@ -4,6 +4,7 @@ const SCREENSHOTS = {
   slidesPerView: "auto",
   roundLengths: true,
   spaceBetween: 32,
+  resizeObserver: true,
   breakpoints: {
     620: {
       spaceBetween: 16,

--- a/static/js/public/snap-details/screenshots.js
+++ b/static/js/public/snap-details/screenshots.js
@@ -33,24 +33,14 @@ function initScreenshots(screenshotsId) {
 
   screenshotsEl.addEventListener("click", clickCallback);
 
-  const config = Object.assign(SCREENSHOTS_CONFIG, {
-    // This hack is to fix a reported Swiper issue in firefox
-    // https://github.com/nolimits4web/swiper/issues/2218
-    // Hack https://github.com/nolimits4web/swiper/issues/2218#issuecomment-388837042
-    // TODO: When the issue linked above is fixed, remove this
-    on: {
-      init() {
-        setTimeout(() => {
-          window.dispatchEvent(new Event("resize"));
-        }, 200);
-      },
-    },
-  });
-
   // We need to resize the iframe on window resize
   iframeSize(".js-video-slide");
 
-  new Swiper(screenshotsEl.querySelector(".swiper-container"), config);
+  const swipeContainer = screenshotsEl.querySelector(".swiper-container");
+
+  if (swipeContainer) {
+    new Swiper(swipeContainer, SCREENSHOTS_CONFIG);
+  }
 }
 
 function terminateScreenshots(screenshotsId) {


### PR DESCRIPTION
## Done
Removed a hack and added safeguarding to prevent this error: https://sentry.is.canonical.com/canonical/snapcraft-io/issues/34008/

## How to QA
- https://snapcraft-io-4279.demos.haus/jfreerails
- Check that the screenshots load and there are no errors

## Issue / Card
Fixes #4278