### PR TITLE
Fix: Rename delete package route

### DIFF
--- a/webapp/publisher/snaps/views.py
+++ b/webapp/publisher/snaps/views.py
@@ -15,7 +15,6 @@ from flask.json import jsonify
 # Local
 from webapp.helpers import api_publisher_session, launchpad
 from webapp.api.exceptions import ApiError
-from webapp.extensions import csrf
 from webapp.decorators import exchange_required, login_required
 from webapp.publisher.snaps import (
     build_views,
@@ -440,10 +439,9 @@ def post_register_name():
     return flask.redirect(flask.url_for("account.get_account"))
 
 
-@publisher_snaps.route("/<package_name>", methods=["DELETE"])
+@publisher_snaps.route("/packages/<package_name>", methods=["DELETE"])
 @login_required
 @exchange_required
-@csrf.exempt
 def delete_package(package_name):
     response = publisher_api.unregister_package_name(
         flask.session, package_name


### PR DESCRIPTION
## Done
- Rename to avoid conflict with default 404 route

## How to QA
Go to https://snapcraft-io-4656.demos.haus/non+exisiting+page , get 404 instead of 405

## Testing
- [ ] This PR has tests
- [X] No testing required (explain why): is a bug fix

## Issue / Card
Fixes  #4654 
Jira: [WD-11679](https://warthogs.atlassian.net/browse/WD-11679?atlOrigin=eyJpIjoiN2RhODA3Zjg4MTExNGIxMGI1Njc5YzY4ZmNlMDUwNDAiLCJwIjoiaiJ9) 


[WD-11679]: https://warthogs.atlassian.net/browse/WD-11679?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ