### PR TITLE
feat: Add endpoint for remodel allowlist

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ canonicalwebteam.discourse==7.0.0
 canonicalwebteam.blog==6.6.0
 canonicalwebteam.search==2.1.2
 canonicalwebteam.image-template==1.9.0
-canonicalwebteam.store-api==7.3.8
+canonicalwebteam.store-api==7.3.10
 canonicalwebteam.launchpad==0.9.0
 django-openid-auth==0.17
 Flask-OpenID==1.3.0

--- a/tests/endpoints/tests_models.py
+++ b/tests/endpoints/tests_models.py
@@ -162,3 +162,103 @@ class TestUpdateModel(TestModelServiceEndpoints):
         self.assertEqual(response.status_code, 500)
         self.assertFalse(data["success"])
         self.assertEqual(data["message"], "Model not found")
+
+
+class TestGetRemodelAllowlist(TestModelServiceEndpoints):
+    @patch(
+        "canonicalwebteam.store_api.publishergw.PublisherGW"
+        + ".get_remodel_allowlist"
+    )
+    def test_get_remodel_allowlist_success(self, mock_get_remodel_allowlist):
+        mock_allowlist = {
+            "allowlist": [
+                {
+                    "created-at": "2026-02-03T11:31:06Z",
+                    "created-by": "test-user-id",
+                    "description": "Test description",
+                    "from-model": "test-from-model",
+                    "from-serial": "test-from-serial",
+                    "modified-at": None,
+                    "modified-by": None,
+                    "to-model": "test-to-model",
+                }
+            ]
+        }
+        mock_get_remodel_allowlist.return_value = mock_allowlist
+
+        response = self.client.get("/api/store/1/models/remodel-allowlist")
+        data = response.json
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(data["success"])
+        self.assertEqual(data["data"], mock_allowlist)
+
+    @patch(
+        "canonicalwebteam.store_api.publishergw.PublisherGW"
+        + ".get_remodel_allowlist"
+    )
+    def test_get_remodel_allowlist_empty(self, mock_get_remodel_allowlist):
+        mock_get_remodel_allowlist.return_value = {"allowlist": []}
+
+        response = self.client.get("/api/store/1/models/remodel-allowlist")
+        data = response.json
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(data["success"])
+        self.assertEqual(data["data"]["allowlist"], [])
+
+    @patch(
+        "canonicalwebteam.store_api.publishergw.PublisherGW"
+        + ".get_remodel_allowlist"
+    )
+    def test_get_remodel_allowlist_unauthorized(
+        self, mock_get_remodel_allowlist
+    ):
+        mock_get_remodel_allowlist.side_effect = StoreApiResponseErrorList(
+            "unauthorized", 401, [{"message": "unauthorized"}]
+        )
+
+        response = self.client.get("/api/store/1/models/remodel-allowlist")
+        data = response.json
+
+        self.assertEqual(response.status_code, 500)
+        self.assertFalse(data["success"])
+        self.assertEqual(data["message"], "Store not found")
+
+    @patch(
+        "canonicalwebteam.store_api.publishergw.PublisherGW"
+        + ".get_remodel_allowlist"
+    )
+    def test_get_remodel_allowlist_store_not_found(
+        self, mock_get_remodel_allowlist
+    ):
+        mock_get_remodel_allowlist.side_effect = StoreApiResponseErrorList(
+            "Store not found", 404, [{"message": "Store not found"}]
+        )
+
+        response = self.client.get("/api/store/999/models/remodel-allowlist")
+        data = response.json
+
+        self.assertEqual(response.status_code, 500)
+        self.assertFalse(data["success"])
+        self.assertEqual(data["message"], "Store not found")
+
+    @patch(
+        "canonicalwebteam.store_api.publishergw.PublisherGW"
+        + ".get_remodel_allowlist"
+    )
+    def test_get_remodel_allowlist_general_error(
+        self, mock_get_remodel_allowlist
+    ):
+        mock_get_remodel_allowlist.side_effect = StoreApiResponseErrorList(
+            "Internal server error",
+            500,
+            [{"message": "Internal server error"}],
+        )
+
+        response = self.client.get("/api/store/1/models/remodel-allowlist")
+        data = response.json
+
+        self.assertEqual(response.status_code, 500)
+        self.assertFalse(data["success"])
+        self.assertEqual(data["message"], "Internal server error")

--- a/webapp/endpoints/models.py
+++ b/webapp/endpoints/models.py
@@ -262,3 +262,42 @@ def update_model(store_id: str, model_name: str):
     if res["success"]:
         return make_response(res, 200)
     return make_response(res, 500)
+
+
+@models.route("/api/store/<store_id>/models/remodel-allowlist")
+@login_required
+@exchange_required
+def get_remodel_allowlist(store_id: str):
+    """
+    Retrieves remodels associated with a given store ID.
+
+    Args:
+        store_id (int): The ID of the store for which to retrieve remodels.
+
+    Returns:
+        dict: A dictionary containing the response message, success status,
+        and data.
+    """
+
+    res = {}
+    try:
+        allowlist = publisher_gateway.get_remodel_allowlist(
+            flask.session, store_id
+        )
+        res["success"] = True
+        res["data"] = allowlist
+        response = make_response(res, 200)
+        response.cache_control.max_age = "3600"
+    except StoreApiResponseErrorList as error_list:
+        error_messages = [
+            f"{error.get('message', 'An error occurred')}"
+            for error in error_list.errors
+        ]
+        if "unauthorized" in error_messages:
+            res["message"] = "Store not found"
+        else:
+            res["message"] = " ".join(error_messages)
+        res["success"] = False
+        response = make_response(res, 500)
+
+    return response


### PR DESCRIPTION
## Done
Adds an endpoint to get remodel allowlist data

## How to QA
- Go to https://snapcraft-io-5576.demos.haus/api/store/njwQYXFnS7ppo7LaGxoh7aqVZc1CPi26/models/remodel-allowlist
- Check there is allowlist data

## Testing

- [x] This PR has tests
- [ ] No testing required (explain why):

## Security

- [ ] Security considerations for review (list them):
  - [ ] Examples:
  - [ ] Access control: users can only access their own data
  - [ ] Input: user input is validated and sanitised
  - [ ] Sensitive data: secret or private data is not exposed in any way
  - [ ] ...
- [x] This PR has no security considerations (explain why): No user input

## Issue / Card

Fixes #

## Screenshots
n/a

## UX Approval

- [x] This PR does not require UX approval
- [ ] This PR does require UX approval (add context):
