### PR TITLE
chore: Move releases endpoint to endpoints section of app

### DIFF
--- a/tests/endpoints/tests_releases.py
+++ b/tests/endpoints/tests_releases.py
@@ -1,0 +1,125 @@
+from unittest.mock import patch
+from tests.endpoints.endpoint_testing import TestEndpoints
+
+
+class TestGetReleaseHistoryData(TestEndpoints):
+    @patch("webapp.endpoints.releases.dashboard.snap_channel_map")
+    @patch("webapp.endpoints.releases.dashboard.snap_release_history")
+    def test_get_release_history_data_success(
+        self, mock_snap_release_history, mock_snap_channel_map
+    ):
+        """Test successful retrieval of release history data"""
+        snap_name = "test-snap"
+
+        # Mock release history response
+        mock_release_history = [
+            {
+                "revision": 1,
+                "version": "1.0",
+                "created_at": "2023-01-01T00:00:00Z",
+                "architectures": ["amd64"],
+                "channels": ["stable"],
+            }
+        ]
+        mock_snap_release_history.return_value = mock_release_history
+
+        # Mock channel map response
+        mock_channel_map_data = {
+            "snap": {
+                "title": "Test Snap",
+                "private": False,
+                "default-track": "latest",
+                "tracks": [{"name": "latest"}],
+                "publisher": {"display-name": "Test Publisher"},
+            },
+            "channel-map": [
+                {"channel": "stable", "revision": 1, "version": "1.0"}
+            ],
+        }
+        mock_snap_channel_map.return_value = mock_channel_map_data
+
+        response = self.client.get(f"/api/{snap_name}/releases")
+        data = response.get_json()
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(data["success"])
+        self.assertIn("data", data)
+
+        context = data["data"]
+        self.assertEqual(context["snap_name"], snap_name)
+        self.assertEqual(context["snap_title"], "Test Snap")
+        self.assertEqual(context["publisher_name"], "Test Publisher")
+        self.assertEqual(context["release_history"], mock_release_history)
+        self.assertFalse(context["private"])
+        self.assertEqual(context["default_track"], "latest")
+        self.assertEqual(
+            context["channel_map"], mock_channel_map_data["channel-map"]
+        )
+        self.assertEqual(
+            context["tracks"], mock_channel_map_data["snap"]["tracks"]
+        )
+
+        # Verify the dashboard methods were called with correct parameters
+        mock_snap_release_history.assert_called_once()
+        mock_snap_channel_map.assert_called_once()
+
+    @patch("webapp.endpoints.releases.dashboard.snap_channel_map")
+    @patch("webapp.endpoints.releases.dashboard.snap_release_history")
+    def test_get_release_history_data_default_track_none(
+        self, mock_snap_release_history, mock_snap_channel_map
+    ):
+        """Test that default track defaults to 'latest' when None"""
+        snap_name = "test-snap"
+
+        mock_snap_release_history.return_value = []
+
+        # Mock channel map with default-track as None
+        mock_channel_map_data = {
+            "snap": {
+                "title": "Test Snap",
+                "private": False,
+                "default-track": None,  # This should default to "latest"
+                "tracks": [],
+                "publisher": {"display-name": "Test Publisher"},
+            },
+            "channel-map": [],
+        }
+        mock_snap_channel_map.return_value = mock_channel_map_data
+
+        response = self.client.get(f"/api/{snap_name}/releases")
+        data = response.get_json()
+
+        self.assertEqual(response.status_code, 200)
+        context = data["data"]
+        self.assertEqual(context["default_track"], "latest")
+
+    @patch("webapp.endpoints.releases.dashboard.snap_channel_map")
+    @patch("webapp.endpoints.releases.dashboard.snap_release_history")
+    def test_get_release_history_data_empty_snap(
+        self, mock_snap_release_history, mock_snap_channel_map
+    ):
+        """Test handling of empty snap data"""
+        snap_name = "test-snap"
+
+        mock_snap_release_history.return_value = []
+
+        # Mock channel map with empty snap data
+        mock_channel_map_data = {
+            "snap": {},  # Empty snap data
+            "channel-map": [],
+        }
+        mock_snap_channel_map.return_value = mock_channel_map_data
+
+        response = self.client.get(f"/api/{snap_name}/releases")
+        data = response.get_json()
+
+        self.assertEqual(response.status_code, 200)
+        context = data["data"]
+        self.assertEqual(context["snap_name"], snap_name)
+        self.assertIsNone(context["snap_title"])
+        # Empty dict for missing publisher
+        self.assertEqual(context["publisher_name"], {})
+        # Should default to latest
+        self.assertEqual(context["default_track"], "latest")
+        self.assertIsNone(context["private"])
+        self.assertIsNone(context["tracks"])

--- a/webapp/endpoints/releases.py
+++ b/webapp/endpoints/releases.py
@@ -1,0 +1,35 @@
+# Packages
+import flask
+from canonicalwebteam.store_api.dashboard import Dashboard
+
+# Local
+from webapp.helpers import api_publisher_session
+from webapp.decorators import login_required
+
+dashboard = Dashboard(api_publisher_session)
+
+
+@login_required
+def get_release_history_data(snap_name):
+    release_history = dashboard.snap_release_history(flask.session, snap_name)
+
+    channel_map = dashboard.snap_channel_map(flask.session, snap_name)
+
+    snap = channel_map.get("snap", {})
+
+    context = {
+        "snap_name": snap_name,
+        "snap_title": snap.get("title"),
+        "publisher_name": snap.get("publisher", {}).get("display-name", {}),
+        "release_history": release_history,
+        "private": snap.get("private"),
+        "default_track": (
+            snap.get("default-track")
+            if snap.get("default-track") is not None
+            else "latest"
+        ),
+        "channel_map": channel_map.get("channel-map"),
+        "tracks": snap.get("tracks"),
+    }
+
+    return flask.jsonify({"success": True, "data": context})

--- a/webapp/publisher/snaps/release_views.py
+++ b/webapp/publisher/snaps/release_views.py
@@ -18,32 +18,6 @@ def redirect_get_release_history(snap_name):
 
 
 @login_required
-def get_release_history_data(snap_name):
-    release_history = dashboard.snap_release_history(flask.session, snap_name)
-
-    channel_map = dashboard.snap_channel_map(flask.session, snap_name)
-
-    snap = channel_map.get("snap", {})
-
-    context = {
-        "snap_name": snap_name,
-        "snap_title": snap.get("title"),
-        "publisher_name": snap.get("publisher", {}).get("display-name", {}),
-        "release_history": release_history,
-        "private": snap.get("private"),
-        "default_track": (
-            snap.get("default-track")
-            if snap.get("default-track") is not None
-            else "latest"
-        ),
-        "channel_map": channel_map.get("channel-map"),
-        "tracks": snap.get("tracks"),
-    }
-
-    return flask.jsonify({"success": True, "data": context})
-
-
-@login_required
 def get_releases(snap_name):
     # If this fails, the page will 404
     dashboard.get_snap_info(flask.session, snap_name)

--- a/webapp/publisher/snaps/views.py
+++ b/webapp/publisher/snaps/views.py
@@ -28,6 +28,7 @@ from webapp.publisher.snaps import (
     settings_views,
     collaboration_views,
 )
+from webapp.endpoints import releases
 from webapp.publisher.snaps.builds import map_snap_build_status
 
 dashboard = Dashboard(api_publisher_session)
@@ -168,7 +169,7 @@ publisher_snaps.add_url_rule(
 )
 publisher_snaps.add_url_rule(
     "/api/<snap_name>/releases",
-    view_func=release_views.get_release_history_data,
+    view_func=releases.get_release_history_data,
     methods=["GET"],
 )
 publisher_snaps.add_url_rule(


### PR DESCRIPTION
## Done
Moves the releases endpoint to the endpoints section of the app

## How to QA
- Go to https://snapcraft-io-5275.demos.haus/api/steve-test-snap/releases
- Check that it is the same as https://snapcraft.io/api/steve-test-snap/releases

## Testing
- [x] This PR has tests
- [ ] No testing required (explain why):

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-24102
