### PR TITLE
feat: Replace YouTube thumbnails with embeds on listing page

### DIFF
--- a/konf/site.yaml
+++ b/konf/site.yaml
@@ -71,11 +71,6 @@ env: &env
       key: lp-api-token-secret
       name: snapcraft-io
 
-  - name: YOUTUBE_API_KEY
-    secretKeyRef:
-      key: youtube-api-key
-      name: snapcraft-io
-
   - name: DISCOURSE_API_KEY
     secretKeyRef:
       key: discourse-api-key

--- a/templates/partials/_video.html
+++ b/templates/partials/_video.html
@@ -1,9 +1,12 @@
 {% if video.type == "youtube" %}
-  <iframe id="youtubeplayer" type="text/html" width="818" height="460" allow="autoplay"></iframe>
-  <button class="youtube-thumbnail-button" id="youtube-thumbnail-button">
-    <img src="https://i3.ytimg.com/vi/{{ video.id }}/maxresdefault.jpg" alt="" width="1280" height="720" id="youtube-thumbnail-image">
-    <img src="{{ static_url('images/yt_play_btn.svg') }}" alt="" width="68" height="48" class="youtube-play-button">
-  </button>
+  <iframe 
+    id="youtubeplayer"
+    type="text/html"
+    width="818"
+    height="460"
+    allow="fullscreen"
+    src="{{ video.url }}?cc_load_policy=1&modestbranding=1&rel=0&fullscreen=1"
+  ></iframe>
 {% elif video.type == "vimeo" %}
   <iframe id="vimeoplayer" width="818" height="460" frameborder="0"
           webkitallowfullscreen mozallowfullscreen allowfullscreen
@@ -16,7 +19,6 @@
   document.addEventListener("DOMContentLoaded", function() {
     const vimeoplayerFrame = document.getElementById("vimeoplayer");
     const asciicastplayerFrame = document.getElementById("asciicastplayer");
-    const youtubeFrame = document.getElementById("youtubeplayer");
 
     if (vimeoplayerFrame) {
       vimeoplayerFrame.src = vimeoplayerFrame.dataset.src;
@@ -29,64 +31,6 @@
       script.src = "{{ video.url }}";
 
       asciicastplayerFrame.appendChild(script);
-    }
-
-    if (youtubeFrame) {
-      const videoId = "{{ video.id }}";
-      const thumbnailUrl = `/youtube/${videoId}`;
-      const thumbnailImage = document.querySelector("#youtube-thumbnail-image");
-      const thumbnailButton = document.querySelector("#youtube-thumbnail-button");
-      const videoUrl = "{{ video.url }}?autoplay=1&cc_load_policy=1&modestbranding=1&rel=0";
-
-      const data = new FormData();
-      data.append("videoId", videoId);
-      data.append("csrf_token", "{{csrf_token() }}");
-
-      fetch(`/youtube`, {
-        method: "POST",
-        body:  data
-      })
-        .then(function(r) {
-          if (r.ok === true) {
-            return r.json();
-          }
-        })
-        .then(function(res) {
-          if (!res.items) {
-            return;
-          }
-
-          const thumbnails = res.items[0].snippet.thumbnails;
-
-          if (thumbnails.maxres) {
-            thumbnailImage.src = thumbnails.maxres.url;
-            thumbnailImage.width = thumbnails.maxres.width;
-            thumbnailImage.height = thumbnails.maxres.height;
-          } else if (thumbnails.standard) {
-            thumbnailImage.src = thumbnails.standard.url;
-            thumbnailImage.width = thumbnails.standard.width;
-            thumbnailImage.height = thumbnails.standard.height;
-          } else if (thumbnails.high) {
-            thumbnailImage.src = thumbnails.high.url;
-            thumbnailImage.width = thumbnails.high.width;
-            thumbnailImage.height = thumbnails.high.height;
-          } else if (thumbnails.medium) {
-            thumbnailImage.src = thumbnails.medium.url;
-            thumbnailImage.width = thumbnails.medium.width;
-            thumbnailImage.height = thumbnails.medium.height;
-          } else {
-            thumbnailImage.src = thumbnails.default.url;
-            thumbnailImage.width = thumbnails.default.width;
-            thumbnailImage.height = thumbnails.default.height;
-          }
-        });
-
-      thumbnailButton.addEventListener("click", function() {
-        youtubeFrame.src = videoUrl;
-        setTimeout(function() {
-          thumbnailButton.classList.add("fade-out");
-        }, 300);
-      });
     }
   });
 </script>

--- a/webapp/handlers.py
+++ b/webapp/handlers.py
@@ -95,7 +95,8 @@ CSP = {
     "frame-src": [
         "'self'",
         "td.doubleclick.net",
-        "www.youtube.com/",
+        "www.youtube.com",
+        "youtube.com",
         "asciinema.org",
         "player.vimeo.com",
         "snapcraft.io",

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -18,7 +18,6 @@ from webapp.api.exceptions import ApiError
 from webapp.store.snap_details_views import snap_details_views
 from webapp.helpers import api_publisher_session, api_session
 from flask.json import jsonify
-import os
 from webapp.extensions import csrf
 from webapp.store.logic import (
     get_categories,
@@ -27,7 +26,6 @@ from cache.cache_utility import redis_cache
 
 session = requests.Session()
 
-YOUTUBE_API_KEY = os.getenv("YOUTUBE_API_KEY")
 dashboard = Dashboard(api_session)
 publisher_gateway = PublisherGW("snap", api_publisher_session)
 device_gateway = DeviceGW("snap", api_session)
@@ -199,22 +197,6 @@ def store_blueprint(store_query=None):
             trending_snaps=trending_snaps,
             top_rated_snaps=top_rated_snaps,
         )
-
-    @store.route("/youtube", methods=["POST"])
-    def get_video_thumbnail_data():
-        body = flask.request.form
-        thumbnail_url = "https://www.googleapis.com/youtube/v3/videos"
-        thumbnail_data = session.get(
-            (
-                f"{thumbnail_url}?id={body['videoId']}"
-                f"&part=snippet&key={YOUTUBE_API_KEY}"
-            )
-        )
-
-        if thumbnail_data:
-            return thumbnail_data.json()
-
-        return {}
 
     @store.route("/publisher/<regex('[a-z0-9-]*[a-z][a-z0-9-]*'):publisher>")
     def publisher_details(publisher):


### PR DESCRIPTION
## Done
Replaces the YouTube thumbnail with a YouTube embed. This is because the thumbnail isn't always available, or the resolution is too low etc. This PR also updates the CSP headers so that YouTube video URLs without the `www` subdomain are also allowed.

## How to QA
- Go to a snap listing page where the video URL has a YouTube video embed without the `www` subdomain, e.g. https://snapcraft-io-5569.demos.haus/0ad
- Check that there is a YouTube video embed and that it is playable
- Go to a snap listing page where the video URL has a YouTube video embed with the `www` subdomain, e.g. https://snapcraft-io-5569.demos.haus/code
- Check that there is a YouTube video embed and that it is playable

## Testing

- [ ] This PR has tests
- [x] No testing required (explain why): No logic changes

## Security

- [ ] Security considerations for review (list them):
  - [ ] Examples:
  - [ ] Access control: users can only access their own data
  - [ ] Input: user input is validated and sanitised
  - [ ] Sensitive data: secret or private data is not exposed in any way
  - [ ] ...
- [x] This PR has no security considerations (explain why): XSS is already handled by escaping user input and the particular input will only accept URLs which must meet a specified format

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-33185

## Screenshots
n/a

## UX Approval

- [x] This PR does not require UX approval
- [ ] This PR does require UX approval (add context):
