### PR TITLE
chore: webpack watch in dev mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "start": "yarn run build && concurrently --raw 'yarn run watch-scss' 'yarn run watch-js' 'yarn run serve'",
     "watch": "watch -p 'static/sass/**/*.scss' -p 'static/js/**/*.js' -c 'yarn run build'",
     "watch-scss": "watch -p 'static/sass/**/*.scss' -c 'yarn run build-css'",
-    "watch-js": "webpack --watch",
+    "watch-js": "webpack --watch --mode development",
     "clean": "rm -rf node_modules yarn-error.log css static/js/modules static/css *.log *.sqlite _site/ build/ .jekyll-metadata .bundle cache.tmp",
     "percy": "node_modules/.bin/percy snapshot snapshots.yml"
   },


### PR DESCRIPTION
## Done
- run `watch-js` in dev mode, which should only rebuild necessary files

## How to QA
- Run locally
- change JS/TS file
- see webpack rebuild only relevant files (hopefully significantly faster)

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why): dev env change

## Issue / Card

Partially addresses [WD-12719](https://warthogs.atlassian.net/browse/WD-12719?atlOrigin=eyJpIjoiOTAwNTI4Nzk2NzNlNGM1ZTgwN2Y3MWE4ZGQ0NTJlMmQiLCJwIjoiaiJ9)

[WD-12719]: https://warthogs.atlassian.net/browse/WD-12719?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ