### PR TITLE
feat: Add top rated section to explore page

### DIFF
--- a/templates/explore/_snaps-list.html
+++ b/templates/explore/_snaps-list.html
@@ -1,11 +1,11 @@
 <section class="p-strip is-shallow u-no-padding--bottom">
   <div class="u-fixed-width">
-    <h2>Most popular snaps</h2>
+    <h2>{{ title }}</h2>
   </div>
 </section>
 <section class="p-strip is-shallow u-no-padding--bottom">
   <div class="row">
-    {% for snap in popular_snaps %}
+    {% for snap in snaps_list %}
       {% if loop.index <= 8 %}
         <div class="col-3">
           <p class="p-heading--4" style="float: left; margin-right: 1rem">{{ loop.index }}</p>

--- a/templates/explore/index.html
+++ b/templates/explore/index.html
@@ -27,11 +27,19 @@
   {% endif %}
 
   {% if popular_snaps %}
-    {% include "explore/_popular-snaps.html" %}
+    {% with snaps_list = popular_snaps, title = "Most popular snaps" %}
+      {% include "explore/_snaps-list.html" %}
+    {% endwith %}
   {% endif %}
 
   {% if categories %}
     {% include "explore/_categories.html" %}
+  {% endif %}
+
+  {% if top_rated_snaps %}
+    {% with snaps_list = top_rated_snaps, title = "Top rated snaps" %}
+      {% include "explore/_snaps-list.html" %}
+    {% endwith %}
   {% endif %}
 
   {% if trending_snaps %}

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -151,6 +151,13 @@ def store_blueprint(store_query=None):
             trending_snaps = []
 
         try:
+            top_rated_snaps = api_requests.get(
+                f"{recommendations_api_url}/top_rated"
+            ).json()
+        except api_requests.exceptions.RequestException:
+            top_rated_snaps = []
+
+        try:
             categories_results = device_gateway.get_categories()
         except StoreApiError:
             categories_results = []
@@ -166,6 +173,7 @@ def store_blueprint(store_query=None):
             popular_snaps=popular_snaps,
             recent_snaps=recent_snaps,
             trending_snaps=trending_snaps,
+            top_rated_snaps=top_rated_snaps,
         )
 
     @store.route("/youtube", methods=["POST"])


### PR DESCRIPTION
## Done
- Adds the "Top rated snaps" section to the explore page
- Creates a reusable include for snaps which are a numbered list

## How to QA
- Go to https://snapcraft-io-5447.demos.haus/explore
- Check that the "Most popular snaps" section is still there
- Check that the "Top rated snaps" section is there

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why): No behavioural changes

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-30623