### PR TITLE
fix(docs): fix broken link and correct typos in HACKING.md and cache/README.md

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -20,7 +20,7 @@ To use this functionality, you need to set up test accounts with **GitHub** and 
 
 Go and [register a new OAuth application](https://github.com/settings/applications/new) in your GitHub account. You can fill in the form however you want, and the only important detail is that you set the "Authorization callback URL" to `http://localhost:8004/github/auth/verify`.
 
-Once you've created the application, you should be given the client id and the client secret. Update your `.env.local` file with the your secrets:
+Once you've created the application, you should be given the client id and the client secret. Update your `.env.local` file with your secrets:
 
 ```bash
 GITHUB_CLIENT_ID=<Your client id>
@@ -66,7 +66,7 @@ For development purposes, visit https://sentry.io/signup/, signup and setup a pr
 https://<user>:<secret>@sentry.io/<project_id>
 ```
 
-Create or update you `.env.local` file:
+Create or update your `.env.local` file:
 
 ```
 SENTRY_DSN=<DSN_FROM_ABOVE>

--- a/cache/README.md
+++ b/cache/README.md
@@ -12,7 +12,7 @@ This setup provides a local Redis instance for development and testing purposes.
    ```
    KEYS *
    ```
-4. To exit the interactive promt, run
+4. To exit the interactive prompt, run
    ```
    exit
    ```


### PR DESCRIPTION
## Done

- Fixed typo "the your" → "your" in HACKING.md (line 23)
- Fixed typo "you" → "your" in HACKING.md (line 69)
- Fixed typo "promt" → "prompt" in cache/README.md (line 15)
- Fixed broken link to Launchpad Credentials creation script in `Hacking.md`. (screenshots attached below)

## How to QA

- Open  HACKING.md and verify line 23 reads: "Update your .env.local file with your secrets:" and also hover over the Download this script link and see the `.py` extension missing.
- Verify line 69 reads: "Create or update your .env.local file:"
- Open  cache/README.md and verify line 15 reads: "To exit the interactive prompt, run"

## Testing
- [x] No testing required (explain why): Documentation-only changes, no code affected

## Issue / Card
Fixes # (N/A - documentation fix)

## Screenshots
<img width="1211" height="758" alt="Screenshot 2025-12-02 at 6 29 25 PM" src="https://github.com/user-attachments/assets/99ec5cca-302c-49e4-a2ce-aa4f2f5832d2" />
<img width="3016" height="1098" alt="image" src="https://github.com/user-attachments/assets/df1476ac-2a65-4432-b15c-4715d35d0254" />