### PR TITLE
Switch custom publisher pages to new snap find API

### DIFF
--- a/tests/store/tests_publisher.py
+++ b/tests/store/tests_publisher.py
@@ -3,51 +3,6 @@ from urllib.parse import urlencode
 from flask_testing import TestCase
 from webapp.app import create_app
 
-
-JETBRAINS_SEARCH_RESPONSE = {
-    "_embedded": {
-        "clickindex:package": [
-            {
-                "apps": ["space"],
-                "architecture": ["amd64"],
-                "developer_id": "28zEonXNoBLvIB7xneRbltOsp0Nf7DwS",
-                "developer_name": "jetbrains",
-                "developer_validation": "verified",
-                "media": [
-                    {
-                        "height": 512,
-                        "type": "icon",
-                        "url": (
-                            "https://dashboard.snapcraft.io/site_media/"
-                            "appmedia/2019/12/ezgif.com-gif-maker.png"
-                        ),
-                        "width": 512,
-                    },
-                    {
-                        "height": 1860,
-                        "type": "screenshot",
-                        "url": (
-                            "https://dashboard.snapcraft.io/site_media/"
-                            "appmedia/2019/12/home_for_teams.png"
-                        ),
-                        "width": 2880,
-                    },
-                ],
-                "origin": "jetbrains",
-                "package_name": "space",
-                "sections": [
-                    {
-                        "featured": False,
-                        "name": "development",
-                    },
-                ],
-                "summary": "Desktop Application for JetBrains Space",
-                "title": "Space",
-            },
-        ]
-    },
-}
-
 JETBRAINS_FIND_RESPONSE = {
     "results": [
         {
@@ -208,12 +163,6 @@ class GetPublisherPageTest(TestCase):
     def test_existant_publisher(self):
         responses.add(
             responses.GET,
-            self.api_url_publisher_items,
-            json=JETBRAINS_SEARCH_RESPONSE,
-            status=200,
-        )
-        responses.add(
-            responses.GET,
             self.api_url_find("jetbrains"),
             json=JETBRAINS_FIND_RESPONSE,
             status=200,
@@ -237,7 +186,7 @@ class GetPublisherPageTest(TestCase):
     @responses.activate
     def test_api_error(self):
         responses.add(
-            responses.GET, self.api_url_publisher_items, json={}, status=504
+            responses.GET, self.api_url_find("jetbrains"), json={}, status=504
         )
         response = self.client.get("/publisher/jetbrains")
         self.assertEqual(response.status_code, 200)
@@ -245,11 +194,10 @@ class GetPublisherPageTest(TestCase):
 
     @responses.activate
     def test_no_snaps_from_api(self):
-        payload = {"_embedded": {"clickindex:package": []}}
         responses.add(
             responses.GET,
-            self.api_url_publisher_items,
-            json=payload,
+            self.api_url_find("jetbrains"),
+            json={"results": []},
             status=200,
         )
         response = self.client.get("/publisher/jetbrains")

--- a/webapp/store/content/publishers/jetbrains.yaml
+++ b/webapp/store/content/publishers/jetbrains.yaml
@@ -9,10 +9,6 @@ website: https://www.jetbrains.com/
 contact: https://www.jetbrains.com/company/contacts/
 developer_validation: verified
 
-publishers: [
-  "28zEonXNoBLvIB7xneRbltOsp0Nf7DwS"
-]
-
 featured_snaps: [
     {
         "developer_validation": "verified",

--- a/webapp/store/content/publishers/kde.yaml
+++ b/webapp/store/content/publishers/kde.yaml
@@ -16,9 +16,4 @@ website: https://kde.org/
 contact: https://kde.org/support/
 developer_validation: verified
 
-publishers: [
-  "2rsYZu6kqYVFsSejExu4YENdXQEO40Xb",
-  "RjmEPUNNh0j9SKha5UfIuEurgGR82h9l"
-]
-
 featured_snaps: []

--- a/webapp/store/content/publishers/snapcrafters.yaml
+++ b/webapp/store/content/publishers/snapcrafters.yaml
@@ -8,7 +8,6 @@ publisher_since: July 2017
 website: https://github.com/snapcrafters
 contact: mailto:snap-advocacy@canonical.com
 developer_validation: starred
-publishers: ["eEoV9TnaNkCzfJBu9SRhr2678vzyYV43"]
 featured_snaps: []
 meta_description: The "Snapcrafters" publisher in the Snap Store is a community of people who maintain snaps of applications that are not their own. Our goal is to be a trusted and reliable source for high-quality snaps. We are a group of Snap Package enthusiasts and stake-holders working together to bring apps and services to the Snap Store for Linux.
 link_to_search: True


### PR DESCRIPTION
## Done

Fixes the issue with custom publisher page for Jetbrains showing unlisted snaps.
Switches to v2 snap find API, removes hardcoded publisher ids from config files.

## How to QA

- check custom publisher pages, make sure they list snaps
  - https://snapcraft-io-5525.demos.haus/publisher/snapcrafters
  - https://snapcraft-io-5525.demos.haus/publisher/kde
  - https://snapcraft-io-5525.demos.haus/publisher/jetbrains
- on JetBrains page make sure unlisted ("community") snaps are not listed, compare with prod version


## Testing
- [x] This PR has tests - updated existing test
- [ ] No testing required (explain why):

## Issue / Card
Fixes #5524
Fixes WD-32049

## Screenshots

<img width="1296" height="413" alt="image" src="https://github.com/user-attachments/assets/d1cb981d-1087-45cb-a44f-44255db42381" />

