### PR TITLE
feat: Add configure remodels form

### DIFF
--- a/static/js/publisher/hooks/__tests__/useRemodels.test.tsx
+++ b/static/js/publisher/hooks/__tests__/useRemodels.test.tsx
@@ -73,9 +73,12 @@ afterAll(() => {
 
 describe("useRemodels", () => {
   test("returns remodels data", async () => {
-    const { result } = renderHook(() => useRemodels("test-brand-id"), {
-      wrapper: createWrapper(),
-    });
+    const { result } = renderHook(
+      () => useRemodels("test-brand-id", "test-to-model"),
+      {
+        wrapper: createWrapper(),
+      },
+    );
 
     await waitFor(() => {
       expect(result.current.isSuccess).toBe(true);
@@ -85,9 +88,12 @@ describe("useRemodels", () => {
   });
 
   test("returns error if request fails", async () => {
-    const { result } = renderHook(() => useRemodels("test-brand-id-fail"), {
-      wrapper: createWrapper(),
-    });
+    const { result } = renderHook(
+      () => useRemodels("test-brand-id-fail", "test-to-model"),
+      {
+        wrapper: createWrapper(),
+      },
+    );
 
     await waitFor(() => {
       expect(result.current.isError).toBe(true);
@@ -97,9 +103,12 @@ describe("useRemodels", () => {
   });
 
   test("returns error if network error", async () => {
-    const { result } = renderHook(() => useRemodels("test-brand-id-error"), {
-      wrapper: createWrapper(),
-    });
+    const { result } = renderHook(
+      () => useRemodels("test-brand-id-error", "test-to-model"),
+      {
+        wrapper: createWrapper(),
+      },
+    );
 
     await waitFor(() => {
       expect(result.current.isError).toBe(true);

--- a/static/js/publisher/hooks/useRemodels.ts
+++ b/static/js/publisher/hooks/useRemodels.ts
@@ -1,11 +1,12 @@
 import { useQuery, UseQueryResult } from "react-query";
-import type { Remodel as RemodelType } from "../types/shared";
+import type { Remodel } from "../types/shared";
 
 const useRemodels = (
   brandId: string | undefined,
-): UseQueryResult<RemodelType[], Error> => {
-  return useQuery<RemodelType[], Error>({
-    queryKey: ["remodels", brandId],
+  modelId: string | undefined,
+): UseQueryResult<Remodel[], Error> => {
+  return useQuery<Remodel[], Error>({
+    queryKey: ["remodels", brandId, modelId],
     queryFn: async () => {
       const response = await fetch(
         `/api/store/${brandId}/models/remodel-allowlist`,
@@ -15,13 +16,31 @@ const useRemodels = (
         throw new Error("There was a problem fetching remodels");
       }
 
-      const remodelsData = await response.json();
+      const data = await response.json();
 
-      if (!remodelsData.success) {
-        throw new Error(remodelsData.message);
+      if (!data.success) {
+        throw new Error(data.message);
       }
 
-      return remodelsData.data.allowlist;
+      const remodelsForCurrentModel = data.data.allowlist.filter(
+        (remodel: Remodel) => {
+          return (
+            remodel["from-model"] === modelId || remodel["to-model"] === modelId
+          );
+        },
+      );
+
+      return remodelsForCurrentModel.sort((a: Remodel, b: Remodel) => {
+        if (a["created-at"] > b["created-at"]) {
+          return -1;
+        }
+
+        if (a["created-at"] < b["created-at"]) {
+          return 1;
+        }
+
+        return 0;
+      });
     },
     enabled: !!brandId,
   });

--- a/static/js/publisher/index.tsx
+++ b/static/js/publisher/index.tsx
@@ -121,11 +121,12 @@ root.render(
                 <Route path="models">
                   <Route index element={<Models />} />
                   <Route path="create" element={<Models />} />
-                  <Route path=":model_id" element={<ModelDetailsPageLayout />}>
+                  <Route path=":modelId" element={<ModelDetailsPageLayout />}>
                     <Route index element={<Model />} />
                     <Route path="policies" element={<Policies />} />
                     <Route path="policies/create" element={<Policies />} />
                     <Route path="remodel" element={<Remodel />} />
+                    <Route path="remodel/configure" element={<Remodel />} />
                   </Route>
                 </Route>
                 <Route path="*" element={<Navigate to="../snaps" replace />} />

--- a/static/js/publisher/layouts/ModelDetailsPageLayout/ModelBreadcrumb.tsx
+++ b/static/js/publisher/layouts/ModelDetailsPageLayout/ModelBreadcrumb.tsx
@@ -2,15 +2,15 @@ import { Link, useParams } from "react-router-dom";
 
 interface RouteParams {
   id?: string;
-  model_id?: string;
+  modelId?: string;
 }
 function ModelBreadcrumb(): React.JSX.Element {
-  const { id, model_id } = useParams() as RouteParams;
+  const { id, modelId } = useParams() as RouteParams;
 
   return (
     <h1 className="p-heading--4">
       <Link to={`/admin/${id ?? ""}/models`}>&lsaquo;&nbsp;Models</Link> /{" "}
-      {model_id ?? ""}
+      {modelId ?? ""}
     </h1>
   );
 }

--- a/static/js/publisher/layouts/ModelDetailsPageLayout/ModelNav.tsx
+++ b/static/js/publisher/layouts/ModelDetailsPageLayout/ModelNav.tsx
@@ -1,14 +1,14 @@
 import { Link, useParams } from "react-router-dom";
 
 function ModelNav({ sectionName }: { sectionName: string }): React.JSX.Element {
-  const { id, model_id } = useParams();
+  const { id, modelId } = useParams();
 
   return (
     <nav className="p-tabs">
       <ul className="p-tabs__list">
         <li className="p-tabs__item">
           <Link
-            to={`/admin/${id}/models/${model_id}`}
+            to={`/admin/${id}/models/${modelId}`}
             className="p-tabs__link"
             aria-selected={sectionName === "overview"}
             role="tab"
@@ -18,7 +18,7 @@ function ModelNav({ sectionName }: { sectionName: string }): React.JSX.Element {
         </li>
         <li className="p-tabs__item">
           <Link
-            to={`/admin/${id}/models/${model_id}/policies`}
+            to={`/admin/${id}/models/${modelId}/policies`}
             className="p-tabs__link"
             aria-selected={sectionName === "policies"}
             role="tab"
@@ -28,7 +28,7 @@ function ModelNav({ sectionName }: { sectionName: string }): React.JSX.Element {
         </li>
         <li className="p-tabs__item">
           <Link
-            to={`/admin/${id}/models/${model_id}/remodel`}
+            to={`/admin/${id}/models/${modelId}/remodel`}
             className="p-tabs__link"
             aria-selected={sectionName === "remodel"}
             role="tab"

--- a/static/js/publisher/layouts/ModelDetailsPageLayout/ModelPageLayout.tsx
+++ b/static/js/publisher/layouts/ModelDetailsPageLayout/ModelPageLayout.tsx
@@ -4,8 +4,10 @@ import ModelNav from "./ModelNav";
 
 function ModelDetailsPageLayout() {
   const { pathname } = useLocation();
-  const isPolicies = pathname.endsWith("policies");
-  const isRemodel = pathname.endsWith("remodel");
+  const isPolicies =
+    pathname.endsWith("policies") || pathname.endsWith("policies/create");
+  const isRemodel =
+    pathname.endsWith("remodel") || pathname.endsWith("remodel/configure");
 
   const getSectionName = () => {
     if (isPolicies) {

--- a/static/js/publisher/pages/Model/CreatePolicyForm.tsx
+++ b/static/js/publisher/pages/Model/CreatePolicyForm.tsx
@@ -24,7 +24,7 @@ function CreatePolicyForm({
   setShowErrorNotification,
   refetchPolicies,
 }: Props): React.JSX.Element {
-  const { id, model_id } = useParams();
+  const { id, modelId } = useParams();
   const brandId = useAtomValue(brandIdState);
   const navigate = useNavigate();
   const location = useLocation();
@@ -37,7 +37,7 @@ function CreatePolicyForm({
 
   const handleError = () => {
     setShowErrorNotification(true);
-    navigate(`/admin/${id}/models/${model_id}/policies`);
+    navigate(`/admin/${id}/models/${modelId}/policies`);
     setNewSigningKey({ name: "" });
     setIsSaving(false);
     setTimeout(() => {
@@ -56,7 +56,7 @@ function CreatePolicyForm({
 
       setNewSigningKey({ name: "" });
 
-      return fetch(`/api/store/${brandId}/models/${model_id}/policies`, {
+      return fetch(`/api/store/${brandId}/models/${modelId}/policies`, {
         method: "POST",
         body: formData,
       });
@@ -77,7 +77,7 @@ function CreatePolicyForm({
       setShowNotification(true);
       setIsSaving(false);
       refetchPolicies();
-      navigate(`/admin/${id}/models/${model_id}/policies`);
+      navigate(`/admin/${id}/models/${modelId}/policies`);
       setTimeout(() => {
         setShowNotification(false);
       }, 5000);
@@ -158,7 +158,7 @@ function CreatePolicyForm({
             <div className="u-align--right">
               <Link
                 className="p-button u-no-margin--bottom"
-                to={`/admin/${id}/models/${model_id}/policies`}
+                to={`/admin/${id}/models/${modelId}/policies`}
                 onClick={() => {
                   setNewSigningKey({ name: "" });
                   setShowErrorNotification(false);

--- a/static/js/publisher/pages/Model/Model.tsx
+++ b/static/js/publisher/pages/Model/Model.tsx
@@ -20,7 +20,7 @@ import type { Model as ModelType } from "../../types/shared";
 import { PortalEntrance } from "../Portals/Portals";
 
 function Model() {
-  const { id, model_id } = useParams();
+  const { id, modelId } = useParams();
   const brandId = useAtomValue(brandIdState);
   const [apiKey, setApiKey] = useState("");
   const [showSuccessNotification, setShowSuccessNotificaton] = useState(false);
@@ -34,7 +34,7 @@ function Model() {
       formData.set("csrf_token", window.CSRF_TOKEN);
       formData.set("api_key", apiKey);
 
-      return fetch(`/api/store/${brandId}/models/${model_id}`, {
+      return fetch(`/api/store/${brandId}/models/${modelId}`, {
         method: "PATCH",
         body: formData,
       });
@@ -84,7 +84,7 @@ function Model() {
       return;
     }
 
-    const current = models.find((model) => model.name === model_id);
+    const current = models.find((model) => model.name === modelId);
 
     if (!current) {
       return;
@@ -95,7 +95,7 @@ function Model() {
     }
 
     return current;
-  }, [models, model_id]);
+  }, [models, modelId]);
 
   currentModel && brandStore
     ? setPageTitle(`${currentModel.name} in ${brandStore.name}`)

--- a/static/js/publisher/pages/Model/Policies.tsx
+++ b/static/js/publisher/pages/Model/Policies.tsx
@@ -27,11 +27,11 @@ import { isClosedPanel, setPageTitle } from "../../utils";
 import { PortalEntrance } from "../Portals/Portals";
 
 function Policies(): React.JSX.Element {
-  const { id, model_id } = useParams();
+  const { id, modelId } = useParams();
   const location = useLocation();
   const navigate = useNavigate();
   const { isLoading, isError, error, refetch, data }: UsePoliciesResponse =
-    usePolicies(id, model_id);
+    usePolicies(id, modelId);
   const signingKeys = useSigningKeys(id);
   const setPoliciesList = useSetAtom(policiesListState);
   const setFilter = useSetAtom(policiesListFilterState);
@@ -87,7 +87,7 @@ function Policies(): React.JSX.Element {
         <Col size={6} className="u-align--right">
           <Link
             className="p-button--positive"
-            to={`/admin/${id}/models/${model_id}/policies/create`}
+            to={`/admin/${id}/models/${modelId}/policies/create`}
           >
             Create policy
           </Link>
@@ -177,13 +177,13 @@ function Policies(): React.JSX.Element {
             isClosedPanel(location.pathname, "create") ? "u-hide" : ""
           }`}
           onClick={() => {
-            navigate(`/admin/${id}/models/${model_id}/policies`);
+            navigate(`/admin/${id}/models/${modelId}/policies`);
             setNewSigningKey({ name: "" });
             setShowErrorNotification(false);
           }}
           onKeyDown={(e) => {
             if (e.key === "Enter" || e.key === " ") {
-              navigate(`/admin/${id}/models/${model_id}/policies`);
+              navigate(`/admin/${id}/models/${modelId}/policies`);
               setNewSigningKey({ name: "" });
               setShowErrorNotification(false);
             }

--- a/static/js/publisher/pages/Model/PoliciesTable.tsx
+++ b/static/js/publisher/pages/Model/PoliciesTable.tsx
@@ -29,13 +29,13 @@ function PoliciesTable({
   setShowDeletePolicyNotification,
   setShowDeletePolicyErrorNotification,
 }: Props): React.JSX.Element {
-  const { id, model_id } = useParams();
+  const { id, modelId } = useParams();
   const brandId = useAtomValue(brandIdState);
   const [policiesList, setPoliciesList] = useAtom(filteredPoliciesListState);
   const [showModal, setShowModal] = useState<boolean>(false);
   const [selectedPolicy, setSelectedPolicy] = useState<number | undefined>();
   const [isLoading, setIsLoading] = useState<boolean>(false);
-  const { refetch } = usePolicies(id, model_id) as UsePoliciesResponse;
+  const { refetch } = usePolicies(id, modelId) as UsePoliciesResponse;
 
   const deletePolicy = async (policyRevision: number | undefined) => {
     if (policyRevision === undefined) {
@@ -52,7 +52,7 @@ function PoliciesTable({
     formData.set("csrf_token", window.CSRF_TOKEN);
 
     const response = await fetch(
-      `/api/store/${brandId}/models/${model_id}/policies/${policyRevision}`,
+      `/api/store/${brandId}/models/${modelId}/policies/${policyRevision}`,
       {
         method: "DELETE",
         body: formData,

--- a/static/js/publisher/pages/Model/__tests__/Model.test.tsx
+++ b/static/js/publisher/pages/Model/__tests__/Model.test.tsx
@@ -40,7 +40,7 @@ const renderComponent = () => {
 vi.mock("react-router-dom", async (importOriginal) => ({
   ...(await importOriginal()),
   useParams: () => ({
-    model_id: "model-1",
+    modelId: "model-1",
   }),
 }));
 

--- a/static/js/publisher/pages/Remodel/ConfigureRemodelForm.tsx
+++ b/static/js/publisher/pages/Remodel/ConfigureRemodelForm.tsx
@@ -1,0 +1,296 @@
+import { useMemo, useState, Dispatch, SetStateAction } from "react";
+import { useParams, Link, useLocation, useNavigate } from "react-router-dom";
+import { useMutation, useQueryClient } from "react-query";
+import { useAtomValue } from "jotai";
+import {
+  Button,
+  Input,
+  Select,
+  Icon,
+  Notification,
+} from "@canonical/react-components";
+
+import { useModels } from "../../hooks";
+import { brandIdState } from "../../state/brandStoreState";
+import { remodelsListState } from "../../state/remodelsState";
+
+import { setPageTitle } from "../../utils";
+
+type Props = {
+  setShowNotification: Dispatch<SetStateAction<boolean>>;
+  setShowErrorNotification: Dispatch<SetStateAction<boolean>>;
+  refetch: () => void;
+  setErrorMessage: Dispatch<SetStateAction<string>>;
+};
+
+function ConfigureRemodelForm({
+  refetch,
+  setShowNotification,
+  setShowErrorNotification,
+  setErrorMessage,
+}: Props): React.JSX.Element {
+  const { id, modelId } = useParams();
+  const location = useLocation();
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const [targetModel, setTargetModel] = useState("");
+  const [serial, setSerial] = useState("");
+  const [description, setDescription] = useState("");
+  const [isSaving, setIsSaving] = useState(false);
+  const [selectAllSerials, setSelectAllSerials] = useState(false);
+
+  const handleError = () => {
+    setShowErrorNotification(true);
+    navigate(`/admin/${id}/models/${modelId}/remodel`);
+    setTargetModel("");
+    setSerial("");
+    setDescription("");
+    setIsSaving(false);
+    setTimeout(() => {
+      setShowErrorNotification(false);
+    }, 5000);
+  };
+
+  if (location.pathname.includes("/configure")) {
+    setPageTitle("Configure a remodel");
+  }
+
+  const brandId = useAtomValue(brandIdState);
+  const remodels = useAtomValue(remodelsListState);
+
+  const { data: models, isLoading, error } = useModels(brandId);
+
+  // Filters out the current model as you
+  // can't remodel a model to the same model
+  const targetModels = useMemo(() => {
+    if (!models || isLoading || error) {
+      return [];
+    }
+
+    return models.filter((m) => m.name !== modelId && m.name !== "undefined");
+  }, [models, isLoading, error, modelId]);
+
+  const isDisabled = () => {
+    if (targetModel && serial) {
+      return false;
+    }
+
+    if (targetModel && selectAllSerials) {
+      return false;
+    }
+
+    return true;
+  };
+
+  const hasConflict = () => {
+    const existingRemodel = remodels.find((remodel) => {
+      const serialMatch = () => {
+        if (!selectAllSerials && !serial) {
+          return false;
+        }
+
+        return (
+          remodel["from-serial"] === serial ||
+          (remodel["from-serial"] === null && !serial)
+        );
+      };
+
+      return (
+        remodel["from-model"] === modelId &&
+        remodel["to-model"] === targetModel &&
+        serialMatch()
+      );
+    });
+
+    if (existingRemodel) {
+      return true;
+    }
+
+    return false;
+  };
+
+  const mutation = useMutation({
+    mutationFn: () => {
+      setIsSaving(true);
+
+      return fetch(`/api/store/${brandId}/models/remodel-allowlist`, {
+        method: "POST",
+        body: JSON.stringify([
+          {
+            "from-model": modelId,
+            "to-model": targetModel,
+            // the store API reads `null` as all serials
+            "from-serial": selectAllSerials ? null : serial,
+            description: description,
+          },
+        ]),
+        headers: {
+          "Content-Type": "application/json",
+          "X-CSRF-Token": window.CSRF_TOKEN,
+        },
+      });
+    },
+    onMutate: async () => {
+      await queryClient.cancelQueries({ queryKey: ["remodels"] });
+      const previousRemodels = queryClient.getQueryData(["remodels"]);
+      return { previousRemodels };
+    },
+    onError: ({ context }) => {
+      queryClient.setQueryData(["remodels"], context?.previousRemodels);
+      handleError();
+      throw new Error("Unable to configure a new remodel");
+    },
+    onSettled: async (res) => {
+      const responseData = await res?.json();
+
+      if (!responseData.success) {
+        let errorMessage = responseData.message;
+
+        // Can't use the default message in this case
+        // due to its formatting
+        if (res?.status === 409) {
+          errorMessage = "Requested remodel conflicts with existing remodels";
+        }
+
+        setErrorMessage(errorMessage);
+        setShowErrorNotification(true);
+      } else {
+        setShowNotification(true);
+        refetch();
+      }
+
+      setTargetModel("");
+      setSerial("");
+      setDescription("");
+
+      queryClient.invalidateQueries({ queryKey: ["remodels"] });
+      setIsSaving(false);
+      navigate(`/admin/${id}/models/${modelId}/remodel`);
+      setTimeout(() => {
+        setShowNotification(false);
+      }, 5000);
+    },
+  });
+
+  return (
+    <form
+      onSubmit={(event) => {
+        event.preventDefault();
+        mutation.mutate();
+      }}
+      style={{ height: "100%" }}
+    >
+      <div className="p-panel is-flex-column">
+        <div className="p-panel__header">
+          <h4 className="p-panel__title p-muted-heading">
+            Configure a remodel
+          </h4>
+        </div>
+        <div className="p-panel__content">
+          {isSaving && (
+            <div className="u-fixed-width">
+              <p>
+                <Icon name="spinner" className="u-animation--spin" />
+                &nbsp;Configuring remodel...
+              </p>
+            </div>
+          )}
+          <div className="u-fixed-width" style={{ marginBottom: "30px" }}>
+            <Select
+              id="target-model"
+              label="Select a target model"
+              options={[{ label: "Select a model", value: "" }].concat(
+                targetModels.map((m) => ({
+                  label: m.name,
+                  value: m.name,
+                })),
+              )}
+              value={targetModel}
+              required
+              disabled={!models || models.length < 1}
+              onChange={(e) => {
+                setTargetModel(e.target.value);
+              }}
+            />
+            <p className="u-no-margin--bottom">* Input devices to target</p>
+            <div style={{ display: "flex", gap: "2rem" }}>
+              <Input
+                type="radio"
+                label="Enter serial"
+                name="serials"
+                checked={!selectAllSerials}
+                onChange={(e) => {
+                  setSelectAllSerials(!e.target.checked);
+                }}
+              />
+              <Input
+                type="radio"
+                label="All serials"
+                name="serials"
+                checked={selectAllSerials}
+                onChange={(e) => {
+                  setSelectAllSerials(e.target.checked);
+                  setSerial("");
+                }}
+              />
+            </div>
+            {!selectAllSerials && (
+              <Input
+                id="input-devices"
+                label="Input devices to target"
+                labelClassName="u-hide"
+                placeholder="Enter serial number"
+                type="text"
+                onChange={(e) => {
+                  setSerial(e.target.value);
+                }}
+                value={serial}
+                required
+              />
+            )}
+            <Input
+              id="note"
+              label="Note (Max 140 characters)"
+              placeholder="Add a note (optional)"
+              type="text"
+              maxLength={140}
+              onChange={(e) => {
+                setDescription(e.target.value);
+              }}
+              value={description}
+            />
+          </div>
+          {hasConflict() && (
+            <div className="u-fixed-width">
+              <Notification severity="negative" title="Remodel conflict">
+                There is an existing remodel with this configuration. Choose
+                another target model or a different device to target.
+              </Notification>
+            </div>
+          )}
+          <div className="u-fixed-width">
+            <hr />
+            <div className="u-align--right">
+              <Link
+                className="p-button u-no-margin--bottom"
+                to={`/admin/${id}/models/${modelId}/remodel`}
+              >
+                Cancel
+              </Link>
+              <Button
+                type="submit"
+                appearance="positive"
+                className="u-no-margin--bottom u-no-margin--right"
+                disabled={isDisabled() || hasConflict()}
+              >
+                Confirm
+              </Button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </form>
+  );
+}
+
+export default ConfigureRemodelForm;

--- a/static/js/publisher/pages/Remodel/Remodel.tsx
+++ b/static/js/publisher/pages/Remodel/Remodel.tsx
@@ -1,6 +1,11 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useAtomValue, useSetAtom } from "jotai";
-import { useParams, useSearchParams } from "react-router-dom";
+import {
+  useParams,
+  useSearchParams,
+  Link,
+  useNavigate,
+} from "react-router-dom";
 import { Notification, Icon, Row, Col } from "@canonical/react-components";
 
 import { useRemodels } from "../../hooks";
@@ -8,45 +13,45 @@ import {
   remodelsListFilterState,
   remodelsListState,
 } from "../../state/remodelsState";
-import { policiesListState } from "../../state/policiesState";
 import { brandIdState, brandStoreState } from "../../state/brandStoreState";
-import { setPageTitle, getPolicies } from "../../utils";
+import { setPageTitle, isClosedPanel } from "../../utils";
+import { PortalEntrance } from "../Portals/Portals";
 
 import Filter from "../../components/Filter";
 import RemodelTable from "./RemodelTable";
+import ConfigureRemodelForm from "./ConfigureRemodelForm";
 
 import type { UseQueryResult } from "react-query";
 import type { Remodel } from "../../types/shared";
 
 function Remodel(): React.JSX.Element {
-  const { id } = useParams();
+  const { id, modelId } = useParams();
   const brandId = useAtomValue(brandIdState);
-  const { isLoading, isError, error, data }: UseQueryResult<Remodel[], Error> =
-    useRemodels(brandId);
+  const {
+    isLoading,
+    isError,
+    error,
+    data,
+    refetch,
+  }: UseQueryResult<Remodel[], Error> = useRemodels(brandId, modelId);
   const setRemodels = useSetAtom(remodelsListState);
-  const setPolicies = useSetAtom(policiesListState);
   const setFilter = useSetAtom(remodelsListFilterState);
+  const [showNotification, setShowNotification] = useState(false);
+  const [showErrorNotification, setShowErrorNotification] = useState(false);
+  const [errorMessage, setErrorMessage] = useState("");
   const brandStore = useAtomValue(brandStoreState(id));
   const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
 
   brandStore
     ? setPageTitle(`Remodels in ${brandStore.name}`)
     : setPageTitle("Remodels");
 
   useEffect(() => {
-    const controller = new AbortController();
-    const signal = controller.signal;
-
     if (!isLoading && !isError && data) {
-      const modelIds = [...new Set(data.map((r) => r["to-model"]))];
       setRemodels(data);
       setFilter(searchParams.get("filter") || "");
-      getPolicies({ modelIds, id, setPolicies, signal });
     }
-
-    return () => {
-      controller.abort();
-    };
   }, [isLoading, error, data, brandId, id]);
 
   return (
@@ -72,6 +77,14 @@ function Remodel(): React.JSX.Element {
                   placeholder="Search remodels"
                 />
               </Col>
+              <Col size={6} className="u-align--right">
+                <Link
+                  className={`p-button--positive ${isError && !data ? "is-disabled" : ""}`}
+                  to={`/admin/${id}/models/${modelId}/remodel/configure`}
+                >
+                  Configure remodels
+                </Link>
+              </Col>
             </Row>
             <div className="u-flex-column u-flex-grow">
               <RemodelTable />
@@ -79,6 +92,65 @@ function Remodel(): React.JSX.Element {
           </>
         )}
       </div>
+
+      <PortalEntrance name="notification">
+        {showNotification && (
+          <div className="u-fixed-width">
+            <Notification
+              severity="positive"
+              onDismiss={() => {
+                setShowNotification(false);
+              }}
+            >
+              New remodel configured
+            </Notification>
+          </div>
+        )}
+
+        {showErrorNotification && (
+          <div className="u-fixed-width">
+            <Notification
+              severity="negative"
+              onDismiss={() => {
+                setShowErrorNotification(false);
+              }}
+            >
+              {errorMessage || "Unable to configure remodel"}
+            </Notification>
+          </div>
+        )}
+      </PortalEntrance>
+
+      <PortalEntrance name="aside">
+        <div
+          className={`l-aside__overlay ${
+            isClosedPanel(location.pathname, "configure") ? "u-hide" : ""
+          }`}
+          onClick={() => {
+            navigate(`/admin/${id}/models/${modelId}/remodel`);
+          }}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" || e.key === " ") {
+              navigate(`/admin/${id}/models/${modelId}/remodel`);
+            }
+          }}
+          role="button"
+          tabIndex={0}
+          aria-label="Return to remodels"
+        ></div>
+        <aside
+          className={`l-aside ${
+            isClosedPanel(location.pathname, "configure") ? "is-collapsed" : ""
+          }`}
+        >
+          <ConfigureRemodelForm
+            refetch={refetch}
+            setShowNotification={setShowNotification}
+            setShowErrorNotification={setShowErrorNotification}
+            setErrorMessage={setErrorMessage}
+          />
+        </aside>
+      </PortalEntrance>
     </>
   );
 }

--- a/static/js/publisher/pages/Remodel/RemodelTable.tsx
+++ b/static/js/publisher/pages/Remodel/RemodelTable.tsx
@@ -1,8 +1,9 @@
 import { useAtomValue } from "jotai";
-import { MainTable } from "@canonical/react-components";
+import { MainTable, TablePagination } from "@canonical/react-components";
 import { format } from "date-fns";
 
 import { filteredRemodelsListState } from "../../state/remodelsState";
+import { useSortTableData } from "../../hooks";
 
 import type { Remodel } from "../../types/shared";
 
@@ -10,13 +11,18 @@ function RemodelTable(): React.JSX.Element {
   const remodels = useAtomValue(filteredRemodelsListState);
 
   const headers = [
-    { content: "Target model", sortKey: "to-model" },
-    { content: "Original model", sortKey: "from-model" },
-    { content: "Allowed devices", className: "u-align--right" },
+    { content: "Target model", sortKey: "to-model", style: { width: "250px" } },
+    {
+      content: "Original model",
+      sortKey: "from-model",
+      style: { width: "250px" },
+    },
+    { content: "Serial" },
     {
       content: "Created date",
       className: "u-align--right",
       sortKey: "created-at",
+      style: { width: "130px" },
     },
     { content: "Note" },
   ];
@@ -24,9 +30,12 @@ function RemodelTable(): React.JSX.Element {
   const rows = remodels.map((remodel: Remodel) => {
     return {
       columns: [
-        { content: remodel["to-model"] },
-        { content: remodel["from-model"] },
-        { content: remodel["serials"], className: "u-align--right" },
+        { content: remodel["to-model"], className: "u-truncate" },
+        { content: remodel["from-model"], className: "u-truncate" },
+        {
+          content: remodel["from-serial"] || "All serial policies",
+          className: "u-truncate",
+        },
         {
           content: format(new Date(remodel["created-at"]), "dd/MM/yyyy"),
           className: "u-align--right",
@@ -41,14 +50,22 @@ function RemodelTable(): React.JSX.Element {
     };
   });
 
+  const { rows: sortedRows, updateSort } = useSortTableData({ rows });
+
   return (
-    <MainTable
-      data-testid="remodel-table"
-      sortable
-      emptyStateMsg="No remodels match this filter"
-      headers={headers}
-      rows={rows}
-    />
+    <TablePagination
+      data={sortedRows}
+      pageLimits={[25, 50, 100, 200]}
+      position="below"
+    >
+      <MainTable
+        data-testid="remodel-table"
+        sortable
+        emptyStateMsg="No remodels match this filter"
+        headers={headers}
+        onUpdateSort={updateSort}
+      />
+    </TablePagination>
   );
 }
 

--- a/static/js/publisher/pages/Remodel/__tests__/ConfigureRemodelForm.test.tsx
+++ b/static/js/publisher/pages/Remodel/__tests__/ConfigureRemodelForm.test.tsx
@@ -1,0 +1,112 @@
+import { BrowserRouter } from "react-router-dom";
+import { QueryClient, QueryClientProvider, useQuery } from "react-query";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import "@testing-library/jest-dom";
+
+import ConfigureRemodelForm from "../ConfigureRemodelForm";
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      refetchOnWindowFocus: false,
+      refetchOnReconnect: false,
+    },
+  },
+});
+
+vi.mock("react-query", async (importOriginal) => ({
+  ...(await importOriginal()),
+  useQuery: vi.fn(),
+}));
+
+const renderComponent = () => {
+  return render(
+    <BrowserRouter>
+      <QueryClientProvider client={queryClient}>
+        <ConfigureRemodelForm
+          setShowErrorNotification={vi.fn()}
+          setErrorMessage={vi.fn()}
+          setShowNotification={vi.fn()}
+          refetch={vi.fn()}
+        />
+      </QueryClientProvider>
+    </BrowserRouter>,
+  );
+};
+
+describe("ConfigureRemodelForm", () => {
+  it("disables the 'Confirm' button by default", () => {
+    // @ts-expect-error - Mocking useQuery to test form behavior with valid fields
+    useQuery.mockReturnValue({
+      data: [
+        {
+          name: "test-model-1",
+        },
+      ],
+    });
+    renderComponent();
+    expect(screen.getByRole("button", { name: "Confirm" })).toHaveAttribute(
+      "aria-disabled",
+      "true",
+    );
+  });
+
+  it("enables the 'Confirm' button if required fields have values", async () => {
+    // @ts-expect-error - Mocking useQuery to test form behavior with valid fields
+    useQuery.mockReturnValue({
+      data: [
+        {
+          name: "test-model-1",
+        },
+      ],
+    });
+    renderComponent();
+    const user = userEvent.setup();
+    await user.selectOptions(screen.getByLabelText("Select a target model"), [
+      "test-model-1",
+    ]);
+    await user.type(
+      screen.getByLabelText("Input devices to target"),
+      "test-serial",
+    );
+    expect(screen.getByRole("button", { name: "Confirm" })).not.toHaveAttribute(
+      "aria-disabled",
+    );
+  });
+
+  it("shows serial number input if 'Enter serial' option is selected", async () => {
+    // @ts-expect-error - Mocking useQuery to test form behavior with valid fields
+    useQuery.mockReturnValue({
+      data: [
+        {
+          name: "test-model-1",
+        },
+      ],
+    });
+    renderComponent();
+    const user = userEvent.setup();
+    await user.click(screen.getByLabelText("Enter serial"));
+    expect(
+      screen.getByLabelText("Input devices to target"),
+    ).toBeInTheDocument();
+  });
+
+  it("doesn't show serial number input if 'All serials' option is selected", async () => {
+    // @ts-expect-error - Mocking useQuery to test form behavior with valid fields
+    useQuery.mockReturnValue({
+      data: [
+        {
+          name: "test-model-1",
+        },
+      ],
+    });
+    renderComponent();
+    const user = userEvent.setup();
+    await user.click(screen.getByLabelText("All serials"));
+    expect(
+      screen.queryByLabelText("Input devices to target"),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/static/js/publisher/pages/Remodel/__tests__/RemodelTable.test.tsx
+++ b/static/js/publisher/pages/Remodel/__tests__/RemodelTable.test.tsx
@@ -43,7 +43,7 @@ describe("RemodelTable", () => {
     ).toBeInTheDocument();
 
     expect(
-      screen.getByRole("columnheader", { name: "Allowed devices" }),
+      screen.getByRole("columnheader", { name: "Serial" }),
     ).toBeInTheDocument();
 
     expect(

--- a/static/js/publisher/state/remodelsState.ts
+++ b/static/js/publisher/state/remodelsState.ts
@@ -1,7 +1,5 @@
 import { atom } from "jotai";
 
-import { policiesListState } from "./policiesState";
-
 import type { Remodel } from "../types/shared";
 
 const remodelsListState = atom([] as Remodel[]);
@@ -31,19 +29,8 @@ function getFilteredRemodels(
 const filteredRemodelsListState = atom<Array<Remodel>>((get) => {
   const filter = get(remodelsListFilterState);
   const remodels = get(remodelsListState);
-  const policies = get(policiesListState);
-  const remodelsWithPolicies = remodels.map((remodel) => {
-    const remodelSerials = policies.filter(
-      (p) => p["model-name"] === remodel["to-model"],
-    );
 
-    return {
-      ...remodel,
-      serials: remodelSerials.length,
-    };
-  });
-
-  return getFilteredRemodels(remodelsWithPolicies, filter);
+  return getFilteredRemodels(remodels, filter);
 });
 
 export {

--- a/static/js/publisher/types/shared.ts
+++ b/static/js/publisher/types/shared.ts
@@ -182,7 +182,7 @@ export type Remodel = {
   "created-by": string;
   description?: string | null;
   "from-model": string;
-  "from-serial": string;
+  "from-serial": string | null;
   "modified-at": string | null;
   "modified-by": string | null;
   "to-model": string;


### PR DESCRIPTION
## Done
Adds a form for users to configure a remodel

## How to QA
- Go to https://snapcraft-io-5592.demos.haus/admin/ahnuP3quahti9vis8aiw/models/testing-model-new2/remodel/configure
- Select a target model and enter a serial number which already appear on the remodels table
- There should be a notification about a conflict
- Enter a new serial number or change the target model
- Check that you can submit the form

## Testing

- [x] This PR has tests
- [ ] No testing required (explain why):

## Security

- [ ] Security considerations for review (list them):
  - [ ] Examples:
  - [ ] Access control: users can only access their own data
  - [ ] Input: user input is validated and sanitised
  - [ ] Sensitive data: secret or private data is not exposed in any way
  - [ ] ...
- [x] This PR has no security considerations (explain why):

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-30821

## Screenshots
n/a

## UX Approval

- [ ] This PR does not require UX approval
- [x] This PR does require UX approval (add context):
