### PR TITLE
WIP: chore: Add nonce attributes to script tags containing global constants

### DIFF
--- a/templates/_base-layout.html
+++ b/templates/_base-layout.html
@@ -80,7 +80,7 @@
 
     {% block scripts %}{% endblock %}
 
-    <script>
+    <script nonce="c4b6e1e692eb">
       window.COMMIT_ID = "{{ COMMIT_ID }}";
       window.ENVIRONMENT = "{{ ENVIRONMENT }}";
       window.SENTRY_DSN = "{{ SENTRY_DSN }}";

--- a/templates/admin/admin.html
+++ b/templates/admin/admin.html
@@ -6,7 +6,7 @@
 <div id="root">
 </div>
 
-<script>
+<script nonce="3fcaedd3d3f5">
   window.CSRF_TOKEN = "{{ csrf_token() }}";
   window.SENTRY_DSN = "{{ SENTRY_DSN }}";
   window.API_URL = "{{ api_url }}";

--- a/templates/publisher/collaboration.html
+++ b/templates/publisher/collaboration.html
@@ -6,7 +6,7 @@ Collaboration for {% if display_title %}{{ display_title }}{% else %}{{ snap_tit
 
 {% block content %}
 <main id="main-content"></main>
-<script>
+<script nonce="4c034a7d15dc">
   window.SENTRY_DSN = "{{ SENTRY_DSN }}";
   window.CSRF_TOKEN = "{{ csrf_token() }}";
   window.data = JSON.parse({{ collaborations_data|tojson }});

--- a/templates/store/publisher.html
+++ b/templates/store/publisher.html
@@ -4,7 +4,7 @@
 {% block content %}
 <div id="root">
 </div>
-<script>
+<script nonce="64e769d4a163">
   window.CSRF_TOKEN = "{{ csrf_token() }}";
 </script>
 {{ vite_import('static/js/publisher/index.tsx') }}

--- a/webapp/handlers.py
+++ b/webapp/handlers.py
@@ -76,7 +76,12 @@ CSP = {
         "'self'",
         "assets.ubuntu.com",
     ],
-    "script-src": [],
+    "script-src": [
+        "nonce-c4b6e1e692eb",
+        "nonce-64e769d4a163",
+        "nonce-3fcaedd3d3f5",
+        "nonce-4c034a7d15dc",
+    ],
     "connect-src": [
         "'self'",
         "ubuntu.com",


### PR DESCRIPTION
## Done
Added nonce attributes to the script tags which contain global constants. This will strengthen our security as once we disabled inline scripts, only scripts we specifically allow will be able to run.

## How to QA
- Go to [the homepage](https://snapcraft-io-5564.demos.haus/) and check that there are no CSP errors in the console
- Go to [a publisher page](https://snapcraft-io-5564.demos.haus/steve-test-snap/listing) and check that there are no CSP errors in the console
- Go to [a brand store page](https://snapcraft-io-5564.demos.haus/admin/ahnuP3quahti9vis8aiw/snaps) and check that there are no CSP errors in the console
- Go to [the collaboration page](https://snapcraft-io-5564.demos.haus/steve-test-snap/collaboration) and check that there are no CSP errors in the console (Note: This page is blank as this feature hasn't been implemented - perhaps the page should be removed?)

## Testing

- [ ] This PR has tests
- [x] No testing required (explain why): No behavioural changes

## Security

- [ ] Security considerations for review (list them):
  - [ ] Examples:
  - [ ] Access control: users can only access their own data
  - [ ] Input: user input is validated and sanitised
  - [ ] Sensitive data: secret or private data is not exposed in any way
  - [ ] ...
- [x] This PR has no security considerations (explain why): This has no impact until inline scripts are disallowed

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-33001

## Screenshots
n/a

## UX Approval

- [x] This PR does not require UX approval
- [ ] This PR does require UX approval (add context):
