### PR TITLE
chore: move Model details page to Publisher layout

### DIFF
--- a/static/js/publisher/index.tsx
+++ b/static/js/publisher/index.tsx
@@ -101,13 +101,13 @@ root.render(
             />
             <Route path="admin/:id/models" element={<Models />} />
             <Route path="admin/:id/models/create" element={<Models />} />
+            <Route path="admin/:id/models/:model_id" element={<Model />} />
           </Route>
           {/* END publisher routes */}
 
           {/* START brand store routes */}
           <Route path="admin" element={<BrandStoreLayout />}>
             <Route path=":id">
-              <Route path="models/:model_id" element={<Model />} />
               <Route path="models/:model_id/policies" element={<Policies />} />
               <Route
                 path="models/:model_id/policies/create"

--- a/static/js/publisher/pages/Model/Model.tsx
+++ b/static/js/publisher/pages/Model/Model.tsx
@@ -14,14 +14,12 @@ import {
 
 import { modelsListState, currentModelState } from "../../state/modelsState";
 import { brandIdState, brandStoreState } from "../../state/brandStoreState";
-
 import ModelNav from "./ModelNav";
 import ModelBreadcrumb from "./ModelBreadcrumb";
-import Navigation from "../../components/Navigation";
-
 import { useModels } from "../../hooks";
 import { setPageTitle } from "../../utils";
 import type { Model as ModelType } from "../../types/shared";
+import { PortalEntry } from "../Portals/Portals";
 
 function Model() {
   const { id, model_id } = useParams();
@@ -97,193 +95,186 @@ function Model() {
   }, [currentModel, modelsIsLoading, modelsError, models]);
 
   return (
-    <div className="l-application" role="presentation">
-      <Navigation />
-      <main className="l-main">
-        <div className="p-panel">
-          <div className="p-panel__content">
-            <div className="u-fixed-width">
-              <ModelBreadcrumb />
-            </div>
-            <div className="u-fixed-width">
-              <ModelNav sectionName="overview" />
-            </div>
-            {showSuccessNotification && (
-              <div className="u-fixed-width">
-                <Notification
-                  severity="positive"
-                  onDismiss={() => {
-                    setShowSuccessNotificaton(false);
-                  }}
-                >
-                  Model updated successfully
-                </Notification>
-              </div>
-            )}
-            {showErrorNotification && (
-              <div className="u-fixed-width">
-                <Notification
-                  severity="negative"
-                  onDismiss={() => {
-                    setShowErrorNotificaton(false);
-                  }}
-                >
-                  Unable to update model
-                </Notification>
-              </div>
-            )}
-            <div className="u-fixed-width u-align--right">
+    <>
+      <div className="u-fixed-width">
+        <ModelBreadcrumb />
+      </div>
+      <div className="u-fixed-width">
+        <ModelNav sectionName="overview" />
+      </div>
+      <div className="u-fixed-width u-align--right">
+        <Button
+          type="button"
+          onClick={() => {
+            setNewApiKey("");
+          }}
+          disabled={!newApiKey}
+        >
+          Revert
+        </Button>
+        <Button
+          type="submit"
+          appearance="positive"
+          className="u-no-margin--right"
+          disabled={!newApiKey}
+          form="save-model-form"
+        >
+          Save
+        </Button>
+      </div>
+
+      {currentModel && (
+        <form
+          className="p-form p-form--stacked"
+          id="save-model-form"
+          onSubmit={(event) => {
+            event.preventDefault();
+            mutation.mutate(newApiKey);
+          }}
+        >
+          <Row>
+            <Col size={3}>
+              <p>Name</p>
+            </Col>
+            <Col size={9}>
+              <p>{currentModel.name}</p>
+            </Col>
+          </Row>
+          <div className="u-fixed-width">
+            <hr />
+          </div>
+          <Row>
+            <Col size={3}>
+              <p>Series</p>
+            </Col>
+            <Col size={9}>
+              <p>{currentModel.series}</p>
+            </Col>
+          </Row>
+          <div className="u-fixed-width">
+            <hr />
+          </div>
+          <Row>
+            <Col size={3}>
+              <p>API key</p>
+            </Col>
+            <Col size={6}>
+              <Input
+                type="text"
+                id="api-key-field"
+                label="API key"
+                labelClassName="u-off-screen"
+                value={newApiKey || currentModel["api-key"] || ""}
+                placeholder="yx6dnxsWQ3XUB5gza8idCuMvwmxtk1xBpa9by8TuMit5dgGnv"
+                className="read-only-dark u-no-margin--bottom"
+                readOnly
+              />
+            </Col>
+            <Col size={3} className="u-align--right">
               <Button
                 type="button"
+                className="u-no-margin--bottom"
                 onClick={() => {
-                  setNewApiKey("");
-                }}
-                disabled={!newApiKey}
-              >
-                Revert
-              </Button>
-              <Button
-                type="submit"
-                appearance="positive"
-                className="u-no-margin--right"
-                disabled={!newApiKey}
-                form="save-model-form"
-              >
-                Save
-              </Button>
-            </div>
-
-            {currentModel && (
-              <form
-                className="p-form p-form--stacked"
-                id="save-model-form"
-                onSubmit={(event) => {
-                  event.preventDefault();
-                  mutation.mutate(newApiKey);
+                  setNewApiKey(
+                    randomstring.generate({
+                      length: 50,
+                    }),
+                  );
                 }}
               >
-                <Row>
-                  <Col size={3}>
-                    <p>Name</p>
-                  </Col>
-                  <Col size={9}>
-                    <p>{currentModel.name}</p>
-                  </Col>
-                </Row>
-                <div className="u-fixed-width">
-                  <hr />
-                </div>
-                <Row>
-                  <Col size={3}>
-                    <p>Series</p>
-                  </Col>
-                  <Col size={9}>
-                    <p>{currentModel.series}</p>
-                  </Col>
-                </Row>
-                <div className="u-fixed-width">
-                  <hr />
-                </div>
-                <Row>
-                  <Col size={3}>
-                    <p>API key</p>
-                  </Col>
-                  <Col size={6}>
-                    <Input
-                      type="text"
-                      id="api-key-field"
-                      label="API key"
-                      labelClassName="u-off-screen"
-                      value={newApiKey || currentModel["api-key"] || ""}
-                      placeholder="yx6dnxsWQ3XUB5gza8idCuMvwmxtk1xBpa9by8TuMit5dgGnv"
-                      className="read-only-dark u-no-margin--bottom"
-                      readOnly
-                    />
-                  </Col>
-                  <Col size={3} className="u-align--right">
-                    <Button
-                      type="button"
-                      className="u-no-margin--bottom"
-                      onClick={() => {
-                        setNewApiKey(
-                          randomstring.generate({
-                            length: 50,
-                          }),
-                        );
-                      }}
-                    >
-                      Generate key
-                    </Button>
-                  </Col>
-                </Row>
-                <div className="u-fixed-width">
-                  <hr />
-                </div>
-                <Row>
-                  <Col size={3}>
-                    <p>Creation date</p>
-                  </Col>
-                  <Col size={9}>
-                    <p>
-                      {format(
-                        new Date(currentModel["created-at"]),
-                        "dd/MM/yyyy",
-                      )}
-                    </p>
-                  </Col>
-                </Row>
-                {currentModel["created-by"] && (
-                  <>
-                    <div className="u-fixed-width">
-                      <hr />
-                    </div>
-                    <Row>
-                      <Col size={3}>
-                        <p>Created by</p>
-                      </Col>
-                      <Col size={9}>
-                        <p>{currentModel["created-by"]["display-name"]}</p>
-                      </Col>
-                    </Row>
-                  </>
-                )}
-                {currentModel["modified-at"] && currentModel["modified-by"] && (
-                  <>
-                    <div className="u-fixed-width">
-                      <hr />
-                    </div>
-                    <Row>
-                      <Col size={3}>
-                        <p>Last updated</p>
-                      </Col>
-                      <Col size={9}>
-                        <p>
-                          {format(
-                            new Date(currentModel["modified-at"]),
-                            "dd/MM/yyyy",
-                          )}
-                        </p>
-                      </Col>
-                    </Row>
-                    <div className="u-fixed-width">
-                      <hr />
-                    </div>
-                    <Row>
-                      <Col size={3}>
-                        <p>Modified by</p>
-                      </Col>
-                      <Col size={9}>
-                        <p>{currentModel["modified-by"]["display-name"]}</p>
-                      </Col>
-                    </Row>
-                  </>
-                )}
-              </form>
-            )}
+                Generate key
+              </Button>
+            </Col>
+          </Row>
+          <div className="u-fixed-width">
+            <hr />
           </div>
-        </div>
-      </main>
-    </div>
+          <Row>
+            <Col size={3}>
+              <p>Creation date</p>
+            </Col>
+            <Col size={9}>
+              <p>
+                {format(new Date(currentModel["created-at"]), "dd/MM/yyyy")}
+              </p>
+            </Col>
+          </Row>
+          {currentModel["created-by"] && (
+            <>
+              <div className="u-fixed-width">
+                <hr />
+              </div>
+              <Row>
+                <Col size={3}>
+                  <p>Created by</p>
+                </Col>
+                <Col size={9}>
+                  <p>{currentModel["created-by"]["display-name"]}</p>
+                </Col>
+              </Row>
+            </>
+          )}
+          {currentModel["modified-at"] && currentModel["modified-by"] && (
+            <>
+              <div className="u-fixed-width">
+                <hr />
+              </div>
+              <Row>
+                <Col size={3}>
+                  <p>Last updated</p>
+                </Col>
+                <Col size={9}>
+                  <p>
+                    {format(
+                      new Date(currentModel["modified-at"]),
+                      "dd/MM/yyyy",
+                    )}
+                  </p>
+                </Col>
+              </Row>
+              <div className="u-fixed-width">
+                <hr />
+              </div>
+              <Row>
+                <Col size={3}>
+                  <p>Modified by</p>
+                </Col>
+                <Col size={9}>
+                  <p>{currentModel["modified-by"]["display-name"]}</p>
+                </Col>
+              </Row>
+            </>
+          )}
+        </form>
+      )}
+
+      <PortalEntry name="notification">
+        {showSuccessNotification && (
+          <div className="u-fixed-width">
+            <Notification
+              severity="positive"
+              onDismiss={() => {
+                setShowSuccessNotificaton(false);
+              }}
+            >
+              Model updated successfully
+            </Notification>
+          </div>
+        )}
+        {showErrorNotification && (
+          <div className="u-fixed-width">
+            <Notification
+              severity="negative"
+              onDismiss={() => {
+                setShowErrorNotificaton(false);
+              }}
+            >
+              Unable to update model
+            </Notification>
+          </div>
+        )}
+      </PortalEntry>
+    </>
   );
 }
 


### PR DESCRIPTION
## Done
- moved Model details page to Publisher layout
- moved notification to bottom right corner for consistency

## How to QA
- log in
- open a brand store's Models page
- select a model
  - the detail page has no visual glitches
- click "Generate key" and save
  - a notification appears in the bottom right corner

## Testing
- [ ] This PR has tests
- [ ] No testing required (explain why):

## Issue / Card
Fixes WD-29283

## Screenshots
BEFORE:
<img width="2950" height="684" alt="immagine" src="https://github.com/user-attachments/assets/e708784a-a3af-4476-b8e1-5ac2c0b00a42" />

AFTER:
<img width="1004" height="476" alt="immagine" src="https://github.com/user-attachments/assets/68cfdc36-fd63-44e4-982e-709f56390d36" />
