### PR TITLE
chore: Add logging for login for SSDLC

### DIFF
--- a/tests/publisher/snaps/tests_get_metrics.py
+++ b/tests/publisher/snaps/tests_get_metrics.py
@@ -60,6 +60,13 @@ class GetActiveDeviceMetrics(TestCase):
     ):
         mock_is_authenticated.return_value = True
 
+        with self.client.session_transaction() as sess:
+            sess["publisher"] = {
+                "nickname": "test_username",
+                "fullname": "Test User",
+                "email": "test@example.com",
+            }
+
         mock_get_item_details.return_value = {"snap_id": "id"}
         random_values = random.sample(range(1, 30), 29)
         dates = [
@@ -125,6 +132,13 @@ class GetActiveDeviceMetrics(TestCase):
             ]
         }
 
+        with self.client.session_transaction() as sess:
+            sess["publisher"] = {
+                "nickname": "test_username",
+                "fullname": "Test User",
+                "email": "test@example.com",
+            }
+
         response = self.client.get(
             self.endpoint_url + "?active-devices=channel"
         )
@@ -175,6 +189,13 @@ class GetActiveDeviceMetrics(TestCase):
             ]
         }
 
+        with self.client.session_transaction() as sess:
+            sess["publisher"] = {
+                "nickname": "test_username",
+                "fullname": "Test User",
+                "email": "test@example.com",
+            }
+
         response = self.client.get(self.endpoint_url + "?active-devices=os")
         self.assertEqual(response.status_code, 200)
         response_json = response.json
@@ -217,6 +238,13 @@ class GetActiveDeviceMetrics(TestCase):
                 }
             ]
         }
+
+        with self.client.session_transaction() as sess:
+            sess["publisher"] = {
+                "nickname": "test_username",
+                "fullname": "Test User",
+                "email": "test@example.com",
+            }
 
         response = self.client.get(
             self.endpoint_url + "?active-devices=architecture&period=3m"
@@ -280,6 +308,13 @@ class GetMetricAnnotation(TestCase):
         mock_is_authenticated.return_value = True
 
         mock_get_snap_info.return_value = self.snap_payload
+
+        with self.client.session_transaction() as sess:
+            sess["publisher"] = {
+                "nickname": "test_username",
+                "fullname": "Test User",
+                "email": "test@example.com",
+            }
 
         response = self.client.get(self.endpoint_url)
         self.assertEqual(response.status_code, 200)
@@ -360,6 +395,13 @@ class GetCountryMetric(TestCase):
                 }
             ]
         }
+
+        with self.client.session_transaction() as sess:
+            sess["publisher"] = {
+                "nickname": "test_username",
+                "fullname": "Test User",
+                "email": "test@example.com",
+            }
 
         response = self.client.get(self.endpoint_url)
         self.assertEqual(response.status_code, 200)

--- a/tests/publisher/tests_account_snaps.py
+++ b/tests/publisher/tests_account_snaps.py
@@ -352,6 +352,7 @@ class AccountSnapsPage(BaseTestCases.EndpointLoggedInErrorHandling):
             sess["publisher"] = {
                 "nickname": "test_username",
                 "fullname": "Test User",
+                "email": "test@example.com",
             }
 
         response = self.client.get("/snap_info/user_snap/test_snap")

--- a/tests/publisher/tests_publisher.py
+++ b/tests/publisher/tests_publisher.py
@@ -77,6 +77,7 @@ class PublisherPage(TestCase):
                 "image": None,
                 "nickname": "Toto",
                 "fullname": "El Toto",
+                "email": "test@example.com",
             }
             s["macaroon_root"] = root.serialize()
             s["macaroon_discharge"] = discharge.serialize()

--- a/yarn.lock
+++ b/yarn.lock
@@ -947,12 +947,12 @@
   resolved "https://registry.yarnpkg.com/@canonical/cookie-policy/-/cookie-policy-3.6.5.tgz#50d82df6da2970b6b5d78d066dd94fcc1317e591"
   integrity sha512-CQJKSkuLXhSumkIIw4YPSjR7k9561hZ3EEdMPQTkAVTxXURhm3WzJm/uyrvcAuU/a//jzWa8ScltCaHFBdACew==
 
-"@canonical/global-nav@3.8.0":
-  version "3.8.0"
-  resolved "https://registry.yarnpkg.com/@canonical/global-nav/-/global-nav-3.8.0.tgz#3f016b337f93a2b50fccb0cbf8f13c9a10dcee5a"
-  integrity sha512-ioJE4tUENS2L8ubD/lUAA+CvIrtqXB1RTv89vyAW/6eDJWRW8U9Fks+SdKoeoa/IwOtzSC02AOWTPo7rxgj+Mw==
+"@canonical/global-nav@3.7.3":
+  version "3.7.3"
+  resolved "https://registry.yarnpkg.com/@canonical/global-nav/-/global-nav-3.7.3.tgz#cac51536f54c88298571301e12504daa3408c1d3"
+  integrity sha512-1G4A2dgIHcqOCWfNJ5F9MWmXNSVGF39Nx53bIk2imiGXGALhDCOGFcnELx0q5uKP2aIy1pMd3D58qX93yX8tzg==
   dependencies:
-    vanilla-framework "4.35.0"
+    vanilla-framework "4.26.1"
 
 "@canonical/react-components@1.9.0":
   version "1.9.0"
@@ -8313,6 +8313,11 @@ uuid@^8.3.2:
   version "8.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
+
+vanilla-framework@4.26.1:
+  version "4.26.1"
+  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-4.26.1.tgz#d076f26a7215cf8b0babae81753ef535e6486257"
+  integrity sha512-7m3qX4rm+I+go5mNjzO8gkp2qxr5m4n1jAxTh+bJ8hx/Wrsx3hiWDmJHylZ2GqjeqdtOiidvWgU2ToZJK6ELUg==
 
 vanilla-framework@4.35.0:
   version "4.35.0"


### PR DESCRIPTION
## Done
Adds logging for authentication to [satisfy SSDLC requirements](https://library.canonical.com/corporate-policies/information-security-policies/ssdlc/ssdlc---security-event-logging#format-8)

## How to QA
- Run locally
- Go to http://localhost:8004/snaps whilst logged out
- Check that in the console you see a warning log with the `datetime`, `event` and `appid`, and a message about failed login
- Login
- Check that in the console you see an info log with the `datetime`, `event` and `appid`, and a message about successful login

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why):

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-29129