### PR TITLE
chore: use Vite bundle for blog.js

### DIFF
--- a/templates/blog/article.html
+++ b/templates/blog/article.html
@@ -110,7 +110,7 @@
 {% endblock %}
 
 {% block scripts_includes %}
-  <script src="{{ static_url('js/dist/blog.js') }}" defer></script>
+  <script type="module" src="{{ static_url('js/dist/vite/blog.js') }}" defer></script>
 {% endblock %}
 
 {% block scripts %}

--- a/templates/blog/index.html
+++ b/templates/blog/index.html
@@ -144,7 +144,7 @@
 {% endblock %}
 
 {% block scripts_includes %}
-  <script src="{{ static_url('js/dist/blog.js') }}" defer></script>
+  <script type="module" src="{{ static_url('js/dist/vite/blog.js') }}" defer></script>
 {% endblock %}
 
 {% block scripts %}


### PR DESCRIPTION
## Done
Changed blog.js bundle to the one built by Vite

## How to QA
- open https://snapcraft-io-5325.demos.haus/blog
- fill out the newsletter form and submit it
- for a split second before the redirect the "Subscribe now" text is replaced by a loader and the button is disabled
- open a blog article
- submit the newsletter again and observe the same behavior

## Testing
- [ ] This PR has tests
- [ ] No testing required (explain why):

## Issue / Card
Fixes WD-24765

## Screenshots
