### PR TITLE
feat: Fix behaviour around model API keys

### DIFF
--- a/static/js/publisher/pages/Model/__tests__/Model.test.tsx
+++ b/static/js/publisher/pages/Model/__tests__/Model.test.tsx
@@ -1,5 +1,5 @@
 import { BrowserRouter } from "react-router-dom";
-import { QueryClient, QueryClientProvider } from "react-query";
+import { QueryClient, QueryClientProvider, useQuery } from "react-query";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom";
@@ -44,78 +44,106 @@ vi.mock("react-router-dom", async (importOriginal) => ({
   }),
 }));
 
+const defaultModel = {
+  "api-key": "K2NjWGA4iKhLmGDDQUJhJyhzS35CBLJClyNu8dAS0TWrTF3aSD",
+  "created-at": "2023-07-13T15:56:35.088052",
+  "created-by": {
+    "display-name": "John Doe",
+    email: "john.doe@canonical.com",
+    id: "prFvYmvaBsQbXLNaVaQFV4EAcJ8zh0Ej",
+    username: "johndoe",
+    validation: "unproven",
+  },
+  name: "model-1",
+  series: "16",
+};
+
+const defaultResponse = {
+  data: [defaultModel],
+};
+
 vi.mock("react-query", async (importOriginal) => ({
   ...(await importOriginal()),
-  useQuery: vi.fn().mockReturnValue({
-    data: [
-      {
-        "api-key": "K2NjWGA4iKhLmGDDQUJhJyhzS35CBLJClyNu8dAS0TWrTF3aSD",
-        "created-at": "2023-07-13T15:56:35.088052",
-        "created-by": {
-          "display-name": "John Doe",
-          email: "john.doe@canonical.com",
-          id: "prFvYmvaBsQbXLNaVaQFV4EAcJ8zh0Ej",
-          username: "johndoe",
-          validation: "unproven",
-        },
-        name: "model-1",
-        series: "16",
-      },
-    ],
-  }),
+  useQuery: vi.fn(),
 }));
 
 describe("Model", () => {
-  it("disables the 'Save' button if the API key hasn't been modified", async () => {
+  it("doesn't render 'Save' and 'Revert' buttons if API key already exists", async () => {
+    // @ts-expect-error - Mocking useQuery without providing types for the mock data
+    useQuery.mockReturnValue(defaultResponse);
     renderComponent();
+    expect(
+      screen.queryByRole("button", { name: "Save" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Revert" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("doesn't render 'Generate key' button if API key already exists", async () => {
+    // @ts-expect-error - Mocking useQuery without providing types for the mock data
+    useQuery.mockReturnValue(defaultResponse);
+    renderComponent();
+    expect(
+      screen.queryByRole("button", { name: "Generate key" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("sets API key field as readonly if API key already exists", async () => {
+    // @ts-expect-error - Mocking useQuery without providing types for the mock data
+    useQuery.mockReturnValue(defaultResponse);
+    renderComponent();
+    expect(screen.getByLabelText("API key")).toHaveAttribute("readonly");
+  });
+
+  it("populates the API key field if API key already exists", async () => {
+    // @ts-expect-error - Mocking useQuery without providing types for the mock data
+    useQuery.mockReturnValue(defaultResponse);
+    renderComponent();
+    expect(screen.getByLabelText("API key")).toHaveValue(
+      defaultResponse.data[0]["api-key"],
+    );
+  });
+
+  it("displays the 'Save' and 'Revert' buttons if no API key", async () => {
+    // @ts-expect-error - Mocking useQuery without providing types for the mock data
+    useQuery.mockReturnValue({ data: [{ ...defaultModel, "api-key": null }] });
+    renderComponent();
+    expect(screen.getByRole("button", { name: "Save" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Save" })).toHaveAttribute(
       "aria-disabled",
       "true",
     );
-  });
-
-  it("enables the 'Save' button when the API key has been modified", async () => {
-    renderComponent();
-    const user = userEvent.setup();
-    await user.click(screen.getByRole("button", { name: "Generate key" }));
-    expect(screen.getByRole("button", { name: "Save" })).not.toBeDisabled();
-  });
-
-  it("generates a new API key when clicking the 'Generate key' button", async () => {
-    renderComponent();
-    const user = userEvent.setup();
-    await user.click(screen.getByRole("button", { name: "Generate key" }));
-    const apiKeyField: HTMLInputElement = screen.getByLabelText("API key");
-    const apiKeyFieldValue = apiKeyField.value;
-    expect(apiKeyFieldValue).not.toEqual(
-      "K2NjWGA4iKhLmGDDQUJhJyhzS35CBLJClyNu8dAS0TWrTF3aSD",
-    );
-  });
-
-  it("disables the 'Revert' button if the API key hasn't been modified", async () => {
-    renderComponent();
+    expect(screen.getByRole("button", { name: "Revert" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Revert" })).toHaveAttribute(
       "aria-disabled",
       "true",
     );
   });
 
-  it("enables the 'Revert' button when the API key has been modified", async () => {
+  it("enables the 'Save' and 'Revert' buttons when the API key has been modified", async () => {
+    // @ts-expect-error - Mocking useQuery without providing types for the mock data
+    useQuery.mockReturnValue({ data: [{ ...defaultModel, "api-key": null }] });
     renderComponent();
     const user = userEvent.setup();
     await user.click(screen.getByRole("button", { name: "Generate key" }));
-    expect(screen.getByRole("button", { name: "Revert" })).not.toBeDisabled();
+    expect(screen.getByRole("button", { name: "Save" })).not.toHaveAttribute(
+      "aria-disabled",
+    );
+    expect(screen.getByRole("button", { name: "Revert" })).not.toHaveAttribute(
+      "aria-disabled",
+    );
   });
 
-  it("resets the API when clicking the 'Revert' button", async () => {
+  it("generates a new API key when clicking the 'Generate key' button", async () => {
+    // @ts-expect-error - Mocking useQuery without providing types for the mock data
+    useQuery.mockReturnValue({ data: [{ ...defaultModel, "api-key": null }] });
     renderComponent();
     const user = userEvent.setup();
     await user.click(screen.getByRole("button", { name: "Generate key" }));
-    expect(screen.getByLabelText("API key")).not.toHaveValue(
-      "K2NjWGA4iKhLmGDDQUJhJyhzS35CBLJClyNu8dAS0TWrTF3aSD",
-    );
-    await user.click(screen.getByRole("button", { name: "Revert" }));
-    expect(screen.getByLabelText("API key")).toHaveValue(
+    const apiKeyField: HTMLInputElement = screen.getByLabelText("API key");
+    const apiKeyFieldValue = apiKeyField.value;
+    expect(apiKeyFieldValue).not.toEqual(
       "K2NjWGA4iKhLmGDDQUJhJyhzS35CBLJClyNu8dAS0TWrTF3aSD",
     );
   });

--- a/static/js/publisher/state/modelsState.ts
+++ b/static/js/publisher/state/modelsState.ts
@@ -1,5 +1,4 @@
 import { atom } from "jotai";
-import { atomFamily } from "jotai-family";
 
 import { policiesListState } from "./policiesState";
 
@@ -51,17 +50,9 @@ const filteredModelsListState = atom<Array<Model>>((get) => {
   return getFilteredModels(modelsWithPolicies, filter);
 });
 
-const currentModelState = atomFamily((modelId) =>
-  atom((get) => {
-    const models = get(modelsListState);
-    return models.find((model) => model.name === modelId);
-  }),
-);
-
 export {
   modelsListState,
   modelsListFilterState,
   newModelState,
   filteredModelsListState,
-  currentModelState,
 };


### PR DESCRIPTION
## Done
Updates the model page so that:
- there is no "Generate key" button if there is an existing API key
- the API key input is editable if there is no existing API key
- the API key is not pre-populated

## How to QA
- Go to a model page with an API key, e.g. https://snapcraft-io-5599.demos.haus/admin/ahnuP3quahti9vis8aiw/models/testing-model-new2
- Check that there is no "Revert" and "Save" buttons on the page
- Check that there is no "Generate key" button on the page
- Check that the "API key" value is readonly
- Go to a model page without an API key
- Check that there are "Revert" and "Save" buttons on the page
- Check that there is a "Generate key" button on the page
- Check that clicking the "Generate key" button populates the "API key" field
- Check that the "API key" field in editable
- Check that when you put a value in the "API key" field that the "Revert" and "Save" buttons are enabled
- Check that the "Revert" button clears the "API key" field
- Check that the "Revert" and "Save" buttons are disabled if there is no API key value
- Check that once you save the API key that the "Revert" and "Save" buttons disappear
- Check that once you save the API key that the "Generate key" button disappears
- Check that once you save the API key that the "API key" field becomes readonly

## Testing

- [x] This PR has tests
- [ ] No testing required (explain why):

## Security

- [ ] Security considerations for review (list them):
  - [ ] Examples:
  - [ ] Access control: users can only access their own data
  - [ ] Input: user input is validated and sanitised
  - [ ] Sensitive data: secret or private data is not exposed in any way
  - [ ] ...
- [x] This PR has no security considerations (explain why):

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-30818

## Screenshots
n/a

## UX Approval

- [x] This PR does not require UX approval
- [ ] This PR does require UX approval (add context):
