### PR TITLE
fix: Fixes bug where wrong member roles selected when adding new members

### DIFF
--- a/static/js/publisher/pages/Members/MemberRoleCheckbox.tsx
+++ b/static/js/publisher/pages/Members/MemberRoleCheckbox.tsx
@@ -1,0 +1,25 @@
+import { CheckboxInput } from "@canonical/react-components";
+
+import ROLES from "./memberRoles";
+
+import type { Member } from "../../types/shared";
+
+type Props = {
+  member: Member;
+  handleRoleChange: (member: Member, role: string) => void;
+  memberRole: "admin" | "review" | "view" | "access";
+};
+
+function MemberRoleCheckbox({ member, handleRoleChange, memberRole }: Props) {
+  return (
+    <CheckboxInput
+      checked={member.roles.includes(memberRole)}
+      onChange={() => {
+        handleRoleChange(member, memberRole);
+      }}
+      label={<span className="u-hide--large">{ROLES[memberRole].name}</span>}
+    />
+  );
+}
+
+export default MemberRoleCheckbox;

--- a/static/js/publisher/pages/Members/MembersTable.tsx
+++ b/static/js/publisher/pages/Members/MembersTable.tsx
@@ -1,6 +1,8 @@
 import { useState, useEffect } from "react";
-import { MainTable, CheckboxInput } from "@canonical/react-components";
+import { MainTable } from "@canonical/react-components";
 import ROLES from "./memberRoles";
+
+import MemberRoleCheckbox from "./MemberRoleCheckbox";
 
 import type { Member } from "../../types/shared";
 
@@ -158,57 +160,38 @@ function MembersTable({
             },
             {
               content: (
-                <>
-                  <CheckboxInput
-                    defaultChecked={member.roles.includes("admin")}
-                    disabled={
-                      member.current_user && member.roles.includes("admin")
-                    }
-                    onChange={() => {
-                      handleRoleChange(member, "admin");
-                    }}
-                    label={<span className="u-hide--large">Admin</span>}
-                  />
-                </>
+                <MemberRoleCheckbox
+                  member={member}
+                  handleRoleChange={handleRoleChange}
+                  memberRole="admin"
+                />
               ),
             },
             {
               content: (
-                <>
-                  <CheckboxInput
-                    defaultChecked={member.roles.includes("review")}
-                    onChange={() => {
-                      handleRoleChange(member, "review");
-                    }}
-                    label={<span className="u-hide--large">Reviewer</span>}
-                  />
-                </>
+                <MemberRoleCheckbox
+                  member={member}
+                  handleRoleChange={handleRoleChange}
+                  memberRole="review"
+                />
               ),
             },
             {
               content: (
-                <>
-                  <CheckboxInput
-                    defaultChecked={member.roles.includes("view")}
-                    onChange={() => {
-                      handleRoleChange(member, "view");
-                    }}
-                    label={<span className="u-hide--large">Viewer</span>}
-                  />
-                </>
+                <MemberRoleCheckbox
+                  member={member}
+                  handleRoleChange={handleRoleChange}
+                  memberRole="view"
+                />
               ),
             },
             {
               content: (
-                <>
-                  <CheckboxInput
-                    defaultChecked={member.roles.includes("access")}
-                    onChange={() => {
-                      handleRoleChange(member, "access");
-                    }}
-                    label={<span className="u-hide--large">Publisher</span>}
-                  />
-                </>
+                <MemberRoleCheckbox
+                  member={member}
+                  handleRoleChange={handleRoleChange}
+                  memberRole="access"
+                />
               ),
             },
           ],

--- a/static/js/publisher/pages/Members/__tests__/MemberRoleCheckbox.test.tsx
+++ b/static/js/publisher/pages/Members/__tests__/MemberRoleCheckbox.test.tsx
@@ -1,0 +1,132 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+import MemberRoleCheckbox from "../MemberRoleCheckbox";
+
+import type { Member } from "../../../types/shared";
+
+const mockMember: Member = {
+  displayname: "John Doe",
+  email: "john.doe@canonical.com",
+  id: "id-1",
+  roles: ["admin", "view"],
+  username: "johndoe",
+  current_user: false,
+};
+
+const mockHandleRoleChange = jest.fn();
+
+function renderComponent(
+  member = mockMember,
+  memberRole: "admin" | "review" | "view" | "access" = "admin",
+  handleRoleChange = mockHandleRoleChange,
+) {
+  return render(
+    <MemberRoleCheckbox
+      member={member}
+      memberRole={memberRole}
+      handleRoleChange={handleRoleChange}
+    />,
+  );
+}
+
+describe("MemberRoleCheckbox", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("renders checkbox with correct label", () => {
+    renderComponent();
+
+    const checkbox = screen.getByRole("checkbox");
+    expect(checkbox).toBeInTheDocument();
+
+    expect(screen.getByText("Admin")).toBeInTheDocument();
+  });
+
+  test("shows checkbox as checked when member has the role", () => {
+    renderComponent(mockMember, "admin");
+
+    const checkbox = screen.getByRole("checkbox");
+    expect(checkbox).toBeChecked();
+  });
+
+  test("shows checkbox as unchecked when member does not have the role", () => {
+    renderComponent(mockMember, "review");
+
+    const checkbox = screen.getByRole("checkbox");
+    expect(checkbox).not.toBeChecked();
+  });
+
+  test("calls handleRoleChange when checkbox is clicked", () => {
+    renderComponent(mockMember, "admin");
+
+    const checkbox = screen.getByRole("checkbox");
+    fireEvent.click(checkbox);
+
+    expect(mockHandleRoleChange).toHaveBeenCalledTimes(1);
+    expect(mockHandleRoleChange).toHaveBeenCalledWith(mockMember, "admin");
+  });
+
+  test("handles different role types correctly", () => {
+    const { rerender } = renderComponent(mockMember, "review");
+    expect(screen.getByText("Reviewer")).toBeInTheDocument();
+    expect(screen.getByRole("checkbox")).not.toBeChecked();
+
+    rerender(
+      <MemberRoleCheckbox
+        member={mockMember}
+        memberRole="view"
+        handleRoleChange={mockHandleRoleChange}
+      />,
+    );
+    expect(screen.getByText("Viewer")).toBeInTheDocument();
+    expect(screen.getByRole("checkbox")).toBeChecked();
+
+    rerender(
+      <MemberRoleCheckbox
+        member={mockMember}
+        memberRole="access"
+        handleRoleChange={mockHandleRoleChange}
+      />,
+    );
+    expect(screen.getByText("Publisher")).toBeInTheDocument();
+    expect(screen.getByRole("checkbox")).not.toBeChecked();
+  });
+
+  test("works with member having no roles", () => {
+    const memberWithoutRoles: Member = {
+      ...mockMember,
+      roles: [],
+    };
+
+    renderComponent(memberWithoutRoles, "admin");
+
+    const checkbox = screen.getByRole("checkbox");
+    expect(checkbox).not.toBeChecked();
+
+    fireEvent.click(checkbox);
+    expect(mockHandleRoleChange).toHaveBeenCalledWith(
+      memberWithoutRoles,
+      "admin",
+    );
+  });
+
+  test("works with member having multiple roles", () => {
+    const memberWithMultipleRoles: Member = {
+      ...mockMember,
+      roles: ["admin", "review", "view", "access"],
+    };
+
+    renderComponent(memberWithMultipleRoles, "review");
+
+    const checkbox = screen.getByRole("checkbox");
+    expect(checkbox).toBeChecked();
+
+    fireEvent.click(checkbox);
+    expect(mockHandleRoleChange).toHaveBeenCalledWith(
+      memberWithMultipleRoles,
+      "review",
+    );
+  });
+});


### PR DESCRIPTION
## Done
Fixes bug where all member roles are selected when adding a new member to a brand store

## How to QA
- Go to https://snapcraft-io-5293.demos.haus/admin/ahnuP3quahti9vis8aiw/members
- Add a new member to a store and only select one role
- Once they have been added, only the roles selected should be checked
- Refresh the page and the roles should be the same

## Testing
- [x] This PR has tests
- [ ] No testing required (explain why):

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-24537
Fixes https://github.com/canonical/snapcraft.io/issues/5291
