### PR TITLE
fix: bad react-query key on publisher pages

### DIFF
--- a/static/js/publisher/pages/Builds/Builds.tsx
+++ b/static/js/publisher/pages/Builds/Builds.tsx
@@ -24,7 +24,7 @@ function Builds(): React.JSX.Element {
   const [repoConnected, setRepoConnected] = useAtom(buildRepoConnectedState);
   const [autoTriggerBuild, setAutoTriggerBuild] = useState<boolean>(false);
   const { isLoading } = useQuery({
-    queryKey: ["githubData"],
+    queryKey: ["githubData", snapId],
     queryFn: async () => {
       const response = await fetch(`/api/${snapId}/repo`);
 

--- a/static/js/publisher/pages/Builds/RepoConnected.tsx
+++ b/static/js/publisher/pages/Builds/RepoConnected.tsx
@@ -31,7 +31,7 @@ function RepoConnected({
     useState<boolean>(false);
   const [triggeringBuild, setTriggeringBuild] = useState<boolean>(false);
   const { isLoading, isFetched, data, refetch } = useQuery({
-    queryKey: ["repo"],
+    queryKey: ["repo", snapId],
     queryFn: async () => {
       const response = await fetch(`/api/${snapId}/builds`);
       const data = await response.json();

--- a/static/js/publisher/pages/Listing/Listing.tsx
+++ b/static/js/publisher/pages/Listing/Listing.tsx
@@ -10,7 +10,7 @@ import { setPageTitle } from "../../utils";
 function Listing(): React.JSX.Element {
   const { snapId } = useParams();
   const { data, isLoading, refetch, status } = useQuery({
-    queryKey: ["listing"],
+    queryKey: ["listing", snapId],
     queryFn: async () => {
       const response = await fetch(`/api/${snapId}/listing`);
 

--- a/static/js/publisher/pages/Publicise/Publicise.tsx
+++ b/static/js/publisher/pages/Publicise/Publicise.tsx
@@ -24,7 +24,7 @@ function Publicise({ view }: Props): React.JSX.Element {
   const { snapId } = useParams();
 
   const { data, isLoading, isFetched } = useQuery({
-    queryKey: ["publiciseData"],
+    queryKey: ["publiciseData", snapId],
     queryFn: async () => {
       const response = await fetch(`/api/${snapId}/publicise`);
 

--- a/static/js/publisher/pages/PublisherSettings/PublisherSettings.tsx
+++ b/static/js/publisher/pages/PublisherSettings/PublisherSettings.tsx
@@ -10,7 +10,7 @@ import { setPageTitle } from "../../utils";
 function PublisherSettings() {
   const { snapId } = useParams();
   const { data, isLoading, isFetched } = useQuery({
-    queryKey: ["settingsData"],
+    queryKey: ["settingsData", snapId],
     queryFn: async () => {
       const response = await fetch(`/api/${snapId}/settings`);
 

--- a/static/js/publisher/pages/Releases/Releases.tsx
+++ b/static/js/publisher/pages/Releases/Releases.tsx
@@ -10,7 +10,7 @@ import { setPageTitle } from "../../utils";
 function Releases(): React.JSX.Element {
   const { snapId } = useParams();
   const { isLoading, isFetched, data } = useQuery({
-    queryKey: ["releases"],
+    queryKey: ["releases", snapId],
     queryFn: async () => {
       const response = await fetch(`/api/${snapId}/releases`);
 


### PR DESCRIPTION
## Done
added `snapId` to react-query `queryKey` when calling APIs that depend on a snap's ID

## How to QA
- log in
- open one of you snaps' Listing page
- open all the other tabs as well
- go back to Overview page
- open another snap's Listing page
  - in your dev tools you should see a GET request
- open the other tabs as well
  - in your dev tools you should see GET requests each time you open a tab

## Testing
- [ ] This PR has tests
- [ ] No testing required (explain why):

## Issue / Card
Fixes WD-30402

## Screenshots
