### PR TITLE
fix: Make validate repo code more robust

### DIFF
--- a/webapp/endpoints/publisher/builds.py
+++ b/webapp/endpoints/publisher/builds.py
@@ -42,14 +42,14 @@ def validate_repo(github_token, snap_name, gh_owner, gh_repo):
                 "and runnable."
             ),
         }
-    # The property name inside the yaml file doesn't match the snap
     else:
         try:
             gh_snap_name = github.get_snapcraft_yaml_data(
                 gh_owner, gh_repo
             ).get("name")
 
-            if gh_snap_name != snap_name:
+            # The property name inside the yaml file doesn't match the snap
+            if gh_snap_name is not None and gh_snap_name != snap_name:
                 result["success"] = False
                 result["error"] = {
                     "type": "SNAP_NAME_DOES_NOT_MATCH",


### PR DESCRIPTION
## Done
Addresses some code review comments which were out of scope of [a previous PR](https://github.com/canonical/snapcraft.io/pull/5294)
- [x] [Comment 1](https://github.com/canonical/snapcraft.io/pull/5294#discussion_r2272425585)
- [ ] [Comment 2](https://github.com/canonical/snapcraft.io/pull/5294#discussion_r2272443796) (Not addressed as the value of `yaml_location` comes from a method of the class that it would be passed to which could get quite confusing)
- [ ] [Comment 2](https://github.com/canonical/snapcraft.io/pull/5294#discussion_r2272449175) (Not addressed `Unauthorized` and `Forbidden` are both raised as exceptions rather than returned as values)
- [x] [Comment 3](https://github.com/canonical/snapcraft.io/pull/5294#discussion_r2272458639) 

## How to QA
- Run locally (doesn't work on demos) - you need to [set up your GH tokens locally](https://github.com/canonical/snapcraft.io/blob/main/HACKING.md#snap-automated-builds)
- Go to the builds page of a snap you own e.g. /<snap_name>/builds
- Make sure you can connect to the GitHub repo

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why): Existing tests

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-25077