### PR TITLE
fix: always display "report this snap" button

### DIFF
--- a/templates/store/snap-details/_details.html
+++ b/templates/store/snap-details/_details.html
@@ -90,152 +90,152 @@
     <hr>
   {% endif %}
 
-  {# REPORT SNAP SECTION - hidden in preview #}
-    {% if not is_preview and not IS_BRAND_STORE %}
-      <h5 class="p-muted-heading">Report a Snap Store violation</h5>
-      <ul class="p-list">
-        <li>
-          <a class="js-modal-open">Report this Snap</a>
-        </li>
-      </ul>
+  <div class="p-modal js-exeternal-link-modal u-hide" id="modal">
+    <section class="p-modal__dialog" role="dialog" aria-modal="true" aria-labelledby="modal-title" aria-describedby="modal-description">
+      <header class="p-modal__header">
+        <h2 class="p-modal__title" id="modal-title"><i class="p-icon--warning" style="width: 1rem; height: 1rem; position: relative; top: 1px; margin-right: 0.24rem;"></i> External link warning</h2>
+      </header>
+      <p class="u-no-max-width">You are about to open <span class="js-external-link-url"></span></p>
+      <p class="u-no-max-width">Do you wish to proceed?</p>
+      </p>
+      <footer class="p-modal__footer">
+        <button class="u-no-margin--bottom js-close-modal" aria-controls="modal">Go back</button>
+        <a class="p-button--positive u-no-margin--bottom js-open-external-link" href="" target="_blank">Proceed</a>
+      </footer>
+    </section>
+  </div>
 
-      {% include "store/snap-details/_report_snap_modal.html" %}
-      <hr>
-    {% endif %}
+  <template id="verified-status">
+    (Ownership verified) 
+    <span class="p-tooltip--btm-right" aria-describedby="verified-explanation">
+      <i class="p-icon--information"></i>
+      <span class="p-tooltip__message" role="tooltip" id="verified-explanation">The publisher has verified that they own this domain. 
+  It does not guarantee the Snap is an official upload from the 
+  upstream project.</span>
+    </span>
+  </template>
 
-<div class="p-modal js-exeternal-link-modal u-hide" id="modal">
-  <section class="p-modal__dialog" role="dialog" aria-modal="true" aria-labelledby="modal-title" aria-describedby="modal-description">
-    <header class="p-modal__header">
-      <h2 class="p-modal__title" id="modal-title"><i class="p-icon--warning" style="width: 1rem; height: 1rem; position: relative; top: 1px; margin-right: 0.24rem;"></i> External link warning</h2>
-    </header>
-    <p class="u-no-max-width">You are about to open <span class="js-external-link-url"></span></p>
-    <p class="u-no-max-width">Do you wish to proceed?</p>
-    </p>
-    <footer class="p-modal__footer">
-      <button class="u-no-margin--bottom js-close-modal" aria-controls="modal">Go back</button>
-      <a class="p-button--positive u-no-margin--bottom js-open-external-link" href="" target="_blank">Proceed</a>
-    </footer>
-  </section>
-</div>
-
-<template id="verified-status">
-  (Ownership verified) 
-  <span class="p-tooltip--btm-right" aria-describedby="verified-explanation">
-    <i class="p-icon--information"></i>
-    <span class="p-tooltip__message" role="tooltip" id="verified-explanation">The publisher has verified that they own this domain. 
-It does not guarantee the Snap is an official upload from the 
-upstream project.</span>
-  </span>
-</template>
-
-<script>
-  // Handle verified domain status
-  const primaryDomainListItem = document.querySelector("[data-js='primary-domain']");
-  
-  function renderVerificationStatus() {
-    if ("content" in document.createElement("template")) {
-      const template = document.querySelector("#verified-status");
-      const clone = template.content.cloneNode(true);
-      primaryDomainListItem.appendChild(clone);
+  <script>
+    // Handle verified domain status
+    const primaryDomainListItem = document.querySelector("[data-js='primary-domain']");
+    
+    function renderVerificationStatus() {
+      if ("content" in document.createElement("template")) {
+        const template = document.querySelector("#verified-status");
+        const clone = template.content.cloneNode(true);
+        primaryDomainListItem.appendChild(clone);
+      }
     }
-  }
-  
-  if (primaryDomainListItem) {
-    async function getVerifiedStatus() {
-      const response = await fetch("/api/{{ package_name }}/verify");
-      
-      if (!response.ok) {
+    
+    if (primaryDomainListItem) {
+      async function getVerifiedStatus() {
+        const response = await fetch("/api/{{ package_name }}/verify");
+        
+        if (!response.ok) {
+          return;
+        }
+
+        const responseData = await response.json();
+
+        if (responseData.primary_domain) {
+          renderVerificationStatus();
+        }
+      }
+
+      getVerifiedStatus();
+    }
+
+    // Handle external links
+    const externalLinks = document.querySelectorAll(".js-external-link");
+    const externalLinkModal = document.querySelector(".js-exeternal-link-modal");
+    const externalLinkModalCloseButton = externalLinkModal.querySelector(
+      ".js-close-modal"
+    );
+    const externalLinkUrl = externalLinkModal.querySelector(
+      ".js-external-link-url"
+    );
+    const openExternalLinkButton = externalLinkModal.querySelector(
+      ".js-open-external-link"
+    );
+    
+    function openModal() {
+      externalLinkModal.classList.remove("u-hide");
+    }
+    
+    function closeModal() {
+      externalLinkModal.classList.add("u-hide");
+    }
+
+    function setLinkDisplayText(href) {
+      if (href.includes("mailto")) {
+        externalLinkUrl.innerText = href;
         return;
       }
 
-      const responseData = await response.json();
+      const url = new URL(href);
 
-      if (responseData.primary_domain) {
-        renderVerificationStatus();
+      const protocolContainer = document.createElement("strong");
+      const hostnameContainer = document.createElement("strong");
+      const pathContainer = document.createElement("span");
+      const searchContainer = document.createElement("span");
+
+      protocolContainer.classList.add(
+        url.protocol === "https:" ? 
+          "external-link-protocol--positive" : "external-link-protocol--negative"
+      );
+
+      pathContainer.classList.add("u-text-muted");
+      searchContainer.classList.add("u-text-muted");
+
+      protocolContainer.innerText = `${url.protocol}//`;
+      hostnameContainer.innerText = url.hostname;
+      
+      if (url.pathname && url.pathname !== "/") {
+        pathContainer.innerText = url.pathname;
+
       }
+      
+      searchContainer.innerText = url.search;
+
+      externalLinkUrl.innerHTML = "";
+      externalLinkUrl.appendChild(protocolContainer);
+      externalLinkUrl.appendChild(hostnameContainer);
+      externalLinkUrl.appendChild(pathContainer);
+      externalLinkUrl.appendChild(searchContainer);
     }
 
-    getVerifiedStatus();
-  }
-
-  // Handle external links
-  const externalLinks = document.querySelectorAll(".js-external-link");
-  const externalLinkModal = document.querySelector(".js-exeternal-link-modal");
-  const externalLinkModalCloseButton = externalLinkModal.querySelector(
-    ".js-close-modal"
-  );
-  const externalLinkUrl = externalLinkModal.querySelector(
-    ".js-external-link-url"
-  );
-  const openExternalLinkButton = externalLinkModal.querySelector(
-    ".js-open-external-link"
-  );
-  
-  function openModal() {
-    externalLinkModal.classList.remove("u-hide");
-  }
-  
-  function closeModal() {
-    externalLinkModal.classList.add("u-hide");
-  }
-
-  function setLinkDisplayText(href) {
-    if (href.includes("mailto")) {
-      externalLinkUrl.innerText = href;
-      return;
-    }
-
-    const url = new URL(href);
-
-    const protocolContainer = document.createElement("strong");
-    const hostnameContainer = document.createElement("strong");
-    const pathContainer = document.createElement("span");
-    const searchContainer = document.createElement("span");
-
-    protocolContainer.classList.add(
-      url.protocol === "https:" ? 
-        "external-link-protocol--positive" : "external-link-protocol--negative"
-    );
-
-    pathContainer.classList.add("u-text-muted");
-    searchContainer.classList.add("u-text-muted");
-
-    protocolContainer.innerText = `${url.protocol}//`;
-    hostnameContainer.innerText = url.hostname;
-    
-    if (url.pathname && url.pathname !== "/") {
-      pathContainer.innerText = url.pathname;
-
-    }
-    
-    searchContainer.innerText = url.search;
-
-    externalLinkUrl.innerHTML = "";
-    externalLinkUrl.appendChild(protocolContainer);
-    externalLinkUrl.appendChild(hostnameContainer);
-    externalLinkUrl.appendChild(pathContainer);
-    externalLinkUrl.appendChild(searchContainer);
-  }
-
-  externalLinkModalCloseButton.addEventListener("click", () => {
-    closeModal();
-  });
-
-  externalLinks.forEach((link) => { 
-    
-    link.addEventListener("click", (e) => {
-      e.preventDefault();
-      const href = e.target.href;
-      openExternalLinkButton.href = href;
-      openExternalLinkButton.addEventListener("click", handleOpenExternalLink); 
-      setLinkDisplayText(href);
-      openModal();
+    externalLinkModalCloseButton.addEventListener("click", () => {
+      closeModal();
     });
-  });
 
-  function handleOpenExternalLink() {
-    closeModal();
-    openExternalLinkButton.removeEventListener("click", handleOpenExternalLink);
-  }
-</script>
+    externalLinks.forEach((link) => { 
+      
+      link.addEventListener("click", (e) => {
+        e.preventDefault();
+        const href = e.target.href;
+        openExternalLinkButton.href = href;
+        openExternalLinkButton.addEventListener("click", handleOpenExternalLink); 
+        setLinkDisplayText(href);
+        openModal();
+      });
+    });
+
+    function handleOpenExternalLink() {
+      closeModal();
+      openExternalLinkButton.removeEventListener("click", handleOpenExternalLink);
+    }
+  </script>
+{% endif %}
+
+{# REPORT SNAP SECTION - hidden in preview #}
+{% if not is_preview and not IS_BRAND_STORE %}
+  <h5 class="p-muted-heading">Report a Snap Store violation</h5>
+  <ul class="p-list">
+    <li>
+      <a class="js-modal-open" aria-controls="#report-snap-modal" href="#report-snap-modal">Report this Snap</a>
+    </li>
+  </ul>
+
+  {% include "store/snap-details/_report_snap_modal.html" %}
+  <hr>
 {% endif %}


### PR DESCRIPTION
## Done
Fixed an issue where the "report this snap" button wouldn't be visible if the snap details don't contain a `links` object.
Most of the changed lines are indentation, the big change is moving the `REPORT SNAP SECTION` block to the bottom of the file, outside the `{% if links %}` clause

## How to QA
- visit a details page for a snap without any links (e.g. https://snapcraft-io-5319.demos.haus/b2)
- look for a "Report this Snap" button

## Testing
- [ ] This PR has tests
- [ ] No testing required (explain why):

## Issue / Card
Fixes #5295

## Screenshots
