### PR TITLE
Force dark theme on featured snap banners

### DIFF
--- a/static/sass/_snapcraft_p-featured-snap.scss
+++ b/static/sass/_snapcraft_p-featured-snap.scss
@@ -9,9 +9,10 @@
 
   .p-featured-snap {
     @extend %vf-card;
+    @include vf-theme-dark;
 
-    background-color: $color-dark;
-    color: $color-light;
+    background-color: $colors--theme--background-default;
+    color: $colors--theme--text-default;
     margin-bottom: $sp-large;
 
     // force color on visited links as well
@@ -19,7 +20,7 @@
     a:focus,
     a:hover,
     a:visited {
-      color: $color-light;
+      color: $colors--theme--text-default;
     }
 
     // update to lighter color in media object


### PR DESCRIPTION
## Done

Forces Vanilla's dark theme on featured snap banners, so that child components correctly adjust colors automatically.

This change is in preparation for JetBrains to update its publisher page in #5472


## How to QA

- Go to https://snapcraft-io-5473.demos.haus/publisher/jetbrains
- Check featured snaps banners
- Text should be white, horizontal line should use light colour
- Inspect styles to verify that components use Vanillas theme colors (apart from the background color that is defined on snap level)

## Issue / Card

Context: https://github.com/canonical/snapcraft.io/pull/5472

## Screenshots

<img width="1354" height="432" alt="image" src="https://github.com/user-attachments/assets/95c420a3-a251-47f1-8284-5368f3ef87b4" />
