### PR TITLE
Use correct variable name for staging API

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -6,7 +6,7 @@
 To use staging APIs locally you can add the following lines to an `.env.local` file:
 
 ```bash
-DEVICE_GATEWAY_API_URL=https://api.staging.snapcraft.io/
+DEVICEGW_URL=https://api.staging.snapcraft.io/
 SNAPSTORE_DASHBOARD_API_URL=https://dashboard.staging.snapcraft.io/
 LOGIN_URL=https://login.staging.ubuntu.com
 CANDID_API_URL=https://api.staging.jujucharms.com/identity/


### PR DESCRIPTION
## Done
Updated `HACKING.md` to use the correct environment variable for staging API