### PR TITLE
fix: Fix issue where www. domains don't show as verified

### DIFF
--- a/webapp/endpoints/snaps.py
+++ b/webapp/endpoints/snaps.py
@@ -65,7 +65,7 @@ def dns_verified_status(snap_name):
     if primary_domain:
         token = helpers.get_dns_verification_token(snap_name, primary_domain)
 
-        domain = re.compile(r"https?://(www.)?")
+        domain = re.compile(r"https?://(www\.)?")
         domain = domain.sub("", primary_domain).strip().strip("/")
 
         res["token"] = token


### PR DESCRIPTION
## Done
Fixes [an issue](https://forum.snapcraft.io/t/verified-publisher-request-for-gimp/48840/7) where a domain isn't showing as verified because the DNS record has been only applied to the hostname which doesn't work if the supplied domain has `www`

## How to QA
- Go to https://snapcraft-io-5416.demos.haus/gimp and check that `www.gimp.org` says it is verified in the "Websites" section of the side bar
- Go to https://snapcraft-io-5416.demos.haus/gimp/listing and check that the "Primary domain" field has "Ownership verified" next to it
- Go to https://snapcraft-io-5416.demos.haus/steve-test-snap and check that `steverydz.com` says it is verified in the "Websites" section of the side bar
- Go to https://snapcraft-io-5416.demos.haus/steve-test-snap/listing and check that the "Primary domain" field has "Ownership verified" next to it
 

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why):

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-29863