### PR TITLE
feat: Add endpoint to post new allowlist

### DIFF
--- a/tests/endpoints/tests_models.py
+++ b/tests/endpoints/tests_models.py
@@ -261,3 +261,84 @@ class TestGetRemodelAllowlist(TestModelServiceEndpoints):
         self.assertEqual(response.status_code, 500)
         self.assertFalse(data["success"])
         self.assertEqual(data["message"], "Internal server error")
+
+
+class TestCreateRemodelAllowlist(TestModelServiceEndpoints):
+    @patch(
+        "canonicalwebteam.store_api.publishergw.PublisherGW"
+        + ".create_remodel_allowlist"
+    )
+    def test_create_remodel_allowlist_success(
+        self, mock_create_remodel_allowlist
+    ):
+        mock_create_remodel_allowlist.return_value = None
+
+        payload = {
+            "description": "Test remodel allowlist",
+            "from-model": "test-from-model",
+            "from-serial": "test-from-serial",
+            "to-model": "test-to-model",
+        }
+
+        response = self.client.post(
+            "/api/store/1/models/remodel-allowlist", json=payload
+        )
+        data = response.json
+
+        self.assertEqual(response.status_code, 201)
+        self.assertTrue(data["success"])
+        mock_create_remodel_allowlist.assert_called_once()
+
+    @patch(
+        "canonicalwebteam.store_api.publishergw.PublisherGW"
+        + ".create_remodel_allowlist"
+    )
+    def test_create_remodel_allowlist_store_not_found(
+        self, mock_create_remodel_allowlist
+    ):
+        mock_create_remodel_allowlist.side_effect = StoreApiResponseErrorList(
+            "Store not found", 404, [{"message": "Store not found"}]
+        )
+
+        payload = {
+            "description": "Test remodel allowlist",
+            "from-model": "test-from-model",
+            "to-model": "test-to-model",
+        }
+
+        response = self.client.post(
+            "/api/store/999/models/remodel-allowlist", json=payload
+        )
+        data = response.json
+
+        self.assertEqual(response.status_code, 404)
+        self.assertFalse(data["success"])
+        self.assertEqual(data["message"], "Store not found")
+
+    @patch(
+        "canonicalwebteam.store_api.publishergw.PublisherGW"
+        + ".create_remodel_allowlist"
+    )
+    def test_create_remodel_allowlist_general_error(
+        self, mock_create_remodel_allowlist
+    ):
+        mock_create_remodel_allowlist.side_effect = StoreApiResponseErrorList(
+            "Internal server error",
+            500,
+            [{"message": "An error occurred"}],
+        )
+
+        payload = {
+            "description": "Test remodel allowlist",
+            "from-model": "test-from-model",
+            "to-model": "test-to-model",
+        }
+
+        response = self.client.post(
+            "/api/store/999/models/remodel-allowlist", json=payload
+        )
+        data = response.json
+
+        self.assertEqual(response.status_code, 500)
+        self.assertFalse(data["success"])
+        self.assertEqual(data["message"], "An error occurred")

--- a/webapp/endpoints/models.py
+++ b/webapp/endpoints/models.py
@@ -300,3 +300,50 @@ def get_remodel_allowlist(store_id: str):
         response = make_response(res, 500)
 
     return response
+
+
+@models.route(
+    "/api/store/<store_id>/models/remodel-allowlist", methods=["POST"]
+)
+@login_required
+@exchange_required
+def create_remodel_allowlist(store_id: str):
+    """
+    Create a remodel allowlist for a given store.
+
+    Args:
+        store_id (str): The ID of the store.
+
+    Returns:
+        dict: A dictionary containing the response message and success
+        status.
+    """
+    res = {}
+
+    try:
+        allowlist = flask.request.json
+        publisher_gateway.create_remodel_allowlist(
+            flask.session, store_id, allowlist
+        )
+
+        res["success"] = True
+        return make_response(res, 201)
+    except StoreApiResponseErrorList as error_list:
+        res["success"] = False
+        messages = [
+            f"{error.get('message', 'An error occurred')}"
+            for error in error_list.errors
+        ]
+        res["message"] = " ".join(messages)
+        return make_response(res, error_list.status_code)
+
+    except StoreApiResourceNotFound:
+        res["success"] = False
+        res["message"] = "Models not found"
+        return make_response(res, 404)
+
+    except Exception:
+        res["success"] = False
+        res["message"] = "An error occurred"
+
+    return make_response(res, 500)


### PR DESCRIPTION
## Done
Adds an endpoint to create a new remodel allowlist

## How to QA
Run locally and use [Postman](https://www.postman.com/) to test the responses

### URL
http://localhost:8004/api/store/njwQYXFnS7ppo7LaGxoh7aqVZc1CPi26/models/remodel-allowlist

### Headers
- Content-Type: application/json
- Cookie: YOUR COOKIE
- X-Csrftoken: YOUR TOKEN

### Body
`[{"from-model":"testmodelzzzz","to-model":"my-name-is-luke","from-serial":"GN4R66MulBPDMooy8Ch_VNzkJBW56zFwEupqSodfKhFbfVz_5hSUgSWztUwbvNPB-Hlkj"}]`

### Requests
- Make a request - you should get a conflict error
- Change the serial to a random string and make a request - it should be successful
- Change one of the model names to a random string - you should get an error
- Change the body to `[]` - you should get an error


## Testing

- [x] This PR has tests
- [ ] No testing required (explain why):

## Security

- [ ] Security considerations for review (list them):
  - [ ] Examples:
  - [ ] Access control: users can only access their own data
  - [ ] Input: user input is validated and sanitised
  - [ ] Sensitive data: secret or private data is not exposed in any way
  - [ ] ...
- [x] This PR has no security considerations (explain why): Follows existing patterns for posting data

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-33419

## Screenshots
n/a

## UX Approval

- [x] This PR does not require UX approval
- [ ] This PR does require UX approval (add context):
