### PR TITLE
fix: Fix issue where publisher shows twice on listing page

### DIFF
--- a/templates/store/snap-details/_package_heading_data.jinja
+++ b/templates/store/snap-details/_package_heading_data.jinja
@@ -52,8 +52,9 @@
     <ul class="p-inline-list--vertical-divider">
       {% if developer %}
         <li class="p-inline-list__item u-hide--small">{{ developer_info(name=developer[0], url=developer[1]) }}</li>
-      {% endif %}
+      {% else %}
       <li class="p-inline-list__item u-hide--small">{{ publisher_info(publisher, username, developer_validation, display_name, VERIFIED_PUBLISHER, STAR_DEVELOPER) }}</li>
+      {% endif %}
       {% for category in categories %}
         <li class="p-inline-list__item">
           <a href="/search?categories={{ category.slug }}">{{ category.name }}</a>


### PR DESCRIPTION
## Done
Fixes issue where the publisher name is shown twice underneath the snap title on the listing page

## How to QA
- Go to https://snapcraft-io-5420.demos.haus/gimp
- Check that the publisher name is just shown once under the snap title

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why): Visual change

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-29895

## Screenshots
