### PR TITLE
fix: upgrade glob version to fix vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,6 +111,7 @@
     "vitest": "^3.2.4"
   },
   "resolutions": {
+    "vitest/**/glob": "10.5.0",
     "lodash": "4.17.21",
     "eslint/**/minimatch": "3.1.2",
     "eslint-*/minimatch": "3.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5043,10 +5043,10 @@ glob-parent@^6.0.2:
   dependencies:
     is-glob "^4.0.3"
 
-glob@^10.4.1:
-  version "10.4.5"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-10.4.5.tgz#f4d9f0b90ffdbab09c9d77f5f29b4262517b0956"
-  integrity sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==
+glob@10.5.0, glob@^10.4.1:
+  version "10.5.0"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-10.5.0.tgz#8ec0355919cd3338c28428a23d4f24ecc5fe738c"
+  integrity sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==
   dependencies:
     foreground-child "^3.1.0"
     jackspeak "^3.1.2"


### PR DESCRIPTION
## Done
- pinned the version of `vitest`'s `glob` dependency to 10.5.0

## How to QA

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why): just pinning a package version

## Issue / Card
Fixes [this dependabot alert](https://github.com/canonical/snapcraft.io/security/dependabot/86)