### PR TITLE
fix: Fix alignment of buttons in build form

### DIFF
--- a/static/js/publisher/pages/Builds/RepoSelector.tsx
+++ b/static/js/publisher/pages/Builds/RepoSelector.tsx
@@ -228,35 +228,37 @@ function RepoSelector({ githubData, setAutoTriggerBuild }: Props) {
           </datalist>
         </Col>
         <Col size={2}>
-          {validRepo === true && (
-            <Button
-              appearance="positive"
-              disabled={building}
-              onClick={() => {
-                connectRepo();
-              }}
-            >
-              Start building
-            </Button>
-          )}
-          {validationError && (
-            <Button
-              className="p-tooltip--btm-center"
-              aria-describedby="recheck-tooltip"
-              onClick={() => {
-                validateRepo(selectedRepo);
-              }}
-            >
-              <i className="p-icon--restart"></i>
-              <span
-                className="p-tooltip__message"
-                role="tooltip"
-                id="recheck-tooltip"
+          <div style={{ display: "flex", alignItems: "end", height: "100%" }}>
+            {validRepo === true && (
+              <Button
+                appearance="positive"
+                disabled={building}
+                onClick={() => {
+                  connectRepo();
+                }}
               >
-                Re-check
-              </span>
-            </Button>
-          )}
+                Start building
+              </Button>
+            )}
+            {validationError && (
+              <Button
+                className="p-tooltip--btm-center"
+                aria-describedby="recheck-tooltip"
+                onClick={() => {
+                  validateRepo(selectedRepo);
+                }}
+              >
+                <i className="p-icon--restart"></i>
+                <span
+                  className="p-tooltip__message"
+                  role="tooltip"
+                  id="recheck-tooltip"
+                >
+                  Re-check
+                </span>
+              </Button>
+            )}
+          </div>
         </Col>
       </Row>
       {validationError && (

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -177,6 +177,7 @@ $color-social-icon-foreground: $color-light;
 @include vf-p-icon-models;
 @include vf-p-icon-edit;
 @include vf-p-icon-units;
+@include vf-p-icon-restart;
 
 dl {
   margin-bottom: $spv--x-large;


### PR DESCRIPTION
## Done
- Fixes alignment of the "Start building" and "Re-check" buttons on the snap builds page
- Drive by: Fixes icon on the "Re-check" button

## How to QA
- Must run locally (will need [tokens](https://github.com/canonical/snapcraft.io/blob/main/HACKING.md#snap-automated-builds))
- Go to http://localhost:8004/<SNAP_NAME>/builds
- Connect a repo
- Check that the "Start building" button is aligned to the bottom of the fields
- Change the repo to the name of another snap
- Check that the "Re-check" button is aligned to the bottom of the fields

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why): Visual change

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-27230

## Screenshots
![Start building](https://github.com/user-attachments/assets/de164090-eef7-43f2-805c-1386b6070653)

![Re-check](https://github.com/user-attachments/assets/cfd4372b-7e82-41ee-a291-41169b2b6148)
