### PR TITLE
chore: Change text in contact info new fields

### DIFF
--- a/static/js/publisher/pages/Listing/ContactInformation/ContactFields.tsx
+++ b/static/js/publisher/pages/Listing/ContactInformation/ContactFields.tsx
@@ -42,7 +42,7 @@ function ContactFields({
                 append({ url: "" });
               }}
             >
-              +&nbsp;Add field
+              +&nbsp;Add link
             </Button>
           </Col>
         </Row>
@@ -90,7 +90,7 @@ function ContactFields({
                 append({ url: "" });
               }}
             >
-              +&nbsp;Add field
+              +&nbsp;Add link
             </Button>
           </Col>
         </Row>

--- a/static/js/publisher/pages/Listing/ContactInformation/__tests__/ContactFields.test.tsx
+++ b/static/js/publisher/pages/Listing/ContactInformation/__tests__/ContactFields.test.tsx
@@ -63,7 +63,7 @@ describe("ContactFields", () => {
     const fieldElement = screen.getByDisplayValue(
       "https://example.com/contact",
     );
-    const addFieldElement = screen.getByText(/Add field/);
+    const addFieldElement = screen.getByText(/Add link/);
 
     expect(fieldElement).toBeVisible();
     expect(addFieldElement).toBeVisible();
@@ -92,7 +92,7 @@ describe("ContactFields", () => {
     const user = userEvent.setup();
     renderComponent();
 
-    const addButton = screen.getByText(/Add field/);
+    const addButton = screen.getByText(/Add link/);
     await user.click(addButton);
     await waitFor(() => {
       const links = screen.queryAllByRole("textbox");


### PR DESCRIPTION
## Done
Changes text from "Add field" to "Add link" on the publisher listing page contact info section

## How to QA
- Go to https://snapcraft-io-5454.demos.haus/<SNAP_NAME>/listing
- Scroll to "Contact information" section
- Check that the buttons to add a new field now says "Add link"

## Testing
- [x] This PR has tests
- [ ] No testing required (explain why):

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-31112