### PR TITLE
fix: Fix not being able to change or remove banner

### DIFF
--- a/static/js/publisher/hooks/useMutateListingData.ts
+++ b/static/js/publisher/hooks/useMutateListingData.ts
@@ -46,8 +46,40 @@ function useMutateListingData({
         formData.append("icon", values.icon[0]);
       }
 
+      // In regards to banners, the `banner` field is the file itself
+      // and the `banner_urls` is a string with the blob URL of the
+      // uploaded banner. If `banner` is a `dirtyField`, that means
+      // the banner itself has changed,
+      // whereas if `banner_urls` shows as a `dirtyField`,
+      // the banner would have been removed
+
+      // If the banner field has changed we need to remove
+      // the existing banner from the changes.images array,
+      // otherwise it overrides it and causes a
+      // "modified during validation" error
+      if (dirtyFields.banner && changes.images) {
+        changes.images = changes.images.filter(
+          (image) => image.type !== "banner",
+        );
+      }
+
+      // If there is a File for the banner, it must
+      // be appended to the formData in order
+      // to be uploaded
       if (values.banner && values.banner.length > 0) {
         formData.append("banner-image", values.banner[0]);
+      }
+
+      // If the banner_urls field has changed, we need to set
+      // the banner URL property in the changes.images array
+      // to the value of that field, otherwise the value doesn't
+      // change and therefore the banner doesn't change
+      if (changes.images && dirtyFields.banner_urls) {
+        const banner = changes.images.find((image) => image.type === "banner");
+
+        if (banner) {
+          banner.url = values.banner_urls;
+        }
       }
 
       if (values.screenshots) {


### PR DESCRIPTION
## Done
Fixes issue where banners are unable to be removed or changed

## How to QA
Remove a banner image:
- Go to https://snapcraft-io-5431.demos.haus/<SNAP_NAME>/listing
- Remove the banner image and save the form
- Check that it saves successfully
- Reload the page
- The banner should not be there

Upload a banner image when there isn't already one there:
- Upload a banner image and save the form
- Check that it saves successfully
- Reload the page
- The new banner should be there

Change an existing banner image:
- Change an existing banner to a new image and save the form
- Check that it saves successfully
- Reload the page
- The updated banner should be there

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why): Existing tests

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-30391
Fixes https://github.com/canonical/snapcraft.io/issues/5430
