### PR TITLE
fix: Uses correct progressive data for charts

### DIFF
--- a/static/js/publisher/pages/Releases/components/revisionsListRow.js
+++ b/static/js/publisher/pages/Releases/components/revisionsListRow.js
@@ -119,8 +119,10 @@ const RevisionsListRow = (props) => {
       {canShowProgressiveReleases && isProgressive ? (
         <td data-heading="Release progress">
           <ProgressiveReleaseProgressChart
-            currentPercentage={revision?.progressive?.["current-percentage"]}
-            targetPercentage={revision?.progressive?.percentage}
+            currentPercentage={
+              revision?.release?.progressive?.["current-percentage"]
+            }
+            targetPercentage={revision?.release?.progressive?.percentage}
           />
         </td>
       ) : isPreviousProgressive ? (


### PR DESCRIPTION
## Done
Fixes issue where some releases aren't showing the correct progression target in the cell view chart

## How to QA
- Go to https://snapcraft-io-5169.demos.haus/steve-test-snap/releases
- Click the latest/beta arm64 cell in the releases table (the third row down which says "60 → 61")
- The pink release progress chart in the top row should have a target of 50% (it's known that the tooltip is also incorrect and that is being addressed separately)

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why): Visual fix

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-22806