### PR TITLE
Publisher pages lazy import, pt7

### DIFF
--- a/static/js/publisher/index.tsx
+++ b/static/js/publisher/index.tsx
@@ -10,10 +10,6 @@ import PublisherLayout from "./layouts/PublisherLayout";
 import SnapsManagementLayout from "./layouts/SnapsManagementLayout";
 import ModelDetailsPageLayout from "./layouts/ModelDetailsPageLayout/ModelPageLayout";
 
-import ValidationSet from "./pages/ValidationSet";
-import ValidationSets from "./pages/ValidationSets";
-import AccountKeys from "./pages/AccountKeys";
-
 const AccountDetails = importComponent(() => import("./pages/AccountDetails"));
 const Publicise = importComponent(() => import("./pages/Publicise"));
 const PublisherSettings = importComponent(
@@ -41,6 +37,9 @@ const BrandStoreSettings = importComponent(
 const Members = importComponent(() => import("./pages/Members"));
 const SigningKeys = importComponent(() => import("./pages/SigningKeys"));
 const Snaps = importComponent(() => import("./pages/Snaps"));
+const ValidationSet = importComponent(() => import("./pages/ValidationSet"));
+const ValidationSets = importComponent(() => import("./pages/ValidationSets"));
+const AccountKeys = importComponent(() => import("./pages/AccountKeys"));
 
 Sentry.init({
   dsn: window.SENTRY_DSN,


### PR DESCRIPTION
## Done
- lazy load validation sets and account keys pages

## How to QA
- log in
- open network tab in browser dev tools and filter by JS resources
- open validation sets page
  - you should see a JS chunk, a loader, then the page will load
- open a validation set
  - you should see a JS chunk, a loader, then the page will load
- go to the account keys page
  - you should see a JS chunk, a loader, then the page will load
- go back to any of the pages you just visited
  - there should be no new JS chunks and no loaders

## Testing
- [ ] This PR has tests
- [ ] No testing required (explain why):

## Issue / Card
Fixes #

## Screenshots
