### PR TITLE
feat: Add categories section to the SSR explore page

### DIFF
--- a/templates/explore/_categories.html
+++ b/templates/explore/_categories.html
@@ -1,0 +1,18 @@
+<section class="p-strip is-shallow u-no-padding--top">
+  <div class="u-fixed-width">
+    <h2>Categories</h2>
+    <div class="p-strip is-shallow u-no-padding--bottom">
+      <div class="row">
+        {% for category in categories %}
+          <div class="col-3">
+            <p class="p-heading--4">
+              <a class="p-link--soft" href="/store?categories={{ category.slug }}">
+                {{ category.name }}
+              </a>
+            </p>
+          </div>
+        {% endfor %}
+      </div>
+    </div>
+  </div>
+</section>

--- a/templates/explore/index.html
+++ b/templates/explore/index.html
@@ -22,6 +22,8 @@
     </div>
   </section>
 
+  {% include "explore/_categories.html" %}
+
   <section class="p-strip u-no-padding--top">
     <div class="u-fixed-width">
       <div class="explore-highlight-block">

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -17,6 +17,9 @@ from webapp.helpers import api_publisher_session, api_session
 from flask.json import jsonify
 import os
 from webapp.extensions import csrf
+from webapp.store.logic import (
+    get_categories,
+)
 
 session = requests.Session()
 
@@ -120,7 +123,19 @@ def store_blueprint(store_query=None):
 
     @store.route("/explore")
     def explore_view():
-        return flask.render_template("explore/index.html")
+        try:
+            categories_results = device_gateway.get_categories()
+        except StoreApiError:
+            categories_results = []
+
+        categories = sorted(
+            get_categories(categories_results),
+            key=lambda category: category["slug"],
+        )
+
+        return flask.render_template(
+            "explore/index.html", categories=categories
+        )
 
     @store.route("/youtube", methods=["POST"])
     def get_video_thumbnail_data():


### PR DESCRIPTION
## Done
Adds the categories section to the SSR explore page

## How to QA
- Go to https://snapcraft-io-5425.demos.haus/explore
- Check that the "Categories" section is the same as it is on https://snapcraft.io/explore

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why): No behavioural changes

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-28155
