### PR TITLE
chore: Move brand endpoint to endpoints section of app

### DIFF
--- a/tests/endpoints/endpoint_testing.py
+++ b/tests/endpoints/endpoint_testing.py
@@ -1,4 +1,5 @@
 from unittest import TestCase
+from unittest.mock import patch
 
 from webapp.app import create_app
 from webapp.authentication import get_publishergw_authorization_header
@@ -26,3 +27,12 @@ class TestEndpoints(TestCase):
         self.app = create_app(testing=True)
         self.client = self.app.test_client()
         self._log_in(self.client)
+
+
+class TestModelServiceEndpoints(TestEndpoints):
+    def setUp(self):
+        self.api_key = "qwertyuioplkjhgfdsazxcvbnmkiopuytrewqasdfghjklmnbv"
+        self.mock_get_store = patch(
+            "webapp.endpoints.views.dashboard.get_store"
+        ).start()
+        super().setUp()

--- a/tests/endpoints/test_brand_store.py
+++ b/tests/endpoints/test_brand_store.py
@@ -1,7 +1,7 @@
 from unittest.mock import patch
 from canonicalwebteam.exceptions import StoreApiResponseErrorList
 
-from tests.admin.tests_models import TestModelServiceEndpoints
+from tests.endpoints.endpoint_testing import TestModelServiceEndpoints
 
 
 class TestGetBrandStoreEndpoint(TestModelServiceEndpoints):

--- a/webapp/admin/views.py
+++ b/webapp/admin/views.py
@@ -497,34 +497,6 @@ def delete_policy(store_id: str, model_name: str, revision: str):
     return make_response(res, 500)
 
 
-@admin.route("/api/store/<store_id>/brand")
-@login_required
-@exchange_required
-def get_brand_store(store_id: str):
-    brand_id = get_brand_id(flask.session, store_id)
-    res = {}
-    try:
-        brand = publisher_gateway.get_brand(flask.session, brand_id)
-
-        res["data"] = brand
-        res["success"] = True
-
-    except StoreApiResponseErrorList as error_list:
-        res["success"] = False
-        res["message"] = " ".join(
-            [
-                f"{error.get('message', 'An error occurred')}"
-                for error in error_list.errors
-            ]
-        )
-        res["data"] = []
-
-    response = make_response(res)
-    response.cache_control.max_age = 3600
-
-    return response
-
-
 @admin.route("/api/store/<store_id>/signing-keys")
 @login_required
 @exchange_required

--- a/webapp/endpoints/views.py
+++ b/webapp/endpoints/views.py
@@ -1,19 +1,30 @@
 # Packages
 import flask
+from flask import make_response
+from canonicalwebteam.exceptions import (
+    StoreApiResponseErrorList,
+)
 from canonicalwebteam.store_api.dashboard import Dashboard
+from canonicalwebteam.store_api.publishergw import PublisherGW
 from flask.json import jsonify
 
 # Local
 from webapp.decorators import login_required, exchange_required
-from webapp.helpers import api_session
+from webapp.helpers import api_publisher_session, api_session
 
 
 dashboard = Dashboard(api_session)
+publisher_gateway = PublisherGW("snap", api_publisher_session)
 
 endpoints = flask.Blueprint(
     "endpoints",
     __name__,
 )
+
+
+def get_brand_id(session, store_id):
+    store = dashboard.get_store(session, store_id)
+    return store["brand-id"]
 
 
 @endpoints.route("/api/stores")
@@ -28,3 +39,31 @@ def get_stores():
     res = {"success": True, "data": stores}
 
     return jsonify(res)
+
+
+@endpoints.route("/api/store/<store_id>/brand")
+@login_required
+@exchange_required
+def get_brand_store(store_id: str):
+    brand_id = get_brand_id(flask.session, store_id)
+    res = {}
+    try:
+        brand = publisher_gateway.get_brand(flask.session, brand_id)
+
+        res["data"] = brand
+        res["success"] = True
+
+    except StoreApiResponseErrorList as error_list:
+        res["success"] = False
+        res["message"] = " ".join(
+            [
+                f"{error.get('message', 'An error occurred')}"
+                for error in error_list.errors
+            ]
+        )
+        res["data"] = []
+
+    response = make_response(res)
+    response.cache_control.max_age = 3600
+
+    return response


### PR DESCRIPTION
## Done
Migrates `/api/store/<store_id>/brand` into a dedicated endpoints module

## How to QA
- Go to https://snapcraft-io-5239.demos.haus/api/store/ahnuP3quahti9vis8aiw/brand
- Check that it is the same as https://snapcraft.io/api/store/ahnuP3quahti9vis8aiw/brand

## Testing
- [x] This PR has tests
- [ ] No testing required (explain why):

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-24129