### PR TITLE
Package name in sidebar (and also near the title, if necessary)

### DIFF
--- a/static/sass/_snapcraft_snap-details.scss
+++ b/static/sass/_snapcraft_snap-details.scss
@@ -106,4 +106,39 @@
       opacity: 0.3;
     }
   }
+
+  .p-package-header {
+    container: pkgname / inline-size;
+
+    &__name {
+      display: inline-block;
+      white-space: nowrap;
+
+      .p-tooltip__message {
+        font-weight: 400;
+      }
+
+      --length: 40; // default value, it should be overridden via inline styles on the element
+      --fs-ratio: 1.765; // height/width (1rem/1ch) ratio measured in the browser
+      // we take the full width of the container and divide it by the number of characters in the
+      // package name (+2 to account for the parentheses): this is the horizontal space that each
+      // character has on average; we multiply this by the fs-ratio to get the font size
+      --target-font-size: calc(
+        (100cqw / (2 + var(--length))) * var(--fs-ratio)
+      );
+      // we limit the font size to the smallest and largest available sizes
+      --max-font-size: #{map-get($settings-text-h1-mobile, font-size)}rem; // size of the title
+      --min-font-size: #{map-get($settings-text-h5-mobile, font-size)}rem; // smallest size we allow
+      font-size: clamp(
+        var(--min-font-size),
+        var(--target-font-size),
+        var(--max-font-size)
+      );
+
+      @media (min-width: $breakpoint-heading-threshold) {
+        --min-font-size: #{map-get($settings-text-h5, font-size)}rem;
+        --max-font-size: #{map-get($settings-text-h1, font-size)}rem;
+      }
+    }
+  }
 }

--- a/static/sass/_snapcraft_snap-details.scss
+++ b/static/sass/_snapcraft_snap-details.scss
@@ -111,13 +111,6 @@
     container: pkgname / inline-size;
 
     &__name {
-      display: inline-block;
-      white-space: nowrap;
-
-      .p-tooltip__message {
-        font-weight: 400;
-      }
-
       --length: 40; // default value, it should be overridden via inline styles on the element
       --fs-ratio: 1.765; // height/width (1rem/1ch) ratio measured in the browser
       // we take the full width of the container and divide it by the number of characters in the
@@ -126,18 +119,26 @@
       --target-font-size: calc(
         (100cqw / (2 + var(--length))) * var(--fs-ratio)
       );
+
       // we limit the font size to the smallest and largest available sizes
       --max-font-size: #{map-get($settings-text-h1-mobile, font-size)}rem; // size of the title
       --min-font-size: #{map-get($settings-text-h5-mobile, font-size)}rem; // smallest size we allow
+
+      @media (min-width: $breakpoint-heading-threshold) {
+        --min-font-size: #{map-get($settings-text-h5, font-size)}rem;
+        --max-font-size: #{map-get($settings-text-h1, font-size)}rem;
+      }
+
+      display: inline-block;
       font-size: clamp(
         var(--min-font-size),
         var(--target-font-size),
         var(--max-font-size)
       );
+      white-space: nowrap;
 
-      @media (min-width: $breakpoint-heading-threshold) {
-        --min-font-size: #{map-get($settings-text-h5, font-size)}rem;
-        --max-font-size: #{map-get($settings-text-h1, font-size)}rem;
+      .p-tooltip__message {
+        font-weight: 400;
       }
     }
   }

--- a/static/sass/_snapcraft_snap-details.scss
+++ b/static/sass/_snapcraft_snap-details.scss
@@ -111,30 +111,39 @@
     container: pkgname / inline-size;
 
     &__name {
-      --length: 40; // default value, it should be overridden via inline styles on the element
-      --fs-ratio: 1.765; // height/width (1rem/1ch) ratio measured in the browser
-      // we take the full width of the container and divide it by the number of characters in the
-      // package name (+2 to account for the parentheses): this is the horizontal space that each
-      // character has on average; we multiply this by the fs-ratio to get the font size
+      // package name string length; 40 is the maximum length the store backend
+      // supports and this is just a default value, it should be overridden via inline styles on
+      // the element
+      --length: 40;
+
+      // font size/character width (1rem/1ch) ratio, a magic number
+      // measured in the browser
+      --fs-width-ratio: 1.77;
+
+      // we take the full width of the container (100cqw) and divide it by the number of
+      // characters in the package name (+2 to account for the parentheses): this is the horizontal
+      // space that each character will use on average; we multiply this by the font size/character
+      // width ratio to get the font size
       --target-font-size: calc(
-        (100cqw / (2 + var(--length))) * var(--fs-ratio)
+        (100cqw / (2 + var(--length))) * var(--fs-width-ratio)
       );
 
-      // we limit the font size to the smallest and largest available sizes
-      --max-font-size: #{map-get($settings-text-h1-mobile, font-size)}rem; // size of the title
-      --min-font-size: #{map-get($settings-text-h5-mobile, font-size)}rem; // smallest size we allow
-
-      @media (min-width: $breakpoint-heading-threshold) {
-        --min-font-size: #{map-get($settings-text-h5, font-size)}rem;
-        --max-font-size: #{map-get($settings-text-h1, font-size)}rem;
-      }
-
-      display: inline-block;
-      font-size: clamp(
+      // we limit the actual font size value to the smallest and largest heading font sizes
+      --font-size: clamp(
         var(--min-font-size),
         var(--target-font-size),
         var(--max-font-size)
       );
+      --min-font-size: #{map-get($settings-text-h6-mobile, font-size)}rem;
+      --max-font-size: #{map-get($settings-text-h1-mobile, font-size)}rem;
+
+      @media (min-width: $breakpoint-heading-threshold) {
+        --min-font-size: #{map-get($settings-text-h6, font-size)}rem;
+        --max-font-size: #{map-get($settings-text-h1, font-size)}rem;
+      }
+
+      display: inline-block;
+      font-size: var(--font-size);
       white-space: nowrap;
 
       .p-tooltip__message {

--- a/templates/store/package_header/_package_header.html
+++ b/templates/store/package_header/_package_header.html
@@ -30,6 +30,7 @@ Other:
     </div>
     <div class="grid-col-6 grid-col-medium-3 grid-col-small-3">
       {{ package_header_data(package_title=snap_title,
+          package_name=package_name,
           icon_url=icon_url,
           developer=developer,
           categories=categories,

--- a/templates/store/package_header/_package_header.html
+++ b/templates/store/package_header/_package_header.html
@@ -3,6 +3,7 @@ Context variables needed for `package_header`:
 
 Snap data:
   snap_title: Title of the snap
+  package_name: the name of the snap (the one you'd type to install it through the CLI)
   icon_url: URL of the icon
   categories: List of categories with slug/name
 

--- a/templates/store/package_header/_package_header_data.html
+++ b/templates/store/package_header/_package_header_data.html
@@ -39,16 +39,16 @@
     developer_validation,
     STAR_DEVELOPER,
     VERIFIED_PUBLISHER) -%}
-  <div class="p-section--shallow">
+  <div class="p-section--shallow p-package-header">
     <h1 class="u-sv-1" data-live="title">
       {{ package_title }}
 
       {# check if the package title could be misleading #}
       {% if package_title.replace(" ", "-").lower() != package_name %}
-        <span class="p-heading--5 p-tooltip--btm-center" aria-label='(registered as "{{ package_name }}")'>
-          ({{ package_name }})
-          <span class="p-tooltip__message" style="font-weight: 400">Package name</span>
-        </span>
+      <span class="p-tooltip--btm-center p-package-header__name" style="--length: {{ package_name | length }};" aria-label='(registered as "{{ package_name }}")'>
+        ({{ package_name }})
+        <span class="p-tooltip__message">Package name</span>
+      </span>
       {% endif %}
     </h1>
     <div class="u-hide--medium u-hide--large">

--- a/templates/store/package_header/_package_header_data.html
+++ b/templates/store/package_header/_package_header_data.html
@@ -28,6 +28,7 @@
 
 {%- macro package_header_data(
     package_title,
+    package_name,
     icon_url,
     developer,
     categories,
@@ -39,7 +40,17 @@
     STAR_DEVELOPER,
     VERIFIED_PUBLISHER) -%}
   <div class="p-section--shallow">
-    <h1 class="u-sv-1" data-live="title">{{ package_title }}</h1>
+    <h1 class="u-sv-1" data-live="title">
+      {{ package_title }}
+
+      {# check if the package title could be misleading #}
+      {% if package_title.replace(" ", "-").lower() != package_name %}
+        <span class="p-heading--5 p-tooltip--btm-center" aria-label='(registered as "{{ package_name }}")'>
+          ({{ package_name }})
+          <span class="p-tooltip__message" style="font-weight: 400">Package name</span>
+        </span>
+      {% endif %}
+    </h1>
     <div class="u-hide--medium u-hide--large">
       {% if developer %}
         {{ developer_info(name=developer[0], url=developer[1]) }}

--- a/templates/store/snap-details/_details.html
+++ b/templates/store/snap-details/_details.html
@@ -1,5 +1,11 @@
 <h2 class="u-off-screen">Details for {{ snap_title }}</h2>
 
+<h3 class="p-muted-heading">Package name</h3>
+<ul class="p-list">
+  <li>{{ package_name }}</li>
+</ul>
+<hr class="p-rule--muted">
+
 <h3 class="p-muted-heading">License</h3>
 <ul class="p-list">
   <li>{{ license }}</li>


### PR DESCRIPTION
## Done
- added package name in details sidebar
- added package name near package title if it differs too much from the name
  - title might be misleading if `package_title.replace(" ", "-").lower() != package_name`

## How to QA
- visit https://snapcraft-io-5602.demos.haus/lxd
  - package title is "LXD"
  - the package name does not appear near the title
- visit https://snapcraft-io-5602.demos.haus/gedit
  - package title is "Text Editor (gedit)"
  - hovering over "(gedit)" displays a tooltip
- visit https://snapcraft-io-5602.demos.haus/test-name-that-is-a-test
  - package title is "looooong package title != package name < line break > (test-name-that-is-a-test)"
  - resize the window, the package name size shrinks

## Testing

- [ ] This PR has tests
- [ ] No testing required (explain why):

## Security

- [ ] Security considerations for review (list them):
  - [ ] Examples:
  - [ ] Access control: users can only access their own data
  - [ ] Input: user input is validated and sanitised
  - [ ] Sensitive data: secret or private data is not exposed in any way
  - [ ] ...
- [x] This PR has no security considerations (explain why): this PR doesn't have any impact on the application from a security point of view

## Issue / Card

Fixes WD-33034

## Screenshots

## UX Approval

- [ ] This PR does not require UX approval
- [x] This PR does require UX approval (add context):
The idea behind this change is to mitigate the risk of fraudulent packages: by making it clear when a snap's title and its name don't match, users will hopefully be able to avoid installing malicious snaps.
To achieve this, adding the package name to the details sidebar is a good first step, but this sidebar isn't always immediately visible on first scroll (e.g. snaps with screenshots/videos), meaning this measure isn't very effective IMO. Adding the package name near the title at the top of the page, on the other hand, makes the mismatch between name and title easier to spot.

Other ideas to consider/explore:
- moving the package name down, putting it on the same line as the publisher info and snap categories
- using some form of string distance to quantify the difference between the package name and package title, adding a warning if it's above a certain threshold
- only showing applying this logic for non-verified publishers