### PR TITLE
fix: Remove need for custom CSS for docs sticky footer

### DIFF
--- a/static/sass/_snapcraft_p-docs.scss
+++ b/static/sass/_snapcraft_p-docs.scss
@@ -9,8 +9,4 @@
   .emoji {
     height: 1rem;
   }
-
-  .l-docs {
-    flex: 1;
-  }
 }

--- a/templates/_base-layout.html
+++ b/templates/_base-layout.html
@@ -61,7 +61,7 @@
     <link rel="author" href="/humans.txt" />
   </head>
 
-  <body class="l-site">
+  <body class="l-site {% if is_docs %}is-paper{% endif %}">
     <!-- Google Tag Manager (noscript) -->
     <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-KCGXHQS"
       height="0" width="0" style="display: none; visibility: hidden;"></iframe></noscript>

--- a/templates/_footer.html
+++ b/templates/_footer.html
@@ -1,5 +1,5 @@
 {% if is_docs %}
-<div class="l-docs__footer">
+<div class="l-docs__footer l-footer--sticky">
 <footer class="p-strip--dark l-docs__subgrid">
   <div class="l-docs__sidebar">
     <p>

--- a/templates/_header.html
+++ b/templates/_header.html
@@ -1,5 +1,5 @@
 {% if docs %}
-<div class="l-docs is-paper">
+<div class="l-docs">
   <div class="l-docs__header">
 {% endif %}
     <header id="navigation" class="p-navigation--sliding is-dark">


### PR DESCRIPTION
## Done
Fixes issue where the footer isn't fixed to the bottom of the screen

In respsonse to [this comment on previous PR](https://github.com/canonical/snapcraft.io/pull/5379#discussion_r2375338126)

## How to QA
- Run locally (`dotrun` or `dotrun -p 5004:5004` on MacOS)
- Go to http://localhost:8004/docs/network-bind-interface
- Check that the footer is fixed to the bottom of the screen

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why): Visual change

## Screenshots

### Before
<img width="1080" height="977" alt="before" src="https://github.com/user-attachments/assets/11facc7c-44b7-47e6-b96e-b61726456c94" />

### After
<img width="1080" height="977" alt="after" src="https://github.com/user-attachments/assets/a798da91-121a-40a6-ad75-48819672e676" />
