### PR TITLE
fix: allow the user to promote a release even if there are some matching revisions

### DIFF
--- a/static/js/publisher/pages/Releases/components/releasesTable/channelHeading.tsx
+++ b/static/js/publisher/pages/Releases/components/releasesTable/channelHeading.tsx
@@ -54,7 +54,7 @@ const canReleaseToChannel = (
   targetChannel: string,
 ) => {
   if (currentRevisionsByArch) {
-    return Object.keys(currentRevisionsByArch).every((arch) => {
+    return Object.keys(currentRevisionsByArch).some((arch) => {
       if (!targetRevisionsByArch?.[arch]) {
         return true; // no target revision for this arch, can release
       }


### PR DESCRIPTION
## Done
- allow the user to promote a release even if there are some matching revisions  (not all)

## How to QA
- go to  https://snapcraft-io-5227.demos.haus/ilayda-test-hello/releases
-  hover on "latest/candidate" cell
- Verify  a button with "Promote/close" appears
- Clicl on that button
- Verify "latest/stable" is visible under the "Promote to:" section
- click on that 
- Verify changes that have different revisions are shown in green.

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why):

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-23853