### PR TITLE
fix: Make verified domain status clearer

### DIFF
--- a/static/js/publisher/pages/Listing/ContactInformation/PrimaryDomainInput.tsx
+++ b/static/js/publisher/pages/Listing/ContactInformation/PrimaryDomainInput.tsx
@@ -9,6 +9,8 @@ import {
 import { nanoid } from "nanoid";
 import { Row, Col, Modal } from "@canonical/react-components";
 
+import VerifiedButton from "./VerifiedButton";
+
 import { useVerified } from "../../../hooks";
 
 import type { ListingData } from "../../../types";
@@ -147,31 +149,17 @@ function PrimaryDomainInput({
                       {!domainChanged() &&
                         pathChanged() &&
                         !domainInNoPathList() && (
-                          <button
-                            type="button"
-                            className="p-button--base has-icon"
-                            onClick={() => {
-                              setShowVerifyModal(true);
-                            }}
-                            disabled={fieldState.isDirty}
-                          >
-                            <span>Verified ownership</span>
-                            <i className="p-icon--chevron-right"></i>
-                          </button>
+                          <VerifiedButton
+                            isDirty={fieldState.isDirty}
+                            setShowVerifyModal={setShowVerifyModal}
+                          />
                         )}
 
                       {!domainChanged() && !pathChanged() && (
-                        <button
-                          type="button"
-                          className="p-button--base has-icon"
-                          onClick={() => {
-                            setShowVerifyModal(true);
-                          }}
-                          disabled={fieldState.isDirty}
-                        >
-                          <span>Verified ownership</span>
-                          <i className="p-icon--chevron-right"></i>
-                        </button>
+                        <VerifiedButton
+                          isDirty={fieldState.isDirty}
+                          setShowVerifyModal={setShowVerifyModal}
+                        />
                       )}
 
                       {domainChanged() && !domainInNoPathList() && (
@@ -184,17 +172,10 @@ function PrimaryDomainInput({
                   )}
 
                   {!fieldState.isDirty && (
-                    <button
-                      type="button"
-                      className="p-button--base has-icon"
-                      onClick={() => {
-                        setShowVerifyModal(true);
-                      }}
-                      disabled={fieldState.isDirty}
-                    >
-                      <span>Verified ownership</span>
-                      <i className="p-icon--chevron-right"></i>
-                    </button>
+                    <VerifiedButton
+                      isDirty={fieldState.isDirty}
+                      setShowVerifyModal={setShowVerifyModal}
+                    />
                   )}
                 </>
               )}

--- a/static/js/publisher/pages/Listing/ContactInformation/VerifiedButton.tsx
+++ b/static/js/publisher/pages/Listing/ContactInformation/VerifiedButton.tsx
@@ -1,0 +1,27 @@
+import { Button, Icon } from "@canonical/react-components";
+
+import type { Dispatch, SetStateAction } from "react";
+
+type Props = {
+  isDirty: boolean;
+  setShowVerifyModal: Dispatch<SetStateAction<boolean>>;
+};
+
+function VerifiedButton({ isDirty, setShowVerifyModal }: Props): JSX.Element {
+  return (
+    <Button
+      type="button"
+      className="p-button--base has-icon"
+      onClick={() => {
+        setShowVerifyModal(true);
+      }}
+      disabled={isDirty}
+    >
+      <Icon name="success" />
+      <span>Ownership verified</span>
+      <Icon name="chevron-right" />
+    </Button>
+  );
+}
+
+export default VerifiedButton;

--- a/static/js/publisher/pages/Listing/ContactInformation/__tests__/PrimaryDomainInput.test.tsx
+++ b/static/js/publisher/pages/Listing/ContactInformation/__tests__/PrimaryDomainInput.test.tsx
@@ -75,7 +75,7 @@ describe("PrimaryDomainInput", () => {
     renderComponent(mockListingData, {
       primary_website: "https://example.com",
     });
-    expect(screen.getByText("Verified ownership")).toBeInTheDocument();
+    expect(screen.getByText("Ownership verified")).toBeInTheDocument();
   });
 
   it("shows message if verified domain is changed", async () => {
@@ -131,7 +131,7 @@ describe("PrimaryDomainInput", () => {
     const input = screen.getByRole("textbox", { name: "Primary website:" });
     await user.clear(input);
     await user.type(input, "/path");
-    expect(screen.getByText("Verified ownership")).toBeInTheDocument();
+    expect(screen.getByText("Ownership verified")).toBeInTheDocument();
   });
 
   it("shows message if verified domain is in no path list", async () => {
@@ -158,7 +158,7 @@ describe("PrimaryDomainInput", () => {
     expect(screen.getByText(/Unable to verify/)).toBeInTheDocument();
   });
 
-  it("'Verified ownership' button opens modal with token", async () => {
+  it("'Ownership verified' button opens modal with token", async () => {
     mockUseQueryReturnValue.data.primary_domain = true;
 
     // @ts-expect-error mocks
@@ -177,7 +177,7 @@ describe("PrimaryDomainInput", () => {
       primary_website: "https://example.com",
     });
     await user.click(
-      screen.getByRole("button", { name: "Verified ownership" }),
+      screen.getByRole("button", { name: "Ownership verified" }),
     );
     expect(
       screen.getByRole("heading", { level: 2, name: "Verify ownership" }),
@@ -199,7 +199,7 @@ describe("PrimaryDomainInput", () => {
     renderComponent(mockListingData, {
       primary_website: "https://example.com",
     });
-    expect(screen.queryByText("Verified ownership")).not.toBeInTheDocument();
+    expect(screen.queryByText("Ownership verified")).not.toBeInTheDocument();
     expect(
       screen.getByRole("button", { name: "Verify ownership" }),
     ).toBeInTheDocument();

--- a/templates/store/snap-details/_details.html
+++ b/templates/store/snap-details/_details.html
@@ -119,7 +119,7 @@
 </div>
 
 <template id="verified-status">
-  (Verified ownership) 
+  (Ownership verified) 
   <span class="p-tooltip--btm-right" aria-describedby="verified-explanation">
     <i class="p-icon--information"></i>
     <span class="p-tooltip__message" role="tooltip" id="verified-explanation">The publisher has verified that they own this domain. 


### PR DESCRIPTION
## Done
Added a success icon to the verified domain status and reworded label. Also extracted the button to it's own component given it is used multiple times.

## How to QA
- Go to https://snapcraft-io-5206.demos.haus/steve-test-snap/listing
- Check that the primary domain has a green tick on the button

## Testing
- [x] This PR has tests
- [ ] No testing required (explain why):

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-23643
Fixes https://github.com/canonical/snapcraft.io/issues/5205
