### PR TITLE
ci: update tics report workflow to include flake8 and pylint

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -111,15 +111,12 @@ jobs:
           name: snapcraftio-coverage
           path: coverage
 
-      - name: Install Dotrun
+      - name: Install Python requirements
         run: |
-          sudo pip3 install dotrun requests==2.31.0 # requests version is pinned to avoid breaking changes, can be removed once issue is resolved: https://github.com/docker/docker-py/issues/3256
+          sudo pip3 install -r requirements.txt
 
-      - name: Install dependencies
-        run: |
-          set -x
-          sudo chmod 0777 .
-          dotrun install
+      - name: Install Python dependencies
+        run: sudo pip3 install pylint
 
       - name: Produce TICS report
         shell: bash


### PR DESCRIPTION
## Done
Update tics coverage to include flake8 and pylint as requested by the TICS team.

## How to QA
- The following action should succeed: https://github.com/canonical/snapcraft.io/actions/runs/9415798652 

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why): CI update

## Issue / Card
Fixes #

## Screenshots
