### PR TITLE
chore: Update text on verified domain tooltip to account for verified publisher

### DIFF
--- a/templates/store/snap-details/_details.html
+++ b/templates/store/snap-details/_details.html
@@ -109,10 +109,9 @@
     (Ownership verified) 
     <span class="p-tooltip--btm-right" aria-describedby="verified-explanation">
       <i class="p-icon--information"></i>
-      <span class="p-tooltip__message" role="tooltip" id="verified-explanation">The publisher has verified that they own this domain. 
-  It does not guarantee the Snap is an official upload from the 
-  upstream project.</span>
-    </span>
+      <span class="p-tooltip__message" role="tooltip" id="verified-explanation">The publisher has verified that they own this domain{%- if developer_validation != VERIFIED_PUBLISHER -%}.
+It does not guarantee the Snap is an official upload
+from the upstream project.{%- endif -%}</span>
   </template>
 
   <script>


### PR DESCRIPTION
## Done
Amends the text for verified domains so verified publishers don't show the disclaimer which non-verified publishers have.

## How to QA
- Go to https://snapcraft-io-5426.demos.haus/gimp
- Hover over the icon next to the ownership verified domain under "Websites" and check that the tooltip says: "The publisher has verified that they own this domain"
- Go to https://snapcraft-io-5426.demos.haus/steve-test-snap
- Hover over the icon next to the ownership verified domain under "Websites" and check that the tooltip says: "The publisher has verified that they own this domain. It does not guarantee the Snap is an official upload from the upstream project."

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why): No behavioural changes

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-30124