### PR TITLE
feat: Add game slice to explore page

### DIFF
--- a/templates/explore/_gaming-slice.html
+++ b/templates/explore/_gaming-slice.html
@@ -1,0 +1,37 @@
+<section class="p-strip is-shallow u-no-padding--bottom">
+  <div class="u-fixed-width">
+    <h2>{{gaming_slice.slice.name}}</h2>
+  </div>
+</section>
+<section class="p-strip is-shallow">
+  <div class="row">
+    {% for snap in gaming_slice.snaps %}
+      {% if loop.index <= 8 %}
+        <div class="col-3 p-card">
+          <div class="p-card__image p-image-container--16-9 is-cover is-highlighted">
+            <a href="/{{snap.name}}">
+              <img class="p-image-container__image" src={{snap.media[1].url}} alt="{{snap.title}} screenshot">
+            </a>
+          </div>
+          <div class="p-card__content">
+            <h3 class="p-heading--5 u-no-margin--bottom">
+              <a class="p-link--soft" href="/{{snap.name}}">{{snap.title}}</a>
+            </h3>
+            <p class="u-text--muted u-no-padding--top">
+              <em>{{snap.publisher}}</em>
+              
+              {% if snap.developer_validation == VERIFIED_PUBLISHER %}
+                {% include "partials/_verified_developer.html" %}
+              {% endif %}
+
+              {% if snap.developer_validation == STAR_DEVELOPER %}
+                {% include "partials/_star_developer.html" %}
+              {% endif %}
+            </p>
+            <p>{{snap.summary}}</p>
+          </div>
+        </div>
+      {% endif %}
+    {% endfor %}
+  </div>
+</section>

--- a/templates/explore/index.html
+++ b/templates/explore/index.html
@@ -30,6 +30,10 @@
     {% include "explore/_popular-snaps.html" %}
   {% endif %}
 
+  {% if gaming_slice %}
+    {% include "explore/_gaming-slice.html" %}
+  {% endif %}
+
   {% if categories %}
     {% include "explore/_categories.html" %}
   {% endif %}

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -125,30 +125,37 @@ def store_blueprint(store_query=None):
 
     @store.route("/explore")
     def explore_view():
-        recommendations_api_url = (
-            "https://recommendations.snapcraft.io/api/category"
-        )
+        recommendations_api_url = "https://recommendations.snapcraft.io/api"
 
         try:
             popular_snaps = api_requests.get(
-                f"{recommendations_api_url}/popular"
+                f"{recommendations_api_url}/category/popular"
             ).json()
         except api_requests.exceptions.RequestException:
             popular_snaps = []
 
         try:
             recent_snaps = api_requests.get(
-                f"{recommendations_api_url}/recent"
+                f"{recommendations_api_url}/category/recent"
             ).json()
         except api_requests.exceptions.RequestException:
             recent_snaps = []
 
         try:
             trending_snaps = api_requests.get(
-                f"{recommendations_api_url}/trending"
+                f"{recommendations_api_url}/category/trending"
             ).json()
         except api_requests.exceptions.RequestException:
             trending_snaps = []
+
+        try:
+            gaming_slice = api_requests.get(
+                f"{recommendations_api_url}/slice/slice_1"
+            ).json()
+        except api_requests.exceptions.RequestException:
+            gaming_slice = None
+
+        print(gaming_slice)
 
         try:
             categories_results = device_gateway.get_categories()
@@ -166,6 +173,7 @@ def store_blueprint(store_query=None):
             popular_snaps=popular_snaps,
             recent_snaps=recent_snaps,
             trending_snaps=trending_snaps,
+            gaming_slice=gaming_slice,
         )
 
     @store.route("/youtube", methods=["POST"])


### PR DESCRIPTION
## Done
Adds the gaming slice section to the explore page.

See [design for reference](https://app.zeplin.io/project/64107f86ec62b30f2acff2de/screen/6410980efdc7cb101d63fbdb)

## How to QA
- Go to https://snapcraft-io-5451.demos.haus/explore
- Check that there is a "Everything for your game night" section
- **Considerations for design review**: 
  - The ratings aren't currently available which is why they are not present
  - I have included four snaps rather than three which are in the design to bring it inline with the current design
  - Whilst in the design the image is full width, I have used [the Vanilla image card pattern](https://vanillaframework.io/docs/patterns/card#image), but can change this
  - The problem with images is that the publisher can upload a variety of sizes so we can't ensure that it matches across all cards
      - I've used [the Vanilla aspect ratio pattern](https://vanillaframework.io/docs/patterns/images#image-container-with-aspect-ratio) to manage this
      - If the ratio doesn't match, it will either crop it's height or have some space either side, depending on the ratio
      - I have added the highlight class so it at least marks the boundaries of the image

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why): No behavioural changes

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-30640