### PR TITLE
fix: Fix publisher breadcrumb link

### DIFF
--- a/static/js/publisher/layouts/SnapsManagementLayout/Breadcrumbs.tsx
+++ b/static/js/publisher/layouts/SnapsManagementLayout/Breadcrumbs.tsx
@@ -26,7 +26,7 @@ function Breadcrumbs(): React.JSX.Element {
           <Fragment key={i}>
             {i + 1 < segments?.length ? (
               <>
-                <Link to={to}>{label}</Link>&nbsp;/&nbsp;
+                <a href={to}>{label}</a>&nbsp;/&nbsp;
               </>
             ) : (
               label


### PR DESCRIPTION
## Done
Fixes an issue where clicking the snap name link from the breadcrumb on a publisher page gives you a blank publisher view, rather than taking you to the snaps listing page.

## How to QA
- Go to https://snapcraft-io-5515.demos.haus/<SNAP_NAME>/listing (or any other publisher page)
- Click the snap name link in the breadcrumb menu
- Check that you are taken to the snaps listing page

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why):

## Issue / Card
Fixes #

## Screenshots
