### PR TITLE
fix: Fix text overflow issue in releases tooltip

### DIFF
--- a/static/js/publisher/pages/Releases/components/releasesTable/cellViews.js
+++ b/static/js/publisher/pages/Releases/components/releasesTable/cellViews.js
@@ -132,7 +132,7 @@ const ProgressiveTooltip = ({ revision, previousRevision }) => {
     <div className="row">
       <div className="col-4">{tooltipLabels}</div>
       <div className="col-4">{previousRevisionData}</div>
-      <div className="col-4">{currentRevisionData}</div>
+      <div className="col-4 u-truncate">{currentRevisionData}</div>
     </div>
   );
 };


### PR DESCRIPTION
## Done
Adds `u-truncate` utility class to releases tooltip text that overflows

## How to QA
- Go to https://snapcraft-io-5183.demos.haus/snapd/releases
- Hover over a cell containing a progressive release
- See that the word `(progressive)` is truncated with an ellipsis

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why): Visual fix

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-22659

## Screenshots

### Before

<img width="518" alt="451888636-b5c4c8dc-e2ef-444d-a6f2-81aacaac208c" src="https://github.com/user-attachments/assets/f4ddc6e2-d23d-43dc-9a26-b8b33d5fd1cf" />

### After

![Screenshot 2025-06-27 at 10 37 53](https://github.com/user-attachments/assets/04f8a3b1-91d5-4474-b7e8-27a9cabb9109)

