### PR TITLE
chore: Move post listing endpoint to endpoints section of app

### DIFF
--- a/webapp/endpoints/publisher/listing.py
+++ b/webapp/endpoints/publisher/listing.py
@@ -1,9 +1,11 @@
 # Standard library
+from json import loads
 
 # Packages
 import flask
 from canonicalwebteam.exceptions import (
     StoreApiError,
+    StoreApiResponseErrorList,
 )
 from canonicalwebteam.store_api.dashboard import Dashboard
 from canonicalwebteam.store_api.devicegw import DeviceGW
@@ -135,3 +137,100 @@ def get_listing_data(snap_name):
     res["success"] = True
 
     return flask.jsonify(res)
+
+
+@login_required
+def post_listing_data(snap_name):
+    changes = None
+    changed_fields = flask.request.form.get("changes")
+
+    if changed_fields:
+        changes = loads(changed_fields)
+
+    if changes:
+        snap_id = flask.request.form.get("snap_id")
+        error_list = []
+
+        if "images" in changes:
+            # Add existing screenshots
+            current_screenshots = dashboard.snap_screenshots(
+                flask.session, snap_id
+            )
+
+            icon_input = (
+                flask.request.files.get("icon")
+                if flask.request.files.get("icon")
+                else None
+            )
+            screenshots_input = [
+                s if s else None
+                for s in flask.request.files.getlist("screenshots")
+            ]
+            banner_image_input = (
+                flask.request.files.get("banner-image")
+                if flask.request.files.get("banner-image")
+                else None
+            )
+
+            images_json, images_files = logic.build_changed_images(
+                changes["images"],
+                current_screenshots,
+                icon_input,
+                screenshots_input,
+                banner_image_input,
+            )
+
+            try:
+                dashboard.snap_screenshots(
+                    flask.session, snap_id, images_json, images_files
+                )
+            except StoreApiResponseErrorList as api_response_error_list:
+                if api_response_error_list.status_code != 404:
+                    error_list = error_list + api_response_error_list.errors
+
+        body_json = logic.filter_changes_data(changes)
+
+        if body_json:
+            if "description" in body_json:
+                body_json["description"] = logic.remove_invalid_characters(
+                    body_json["description"]
+                )
+
+            try:
+                dashboard.snap_metadata(flask.session, snap_id, body_json)
+            except StoreApiResponseErrorList as api_response_error_list:
+                if api_response_error_list.status_code != 404:
+                    error_list = error_list + api_response_error_list.errors
+
+        if error_list:
+            try:
+                snap_details = dashboard.get_snap_info(
+                    flask.session, snap_name
+                )
+            except StoreApiResponseErrorList as api_response_error_list:
+                if api_response_error_list.status_code == 404:
+                    return flask.abort(
+                        404, "No snap named {}".format(snap_name)
+                    )
+                else:
+                    error_list = error_list + api_response_error_list.errors
+
+            licenses = []
+            for license in helpers.get_licenses():
+                licenses.append(
+                    {"key": license["licenseId"], "name": license["name"]}
+                )
+
+            license = snap_details["license"]
+
+            snap_categories = logic.replace_reserved_categories_key(
+                snap_details["categories"]
+            )
+
+            snap_categories = logic.filter_categories(snap_categories)
+
+            res = {"success": True, "errors": error_list}
+
+            return flask.make_response(res, 200)
+
+    return flask.make_response({"success": True}, 200)

--- a/webapp/publisher/snaps/listing_views.py
+++ b/webapp/publisher/snaps/listing_views.py
@@ -4,9 +4,6 @@ from json import loads
 # Packages
 import bleach
 import flask
-from canonicalwebteam.exceptions import (
-    StoreApiResponseErrorList,
-)
 from canonicalwebteam.store_api.dashboard import Dashboard
 
 # Local
@@ -14,7 +11,7 @@ from webapp import helpers
 from webapp.helpers import api_session
 from webapp.decorators import login_required
 from webapp.markdown import parse_markdown_description
-from webapp.publisher.snaps import logic, preview_data
+from webapp.publisher.snaps import preview_data
 from webapp.store.logic import (
     filter_screenshots,
     get_video,
@@ -48,103 +45,6 @@ def get_listing_snap(snap_name):
         snap_name=snap_name,
         dns_verification_token=token,
     )
-
-
-@login_required
-def post_listing_data(snap_name):
-    changes = None
-    changed_fields = flask.request.form.get("changes")
-
-    if changed_fields:
-        changes = loads(changed_fields)
-
-    if changes:
-        snap_id = flask.request.form.get("snap_id")
-        error_list = []
-
-        if "images" in changes:
-            # Add existing screenshots
-            current_screenshots = dashboard.snap_screenshots(
-                flask.session, snap_id
-            )
-
-            icon_input = (
-                flask.request.files.get("icon")
-                if flask.request.files.get("icon")
-                else None
-            )
-            screenshots_input = [
-                s if s else None
-                for s in flask.request.files.getlist("screenshots")
-            ]
-            banner_image_input = (
-                flask.request.files.get("banner-image")
-                if flask.request.files.get("banner-image")
-                else None
-            )
-
-            images_json, images_files = logic.build_changed_images(
-                changes["images"],
-                current_screenshots,
-                icon_input,
-                screenshots_input,
-                banner_image_input,
-            )
-
-            try:
-                dashboard.snap_screenshots(
-                    flask.session, snap_id, images_json, images_files
-                )
-            except StoreApiResponseErrorList as api_response_error_list:
-                if api_response_error_list.status_code != 404:
-                    error_list = error_list + api_response_error_list.errors
-
-        body_json = logic.filter_changes_data(changes)
-
-        if body_json:
-            if "description" in body_json:
-                body_json["description"] = logic.remove_invalid_characters(
-                    body_json["description"]
-                )
-
-            try:
-                dashboard.snap_metadata(flask.session, snap_id, body_json)
-            except StoreApiResponseErrorList as api_response_error_list:
-                if api_response_error_list.status_code != 404:
-                    error_list = error_list + api_response_error_list.errors
-
-        if error_list:
-            try:
-                snap_details = dashboard.get_snap_info(
-                    flask.session, snap_name
-                )
-            except StoreApiResponseErrorList as api_response_error_list:
-                if api_response_error_list.status_code == 404:
-                    return flask.abort(
-                        404, "No snap named {}".format(snap_name)
-                    )
-                else:
-                    error_list = error_list + api_response_error_list.errors
-
-            licenses = []
-            for license in helpers.get_licenses():
-                licenses.append(
-                    {"key": license["licenseId"], "name": license["name"]}
-                )
-
-            license = snap_details["license"]
-
-            snap_categories = logic.replace_reserved_categories_key(
-                snap_details["categories"]
-            )
-
-            snap_categories = logic.filter_categories(snap_categories)
-
-            res = {"success": True, "errors": error_list}
-
-            return flask.make_response(res, 200)
-
-    return flask.make_response({"success": True}, 200)
 
 
 @login_required

--- a/webapp/publisher/snaps/views.py
+++ b/webapp/publisher/snaps/views.py
@@ -75,7 +75,7 @@ publisher_snaps.add_url_rule(
 )
 publisher_snaps.add_url_rule(
     "/api/<snap_name>/listing",
-    view_func=listing_views.post_listing_data,
+    view_func=listing_endpoint.post_listing_data,
     methods=["POST"],
 )
 publisher_snaps.add_url_rule(


### PR DESCRIPTION
## Done
Moves the post listing data endpoint to the endpoints section of the app

## How to QA
- Go to https://snapcraft-io-5290.demos.haus/<snap_name>/listing
- Make changes and save them
- It should work

## Testing
- [x] This PR has tests
- [ ] No testing required (explain why):

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-24587
