### PR TITLE
chore: Remove GIMP from snap developers at their request

### DIFF
--- a/webapp/store/content/developers/snaps.yaml
+++ b/webapp/store/content/developers/snaps.yaml
@@ -26,9 +26,6 @@ get-iplayer:
 ghost-desktop:
 - ghost
 - https://ghost.org/
-gimp:
-- GIMP
-- https://gimp.org/
 gitter-desktop:
 - Gitter
 - https://gitter.im/


### PR DESCRIPTION
## Done
Removes GIMP from the snaps developers [at their request](https://forum.snapcraft.io/t/verified-publisher-request-for-gimp/48840/12)

## How to QA
- Go to https://snapcraft-io-5422.demos.haus/gimp
- Check that only the publisher shows under the header

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why): No behavioural changes

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-29973

## Screenshots

### Before
![before](https://github.com/user-attachments/assets/5cb6687c-6365-41dc-bb1d-ea19c8176d3f)

### After 
![after](https://github.com/user-attachments/assets/73764064-0839-4263-a62c-c1299a7b47b9)
