### PR TITLE
chore: Refactor yaml template to readable string

### DIFF
--- a/static/js/publisher/pages/Builds/RepoSelector.tsx
+++ b/static/js/publisher/pages/Builds/RepoSelector.tsx
@@ -34,7 +34,7 @@ function generateYamlTemplateUrl(
   const url = `https://github.com/${org}/${repo}/new/${branch}`;
   const searchParams = new URLSearchParams();
   const templateContent = `# After registering a name on snapcraft.io, commit an uncommented line:
-# name: ${snapId} 
+# name: ${snapId}
 version: '0.1' # just for humans, typically '1.2+git' or '1.3.2'
 summary: Single-line elevator pitch for your amazing snap # 79 char long summary
 description: |
@@ -52,7 +52,7 @@ parts:
   searchParams.set("filename", "snap/snapcraft.yaml");
   searchParams.set("value", templateContent);
 
-  return `${encodeURI(url)}?${searchParams.toString()}`;
+  return `${url}?${searchParams.toString()}`;
 }
 
 function RepoSelector({ githubData, setAutoTriggerBuild }: Props) {


### PR DESCRIPTION
## Done
Refactors the `snapcraft.yaml` template URL from the builds page so it is readable and easier to maintain

## How to QA
- Must run locally (will need [tokens](https://github.com/canonical/snapcraft.io/blob/main/HACKING.md#snap-automated-builds))
- Go to http://localhost:8004/<SNAP_NAME>/builds (must be a snap without a `snapcraft.yaml` file)
- Connect the repo
- Click the "get started with a template" link
- Check that it opens a page on GitHub where you can create a new `snapcraft.yaml` file

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why): No behavioural changes

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-27507