### PR TITLE
feat: Add popular snaps to SSR explore page

### DIFF
--- a/templates/explore/_popular-snaps.html
+++ b/templates/explore/_popular-snaps.html
@@ -1,0 +1,37 @@
+<section class="p-strip is-shallow u-no-padding--bottom">
+  <div class="u-fixed-width">
+    <h2>Most popular snaps</h2>
+  </div>
+</section>
+<section class="p-strip is-shallow u-no-padding--bottom">
+  <div class="row">
+    {% for snap in popular_snaps %}
+      {% if loop.index <= 8 %}
+        <div class="col-3">
+          <p class="p-heading--4" style="float: left; margin-right: 1rem">{{ loop.index }}</p>
+          <div class="p-media-object">
+            <a href="{{ snap.details.name }}">
+              <img src="{{ snap.details.icon }}" class="p-media-object__image" alt="{{ snap.details.title }}" width="48" height="48">
+            </a>
+            <div class="p-media-object__details" style="min-width: 0">
+              <h3 class="p-media-object__title u-truncate">
+                <a href="{{ snap.details.name }}">{{ snap.details.title }}</a>
+              </h3>
+              <p class="u-text--muted">
+                <em>{{ snap.details.publisher }}</em>
+                
+                {% if snap.details.developer_validation == VERIFIED_PUBLISHER %}
+                  {% include "partials/_verified_developer.html" %}
+                {% endif %}
+
+                {% if snap.details.developer_validation == STAR_DEVELOPER %}
+                  {% include "partials/_star_developer.html" %}
+                {% endif %}
+              </p>
+            </div>
+          </div>
+        </div>
+      {% endif %}
+    {% endfor %}
+  </div>
+</section>

--- a/templates/explore/index.html
+++ b/templates/explore/index.html
@@ -22,6 +22,8 @@
     </div>
   </section>
 
+  {% include "explore/_popular-snaps.html" %}
+
   {% include "explore/_categories.html" %}
 
   <section class="p-strip u-no-padding--top">

--- a/tests/store/tests_explore.py
+++ b/tests/store/tests_explore.py
@@ -1,0 +1,41 @@
+import unittest
+from unittest.mock import patch, Mock
+
+
+class ExploreViewTest(unittest.TestCase):
+    def setUp(self):
+        self.recommendations_url = (
+            "https://recommendations.snapcraft.io/api/category/popular"
+        )
+
+    @patch("requests.get")
+    def test_recommendations_api_call(self, mock_requests_get):
+        mock_popular_snaps = [
+            {
+                "details": {
+                    "contact": "https://example.com/contact",
+                    "description": "Test description",
+                    "icon": "https://example.com/icon.png",
+                    "links": {
+                        "contact": ["https://example.com/contact"],
+                        "website": ["https://example.com"],
+                    },
+                    "name": "test-snap",
+                    "publisher": "Canonical",
+                    "title": "Test snap",
+                },
+                "snap_id": "test-snap-id",
+            }
+        ]
+        mock_response = Mock()
+        mock_response.json.return_value = mock_popular_snaps
+        mock_requests_get.return_value = mock_response
+
+        import requests
+
+        r = requests.get(
+            "https://recommendations.snapcraft.io/api/category/popular"
+        )
+        popular_snaps = r.json()
+
+        self.assertEqual(popular_snaps, mock_popular_snaps)

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -1,4 +1,6 @@
 from math import floor
+
+import requests as api_requests
 import flask
 from dateutil import parser
 from webapp.decorators import exchange_required, login_required
@@ -123,6 +125,12 @@ def store_blueprint(store_query=None):
 
     @store.route("/explore")
     def explore_view():
+        r = api_requests.get(
+            "https://recommendations.snapcraft.io/api/category/popular"
+        )
+
+        popular_snaps = r.json()
+
         try:
             categories_results = device_gateway.get_categories()
         except StoreApiError:
@@ -134,7 +142,9 @@ def store_blueprint(store_query=None):
         )
 
         return flask.render_template(
-            "explore/index.html", categories=categories
+            "explore/index.html",
+            categories=categories,
+            popular_snaps=popular_snaps,
         )
 
     @store.route("/youtube", methods=["POST"])


### PR DESCRIPTION
## Done
Adds the popular snaps section to the server-side rendered explore page

## How to QA
- Go to https://snapcraft-io-5438.demos.haus/explore
- Check that there is a "Most popular snaps" section and that it is the same as it is on the [live Explore page](https://snapcraft.io/explore)

## Testing
- [x] This PR has tests
- [ ] No testing required (explain why): No behavioural changes

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-28154
