### PR TITLE
feat: Add updated and trending snaps to SSR explore page

### DIFF
--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -192,10 +192,10 @@ dl {
   transition: opacity 0.5s ease-in;
 }
 
-.u-line-clamp--3 {
+.u-line-clamp--2 {
   -webkit-box-orient: vertical;
-  display: flex;
-  -webkit-line-clamp: 3;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
   overflow: hidden;
   text-overflow: ellipsis;
 }
@@ -568,3 +568,4 @@ html {
   background-size: contain;
   padding: 67px;
 }
+

--- a/templates/explore/_trending-snaps.html
+++ b/templates/explore/_trending-snaps.html
@@ -1,0 +1,39 @@
+<section class="p-strip is-shallow u-no-padding--bottom">
+  <div class="u-fixed-width">
+    <h2>Trending snaps</h2>
+  </div>
+</section>
+<section class="p-strip is-shallow">
+  <div class="row u-equal-height">
+    {% for snap in trending_snaps %}
+      {% if loop.index <= 8 %}
+        <div class="col-3 p-card">
+          <div class="p-card__content">
+            <div class="p-media-object u-no-margin--bottom">
+              <a href="{{ snap.details.name }}">
+                <img src="{{ snap.details.icon }}" class="p-media-object__image" alt="{{ snap.details.title }}" width="48" height="48">
+              </a>
+              <div class="p-media-object__details">
+                <h3 class="p-heading--5 u-no-margin--bottom">
+                  <a href="{{ snap.details.name }}" class="p-link--soft">{{ snap.details.title }}</a>
+                </h3>
+                <p class="u-text--muted u-no-padding--top">
+                  <em>{{ snap.details.publisher }}</em>
+                  
+                  {% if snap.details.developer_validation == VERIFIED_PUBLISHER %}
+                    {% include "partials/_verified_developer.html" %}
+                  {% endif %}
+
+                  {% if snap.details.developer_validation == STAR_DEVELOPER %}
+                    {% include "partials/_star_developer.html" %}
+                  {% endif %}
+                </p>
+                <p class="u-no-margin--bottom u-line-clamp--2">{{snap.details.summary}}</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      {% endif %}
+    {% endfor %}
+  </div>
+</section>

--- a/templates/explore/_updated-snaps.html
+++ b/templates/explore/_updated-snaps.html
@@ -1,0 +1,39 @@
+<section class="p-strip is-shallow u-no-padding--bottom">
+  <div class="u-fixed-width">
+    <h2>Recently updated snaps</h2>
+  </div>
+</section>
+<section class="p-strip is-shallow u-no-padding--bottom">
+  <div class="row">
+    {% for snap in recent_snaps %}
+      {% if loop.index <= 8 %}
+        <div class="col-3 p-card" style="border-top: 3px solid #0f95a1;">
+          <div class="p-card__content">
+            <div class="p-media-object u-no-margin--bottom">
+              <a href="{{ snap.details.name }}">
+                <img src="{{ snap.details.icon }}" class="p-media-object__image" alt="{{ snap.details.title }}" width="48" height="48">
+              </a>
+              <div class="p-media-object__details">
+                <h3 class="p-heading--5 u-no-margin--bottom">
+                  <a href="{{ snap.details.name }}" class="p-link--soft">{{ snap.details.title }}</a>
+                </h3>
+                <p class="u-text--muted u-no-padding--top">
+                  <em>{{ snap.details.publisher }}</em>
+                  
+                  {% if snap.details.developer_validation == VERIFIED_PUBLISHER %}
+                    {% include "partials/_verified_developer.html" %}
+                  {% endif %}
+
+                  {% if snap.details.developer_validation == STAR_DEVELOPER %}
+                    {% include "partials/_star_developer.html" %}
+                  {% endif %}
+                </p>
+                <p class="u-no-margin--bottom u-line-clamp--2">{{snap.details.summary}}</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      {% endif %}
+    {% endfor %}
+  </div>
+</section>

--- a/templates/explore/index.html
+++ b/templates/explore/index.html
@@ -22,9 +22,21 @@
     </div>
   </section>
 
-  {% include "explore/_popular-snaps.html" %}
+  {% if recent_snaps %}
+    {% include "explore/_updated-snaps.html" %}
+  {% endif %}
 
-  {% include "explore/_categories.html" %}
+  {% if popular_snaps %}
+    {% include "explore/_popular-snaps.html" %}
+  {% endif %}
+
+  {% if categories %}
+    {% include "explore/_categories.html" %}
+  {% endif %}
+
+  {% if trending_snaps %}
+    {% include "explore/_trending-snaps.html" %}
+  {% endif %}
 
   <section class="p-strip u-no-padding--top">
     <div class="u-fixed-width">

--- a/tests/store/tests_explore.py
+++ b/tests/store/tests_explore.py
@@ -1,16 +1,15 @@
 import unittest
 from unittest.mock import patch, Mock
+import requests
 
 
 class ExploreViewTest(unittest.TestCase):
     def setUp(self):
         self.recommendations_url = (
-            "https://recommendations.snapcraft.io/api/category/popular"
+            "https://recommendations.snapcraft.io/api/category"
         )
 
-    @patch("requests.get")
-    def test_recommendations_api_call(self, mock_requests_get):
-        mock_popular_snaps = [
+        self.mock_snaps = [
             {
                 "details": {
                     "contact": "https://example.com/contact",
@@ -27,15 +26,36 @@ class ExploreViewTest(unittest.TestCase):
                 "snap_id": "test-snap-id",
             }
         ]
+
+    @patch("requests.get")
+    def test_popular_snaps(self, mock_requests_get):
         mock_response = Mock()
-        mock_response.json.return_value = mock_popular_snaps
+        mock_response.json.return_value = self.mock_snaps
         mock_requests_get.return_value = mock_response
 
-        import requests
+        res = requests.get(f"{self.recommendations_url}/popular")
+        popular_snaps = res.json()
 
-        r = requests.get(
-            "https://recommendations.snapcraft.io/api/category/popular"
-        )
-        popular_snaps = r.json()
+        self.assertEqual(popular_snaps, self.mock_snaps)
 
-        self.assertEqual(popular_snaps, mock_popular_snaps)
+    @patch("requests.get")
+    def test_recent_snaps(self, mock_requests_get):
+        mock_response = Mock()
+        mock_response.json.return_value = self.mock_snaps
+        mock_requests_get.return_value = mock_response
+
+        res = requests.get(f"{self.recommendations_url}/recent")
+        recent_snaps = res.json()
+
+        self.assertEqual(recent_snaps, self.mock_snaps)
+
+    @patch("requests.get")
+    def test_trending_snaps(self, mock_requests_get):
+        mock_response = Mock()
+        mock_response.json.return_value = self.mock_snaps
+        mock_requests_get.return_value = mock_response
+
+        res = requests.get(f"{self.recommendations_url}/trending")
+        trending_snaps = res.json()
+
+        self.assertEqual(trending_snaps, self.mock_snaps)

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -125,11 +125,30 @@ def store_blueprint(store_query=None):
 
     @store.route("/explore")
     def explore_view():
-        r = api_requests.get(
-            "https://recommendations.snapcraft.io/api/category/popular"
+        recommendations_api_url = (
+            "https://recommendations.snapcraft.io/api/category"
         )
 
-        popular_snaps = r.json()
+        try:
+            popular_snaps = api_requests.get(
+                f"{recommendations_api_url}/popular"
+            ).json()
+        except StoreApiError:
+            popular_snaps = []
+
+        try:
+            recent_snaps = api_requests.get(
+                f"{recommendations_api_url}/recent"
+            ).json()
+        except StoreApiError:
+            recent_snaps = []
+
+        try:
+            trending_snaps = api_requests.get(
+                f"{recommendations_api_url}/trending"
+            ).json()
+        except StoreApiError:
+            trending_snaps = []
 
         try:
             categories_results = device_gateway.get_categories()
@@ -145,6 +164,8 @@ def store_blueprint(store_query=None):
             "explore/index.html",
             categories=categories,
             popular_snaps=popular_snaps,
+            recent_snaps=recent_snaps,
+            trending_snaps=trending_snaps,
         )
 
     @store.route("/youtube", methods=["POST"])


### PR DESCRIPTION
## Done
Adds updated and trending snaps to the server-side rendered explore page

**Drive by**: Fixed the line clamp utility class and changed it to two lines as it wasn't being used anywhere else

## How to QA
- Go to https://snapcraft-io-5439.demos.haus/explore
- Check that it has "Recently updated snaps" which are the same as [the live version](https://snapcraft.io/explore)
- Check that it has "Trending snaps" which are the same as [the live version](https://snapcraft.io/explore)

## Testing
- [x] This PR has tests
- [ ] No testing required (explain why):

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-28156
Fixes https://warthogs.atlassian.net/browse/WD-28153
