### PR TITLE
chore: Convert brand stores related state from Recoil to Jotai

### DIFF
--- a/static/js/publisher/components/Navigation/Navigation.tsx
+++ b/static/js/publisher/components/Navigation/Navigation.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from "react";
-import { useRecoilState, useRecoilValue } from "recoil";
-import { useAtom as useJotaiState } from "jotai";
+import { useRecoilState } from "recoil";
+import { useAtom as useJotaiState, useAtomValue as useJotaiValue } from "jotai";
 import { useParams, NavLink } from "react-router-dom";
 import { Icon } from "@canonical/react-components";
 
@@ -18,7 +18,7 @@ function Navigation({
 }: {
   sectionName: string | null;
 }): React.JSX.Element {
-  const brandStoresList = useRecoilValue(brandStoresState);
+  const brandStoresList = useJotaiValue(brandStoresState);
   const { id } = useParams();
   const { data: brand } = useBrand(id);
   const { data: publisherData } = usePublisher();

--- a/static/js/publisher/components/PrimaryNav/PrimaryNav.tsx
+++ b/static/js/publisher/components/PrimaryNav/PrimaryNav.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from "react";
 import { useLocation } from "react-router-dom";
-import { useSetRecoilState } from "recoil";
+import { useSetAtom as useSetJotaiState } from "jotai";
 import {
   SideNavigation,
   SideNavigationText,
@@ -24,7 +24,7 @@ function PrimaryNav({
   const { data: validationSetsData } = useValidationSets();
   const { data: brandStoresList } = useBrandStores();
 
-  const setRecoilBrandStores = useSetRecoilState(brandStoresState);
+  const setRecoilBrandStores = useSetJotaiState(brandStoresState);
 
   useEffect(() => {
     if (brandStoresList) {

--- a/static/js/publisher/components/StoreSelector/StoreSelector.tsx
+++ b/static/js/publisher/components/StoreSelector/StoreSelector.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import { useRecoilValue } from "recoil";
+import { useAtomValue as useJotaiValue } from "jotai";
 import { useParams, NavLink } from "react-router-dom";
 
 import { brandStoresState } from "../../state/brandStoreState";
@@ -12,7 +12,7 @@ type Props = {
 
 function StoreSelector({ nativeNavLink }: Props): React.JSX.Element {
   const { id } = useParams();
-  const brandStoresList = useRecoilValue(brandStoresState);
+  const brandStoresList = useJotaiValue(brandStoresState);
   const [showStoreSelector, setShowStoreSelector] = useState<boolean>(false);
   const [searchValue, setSearchValue] = useState("");
   const [filteredBrandStores, setFilteredBrandstores] =

--- a/static/js/publisher/pages/Members/Members.tsx
+++ b/static/js/publisher/pages/Members/Members.tsx
@@ -1,6 +1,6 @@
 import { ChangeEvent, useEffect, useState } from "react";
 import { useParams, Navigate } from "react-router-dom";
-import { useRecoilValue } from "recoil";
+import { useAtomValue as useJotaiValue } from "jotai";
 import {
   Spinner,
   Accordion,
@@ -42,7 +42,7 @@ type Member = {
 };
 
 function Members(): React.JSX.Element {
-  const brandStoresList = useRecoilValue(brandStoresState);
+  const brandStoresList = useJotaiValue(brandStoresState);
   const { id } = useParams();
   const {
     data: members,

--- a/static/js/publisher/pages/Members/__tests__/Members.test.tsx
+++ b/static/js/publisher/pages/Members/__tests__/Members.test.tsx
@@ -7,15 +7,13 @@ import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom";
 
 import {
-  RecoilObserver,
+  JotaiTestProvider,
   brandStoreRequests,
   storesResponse,
 } from "../../../test-utils";
 import { brandStoresState } from "../../../state/brandStoreState";
 
 import Members from "../Members";
-
-import type { MutableSnapshot } from "recoil";
 
 jest.mock("react-router-dom", () => ({
   ...jest.requireActual("react-router-dom"),
@@ -28,15 +26,14 @@ function renderComponent() {
   const queryClient = new QueryClient();
 
   render(
-    <RecoilRoot
-      initializeState={(snapshot: MutableSnapshot) => {
-        return snapshot.set(brandStoresState, storesResponse);
-      }}
-    >
+    <RecoilRoot>
       <QueryClientProvider client={queryClient}>
         <BrowserRouter>
-          <RecoilObserver node={brandStoresState} event={jest.fn()} />
-          <Members />
+          <JotaiTestProvider
+            initialValues={[[brandStoresState, storesResponse]]}
+          >
+            <Members />
+          </JotaiTestProvider>
         </BrowserRouter>
       </QueryClientProvider>
     </RecoilRoot>,

--- a/static/js/publisher/pages/Model/CreatePolicyForm.tsx
+++ b/static/js/publisher/pages/Model/CreatePolicyForm.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, Dispatch, SetStateAction } from "react";
-import { useRecoilState, useRecoilValue } from "recoil";
+import { useRecoilState } from "recoil";
 import { useAtomValue as useJotaiValue } from "jotai";
 import { useParams, Link, useNavigate, useLocation } from "react-router-dom";
 import { useMutation, useQueryClient } from "react-query";
@@ -32,7 +32,7 @@ function CreatePolicyForm({
   const { isLoading, isError, error, data } = useSigningKeys(id);
   const [signingKeys, setSigningKeys] = useRecoilState(signingKeysListState);
   const [newSigningKey, setNewSigningKey] = useRecoilState(newSigningKeyState);
-  const brandStore = useRecoilValue(brandStoreState(id));
+  const brandStore = useJotaiValue(brandStoreState(id));
   const [isSaving, setIsSaving] = useState(false);
   const queryClient = useQueryClient();
 

--- a/static/js/publisher/pages/Model/Model.tsx
+++ b/static/js/publisher/pages/Model/Model.tsx
@@ -32,7 +32,7 @@ function Model() {
   const [showSuccessNotification, setShowSuccessNotificaton] = useState(false);
   const [showErrorNotification, setShowErrorNotificaton] = useState(false);
   const setModelsList = useSetRecoilState<ModelType[]>(modelsListState);
-  const brandStore = useRecoilValue(brandStoreState(id));
+  const brandStore = useJotaiValue(brandStoreState(id));
 
   const mutation = useMutation({
     mutationFn: (apiKey: string) => {

--- a/static/js/publisher/pages/Model/Policies.tsx
+++ b/static/js/publisher/pages/Model/Policies.tsx
@@ -6,7 +6,8 @@ import {
   useLocation,
   useNavigate,
 } from "react-router-dom";
-import { useSetRecoilState, useRecoilValue } from "recoil";
+import { useSetRecoilState } from "recoil";
+import { useAtomValue as useJotaiValue } from "jotai";
 import { Row, Col, Notification, Icon } from "@canonical/react-components";
 
 import ModelNav from "./ModelNav";
@@ -42,7 +43,7 @@ function Policies(): React.JSX.Element {
   const setPoliciesList = useSetRecoilState<Array<Policy>>(policiesListState);
   const setFilter = useSetRecoilState<string>(policiesListFilterState);
   const setNewSigningKey = useSetRecoilState(newSigningKeyState);
-  const brandStore = useRecoilValue(brandStoreState(id));
+  const brandStore = useJotaiValue(brandStoreState(id));
   const [searchParams] = useSearchParams();
   const [showNotification, setShowNotification] = useState<boolean>(false);
   const [showErrorNotification, setShowErrorNotification] =

--- a/static/js/publisher/pages/Models/CreateModelForm.tsx
+++ b/static/js/publisher/pages/Models/CreateModelForm.tsx
@@ -1,7 +1,7 @@
 import { Dispatch, SetStateAction, useState } from "react";
 import { useNavigate, useParams, useLocation, Link } from "react-router-dom";
 import { useRecoilState, useRecoilValue, useSetRecoilState } from "recoil";
-import { useAtomValue as useJotaiValue } from "jotai";
+import { useAtomValue as useJotaiValue, useAtom as useJotaiState } from "jotai";
 import { useMutation, useQueryClient } from "react-query";
 import { Input, Button, Icon } from "@canonical/react-components";
 import randomstring from "randomstring";
@@ -35,10 +35,10 @@ function CreateModelForm({
   const { id } = useParams();
   const brandId = useJotaiValue(brandIdState);
   const [newModel, setNewModel] = useRecoilState(newModelState);
-  const stores = useRecoilState(brandStoresState);
+  const stores = useJotaiState(brandStoresState);
   const currentStore = stores[0].find((store: Store) => store.id === id);
   const modelsList = useRecoilValue(filteredModelsListState);
-  const brandStore = useRecoilValue(brandStoreState(id));
+  const brandStore = useJotaiValue(brandStoreState(id));
   const setModelsList = useSetRecoilState<Array<Model>>(modelsListState);
   const [isSaving, setIsSaving] = useState(false);
 

--- a/static/js/publisher/pages/Models/Models.tsx
+++ b/static/js/publisher/pages/Models/Models.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import { useSetRecoilState, useRecoilValue } from "recoil";
+import { useSetRecoilState } from "recoil";
 import { useAtomValue as useJotaiValue } from "jotai";
 import {
   Link,
@@ -46,7 +46,7 @@ function Models(): React.JSX.Element {
   const setPolicies = useSetRecoilState<Array<Policy>>(policiesListState);
   const setNewModel = useSetRecoilState(newModelState);
   const setFilter = useSetRecoilState<string>(modelsListFilterState);
-  const brandStore = useRecoilValue(brandStoreState(id));
+  const brandStore = useJotaiValue(brandStoreState(id));
   const [searchParams] = useSearchParams();
   const [showNotification, setShowNotification] = useState<boolean>(false);
   const [showErrorNotification, setShowErrorNotification] =

--- a/static/js/publisher/pages/RegisterNameDispute/__tests__/RegisterNameDisputeForm.test.tsx
+++ b/static/js/publisher/pages/RegisterNameDispute/__tests__/RegisterNameDisputeForm.test.tsx
@@ -4,13 +4,11 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom";
 
-import { RecoilObserver, storesResponse } from "../../../test-utils";
+import { JotaiTestProvider, storesResponse } from "../../../test-utils";
 
 import { brandStoresState } from "../../../state/brandStoreState";
 
 import RegisterNameDisputeForm from "../RegisterNameDisputeForm";
-
-import type { MutableSnapshot } from "recoil";
 
 const testSnapName = "test-snap-name";
 const testStoreName = "Test store";
@@ -18,17 +16,14 @@ const testStoreName = "Test store";
 function renderComponent() {
   render(
     <BrowserRouter>
-      <RecoilRoot
-        initializeState={(snapshot: MutableSnapshot) => {
-          return snapshot.set(brandStoresState, storesResponse);
-        }}
-      >
-        <RecoilObserver node={brandStoresState} event={jest.fn()} />
-        <RegisterNameDisputeForm
-          snapName={testSnapName}
-          store={testStoreName}
-          setClaimSubmitted={jest.fn()}
-        />
+      <RecoilRoot>
+        <JotaiTestProvider initialValues={[[brandStoresState, storesResponse]]}>
+          <RegisterNameDisputeForm
+            snapName={testSnapName}
+            store={testStoreName}
+            setClaimSubmitted={jest.fn()}
+          />
+        </JotaiTestProvider>
       </RecoilRoot>
     </BrowserRouter>,
   );

--- a/static/js/publisher/pages/RequestReservedName/RequestReservedName.tsx
+++ b/static/js/publisher/pages/RequestReservedName/RequestReservedName.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { Link, useSearchParams } from "react-router-dom";
-import { useRecoilValue } from "recoil";
+import { useAtomValue as useJotaiValue } from "jotai";
 import {
   Form,
   Button,
@@ -20,7 +20,7 @@ function RequestReservedName(): React.JSX.Element {
   const [showSuccessNotification, setShowSuccessNotification] =
     useState<boolean>(false);
   const [errorNotification, setErrorNotification] = useState<string>();
-  const stores = useRecoilValue(brandStoresState);
+  const stores = useJotaiValue(brandStoresState);
   const [searchParams] = useSearchParams();
   const snapName = searchParams.get("snap_name");
   const store = searchParams.get("store");

--- a/static/js/publisher/pages/RequestReservedName/__tests__/RequestReservedName.test.tsx
+++ b/static/js/publisher/pages/RequestReservedName/__tests__/RequestReservedName.test.tsx
@@ -6,13 +6,11 @@ import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom";
 
-import { RecoilObserver, storesResponse } from "../../../test-utils";
+import { JotaiTestProvider, storesResponse } from "../../../test-utils";
 
 import { brandStoresState } from "../../../state/brandStoreState";
 
 import RequestReservedName from "../RequestReservedName";
-
-import type { MutableSnapshot } from "recoil";
 
 const testSnapName = "test-snap-name";
 const testStoreName = "Test store";
@@ -22,13 +20,10 @@ window.CSRF_TOKEN = "test-csrf-token";
 function renderComponent() {
   render(
     <BrowserRouter>
-      <RecoilRoot
-        initializeState={(snapshot: MutableSnapshot) => {
-          return snapshot.set(brandStoresState, storesResponse);
-        }}
-      >
-        <RecoilObserver node={brandStoresState} event={jest.fn()} />
-        <RequestReservedName />
+      <RecoilRoot>
+        <JotaiTestProvider initialValues={[[brandStoresState, storesResponse]]}>
+          <RequestReservedName />
+        </JotaiTestProvider>
       </RecoilRoot>
     </BrowserRouter>,
   );

--- a/static/js/publisher/pages/SigningKeys/CreateSigningKeyForm.tsx
+++ b/static/js/publisher/pages/SigningKeys/CreateSigningKeyForm.tsx
@@ -33,7 +33,7 @@ function CreateSigningKeyForm({
   const brandId = useJotaiValue(brandIdState);
   const [newSigningKey, setNewSigningKey] = useRecoilState(newSigningKeyState);
   const signingKeysList = useRecoilValue(filteredSigningKeysListState);
-  const brandStore = useRecoilValue(brandStoreState(id));
+  const brandStore = useJotaiValue(brandStoreState(id));
   const setSigningKeysList =
     useSetRecoilState<Array<SigningKey>>(signingKeysListState);
   const [isSaving, setIsSaving] = useState(false);

--- a/static/js/publisher/pages/SigningKeys/SigningKeys.tsx
+++ b/static/js/publisher/pages/SigningKeys/SigningKeys.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import { useSetRecoilState, useRecoilValue } from "recoil";
+import { useSetRecoilState } from "recoil";
 import { useAtomValue as useJotaiValue } from "jotai";
 import {
   Link,
@@ -51,7 +51,7 @@ function SigningKeys(): React.JSX.Element {
   const setPolicies = useSetRecoilState<Array<Policy>>(policiesListState);
   const setFilter = useSetRecoilState<string>(signingKeysListFilterState);
   const setNewSigningKey = useSetRecoilState(newSigningKeyState);
-  const brandStore = useRecoilValue(brandStoreState(id));
+  const brandStore = useJotaiValue(brandStoreState(id));
   const [searchParams] = useSearchParams();
   const [showNotification, setShowNotification] = useState<boolean>(false);
   const [errorMessage, setErrorMessage] = useState<string>("");

--- a/static/js/publisher/pages/Snaps/Snaps.tsx
+++ b/static/js/publisher/pages/Snaps/Snaps.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from "react";
 import { useParams, Link } from "react-router-dom";
-import { useRecoilValue } from "recoil";
+import { useAtomValue as useJotaiValue } from "jotai";
 import {
   Spinner,
   Row,
@@ -31,7 +31,7 @@ import type { Store, Snap, SnapsList, Member } from "../../types/shared";
 
 function Snaps() {
   const { id } = useParams();
-  const brandStoresList = useRecoilValue(brandStoresState);
+  const brandStoresList = useJotaiValue(brandStoresState);
   const {
     data: snaps,
     isLoading: snapsLoading,

--- a/static/js/publisher/pages/Snaps/__tests__/Snaps.test.tsx
+++ b/static/js/publisher/pages/Snaps/__tests__/Snaps.test.tsx
@@ -1,4 +1,4 @@
-import { RecoilRoot, MutableSnapshot } from "recoil";
+import { RecoilRoot } from "recoil";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { BrowserRouter } from "react-router-dom";
 import { setupServer } from "msw/node";
@@ -7,7 +7,7 @@ import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom";
 
 import {
-  RecoilObserver,
+  JotaiTestProvider,
   brandStoreRequests,
   storesResponse,
 } from "../../../test-utils";
@@ -29,15 +29,14 @@ const queryClient = new QueryClient();
 
 function renderComponent() {
   return render(
-    <RecoilRoot
-      initializeState={(snapshot: MutableSnapshot) => {
-        return snapshot.set(brandStoresState, storesResponse);
-      }}
-    >
+    <RecoilRoot>
       <QueryClientProvider client={queryClient}>
         <BrowserRouter>
-          <RecoilObserver node={brandStoresState} event={jest.fn()} />
-          <Snaps />
+          <JotaiTestProvider
+            initialValues={[[brandStoresState, storesResponse]]}
+          >
+            <Snaps />
+          </JotaiTestProvider>
         </BrowserRouter>
       </QueryClientProvider>
     </RecoilRoot>,

--- a/static/js/publisher/routes/brand-store-root.tsx
+++ b/static/js/publisher/routes/brand-store-root.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from "react";
-import { useSetRecoilState } from "recoil";
+import { useSetAtom as useSetJotaiState } from "jotai";
 import {
   BrowserRouter as Router,
   Routes,
@@ -24,7 +24,7 @@ import StoreNotFound from "../pages/StoreNotFound";
 function BrandStoreRoot() {
   const { data: brandStoresList, isLoading } = useBrandStores();
 
-  const setRecoilBrandStores = useSetRecoilState(brandStoresState);
+  const setRecoilBrandStores = useSetJotaiState(brandStoresState);
 
   useEffect(() => {
     if (brandStoresList) {

--- a/static/js/publisher/state/brandStoreState.ts
+++ b/static/js/publisher/state/brandStoreState.ts
@@ -1,23 +1,17 @@
-import { atom, selectorFamily } from "recoil";
-import { atom as jotaiAtom } from "jotai";
+import { atom } from "jotai";
+import { atomFamily } from "jotai/utils";
 
 import type { Store } from "../types/shared";
 
-const brandStoresState = atom({
-  key: "brandStores",
-  default: [] as Array<Store>,
-});
+const brandStoresState = atom([] as Store[]);
 
-const brandIdState = jotaiAtom("");
+const brandIdState = atom("");
 
-const brandStoreState = selectorFamily({
-  key: "brandStore",
-  get:
-    (storeId) =>
-    ({ get }) => {
-      const brandStores = get(brandStoresState);
-      return brandStores.find((store) => store.id === storeId);
-    },
+const brandStoreState = atomFamily((storeId) => {
+  return atom((get) => {
+    const brandStores: Store[] = get(brandStoresState);
+    return brandStores.find((store) => store.id === storeId);
+  });
 });
 
 export { brandStoresState, brandIdState, brandStoreState };

--- a/static/js/publisher/test-utils/JotaiTestProvider.tsx
+++ b/static/js/publisher/test-utils/JotaiTestProvider.tsx
@@ -1,0 +1,33 @@
+import { Provider as JotaiProvider } from "jotai";
+import { useHydrateAtoms } from "jotai/utils";
+
+import type { PrimitiveAtom } from "jotai";
+
+import type { Store } from "../types/shared";
+
+type InitialValues = Array<readonly [PrimitiveAtom<Store[]>, Store[]]>;
+
+const HydrateAtoms = ({
+  initialValues,
+  children,
+}: {
+  initialValues: InitialValues;
+  children: JSX.Element;
+}) => {
+  useHydrateAtoms(initialValues);
+  return children;
+};
+
+const JotaiTestProvider = ({
+  initialValues,
+  children,
+}: {
+  initialValues: InitialValues;
+  children: JSX.Element;
+}) => (
+  <JotaiProvider>
+    <HydrateAtoms initialValues={initialValues}>{children}</HydrateAtoms>
+  </JotaiProvider>
+);
+
+export default JotaiTestProvider;

--- a/static/js/publisher/test-utils/index.ts
+++ b/static/js/publisher/test-utils/index.ts
@@ -14,6 +14,7 @@ import {
   membersResponse,
   storesResponse,
 } from "./brand-store-responses";
+import JotaiTestProvider from "./JotaiTestProvider";
 
 export {
   mockListingData,
@@ -30,4 +31,5 @@ export {
   mockReleasedChannels,
   mockReleasesData,
   mockRevisionsMap,
+  JotaiTestProvider,
 };


### PR DESCRIPTION
## Done
Converts the state related to brand stores from Recoil to Jotai

## How to QA
- Go to https://snapcraft-io-5207.demos.haus/admin
- Check that the brand stores dropdown navigation works as expected
- If you have access to models, check that you can create a new model

## Testing
- [x] This PR has tests
- [ ] No testing required (explain why):

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-23493
