### PR TITLE
fix: automatic progressive releases

### DIFF
--- a/static/js/publisher/pages/Releases/releasesState.js
+++ b/static/js/publisher/pages/Releases/releasesState.js
@@ -50,10 +50,19 @@ function initReleasesData(revisionsMap, releases, channelMap) {
               if (currentChannel) {
                 release.progressive["current-percentage"] =
                   currentChannel.progressive["current-percentage"];
-                  if (currentChannel.progressive.percentage !== release.progressive.percentage) {
-                    release.progressive.percentage =
-                      currentChannel.progressive.percentage || 100;
-                  }
+                // if the current channel has a different percentage
+                // than the release, we need to update the release
+                // to match the current channel's percentage
+                // If the current channel is null, this means that
+                // an automatic release was completed
+                // and we need to set the percentage to 100
+                if (
+                  currentChannel.progressive.percentage !==
+                  release.progressive.percentage
+                ) {
+                  release.progressive.percentage =
+                    currentChannel.progressive.percentage || 100;
+                }
               }
             }
           }


### PR DESCRIPTION
## Done
If a progressive release has been marked as "automatic" an explicit release is not created, therefore we need to:
1. Check the current release against the channel map (like we do to get the up-to-date percentage of current users.
2. Update the percentage of the release if the channel map has a different percentage
3. if the progressive release has "finished" the percentage in the channel map will be `null`, in this case set the percentage to `100`.

## How to QA
- Visit https://snapcraft-io-5219.demos.haus/firefox/releases
- The stable track should show progressive releases, if you open the history the target should be shown as 100
- Visit https://snapcraft-io-5219.demos.haus/deno/releases
- The beta track should show progressive releases, it should be set to 41% correctly.

## Testing
- [x] This PR has tests - covered by current tests
- [ ] No testing required (explain why):

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-23858

## Screenshots
