### PR TITLE
fix: Update CSP header to allow GA subdomains

### DIFF
--- a/webapp/handlers.py
+++ b/webapp/handlers.py
@@ -80,7 +80,7 @@ CSP = {
     "connect-src": [
         "'self'",
         "ubuntu.com",
-        "analytics.google.com",
+        "*.analytics.google.com",
         "stats.g.doubleclick.net",
         "www.googletagmanager.com",
         "sentry.is.canonical.com",


### PR DESCRIPTION
## Done
Updated the CSP header to allow for GA subdomains as they are being blocked by the CSP

## How to QA
Can only be QA'd in production

## Testing

- [ ] This PR has tests
- [x] No testing required (explain why): No logic changes

## Security

- [ ] Security considerations for review (list them):
  - [ ] Examples:
  - [ ] Access control: users can only access their own data
  - [ ] Input: user input is validated and sanitised
  - [ ] Sensitive data: secret or private data is not exposed in any way
  - [ ] ...
- [x] This PR has no security considerations (explain why): Fixes issue with blocked scripts

## Issue / Card

Fixes # n/a

## Screenshots
n/a

## UX Approval

- [x] This PR does not require UX approval
- [ ] This PR does require UX approval (add context):
