### PR TITLE
fix: expose FSF helpers for /about/publish page

### DIFF
--- a/webpack.config.rules.js
+++ b/webpack.config.rules.js
@@ -82,6 +82,13 @@ module.exports = [
     ],
   },
   {
+    test: require.resolve(__dirname + "/static/js/public/about/index.ts"),
+    use: [
+      "expose-loader?exposes=snapcraft.about",
+      "babel-loader",
+    ],
+  },
+  {
     test: /\.tsx?/,
     use: ["ts-loader"],
   },


### PR DESCRIPTION
## Done
Fixed a bug where the contents of https://snapcraft.io/about/publish#language is not populated correctly

## How to QA
- Open https://snapcraft-io-5309.demos.haus/about/publish#language
- The right side of the layout should have content related to Python
- Switch to another language tab
- You should see the contents updating to reflect the selection

## Testing
- [ ] This PR has tests
- [ ] No testing required (explain why):

## Issue / Card
Fixes #5307

## Screenshots
