### PR TITLE
chore: move models page to Publisher layout

### DIFF
--- a/static/js/publisher/index.tsx
+++ b/static/js/publisher/index.tsx
@@ -99,14 +99,14 @@ root.render(
               path="admin/:id/signing-keys/create"
               element={<SigningKeys />}
             />
+            <Route path="admin/:id/models" element={<Models />} />
+            <Route path="admin/:id/models/create" element={<Models />} />
           </Route>
           {/* END publisher routes */}
 
           {/* START brand store routes */}
           <Route path="admin" element={<BrandStoreLayout />}>
             <Route path=":id">
-              <Route path="models" element={<Models />} />
-              <Route path="models/create" element={<Models />} />
               <Route path="models/:model_id" element={<Model />} />
               <Route path="models/:model_id/policies" element={<Policies />} />
               <Route

--- a/static/js/publisher/pages/Models/Models.tsx
+++ b/static/js/publisher/pages/Models/Models.tsx
@@ -21,12 +21,12 @@ import { brandIdState, brandStoreState } from "../../state/brandStoreState";
 import Filter from "../../components/Filter";
 import ModelsTable from "./ModelsTable";
 import CreateModelForm from "./CreateModelForm";
-import Navigation from "../../components/Navigation";
 
 import { useModels } from "../../hooks";
 import { isClosedPanel, setPageTitle, getPolicies } from "../../utils";
 
 import type { Model as ModelType } from "../../types/shared";
+import { PortalEntry } from "../Portals/Portals";
 
 function Models(): React.JSX.Element {
   const { id } = useParams();
@@ -71,108 +71,107 @@ function Models(): React.JSX.Element {
   }, [modelsIsLoading, modelsError, models]);
 
   return (
-    <div className="l-application" role="presentation">
-      <Navigation />
-      <main className="l-main">
-        <div className="p-panel u-flex-column">
-          <div className="p-panel__content u-flex-column u-flex-grow">
-            <div className="u-fixed-width">
-              <h1 className="p-heading--4">Models</h1>
+    <>
+      <div className="u-fixed-width">
+        <h1 className="p-heading--4">Models</h1>
+      </div>
+      <Row>
+        <Col size={6}>
+          <Filter
+            state={modelsListFilterState}
+            label="Search models"
+            placeholder="Search models"
+          />
+        </Col>
+        <Col size={6} className="u-align--right">
+          <Link
+            className="p-button--positive"
+            to={`/admin/${id}/models/create`}
+          >
+            Create new model
+          </Link>
+        </Col>
+      </Row>
+      <div className="u-fixed-width u-flex-column u-flex-grow">
+        <div>
+          {modelsIsError && modelsError instanceof Error && (
+            <Notification severity="negative">
+              Error: {modelsError.message}
+            </Notification>
+          )}
+          {modelsIsLoading ? (
+            <p>
+              <Icon name="spinner" className="u-animation--spin" />
+              &nbsp;Fetching models...
+            </p>
+          ) : (
+            <div className="u-flex-column u-flex-grow">
+              <ModelsTable />
             </div>
-            {showNotification && (
-              <div className="u-fixed-width">
-                <Notification
-                  severity="positive"
-                  onDismiss={() => {
-                    setShowNotification(false);
-                  }}
-                >
-                  New model created
-                </Notification>
-              </div>
-            )}
-            {showErrorNotification && (
-              <div className="u-fixed-width">
-                <Notification
-                  severity="negative"
-                  onDismiss={() => {
-                    setShowErrorNotification(false);
-                  }}
-                >
-                  Unable to create model
-                </Notification>
-              </div>
-            )}
-            <Row>
-              <Col size={6}>
-                <Filter
-                  state={modelsListFilterState}
-                  label="Search models"
-                  placeholder="Search models"
-                />
-              </Col>
-              <Col size={6} className="u-align--right">
-                <Link
-                  className="p-button--positive"
-                  to={`/admin/${id}/models/create`}
-                >
-                  Create new model
-                </Link>
-              </Col>
-            </Row>
-            <div className="u-fixed-width u-flex-column u-flex-grow">
-              <div>
-                {modelsIsError && modelsError instanceof Error && (
-                  <Notification severity="negative">
-                    Error: {modelsError.message}
-                  </Notification>
-                )}
-                {modelsIsLoading ? (
-                  <p>
-                    <Icon name="spinner" className="u-animation--spin" />
-                    &nbsp;Fetching models...
-                  </p>
-                ) : (
-                  <div className="u-flex-column u-flex-grow">
-                    <ModelsTable />
-                  </div>
-                )}
-              </div>
-            </div>
-          </div>
+          )}
         </div>
-      </main>
-      <div
-        className={`l-aside__overlay ${
-          isClosedPanel(location.pathname, "create") ? "u-hide" : ""
-        }`}
-        onClick={() => {
-          navigate(`/admin/${id}/models`);
-          setShowErrorNotification(false);
-          setNewModel({ name: "", apiKey: "" });
-        }}
-        onKeyDown={(e) => {
-          if (e.key === "Enter" || e.key === " ") {
+      </div>
+
+      <PortalEntry name="notification">
+        {showNotification && (
+          <div className="u-fixed-width">
+            <Notification
+              severity="positive"
+              onDismiss={() => {
+                setShowNotification(false);
+              }}
+            >
+              New model created
+            </Notification>
+          </div>
+        )}
+        {showErrorNotification && (
+          <div className="u-fixed-width">
+            <Notification
+              severity="negative"
+              onDismiss={() => {
+                setShowErrorNotification(false);
+              }}
+            >
+              Unable to create model
+            </Notification>
+          </div>
+        )}
+      </PortalEntry>
+
+      <PortalEntry name="aside">
+        <div
+          className={`l-aside__overlay ${
+            isClosedPanel(location.pathname, "create") ? "u-hide" : ""
+          }`}
+          onClick={() => {
             navigate(`/admin/${id}/models`);
             setShowErrorNotification(false);
             setNewModel({ name: "", apiKey: "" });
-          }
-        }}
-        role="button"
-        tabIndex={0}
-        aria-label="Navigate to models page"
-      ></div>
-      <aside
-        className={`l-aside ${
-          isClosedPanel(location.pathname, "create") ? "is-collapsed" : ""
-        }`}
-      >
-        <CreateModelForm
-          setShowNotification={setShowNotification}
-          setShowErrorNotification={setShowErrorNotification}
-        />
-      </aside>
-    </div>
+          }}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" || e.key === " ") {
+              navigate(`/admin/${id}/models`);
+              setShowErrorNotification(false);
+              setNewModel({ name: "", apiKey: "" });
+            }
+          }}
+          role="button"
+          tabIndex={0}
+          aria-label="Navigate to models page"
+        ></div>
+        <aside
+          className={`l-aside ${
+            isClosedPanel(location.pathname, "create") ? "is-collapsed" : ""
+          }`}
+        >
+          <CreateModelForm
+            setShowNotification={setShowNotification}
+            setShowErrorNotification={setShowErrorNotification}
+          />
+        </aside>
+      </PortalEntry>
+    </>
   );
 }
 

--- a/static/js/publisher/pages/Models/__tests__/Models.test.tsx
+++ b/static/js/publisher/pages/Models/__tests__/Models.test.tsx
@@ -14,6 +14,11 @@ vi.mock("react-router-dom", async (importOriginal) => ({
   useSearchParams: () => [new URLSearchParams({ filter: mockFilterQuery })],
 }));
 
+vi.mock("../../Portals/Portals", async (importOriginal) => ({
+  ...(await importOriginal()),
+  PortalEntry: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
 const queryClient = new QueryClient({
   defaultOptions: {
     queries: {


### PR DESCRIPTION
## Done
- moved brand store models page to publisher layout
- moved notifications to bottom right corner for consistency
- fixed page tests

## How to QA
- log in
- go to a brand store's models page
  - there shouldn't be any visual glitch
- click "Create new model"
  - a form appears in an aside panel
- fill out the form and submit it
  - a notification appears in the bottom right corner

## Testing
- [ ] This PR has tests
- [ ] No testing required (explain why):

## Issue / Card
Fixes WD-29282

## Screenshots
BEFORE:
<img width="2506" height="672" alt="immagine" src="https://github.com/user-attachments/assets/3f8aa183-26bc-49de-8247-7e5889796820" />

AFTER:
<img height="500" alt="immagine" src="https://github.com/user-attachments/assets/6331f0dd-b11e-4f28-821c-48524bd66661" />
