### PR TITLE
WD-26684 - Fix bug with dropdown preventing clicks when closed

### DIFF
--- a/static/js/base/global-nav.ts
+++ b/static/js/base/global-nav.ts
@@ -12,7 +12,7 @@ import { createNav } from "@canonical/global-nav";
 const DROPDOWN_ANIMATION_DURATION = 333;
 const toggles = [
   ...document.querySelectorAll(
-    ".p-navigation__nav .p-navigation__link[aria-controls]:not(.js-back-button)"
+    ".p-navigation__nav .p-navigation__link[aria-controls]:not(.js-back-button)",
   ),
 ].filter((element) => element.id !== "all-canonical-link");
 
@@ -28,8 +28,10 @@ const toggleAnimationPlaying = (element: Element) => {
 const setAnimationPlaying = () => {
   // get all open toggles to add the animation playing to them
   toggles
-    .filter((toggle: Element): toggle is Element =>
-      toggle.parentElement != null && toggle.parentElement.classList.contains("is-active")
+    .filter(
+      (toggle: Element): toggle is Element =>
+        toggle.parentElement != null &&
+        toggle.parentElement.classList.contains("is-active"),
     )
     .forEach((toggle: Element) => {
       toggleAnimationPlaying(toggle.parentElement!);

--- a/static/sass/_snapcraft_p-navigation.scss
+++ b/static/sass/_snapcraft_p-navigation.scss
@@ -66,11 +66,6 @@
         position: relative;
       }
 
-      .js-animation-playing .p-navigation__dropdown--container,
-      .is-active .p-navigation__dropdown--container {
-        display: block;
-      }
-
       .p-navigation__dropdown--container {
         // a bit extra % to be able to show the shadow of the box if present
         clip-path: rect(0 105% 105% 0);
@@ -95,6 +90,11 @@
             --up: 0%;
           }
         }
+      }
+
+      .js-animation-playing .p-navigation__dropdown--container,
+      .is-active .p-navigation__dropdown--container {
+        display: block;
       }
     }
   }


### PR DESCRIPTION
## Done

Fix navigation dropdown blocking clicks to elements under it when closed.

## How to QA

- Go to Demos
- Log in
- Open the dropdown with your user name
- Close it
- Make sure you can click on the Install button that was under the dropdown

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why): This code will be refactored/removed next pulse when we move functionality currently in global-nav to Snapcraft.io.

## Issue / Card

Fixes [WD-26684](https://warthogs.atlassian.net/browse/WD-26684)


[WD-26684]: https://warthogs.atlassian.net/browse/WD-26684?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ