### PR TITLE
chore: use Vite bundle for store.js

### DIFF
--- a/templates/store/store.html
+++ b/templates/store/store.html
@@ -25,5 +25,5 @@
 
 {% block content %}
 <main id="root"></main>
-<script src="{{ versioned_static('js/dist/store.js') }}" defer></script>
+<script type="module" src="{{ versioned_static('js/dist/vite/store.js') }}" defer></script>
 {% endblock %}


### PR DESCRIPTION
## Done
Changed store.js bundle to the one built by Vite

## How to QA
- visit https://snapcraft-io-5324.demos.haus/store?categories=development%2Cgames
- check that the snap listing section is rendered correctly and filters work

## Testing
- [x] This PR has tests -> run-cypress tests that the snap list renders
- [ ] No testing required (explain why):

## Issue / Card
Fixes WD-24771

## Screenshots
