### PR TITLE
fix: Fix show more functionality in the snap usage chart

### DIFF
--- a/static/sass/_snapcraft_distro-chart.scss
+++ b/static/sass/_snapcraft_distro-chart.scss
@@ -26,7 +26,6 @@
       line-height: 1rem;
       margin-top: 1px;
       overflow: hidden;
-      text-align: right;
       text-overflow: ellipsis;
       white-space: nowrap;
     }

--- a/templates/store/snap-details.html
+++ b/templates/store/snap-details.html
@@ -234,9 +234,7 @@
                     </div>
                     <div class="p-show-more__fade">
                       <div class="p-show-more__link-container">
-                        <small>
-                          <button class="p-button--link p-show-more__link" aria-expanded="false">Show more</button>
-                        </small>
+                        <button class="p-button--link p-show-more__link is-small u-no-padding" aria-expanded="false">Show more</button>
                       </div>
                     </div>
                   </div>


### PR DESCRIPTION
## Done

Fixes "Show more" functionality of the OS usage chart on snap details page.

### Before:

When OS usage chart contained more than 20 OSes on the list, it gets fully collapsed, not showing anything, not even hinting what is collapsed (just "Show more" link).
<img width="1279" height="652" alt="image" src="https://github.com/user-attachments/assets/894f6474-dbcf-419e-96f0-fe0b205aceba" />

Only when expanded it shows everything:
<img width="1281" height="890" alt="image" src="https://github.com/user-attachments/assets/083114c9-0729-4606-af53-328bfdefb0ca" />

Heading size is also inconsistent with snaps that have less than 20 OSes on the list:

<img width="1289" height="538" alt="image" src="https://github.com/user-attachments/assets/9eaa3bae-2a94-4d25-887d-90bab1ef5a72" />

### After:

<img width="1411" height="663" alt="image" src="https://github.com/user-attachments/assets/bc4d404c-0c54-417b-996b-b9cc56749da5" />


## How to QA

- Go to a snap with many OSes in usage graph, make sure the list is truncated (but visible) https://snapcraft-io-5463.demos.haus/josm
- Go to a snap with few OSes in usage graph, make sure the list still renders fine https://snapcraft.io/bomber
- In both cases heading should look the same

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why):

