### PR TITLE
chore: Add validation for register snap rules

### DIFF
--- a/static/js/publisher/pages/RegisterSnap/RegisterSnapForm.tsx
+++ b/static/js/publisher/pages/RegisterSnap/RegisterSnapForm.tsx
@@ -33,6 +33,8 @@ function RegisterSnapForm({
 }: Props): React.JSX.Element {
   const [snapName, setSnapName] = useState<string>();
   const [privacy, setPrivacy] = useState<string>("private");
+  const [showSnapNameConstraints, setShowSnapNameConstraints] =
+    useState<boolean>(false);
 
   const navigate = useNavigate();
 
@@ -71,6 +73,23 @@ function RegisterSnapForm({
     }, 1000);
   };
 
+  // Must satisfy the following requriements:
+  // - Contain no more than 40 characters
+  // - Consist of only lowercase letters, numbers, and hyphens
+  // - Contain at least one letter
+  // - Not start or end with a hyphen
+  //
+  // See: https://documentation.ubuntu.com/snapcraft/stable/how-to/publishing/register-a-snap/#name-your-snap
+  const isValid = (): boolean => {
+    const snapNamePattern = /^(?<!-)\d*[a-z][a-z0-9-]*(?<!-)$/;
+
+    if (snapName && snapName.length < 40 && snapName.match(snapNamePattern)) {
+      return true;
+    }
+
+    return false;
+  };
+
   return (
     <Form onSubmit={handleSubmit}>
       <Row>
@@ -99,7 +118,43 @@ function RegisterSnapForm({
             }}
             required
           />
-          <label htmlFor="public">Snap privacy</label>
+
+          <Button
+            type="button"
+            appearance="link"
+            onClick={() => {
+              setShowSnapNameConstraints(!showSnapNameConstraints);
+            }}
+          >
+            <small>
+              {showSnapNameConstraints ? <>Hide</> : <>Show</>} snap name
+              constraints
+            </small>
+          </Button>
+
+          {showSnapNameConstraints && (
+            <ul>
+              <li>
+                <small>Contain no more than 40 characters</small>
+              </li>
+              <li>
+                <small>
+                  Consist of only lowercase letters, numbers, and hyphens
+                </small>
+              </li>
+              <li>
+                <small>Contain at least one letter</small>
+              </li>
+              <li>
+                <small>Not start or end with a hyphen</small>
+              </li>
+            </ul>
+          )}
+
+          <p>
+            <label htmlFor="public">Snap privacy</label>
+          </p>
+
           <p className="p-form-help-text">
             This can be changed at any time after the initial upload
           </p>
@@ -133,7 +188,7 @@ function RegisterSnapForm({
         <Button
           type="submit"
           appearance="positive"
-          disabled={!snapName || isSending}
+          disabled={isSending || !isValid()}
         >
           {isSending ? (
             <>

--- a/static/js/publisher/pages/RegisterSnap/__tests__/RegisterSnap.test.tsx
+++ b/static/js/publisher/pages/RegisterSnap/__tests__/RegisterSnap.test.tsx
@@ -121,7 +121,7 @@ describe("RegisterSnap", () => {
     renderComponent();
 
     await waitFor(() => {
-      user.type(screen.getByLabelText("Snap name"), "Test");
+      user.type(screen.getByLabelText("Snap name"), "test");
       expect(
         screen.getByRole("button", { name: "Register" }),
       ).not.toHaveAttribute("aria-disabled");

--- a/static/js/publisher/pages/RegisterSnap/__tests__/RegisterSnapForm.test.tsx
+++ b/static/js/publisher/pages/RegisterSnap/__tests__/RegisterSnapForm.test.tsx
@@ -1,0 +1,124 @@
+import { BrowserRouter } from "react-router-dom";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import "@testing-library/jest-dom";
+
+import RegisterSnapForm from "../RegisterSnapForm";
+
+function renderComponent() {
+  const props = {
+    isSending: false,
+    setIsSending: jest.fn(),
+    setRegistrationResponse: jest.fn(),
+    availableStores: [],
+    selectedStore: "global",
+    setSelectedStore: jest.fn(),
+  };
+
+  return render(
+    <BrowserRouter>
+      <RegisterSnapForm {...props} />
+    </BrowserRouter>,
+  );
+}
+
+describe("RegisterSnapForm", () => {
+  test("form disabled if no snap name", () => {
+    renderComponent();
+
+    expect(screen.getByRole("button", { name: "Register" })).toHaveAttribute(
+      "aria-disabled",
+      "true",
+    );
+  });
+
+  test("form disabled if snap name longer than 40 characters", async () => {
+    const user = userEvent.setup();
+
+    renderComponent();
+
+    await user.type(
+      screen.getByLabelText("Snap name"),
+      "thisisalongsnapnamethatislongerthan40characters",
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Register" })).toHaveAttribute(
+        "aria-disabled",
+        "true",
+      );
+    });
+  });
+
+  test("form disabled if snap name contains uppercase characters", async () => {
+    const user = userEvent.setup();
+
+    renderComponent();
+
+    await user.type(screen.getByLabelText("Snap name"), "Test");
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Register" })).toHaveAttribute(
+        "aria-disabled",
+        "true",
+      );
+    });
+  });
+
+  test("form disabled if snap name contains no letters", () => {
+    renderComponent();
+    expect(screen.getByRole("button", { name: "Register" })).toHaveAttribute(
+      "aria-disabled",
+      "true",
+    );
+  });
+
+  test("form disabled if snap name starts with hyphen", async () => {
+    const user = userEvent.setup();
+
+    renderComponent();
+
+    await user.type(screen.getByLabelText("Snap name"), "-test-snap");
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Register" })).toHaveAttribute(
+        "aria-disabled",
+        "true",
+      );
+    });
+  });
+
+  test("form disabled if snap name ends with hyphen", async () => {
+    const user = userEvent.setup();
+
+    renderComponent();
+
+    await user.type(screen.getByLabelText("Snap name"), "test-snap-");
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Register" })).toHaveAttribute(
+        "aria-disabled",
+        "true",
+      );
+    });
+  });
+
+  test("form enabled if snap name meets requirements", async () => {
+    // Requirements are:
+    // - Less than 40 characters
+    // - Only lowercase letters, numbers and hyphens
+    // - At least one letter
+    // - Doesn't start or end with hyphen
+    const user = userEvent.setup();
+
+    renderComponent();
+
+    await user.type(screen.getByLabelText("Snap name"), "test-snap-name-1");
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: "Register" }),
+      ).not.toHaveAttribute("aria-disabled");
+    });
+  });
+});


### PR DESCRIPTION
## Done
Adds validation and constraints to the register snap name form, using the image size restrictions pattern from the listing form

## How to QA
- Go to https://snapcraft-io-5308.demos.haus/register-snap
- Check that there is a button/link to toggle the snap name constraints beneath the "Snap name" input
- Type a valid snap name, e.g. test-snap-1 and check that the register button is enabled
- Type a snap name which is longer than 40 characters and check that the "Register" button is disabled
- Type a snap name which contains a capital letter and check that the "Register" button is disabled
- Type a snap name which is only numbers and check that the "Register" button is disabled
- Type a snap name that beings with a hyphen and check that the "Register" button is disabled
- Type a snap name that ends with a hyphen and check that the "Register" button is disabled

## Testing
- [x] This PR has tests
- [ ] No testing required (explain why):

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-25571
Fixes https://github.com/canonical/snapcraft.io/issues/5305
