### PR TITLE
fix: self serve track creation optional params

### DIFF
--- a/static/js/publisher/release/components/releasesHeading.js
+++ b/static/js/publisher/release/components/releasesHeading.js
@@ -78,7 +78,7 @@ function ReleasesHeading(props) {
   const [trackGuardrailsStatus, setTrackGuardrailsStatus] = useState(null);
   const [guardrailsLoading, setGuardrailsLoading] = useState(true);
 
-  const [isTrackNameFilled, setIsTrackNameFilled] = useState(false);
+  const isTrackNameFilled = trackName.trim().length > 0;
   const [isLoading, setIsLoading] = useState(false);
   const [notification, setNotification] = useState(null);
 
@@ -134,7 +134,6 @@ function ReleasesHeading(props) {
     setTrackNameError("");
     const { value } = event.target;
     setTrackName(value);
-    setIsTrackNameFilled(value.trim().length > 0);
   };
 
   const handleVersionPatternChange = (event) => {

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -429,7 +429,6 @@ def store_blueprint(store_query=None):
             version_pattern,
             auto_phasing_percentage,
         )
-        print(response)
         if response.status_code == 201:
             return response.json(), response.status_code
         if response.status_code == 409:


### PR DESCRIPTION
## Done
- Self serve track creation was giving 400 error when the optional parameters were not provided. This ensures optional params are optional
 
## How to QA
- make sure you can create tracks (with and without) optional parameters, and that they're being passed correctly

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why): bug fix

## Issue / Card
Fixes WD-14532

