### PR TITLE
chore: use Vite bundle for about.js

### DIFF
--- a/templates/about/publish.html
+++ b/templates/about/publish.html
@@ -192,7 +192,7 @@
 {% endblock %}
 
 {% block scripts_includes %}
-<script src="{{ static_url('js/dist/about.js') }}" defer></script>
+<script type="module" src="{{ static_url('js/dist/vite/about.js') }}" defer></script>
 {% endblock %}
 
 {% block scripts %}


### PR DESCRIPTION
## Done
Changed about.js bundle to the one built by Vite

## How to QA
- go to https://snapcraft-io-5316.demos.haus/about/publish#language
- change language
- click the "show more" button
- everything should work

## Testing
- [x] This PR has tests -> run-cypress checks that about.js exports its variables in the global scope
- [ ] No testing required (explain why):

## Issue / Card
Fixes WD-24761

## Screenshots
