### PR TITLE
fix: Round progressive bar corners

### DIFF
--- a/static/js/publisher/pages/Releases/components/ProgressiveReleaseProgressChart.tsx
+++ b/static/js/publisher/pages/Releases/components/ProgressiveReleaseProgressChart.tsx
@@ -9,6 +9,15 @@ function ProgressiveReleaseProgressChart({
   targetPercentage,
   isPreviousRevision,
 }: ReleaseProgress) {
+  const roundedEnd = currentPercentage !== targetPercentage;
+  const innerStyle: React.CSSProperties = {
+    width: `${currentPercentage ? currentPercentage : 0}%`,
+  };
+
+  if (roundedEnd) {
+    innerStyle.borderRadius = "10px";
+  }
+
   return (
     <div
       className={
@@ -18,7 +27,7 @@ function ProgressiveReleaseProgressChart({
       <div className="progressive-progress-bar u-hide--small">
         <div
           className="progressive-progress-bar__inner"
-          style={{ width: `${currentPercentage ? currentPercentage : 0}%` }}
+          style={innerStyle}
         ></div>
         <div
           className="progressive-progress-bar__marker"

--- a/static/js/publisher/pages/Releases/components/releasesTable/cellViews.js
+++ b/static/js/publisher/pages/Releases/components/releasesTable/cellViews.js
@@ -73,8 +73,8 @@ const ProgressiveTooltip = ({ revision, previousRevision }) => {
       <strong>{previousRevision?.revision || "Unknown"}</strong>
       <br />
       <strong>
-        {Math.round(100 - revision?.progressive?.["current-percentage"]) || 0}% →{" "}
-        {Math.round(100 - revision?.progressive?.percentage)}%
+        {Math.round(100 - revision?.progressive?.["current-percentage"]) || 0}%
+        → {Math.round(100 - revision?.progressive?.percentage)}%
       </strong>
       <br />
       <strong>{previousRevision?.version || "Unknown"}</strong>


### PR DESCRIPTION
## Done
Made sure progressive bars show rounded corners if the current delimiter "|" is a different percentage.
If they are the same you get some missing pixels.

## How to QA
- Visit the demo, and a snap releases page for a snap with progressive releases.
- View the bar.

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why): no functional updates

## Issue / Card

## Screenshots
![image](https://github.com/user-attachments/assets/0c053d7a-39b7-4212-9c1e-c0226a2ad099)
![image](https://github.com/user-attachments/assets/90fd55fd-9a6e-46c5-a18f-fa4189ea2b63)
![image](https://github.com/user-attachments/assets/d1fb4a8b-d1ad-4493-bf24-8d70151e5f8e)
