### PR TITLE
chore: Update API key functionality when creating model

### DIFF
--- a/static/js/publisher/pages/Models/CreateModelForm.tsx
+++ b/static/js/publisher/pages/Models/CreateModelForm.tsx
@@ -9,7 +9,6 @@ import { checkModelNameExists, setPageTitle } from "../../utils";
 
 import {
   modelsListState,
-  newModelState,
   filteredModelsListState,
 } from "../../state/modelsState";
 import {
@@ -29,11 +28,13 @@ function CreateModelForm({
   setShowNotification,
   setShowErrorNotification,
 }: Props): React.JSX.Element {
+  const API_KEY_LENGTH = 50;
   const navigate = useNavigate();
   const location = useLocation();
   const { id } = useParams();
   const brandId = useAtomValue(brandIdState);
-  const [newModel, setNewModel] = useAtom(newModelState);
+  const [newModelName, setNewModelName] = useState("");
+  const [apiKey, setApiKey] = useState("");
   const stores = useAtom(brandStoresState);
   const currentStore = stores[0].find((store: Store) => store.id === id);
   const modelsList = useAtomValue(filteredModelsListState);
@@ -47,10 +48,11 @@ function CreateModelForm({
     setShowErrorNotification(true);
     setIsSaving(false);
     setModelsList((oldModelsList: Array<Model>) => {
-      return oldModelsList.filter((model) => model.name !== newModel.name);
+      return oldModelsList.filter((model) => model.name !== newModelName);
     });
     navigate(`/admin/${id}/models`);
-    setNewModel({ name: "", apiKey: "" });
+    setNewModelName("");
+    setApiKey("");
     setTimeout(() => {
       setShowErrorNotification(false);
     }, 5000);
@@ -66,8 +68,8 @@ function CreateModelForm({
       formData.set("name", newModel.name);
       formData.set("api_key", newModel.apiKey);
 
-      setNewModel({ name: "", apiKey: "" });
-
+      setNewModelName("");
+      setApiKey("");
       setModelsList((oldModelsList: Array<Model>) => {
         return [
           {
@@ -115,7 +117,7 @@ function CreateModelForm({
     <form
       onSubmit={(event) => {
         event.preventDefault();
-        mutation.mutate({ name: newModel.name, apiKey: newModel.apiKey });
+        mutation.mutate({ name: newModelName, apiKey });
       }}
       style={{ height: "100%" }}
     >
@@ -144,14 +146,13 @@ function CreateModelForm({
               placeholder="e.g. display-name-123"
               label="Name"
               help="Name should contain lowercase alphanumeric characters and hyphens only"
-              value={newModel.name}
+              value={newModelName}
               onChange={(e) => {
-                const value = e.target.value;
-                setNewModel({ ...newModel, name: value });
+                setNewModelName(e.target.value);
               }}
               error={
-                checkModelNameExists(newModel.name, modelsList)
-                  ? `Model ${newModel.name} already exists`
+                checkModelNameExists(newModelName, modelsList)
+                  ? `Model ${newModelName} already exists`
                   : null
               }
               required
@@ -160,21 +161,19 @@ function CreateModelForm({
               type="text"
               id="api-key-field"
               label="API key"
-              value={newModel.apiKey}
-              placeholder="yx6dnxsWQ3XUB5gza8idCuMvwmxtk1xBpa9by8TuMit5dgGnv"
-              className="read-only-dark"
-              readOnly
+              value={apiKey}
+              required
+              maxLength={API_KEY_LENGTH}
+              onChange={(e) => {
+                setApiKey(e.target.value);
+              }}
+              help={`API key should be exactly ${API_KEY_LENGTH} alphanumeric characters long (${apiKey.length}/${API_KEY_LENGTH})`}
             />
             <Button
               type="button"
               className="u-no-margin--bottom"
               onClick={() => {
-                setNewModel({
-                  ...newModel,
-                  apiKey: randomstring.generate({
-                    length: 50,
-                  }),
-                });
+                setApiKey(randomstring.generate({ length: API_KEY_LENGTH }));
               }}
             >
               Generate key
@@ -188,7 +187,8 @@ function CreateModelForm({
                 className="p-button u-no-margin--bottom"
                 to={`/admin/${id}/models`}
                 onClick={() => {
-                  setNewModel({ name: "", apiKey: "" });
+                  setNewModelName("");
+                  setApiKey("");
                   setShowErrorNotification(false);
                 }}
               >
@@ -199,8 +199,9 @@ function CreateModelForm({
                 appearance="positive"
                 className="u-no-margin--bottom u-no-margin--right"
                 disabled={
-                  !newModel.name ||
-                  checkModelNameExists(newModel.name, modelsList)
+                  !newModelName ||
+                  apiKey.length !== API_KEY_LENGTH ||
+                  checkModelNameExists(newModelName, modelsList)
                 }
               >
                 Add model

--- a/static/js/publisher/pages/Models/__tests__/CreateModelForm.test.tsx
+++ b/static/js/publisher/pages/Models/__tests__/CreateModelForm.test.tsx
@@ -30,7 +30,7 @@ const renderComponent = () => {
 };
 
 describe("CreateModelForm", () => {
-  it("disables 'Add model' button if no new model name", async () => {
+  it("disables 'Add model' button if no new model name or API key", async () => {
     renderComponent();
     expect(screen.getByRole("button", { name: "Add model" })).toHaveAttribute(
       "aria-disabled",
@@ -38,16 +38,46 @@ describe("CreateModelForm", () => {
     );
   });
 
-  it("enables 'Add model' button if there is a new model name", async () => {
+  it("disables 'Add model' button if new model name but no API key", async () => {
     const user = userEvent.setup();
     renderComponent();
     await user.type(
       screen.getByRole("textbox", { name: "Name" }),
       "test-model-name",
     );
+    expect(screen.getByRole("button", { name: "Add model" })).toHaveAttribute(
+      "aria-disabled",
+      "true",
+    );
+  });
+
+  it("disables 'Add model' button if new API key but no new model name", async () => {
+    const user = userEvent.setup();
+    renderComponent();
+    await user.type(
+      screen.getByRole("textbox", { name: "API key" }),
+      "AJXdC7aAMrQfElvccQAV0lPkJ0bEnmdjDxuL6C1Di0kxILmiyk",
+    );
+    expect(screen.getByRole("button", { name: "Add model" })).toHaveAttribute(
+      "aria-disabled",
+      "true",
+    );
+  });
+
+  it("enables 'Add model' button if there is a new model name and API key", async () => {
+    const user = userEvent.setup();
+    renderComponent();
+    await user.type(
+      screen.getByRole("textbox", { name: "Name" }),
+      "test-model-name",
+    );
+    await user.type(
+      screen.getByRole("textbox", { name: "API key" }),
+      "AJXdC7aAMrQfElvccQAV0lPkJ0bEnmdjDxuL6C1Di0kxILmiyk",
+    );
     expect(
       screen.getByRole("button", { name: "Add model" }),
-    ).not.toBeDisabled();
+    ).not.toHaveAttribute("aria-disabled");
   });
 
   it("generates an API key when clicking 'Generate key'", async () => {


### PR DESCRIPTION
## Done
Addresses UX improvements around the "API key" field when creating a new model. The requirements were:
- the field should not be pre-populated
- the field should be required
- the user should be able to type or paste an existing key into the form

## How to QA
- Go to https://snapcraft-io-5601.demos.haus/admin/ahnuP3quahti9vis8aiw/models/create
- Check that the "API key" field is not pre-populated
- Check that the "Add model" button is not active unless both a "Name" and valid "API key" (50 chars) exist
- Check that you can manually type an "API key"
- Check that you can create a model successfully

## Testing

- [x] This PR has tests
- [ ] No testing required (explain why):

## Security

- [ ] Security considerations for review (list them):
  - [ ] Examples:
  - [ ] Access control: users can only access their own data
  - [ ] Input: user input is validated and sanitised
  - [ ] Sensitive data: secret or private data is not exposed in any way
  - [ ] ...
- [x] This PR has no security considerations (explain why):

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-30817

## Screenshots
n/a

## UX Approval

- [ ] This PR does not require UX approval
- [x] This PR does require UX approval (add context): This was a feature discussed at the last engineering sprint in Gothenburg where the user shouldn't be able to create a model without an API key and should also be able to type or paste an existing key into the field.
