### PR TITLE
feat: Add initial view for SSR explore page

### DIFF
--- a/templates/explore/index.html
+++ b/templates/explore/index.html
@@ -1,0 +1,25 @@
+{% extends "_layout.html" %}
+
+{% block meta_title %}Install Linux apps using the Snap Store | Snapcraft {% endblock %}
+
+{% block content %}
+<main id="root">
+  <section class="p-strip--dark">
+    <div class="row">
+      <div class="col-start-large-4 col-6">
+        <h1 class="p-heading--2">The app store for Linux</h1>
+        <form class="p-search-box" action="/store">
+          <label class="u-off-screen" for="search">Search snap store</label>
+          <input type="search" id="search" class="p-search-box__input" placeholder="Search snap store" name="q">
+          <button type="reset" class="p-button p-search-box__reset">
+            <i class="p-icon--close">Close</i>
+          </button>
+          <button type="submit" class="p-button p-search-box__button">
+            <i class="p-icon--search">Search</i> 
+          </button>
+        </form>
+      </div>
+    </div>
+  </section>
+</main>
+{% endblock %}

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -120,7 +120,7 @@ def store_blueprint(store_query=None):
 
     @store.route("/explore")
     def explore_view():
-        return flask.render_template("store/store.html")
+        return flask.render_template("explore/index.html")
 
     @store.route("/youtube", methods=["POST"])
     def get_video_thumbnail_data():


### PR DESCRIPTION
## Done
Adds the initial page view for the server-side rendered store page

## How to QA
- Go to https://snapcraft-io-5423.demos.haus/explore
- Check that there is a page and that it has the same search section as http://snapcraft.io/store

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why):

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-28152
