### PR TITLE
chore: Move get repo endpoint to endpoints section of app

### DIFF
--- a/tests/endpoints/tests_builds.py
+++ b/tests/endpoints/tests_builds.py
@@ -1,0 +1,189 @@
+from unittest.mock import patch, MagicMock
+from tests.endpoints.endpoint_testing import TestEndpoints
+
+
+class TestGetSnapRepo(TestEndpoints):
+    def setUp(self):
+        super().setUp()
+        self.snap_name = "test-snap"
+        self.endpoint_url = f"/api/{self.snap_name}/repo"
+
+    @patch("webapp.endpoints.builds.GitHub")
+    @patch("webapp.endpoints.builds.launchpad")
+    @patch("webapp.endpoints.builds.dashboard")
+    def test_get_snap_repo_with_existing_lp_snap_success(
+        self, mock_dashboard, mock_launchpad, mock_github_class
+    ):
+        """Test get_snap_repo when snap exists in Launchpad and GitHub
+        repo is accessible"""
+        # Mock dashboard responses
+        mock_snap_info = {"snap_name": self.snap_name}
+        mock_dashboard.get_snap_info.return_value = mock_snap_info
+        mock_dashboard.get_package_upload_macaroon.return_value = None
+
+        # Mock Launchpad response
+        mock_lp_snap = {
+            "git_repository_url": "https://github.com/test-owner/test-repo"
+        }
+        mock_launchpad.get_snap_by_store_name.return_value = mock_lp_snap
+
+        # Mock GitHub responses
+        mock_github = MagicMock()
+        mock_github.check_if_repo_exists.return_value = True
+        mock_github.get_user.return_value = {"login": "test-user"}
+        mock_github.get_orgs.return_value = [{"login": "test-org"}]
+        mock_github_class.return_value = mock_github
+
+        response = self.client.get(self.endpoint_url)
+        data = response.get_json()
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(data["success"])
+        self.assertEqual(data["message"], "")
+        self.assertEqual(
+            data["data"]["github_repository"], "test-owner/test-repo"
+        )
+        self.assertEqual(data["data"]["github_user"], {"login": "test-user"})
+        self.assertEqual(data["data"]["github_orgs"], [{"login": "test-org"}])
+
+        # Verify dashboard methods were called
+        mock_dashboard.get_snap_info.assert_called_once()
+        mock_dashboard.get_package_upload_macaroon.assert_called_once()
+
+    @patch("webapp.endpoints.builds.GitHub")
+    @patch("webapp.endpoints.builds.launchpad")
+    @patch("webapp.endpoints.builds.dashboard")
+    def test_get_snap_repo_with_revoked_github_access(
+        self, mock_dashboard, mock_launchpad, mock_github_class
+    ):
+        """Test get_snap_repo when GitHub repo access has been revoked"""
+        # Mock dashboard responses
+        mock_snap_info = {"snap_name": self.snap_name}
+        mock_dashboard.get_snap_info.return_value = mock_snap_info
+        mock_dashboard.get_package_upload_macaroon.return_value = None
+
+        # Mock Launchpad response
+        mock_lp_snap = {
+            "git_repository_url": "https://github.com/test-owner/test-repo"
+        }
+        mock_launchpad.get_snap_by_store_name.return_value = mock_lp_snap
+
+        # Mock GitHub responses - repo doesn't exist (revoked access)
+        mock_github = MagicMock()
+        mock_github.check_if_repo_exists.return_value = False
+        mock_github.get_user.return_value = {"login": "test-user"}
+        mock_github.get_orgs.return_value = [{"login": "test-org"}]
+        mock_github_class.return_value = mock_github
+
+        response = self.client.get(self.endpoint_url)
+        data = response.get_json()
+
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(data["data"]["success"])
+        self.assertEqual(data["data"]["message"], "This app has been revoked")
+        self.assertEqual(
+            data["data"]["github_repository"], "test-owner/test-repo"
+        )
+
+    @patch("webapp.endpoints.builds.GitHub")
+    @patch("webapp.endpoints.builds.launchpad")
+    @patch("webapp.endpoints.builds.dashboard")
+    def test_get_snap_repo_without_lp_snap_authorized(
+        self, mock_dashboard, mock_launchpad, mock_github_class
+    ):
+        """Test get_snap_repo when no Launchpad snap exists but user is
+        authorized"""
+        # Mock dashboard responses
+        mock_snap_info = {"snap_name": self.snap_name}
+        mock_dashboard.get_snap_info.return_value = mock_snap_info
+        mock_dashboard.get_package_upload_macaroon.return_value = None
+
+        # Mock Launchpad response - no snap found
+        mock_launchpad.get_snap_by_store_name.return_value = None
+
+        # Mock GitHub responses
+        mock_github = MagicMock()
+        mock_github.get_user.return_value = {"login": "test-user"}
+        mock_github.get_orgs.return_value = [{"login": "test-org"}]
+        mock_github_class.return_value = mock_github
+
+        response = self.client.get(self.endpoint_url)
+        data = response.get_json()
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(data["success"])
+        self.assertEqual(data["message"], "")
+        self.assertIsNone(data["data"]["github_repository"])
+        self.assertEqual(data["data"]["github_user"], {"login": "test-user"})
+        self.assertEqual(data["data"]["github_orgs"], [{"login": "test-org"}])
+
+    @patch("webapp.endpoints.builds.GitHub")
+    @patch("webapp.endpoints.builds.launchpad")
+    @patch("webapp.endpoints.builds.dashboard")
+    def test_get_snap_repo_without_lp_snap_unauthorized(
+        self, mock_dashboard, mock_launchpad, mock_github_class
+    ):
+        """Test get_snap_repo when no Launchpad snap exists and user is
+        unauthorized"""
+        # Mock dashboard responses
+        mock_snap_info = {"snap_name": self.snap_name}
+        mock_dashboard.get_snap_info.return_value = mock_snap_info
+        mock_dashboard.get_package_upload_macaroon.return_value = None
+
+        # Mock Launchpad response - no snap found
+        mock_launchpad.get_snap_by_store_name.return_value = None
+
+        # Mock GitHub responses - no user (unauthorized)
+        mock_github = MagicMock()
+        mock_github.get_user.return_value = None
+        mock_github_class.return_value = mock_github
+
+        response = self.client.get(self.endpoint_url)
+        data = response.get_json()
+
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(data["data"]["success"])
+        self.assertEqual(data["data"]["message"], "Unauthorized")
+        self.assertIsNone(data["data"]["github_repository"])
+
+    @patch(
+        "webapp.endpoints.builds.GITHUB_SNAPCRAFT_USER_TOKEN", "fallback-token"
+    )
+    @patch("webapp.endpoints.builds.GitHub")
+    @patch("webapp.endpoints.builds.launchpad")
+    @patch("webapp.endpoints.builds.dashboard")
+    def test_get_snap_repo_uses_fallback_token_when_no_session_token(
+        self, mock_dashboard, mock_launchpad, mock_github_class
+    ):
+        """Test get_snap_repo uses fallback token when no GitHub token
+        in session"""
+        # Mock dashboard responses
+        mock_snap_info = {"snap_name": self.snap_name}
+        mock_dashboard.get_snap_info.return_value = mock_snap_info
+        mock_dashboard.get_package_upload_macaroon.return_value = None
+
+        # Mock Launchpad response
+        mock_lp_snap = {
+            "git_repository_url": "https://github.com/test-owner/test-repo"
+        }
+        mock_launchpad.get_snap_by_store_name.return_value = mock_lp_snap
+
+        # Mock GitHub responses
+        mock_github = MagicMock()
+        mock_github.check_if_repo_exists.return_value = True
+        mock_github.get_user.return_value = {"login": "snapcraft-user"}
+        mock_github.get_orgs.return_value = []
+        mock_github_class.return_value = mock_github
+
+        # Clear GitHub token from session
+        with self.client.session_transaction() as session:
+            session.pop("github_auth_secret", None)
+
+        response = self.client.get(self.endpoint_url)
+        data = response.get_json()
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(data["success"])
+
+        # Verify GitHub was initialized with fallback token
+        mock_github_class.assert_called_with("fallback-token")

--- a/webapp/endpoints/builds.py
+++ b/webapp/endpoints/builds.py
@@ -1,0 +1,70 @@
+# Standard library
+import os
+
+# Packages
+import flask
+from canonicalwebteam.store_api.dashboard import Dashboard
+
+
+# Local
+from webapp.helpers import api_publisher_session, launchpad
+from webapp.api.github import GitHub
+from webapp.decorators import login_required
+
+GITHUB_SNAPCRAFT_USER_TOKEN = os.getenv("GITHUB_SNAPCRAFT_USER_TOKEN")
+GITHUB_WEBHOOK_HOST_URL = os.getenv("GITHUB_WEBHOOK_HOST_URL")
+BUILDS_PER_PAGE = 15
+dashboard = Dashboard(api_publisher_session)
+
+
+@login_required
+def get_snap_repo(snap_name):
+    res = {"message": "", "success": True}
+    data = {"github_orgs": [], "github_repository": None, "github_user": None}
+
+    details = dashboard.get_snap_info(flask.session, snap_name)
+
+    # API call to make users without needed permissions refresh the session
+    # Users needs package_upload_request permission to use this feature
+    dashboard.get_package_upload_macaroon(
+        session=flask.session, snap_name=snap_name, channels=["edge"]
+    )
+
+    # Get built snap in launchpad with this store name
+    lp_snap = launchpad.get_snap_by_store_name(details["snap_name"])
+
+    if lp_snap:
+        # In this case we can use the GitHub user account or
+        # the Snapcraft GitHub user to check the snapcraft.yaml
+        github = GitHub(
+            flask.session.get(
+                "github_auth_secret", GITHUB_SNAPCRAFT_USER_TOKEN
+            )
+        )
+
+        # Git repository without GitHub hostname
+        data["github_repository"] = lp_snap["git_repository_url"][19:]
+        github_owner, github_repo = data["github_repository"].split("/")
+
+        if not github.check_if_repo_exists(github_owner, github_repo):
+            data["success"] = False
+            data["message"] = "This app has been revoked"
+
+        if github.get_user():
+            data["github_user"] = github.get_user()
+            data["github_orgs"] = github.get_orgs()
+
+    else:
+        data["github_repository"] = None
+        github = GitHub(flask.session.get("github_auth_secret"))
+
+        if github.get_user():
+            data["github_user"] = github.get_user()
+            data["github_orgs"] = github.get_orgs()
+        else:
+            data["success"] = False
+            data["message"] = "Unauthorized"
+
+    res["data"] = data
+
+    return flask.jsonify(res)

--- a/webapp/publisher/snaps/build_views.py
+++ b/webapp/publisher/snaps/build_views.py
@@ -66,59 +66,6 @@ def get_builds(lp_snap, selection):
 
 
 @login_required
-def get_snap_repo(snap_name):
-    res = {"message": "", "success": True}
-    data = {"github_orgs": [], "github_repository": None, "github_user": None}
-
-    details = dashboard.get_snap_info(flask.session, snap_name)
-
-    # API call to make users without needed permissions refresh the session
-    # Users needs package_upload_request permission to use this feature
-    dashboard.get_package_upload_macaroon(
-        session=flask.session, snap_name=snap_name, channels=["edge"]
-    )
-
-    # Get built snap in launchpad with this store name
-    lp_snap = launchpad.get_snap_by_store_name(details["snap_name"])
-
-    if lp_snap:
-        # In this case we can use the GitHub user account or
-        # the Snapcraft GitHub user to check the snapcraft.yaml
-        github = GitHub(
-            flask.session.get(
-                "github_auth_secret", GITHUB_SNAPCRAFT_USER_TOKEN
-            )
-        )
-
-        # Git repository without GitHub hostname
-        data["github_repository"] = lp_snap["git_repository_url"][19:]
-        github_owner, github_repo = data["github_repository"].split("/")
-
-        if not github.check_if_repo_exists(github_owner, github_repo):
-            data["success"] = False
-            data["message"] = "This app has been revoked"
-
-        if github.get_user():
-            data["github_user"] = github.get_user()
-            data["github_orgs"] = github.get_orgs()
-
-    else:
-        data["github_repository"] = None
-        github = GitHub(flask.session.get("github_auth_secret"))
-
-        if github.get_user():
-            data["github_user"] = github.get_user()
-            data["github_orgs"] = github.get_orgs()
-        else:
-            data["success"] = False
-            data["message"] = "Unauthorized"
-
-    res["data"] = data
-
-    return flask.jsonify(res)
-
-
-@login_required
 def get_snap_builds_page(snap_name):
     # If this fails, the page will 404
     dashboard.get_snap_info(flask.session, snap_name)

--- a/webapp/publisher/snaps/views.py
+++ b/webapp/publisher/snaps/views.py
@@ -28,7 +28,7 @@ from webapp.publisher.snaps import (
     settings_views,
     collaboration_views,
 )
-from webapp.endpoints import releases
+from webapp.endpoints import releases, builds
 from webapp.publisher.snaps.builds import map_snap_build_status
 
 dashboard = Dashboard(api_publisher_session)
@@ -98,7 +98,7 @@ publisher_snaps.add_url_rule(
 
 publisher_snaps.add_url_rule(
     "/api/<snap_name>/repo",
-    view_func=build_views.get_snap_repo,
+    view_func=builds.get_snap_repo,
     methods=["GET"],
 )
 publisher_snaps.add_url_rule(


### PR DESCRIPTION
## Done
Moves the get repo endpoint to the endpoints section of the app

## How to QA
- Run locally (doesn't work on demos) - you need to [set up your GH tokens locally](https://github.com/canonical/snapcraft.io/blob/main/HACKING.md#snap-automated-builds)
- Go to /<snap_name>/builds
- Connect the GitHub repo
- It should work (check that /api/<snap_name>/repo is successful)

## Testing
- [x] This PR has tests
- [ ] No testing required (explain why):

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-24109
