### PR TITLE
Remove p-strip--dark override

### DIFF
--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -444,10 +444,6 @@ dl {
   box-shadow: 0 3px 3px rgba(51, 51, 51, 0.2);
 }
 
-.p-strip--dark {
-  background-color: #333 !important;
-}
-
 .p-navigation__row.is-full-width {
   max-width: 100%;
 }


### PR DESCRIPTION
## Done
Remove override from `styles.scss`

## How to QA
- Visit https://snapcraft-io-4465.demos.haus/beta-store
- The header strip should be darker, and match https://charmhub.io

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-7673

## Screenshots
