### PR TITLE
chore: use Vite bundle for featured-snaps.js

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -162,7 +162,7 @@
 
 {% block scripts_includes %}
 <script type="module" src="{{ static_url('js/dist/vite/homepage.js') }}" defer></script>
-<script src="{{ static_url('js/dist/featured-snaps.js') }}" defer></script>
+<script type="module" src="{{ static_url('js/dist/vite/featured-snaps.js') }}" defer></script>
 {% if nps %}
 <script src="//app-sjg.marketo.com/js/forms2/js/forms2.min.js" defer></script>
 {% endif %}


### PR DESCRIPTION
## Done
Changed featured-snaps.js bundle to the one built by Vite

## How to QA
- open https://snapcraft-io-5320.demos.haus/
- check that the "snaps you may like" section is populated correctly
- try to switch to any of the other tabs

## Testing
- [x] This PR has tests -> run-cypress checks that featured-snaps.js exports snapcraft.public.featuredSnaps.init
- [ ] No testing required (explain why):

## Issue / Card
Fixes WD-24762

## Screenshots
