### PR TITLE
Fixes latest channel logic

### DIFF
--- a/webapp/store/logic.py
+++ b/webapp/store/logic.py
@@ -306,6 +306,7 @@ def get_latest_versions(channel_maps, default_track, lowest_risk):
                 and channel["risk"] == lowest_risk
             ):
                 default_stable = channel
+                break
 
     if default_stable:
         default_stable["released-at-display"] = convert_date(


### PR DESCRIPTION
## Done
- Fixes #4648 

## How to QA

- Go to any snap, the last updated date for the default/stable channel are correct. (compare https://snapcraft-io-4650.demos.haus/vault with main for an example of a snap that reflected the previous incorrect logic)

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why): Is a bug fix

## Issue / Card
https://warthogs.atlassian.net/browse/WD-11521
