### PR TITLE
Update TiCS action to use self-hosted runners

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -2,6 +2,7 @@ name: Test coverage
 on:
   schedule:
     - cron: "0 22 * * *"
+  workflow_dispatch: # Allows manual triggering
 
 jobs:
   test:
@@ -39,7 +40,7 @@ jobs:
       - name: Zip coverage report
         run: |
           zip -r coverage/cobertura-coverage.zip coverage/cobertura-coverage.xml coverage/coverage.xml
-      
+
       - name: Upload coverage report
         if: always()
         uses: actions/upload-artifact@v4
@@ -47,60 +48,59 @@ jobs:
           name: snapcraftio-coverage
           path: coverage
           retention-days: 1
-  
-  publish-coverage-report:
-      name: publish-coverage-report
-      runs-on: ubuntu-latest
-      needs: test
-      continue-on-error: true
-      steps:
-        - uses: actions/checkout@v4
-          with:
-            ref: gh-pages
-            token: ${{ secrets.GITHUB_TOKEN }}
-        - name: Cleanup coverage directory
-          run: |
-            rm -rf coverage
-            mkdir coverage
-        - name: Download coverage report artifact
-          uses: actions/download-artifact@v4
-          with:
-            name: snapcraftio-coverage
-            path: coverage
-        # user git configs are needed for git commands to work
-        # actual authentication is done using secrets.GITHUB_TOKEN with write permission
-        - name: Set Git User
-          run: |
-            git config --global user.email "github-action@example.com"
-            git config --global user.name "GitHub Action"
-        - name: Push coverage Report
-          timeout-minutes: 3
-          run: |
-            git add .
-            git commit -m "workflow: update coverage report"
-            
-            # In case of another action job pushing to gh-pages while we are rebasing for the current job
-            while true; do
-              git pull --rebase
-              if [ $? -ne 0 ]; then
-                echo "Failed to rebase. Please review manually."
-                exit 1
-              fi
-  
-              git push
-              if [ $? -eq 0 ]; then
-                echo "Successfully pushed HTML report to repo."
-                exit 0
-              fi
-            done
-        - name: Output Report URL as Worfklow Annotation
-          run: |
-            FULL_HTML_REPORT_URL=https://canonical.github.io/snapcraft.io/coverage
-            echo "::notice title=Published Playwright Test Report::$FULL_HTML_REPORT_URL"
 
+  publish-coverage-report:
+    name: publish-coverage-report
+    runs-on: ubuntu-latest
+    needs: test
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Cleanup coverage directory
+        run: |
+          rm -rf coverage
+          mkdir coverage
+      - name: Download coverage report artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: snapcraftio-coverage
+          path: coverage
+      # user git configs are needed for git commands to work
+      # actual authentication is done using secrets.GITHUB_TOKEN with write permission
+      - name: Set Git User
+        run: |
+          git config --global user.email "github-action@example.com"
+          git config --global user.name "GitHub Action"
+      - name: Push coverage Report
+        timeout-minutes: 3
+        run: |
+          git add .
+          git commit -m "workflow: update coverage report"
+
+          # In case of another action job pushing to gh-pages while we are rebasing for the current job
+          while true; do
+            git pull --rebase
+            if [ $? -ne 0 ]; then
+              echo "Failed to rebase. Please review manually."
+              exit 1
+            fi
+
+            git push
+            if [ $? -eq 0 ]; then
+              echo "Successfully pushed HTML report to repo."
+              exit 0
+            fi
+          done
+      - name: Output Report URL as Worfklow Annotation
+        run: |
+          FULL_HTML_REPORT_URL=https://canonical.github.io/snapcraft.io/coverage
+          echo "::notice title=Published Playwright Test Report::$FULL_HTML_REPORT_URL"
 
   tics-report:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, reactive, amd64, tiobe, noble]
     needs: publish-coverage-report
     steps:
       - uses: actions/checkout@v4
@@ -111,21 +111,35 @@ jobs:
           name: snapcraftio-coverage
           path: coverage
 
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+          cache: "pip"
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "yarn"
+
       - name: Install Python requirements
         run: |
-          sudo pip3 install -r requirements.txt
-
-      - name: Install Python dependencies
-        run: sudo pip3 install pylint
+          python -m pip install --upgrade pip
+          pip3 install -r requirements.txt
+          pip3 install pylint
 
       - name: Install JS dependencies
-        run: yarn install --immutable
-
-      - name: Produce TICS report
-        shell: bash
         run: |
-          set -x
-          export TICSAUTHTOKEN=${{ secrets.TICSAUTHTOKEN }}
-          curl --silent --show-error "https://canonical.tiobe.com/tiobeweb/TICS/api/public/v1/fapi/installtics/Script?cfg=default&platform=linux&url=https://canonical.tiobe.com/tiobeweb/TICS/" > install_tics.sh
-          . ./install_tics.sh
-          TICSQServer -project snapcraft.io -tmpdir /tmp/tics -branchdir . -nosanity
+          yarn install --immutable
+
+      - name: Run TICS analysis with github-action
+        uses: tiobe/tics-github-action@v3
+        with:
+          mode: qserver
+          project: snapcraft.io
+          branchdir: .
+          viewerUrl: https://canonical.tiobe.com/tiobeweb/TICS/api/cfg?name=default
+          ticsAuthToken: ${{ secrets.TICSAUTHTOKEN }}
+          installTics: true
+


### PR DESCRIPTION
## Done
Updated TiCS action with the following:
1. use a self-hosted runner
2. use `tiobe/tics-github-action` rather than rolling our own script
3. enable manual triggering
4. fix wrong indentation on some blocks

## How to QA
There's no real way to QA it except by triggering the action and letting it run

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why): Here's a successful run of the action https://github.com/canonical/snapcraft.io/actions/runs/16493890465
