### PR TITLE
fix: Update GTM code so it isn't blocked by CSP

### DIFF
--- a/templates/_base-layout.html
+++ b/templates/_base-layout.html
@@ -17,7 +17,8 @@
     <script nonce="{{ CSP_NONCE }}">(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
     new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
     j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;var n=d.querySelector('[nonce]');
+    n&&j.setAttribute('nonce',n.nonce||n.getAttribute('nonce'));f.parentNode.insertBefore(j,f);
     })(window,document,'script','dataLayer','GTM-KCGXHQS');</script>
     <!-- End Google Tag Manager -->
 

--- a/webapp/handlers.py
+++ b/webapp/handlers.py
@@ -91,6 +91,7 @@ CSP = {
         "px.ads.linkedin.com",
         "*.snapcraft.io",
         "*.snapcraftcontent.com",
+        "www.google.com",
     ],
     "frame-src": [
         "'self'",


### PR DESCRIPTION
## Done
Updates the Google Tag Manager code so it propagates the `nonce` attribute so it isn't blocked by the CPS as well as updating the headers with the values that are different from [the official guide](https://developers.google.com/tag-platform/security/guides/csp).

## How to QA
- Go to https://snapcraft-io-5570.demos.haus/
- Open the network tab and filter by JS
- Check that gtm.js loads

## Testing

- [ ] This PR has tests
- [x] No testing required (explain why): No logic change

## Security

- [ ] Security considerations for review (list them):
  - [ ] Examples:
  - [ ] Access control: users can only access their own data
  - [ ] Input: user input is validated and sanitised
  - [ ] Sensitive data: secret or private data is not exposed in any way
  - [ ] ...
- [x] This PR has no security considerations (explain why): This PR fixes a security isse

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-33255

## Screenshots
n/a

## UX Approval

- [ ] This PR does not require UX approval
- [x] This PR does require UX approval (add context):
