### PR TITLE
fix save revert buttons on preview page

### DIFF
--- a/templates/store/snap-details.html
+++ b/templates/store/snap-details.html
@@ -411,6 +411,81 @@
             }
           });
         }
+
+      const previewSaveButton = document.querySelector('.js-save');
+      const previewRevertButton = document.querySelector('.js-revert');
+
+      const getOpenerButtons = () => {
+        if (!window.opener) {
+          return { saveButton: null, revertButton: null };
+        }
+
+        try {
+          const openerDocument = window.opener.document;
+          return {
+            saveButton: openerDocument.querySelector(
+              '[data-js="save-and-preview-save"]'
+            ),
+            revertButton: openerDocument.querySelector(
+              '[data-js="save-and-preview-revert"]'
+            )
+          };
+        } catch (error) {
+          return { saveButton: null, revertButton: null };
+        }
+      };
+
+      const syncPreviewButtons = () => {
+        const { saveButton, revertButton } = getOpenerButtons();
+
+        if (previewSaveButton) {
+          previewSaveButton.disabled = !saveButton || saveButton.disabled;
+        }
+
+        if (previewRevertButton) {
+          previewRevertButton.disabled = !revertButton || revertButton.disabled;
+        }
+      };
+
+        const sendPreviewAction = (action) => {
+          if (!window.opener) {
+            return false;
+          }
+
+        window.opener.postMessage(
+          { type: "snapcraft-preview-action", action },
+          window.location.origin
+        );
+        window.opener.focus();
+        window.close();
+
+          return true;
+        };
+
+        const attachPreviewAction = (button, action) => {
+          if (!button) {
+            return;
+          }
+
+          button.addEventListener("click", (event) => {
+            const { saveButton, revertButton } = getOpenerButtons();
+            const openerButton = action === "save" ? saveButton : revertButton;
+
+            if (!openerButton) {
+              event.preventDefault();
+              return;
+            }
+
+            if (!sendPreviewAction(action)) {
+              event.preventDefault();
+            }
+          });
+        };
+
+        syncPreviewButtons();
+
+        attachPreviewAction(previewSaveButton, "save");
+        attachPreviewAction(previewRevertButton, "revert");
       {% endif %}
     });
   </script>


### PR DESCRIPTION
## Done
- Makes sure "Revert" and "Save" buttons work on preview page

## How to QA
- Go to one of your own snaps and edit something on the Listing page
- Click "Preview" at the top
- Make sure that the "Revert" and "Save" buttons are enabled
- When clicking Revert, the tab should close and the changes should be reverted on the original Listing page
- When clicking Save, the tab should close and the changes should be saved on the original Listing page
- If "Edit" is clicked, the tab should close and the changes made should still be there on the Listing page (existing behaviour on prod)

## Testing

- [x] This PR has tests

## Security

- [x] This PR has no security considerations (explain why): no changes to auth, APIs - only using existing actions

## Issue / Card

Fixes [WD-32910](https://warthogs.atlassian.net/browse/WD-32910)

## Screenshots

## UX Approval

- [x] This PR does not require UX approval


[WD-32910]: https://warthogs.atlassian.net/browse/WD-32910?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ