### PR TITLE
fix: Update Ubuntu logo to current version on distro section

### DIFF
--- a/templates/store/snap-details/_distro-instructions-for-snap-support.html
+++ b/templates/store/snap-details/_distro-instructions-for-snap-support.html
@@ -210,7 +210,7 @@
         <span class="p-media-object__image">
             {{
                 image(
-                    url="https://assets.ubuntu.com/v1/100386fb-Distro_Logo_Ubuntu.svg",
+                    url="https://assets.ubuntu.com/v1/2d850f3f-CoF%20Circle%20New.svg",
                     alt="",
                     width="48",
                     height="48",

--- a/webapp/store/content/distros/ubuntu.yaml
+++ b/webapp/store/content/distros/ubuntu.yaml
@@ -1,8 +1,8 @@
 name: Ubuntu
 color-1: "#E95420"
 color-2: "#B54119"
-logo: https://assets.ubuntu.com/v1/100386fb-Distro_Logo_Ubuntu.svg
-logo-mono: https://assets.ubuntu.com/v1/20ba8b71-Distro_Logo_Ubuntu_White.svg
+logo: https://assets.ubuntu.com/v1/2d850f3f-CoF%20Circle%20New.svg
+logo-mono: https://assets.ubuntu.com/v1/4aff6463-ubuntu-logo-mono.svg
 install:
   -
     action: |


### PR DESCRIPTION
## Done
Updates the Ubuntu logo on the snap page distros section and install page

## How to QA
- Go to https://snapcraft-io-5074.demos.haus/josm
- Scroll down to the "Install josm on your Linux distribution" section
- Check that the Ubuntu icon is the latest version (see screenshots)
- Go to https://snapcraft-io-5074.demos.haus/install/josm/ubuntu
- Check that the two Ubuntu icons are the latest version (see screenshots)

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why): No behavioural changes

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-21060
Fixes #5073

## Screenshots

### Snap page before
![snap-page-before](https://github.com/user-attachments/assets/14d793f4-561f-4abc-8e32-c877df8f08bb)

### Snap page after
![snap-page-after](https://github.com/user-attachments/assets/696a8541-17f2-4f8b-9770-5c14266d76fe)

### Install page before
![install-page-before](https://github.com/user-attachments/assets/c19c93f4-a94f-41e8-ab9b-f3e50f8ab4b0)

### Install page after
![install-page-after](https://github.com/user-attachments/assets/c38d8926-eb99-49f0-9db5-6c7049b65b2a)