### PR TITLE
fix: clear all session data on logout

### DIFF
--- a/tests/publisher/tests_account_logout.py
+++ b/tests/publisher/tests_account_logout.py
@@ -1,5 +1,6 @@
 import responses
 from tests.publisher.endpoint_testing import BaseTestCases
+from webapp.authentication import SESSION_DATA_KEYS
 
 # Make sure tests fail on stray responses.
 responses.mock.assert_all_requests_are_fired = True
@@ -13,8 +14,14 @@ class LogoutRedirects(BaseTestCases.BaseAppTesting):
 
     @responses.activate
     def test_logout(self):
+        with self.client.session_transaction() as session:
+            for key in SESSION_DATA_KEYS:
+                session[key] = "MOCK VALUE"
+
         response = self.client.get(self.endpoint_url)
 
         self.assertEqual(302, response.status_code)
 
         self.assertEqual("/", response.location)
+
+        self.assertIn("session=;", response.headers.get("Set-Cookie"))

--- a/webapp/authentication.py
+++ b/webapp/authentication.py
@@ -20,6 +20,18 @@ PERMISSIONS = [
 ]
 
 
+SESSION_DATA_KEYS = [
+    "macaroons",
+    "macaroon_root",
+    "macaroon_discharge",
+    "publisher",
+    "github_auth_secret",
+    "developer_token",
+    "exchanged_developer_token",
+    "csrf_token",
+]  # keys for data stored in the session that should be cleared on logout
+
+
 def get_authorization_header(root, discharge):
     """
     Bind root and discharge macaroons and return the authorization header.
@@ -52,11 +64,8 @@ def empty_session(session):
     """
     Empty the session, used to logout.
     """
-    session.pop("macaroons", None)
-    session.pop("macaroon_root", None)
-    session.pop("macaroon_discharge", None)
-    session.pop("publisher", None)
-    session.pop("github_auth_secret", None)
+    for key in SESSION_DATA_KEYS:
+        session.pop(key, None)
 
 
 def get_caveat_id(root):


### PR DESCRIPTION
This PR updates logout logic to remove `developer_token`, `exchanged_developer_token` and `csrf_token` from the Flask session cookie. Currently the old values are never removed from the session and some brand store features (e.g. Models) become inaccessible after 24 hours even after logging out, unless the session cookie is removed manually by the user.

## Done
- updated logout logic to remove all data from the Flask session cookie
- updated unit logout test to check the session is cleared correctly

## How to QA
Ideally the best way to make sure that this fixes the issue is by logging in on the demo site and waiting for 24 hours for the macaroons to expire, then go though the SSO auth again to check if the `developer_token` gets refreshed correctly. This is quite cumbersome, so the next best thing to test is what happens when you log out (since this is effectively what happens when visiting publisher routes with an expired macaroon).

- visit https://snapcraft-io-5429.demos.haus
- log in and open a brand store
- open the browser dev tools and head to the Cookies section
  - Chromium browsers: "Application" tab -> "Cookies" in the left sidenav
  - Firefox browsers: "Storage" tab -> "Cookies" in the left sidenav
- look for the `session` cookie
  - it should be a few thousand characters long
- go to the Network tab of the dev tools
- log out
- look for the navigation event to `/logout` and check the response cookies
  - the `Set-Cookie` header should start with `session=;`
- go back to the Cookies section in dev tools
  - the `session` cookie should have disappeared

## Testing
- [x] This PR has tests
- [ ] No testing required (explain why):

## Issue / Card
Fixes #5414 (WD-29847)

## Screenshots
