### PR TITLE
feat: Add serial log table

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ canonicalwebteam.discourse==7.2.0
 canonicalwebteam.blog==6.8.4
 canonicalwebteam.search==2.1.2
 canonicalwebteam.image-template==1.9.0
-canonicalwebteam.store-api==7.4.10
+canonicalwebteam.store-api==7.7.0
 canonicalwebteam.launchpad==0.9.0
 django-openid-auth==0.17
 Flask-OpenID==1.3.1

--- a/static/js/publisher/hooks/__tests__/useSerialLogs.test.tsx
+++ b/static/js/publisher/hooks/__tests__/useSerialLogs.test.tsx
@@ -1,0 +1,113 @@
+import { QueryClient, QueryClientProvider } from "react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
+import { setupServer } from "msw/node";
+
+import useSerialLogs from "../useSerialLogs";
+
+import type { ReactNode } from "react";
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: false,
+    },
+  },
+});
+
+const createWrapper = () => {
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+};
+
+const serialLogData = [
+  {
+    "brand-id": "test-brand",
+    "created-at": "2023-09-05T11:55:53.732366",
+    "model-name": "test-model",
+    serial: "test-serial",
+  },
+];
+
+const handlers = [
+  http.get("/api/store/test-brand/models/test-model/serial-log", () => {
+    return HttpResponse.json({
+      data: serialLogData,
+      message: "",
+      success: true,
+    });
+  }),
+  http.get("/api/store/test-brand-fail/models/test-model/serial-log", () => {
+    return HttpResponse.json({
+      data: [],
+      message: "There was a problem fetching serial logs",
+      success: false,
+    });
+  }),
+  http.get("/api/store/test-brand-error/models/test-model/serial-log", () => {
+    return HttpResponse.error();
+  }),
+];
+
+const server = setupServer(...handlers);
+
+beforeAll(() => {
+  server.listen();
+});
+
+afterEach(() => {
+  server.resetHandlers();
+  queryClient.clear();
+});
+
+afterAll(() => {
+  server.close();
+});
+
+describe("useSerialLogs", () => {
+  test("returns serial log data", async () => {
+    const { result } = renderHook(
+      () => useSerialLogs("test-brand", "test-model"),
+      {
+        wrapper: createWrapper(),
+      },
+    );
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(result.current.data).toEqual(serialLogData);
+  });
+
+  test("returns error if request fails", async () => {
+    const { result } = renderHook(
+      () => useSerialLogs("test-brand-fail", "test-model"),
+      {
+        wrapper: createWrapper(),
+      },
+    );
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+
+    expect(result.current.data).toBeUndefined();
+  });
+
+  test("returns error if network error", async () => {
+    const { result } = renderHook(
+      () => useSerialLogs("test-brand-error", "test-model"),
+      {
+        wrapper: createWrapper(),
+      },
+    );
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+
+    expect(result.current.data).toBeUndefined();
+  });
+});

--- a/static/js/publisher/hooks/index.ts
+++ b/static/js/publisher/hooks/index.ts
@@ -16,6 +16,7 @@ import useFetchPublishedSnapMetrics from "./useFetchPublishedSnapMetrics";
 import useSortTableData from "./useSortTableData";
 import useAccountKeys from "./useAccountKeys";
 import useRemodels from "./useRemodels";
+import useSerialLogs from "./useSerialLogs";
 
 export {
   useValidationSets,
@@ -36,4 +37,5 @@ export {
   useSortTableData,
   useAccountKeys,
   useRemodels,
+  useSerialLogs,
 };

--- a/static/js/publisher/hooks/useSerialLogs.ts
+++ b/static/js/publisher/hooks/useSerialLogs.ts
@@ -1,0 +1,31 @@
+import { useQuery, UseQueryResult } from "react-query";
+import type { SerialLog } from "../types/shared";
+
+const useSerialLogs = (
+  brandId: string | undefined,
+  modelId: string | undefined,
+): UseQueryResult<SerialLog[], Error> => {
+  return useQuery<SerialLog[], Error>({
+    queryKey: ["serialLogs", brandId, modelId],
+    queryFn: async () => {
+      const response = await fetch(
+        `/api/store/${brandId}/models/${modelId}/serial-log`,
+      );
+
+      if (!response.ok) {
+        throw new Error("There was a problem fetching serial logs");
+      }
+
+      const data = await response.json();
+
+      if (!data.success) {
+        throw new Error(data.message);
+      }
+
+      return data.data;
+    },
+    enabled: !!brandId,
+  });
+};
+
+export default useSerialLogs;

--- a/static/js/publisher/index.tsx
+++ b/static/js/publisher/index.tsx
@@ -41,6 +41,7 @@ const ValidationSet = importComponent(() => import("./pages/ValidationSet"));
 const ValidationSets = importComponent(() => import("./pages/ValidationSets"));
 const AccountKeys = importComponent(() => import("./pages/AccountKeys"));
 const Remodel = importComponent(() => import("./pages/Remodel"));
+const SerialLogs = importComponent(() => import("./pages/SerialLogs"));
 
 Sentry.init({
   dsn: window.SENTRY_DSN,
@@ -127,6 +128,7 @@ root.render(
                     <Route path="policies/create" element={<Policies />} />
                     <Route path="remodel" element={<Remodel />} />
                     <Route path="remodel/configure" element={<Remodel />} />
+                    <Route path="serial-log" element={<SerialLogs />} />
                   </Route>
                 </Route>
                 <Route path="*" element={<Navigate to="../snaps" replace />} />

--- a/static/js/publisher/pages/SerialLogs/SerialLogs.tsx
+++ b/static/js/publisher/pages/SerialLogs/SerialLogs.tsx
@@ -1,0 +1,75 @@
+import { useEffect } from "react";
+import { useAtomValue, useSetAtom } from "jotai";
+import { useParams, useSearchParams } from "react-router-dom";
+import { Notification, Icon, Row, Col } from "@canonical/react-components";
+
+import { useSerialLogs } from "../../hooks";
+import {
+  serialLogsListState,
+  serialLogsListFilterState,
+} from "../../state/serialLogsState";
+import { brandIdState, brandStoreState } from "../../state/brandStoreState";
+import { setPageTitle } from "../../utils";
+
+import Filter from "../../components/Filter";
+import SerialLogsTable from "./SerialLogsTable";
+
+import type { UseQueryResult } from "react-query";
+import type { SerialLog } from "../../types/shared";
+
+function SerialLogs() {
+  const { id, modelId } = useParams();
+  const brandId = useAtomValue(brandIdState);
+  const {
+    isLoading,
+    isError,
+    error,
+    data,
+  }: UseQueryResult<SerialLog[], Error> = useSerialLogs(brandId, modelId);
+  const setSerialLogs = useSetAtom(serialLogsListState);
+  const setFilter = useSetAtom(serialLogsListFilterState);
+  const brandStore = useAtomValue(brandStoreState(id));
+  const [searchParams] = useSearchParams();
+
+  brandStore
+    ? setPageTitle(`Serial logs for ${modelId} in ${brandStore.name}`)
+    : setPageTitle("Serial logs");
+
+  useEffect(() => {
+    if (!isLoading && !isError && data) {
+      setSerialLogs(data);
+      setFilter(searchParams.get("filter") || "");
+    }
+  }, [isLoading, data, error, brandId, id]);
+
+  return (
+    <div className="u-fixed-width u-flex-column u-flex-grow">
+      {isError && error && (
+        <Notification severity="negative">Error: {error.message}</Notification>
+      )}
+      {isLoading ? (
+        <p>
+          <Icon name="spinner" className="u-animation--spin" />
+          &nbsp;Fetching serial logs...
+        </p>
+      ) : (
+        <>
+          <Row>
+            <Col size={6}>
+              <Filter
+                state={serialLogsListFilterState}
+                label="Search serial logs"
+                placeholder="Search serial logs"
+              />
+            </Col>
+          </Row>
+          <div className="u-flex-column u-flex-grow">
+            <SerialLogsTable />
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+export default SerialLogs;

--- a/static/js/publisher/pages/SerialLogs/SerialLogsTable.tsx
+++ b/static/js/publisher/pages/SerialLogs/SerialLogsTable.tsx
@@ -1,0 +1,62 @@
+import { useAtomValue } from "jotai";
+import { useParams } from "react-router-dom";
+import { MainTable, TablePagination } from "@canonical/react-components";
+import { format } from "date-fns";
+
+import { brandStoreState } from "../../state/brandStoreState";
+import { filteredSerialLogsListState } from "../../state/serialLogsState";
+import { useSortTableData } from "../../hooks";
+
+import type { SerialLog } from "../../types/shared";
+
+function SerialLogsTable(): React.JSX.Element {
+  const { id } = useParams();
+  const serialLogs = useAtomValue(filteredSerialLogsListState);
+  const brandStore = useAtomValue(brandStoreState(id));
+
+  const headers = [
+    { content: "Brand" },
+    { content: "Model" },
+    { content: "Serial number" },
+    { content: "Date", sortKey: "created-at" },
+  ];
+
+  const rows = serialLogs.map((serialLog: SerialLog) => {
+    return {
+      columns: [
+        { content: brandStore?.name },
+        { content: serialLog["model-name"] },
+        { content: serialLog.serial },
+        {
+          content: format(
+            new Date(serialLog["created-at"]),
+            "dd/MM/yyyy 'at' HH:mm",
+          ),
+        },
+      ],
+      sortData: {
+        "created-at": serialLog["created-at"],
+      },
+    };
+  });
+
+  const { rows: sortedRows, updateSort } = useSortTableData({ rows });
+
+  return (
+    <TablePagination
+      data={sortedRows}
+      pageLimits={[25, 50, 100, 200]}
+      position="below"
+    >
+      <MainTable
+        data-testid="serial-log-table"
+        sortable
+        emptyStateMsg="No serial logs match this filter"
+        headers={headers}
+        onUpdateSort={updateSort}
+      />
+    </TablePagination>
+  );
+}
+
+export default SerialLogsTable;

--- a/static/js/publisher/pages/SerialLogs/__tests__/SerialLogs.test.tsx
+++ b/static/js/publisher/pages/SerialLogs/__tests__/SerialLogs.test.tsx
@@ -1,0 +1,54 @@
+import { BrowserRouter } from "react-router-dom";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { render, screen } from "@testing-library/react";
+
+import "@testing-library/jest-dom";
+
+import SerialLogs from "../SerialLogs";
+
+const mockFilterQuery = "test-serial";
+
+vi.mock("react-router-dom", async (importOriginal) => ({
+  ...(await importOriginal()),
+  useSearchParams: () => [new URLSearchParams({ filter: mockFilterQuery })],
+}));
+
+vi.mock("../../Portals/Portals", async (importOriginal) => ({
+  ...(await importOriginal()),
+  PortalEntrance: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+}));
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      refetchOnWindowFocus: false,
+      refetchOnReconnect: false,
+    },
+  },
+});
+
+function renderComponent() {
+  return render(
+    <BrowserRouter>
+      <QueryClientProvider client={queryClient}>
+        <SerialLogs />
+      </QueryClientProvider>
+    </BrowserRouter>,
+  );
+}
+
+describe("SerialLogs", () => {
+  it("displays a filter input", () => {
+    renderComponent();
+    expect(screen.getByLabelText("Search serial logs")).toBeInTheDocument();
+  });
+
+  it("populates filter with the filter query parameter", () => {
+    renderComponent();
+    expect(screen.getByLabelText("Search serial logs")).toHaveValue(
+      mockFilterQuery,
+    );
+  });
+});

--- a/static/js/publisher/pages/SerialLogs/__tests__/SerialLogsTable.test.tsx
+++ b/static/js/publisher/pages/SerialLogs/__tests__/SerialLogsTable.test.tsx
@@ -1,0 +1,52 @@
+import { BrowserRouter } from "react-router-dom";
+import { QueryClientProvider, QueryClient } from "react-query";
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+import SerialLogsTable from "../SerialLogsTable";
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      refetchOnWindowFocus: false,
+      refetchOnReconnect: false,
+    },
+  },
+});
+
+const renderComponent = () => {
+  return render(
+    <BrowserRouter>
+      <QueryClientProvider client={queryClient}>
+        <SerialLogsTable />
+      </QueryClientProvider>
+    </BrowserRouter>,
+  );
+};
+
+describe("SerialLogsTable", () => {
+  it("renders", () => {
+    renderComponent();
+    expect(screen.getByTestId("serial-log-table")).toBeInTheDocument();
+  });
+
+  it("renders the correct columns", () => {
+    renderComponent();
+
+    expect(
+      screen.getByRole("columnheader", { name: "Brand" }),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByRole("columnheader", { name: "Model" }),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByRole("columnheader", { name: "Serial number" }),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByRole("columnheader", { name: "Date" }),
+    ).toBeInTheDocument();
+  });
+});

--- a/static/js/publisher/pages/SerialLogs/index.ts
+++ b/static/js/publisher/pages/SerialLogs/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./SerialLogs";

--- a/static/js/publisher/state/serialLogsState.ts
+++ b/static/js/publisher/state/serialLogsState.ts
@@ -1,0 +1,42 @@
+import { atom } from "jotai";
+
+import type { SerialLog } from "../types/shared";
+
+const serialLogsListState = atom([] as SerialLog[]);
+
+const serialLogsListFilterState = atom("" as string);
+
+function getFilteredSerialLogs(
+  serialLogs: Array<SerialLog>,
+  filterQuery?: string | null,
+) {
+  if (!filterQuery) {
+    return serialLogs;
+  }
+
+  return serialLogs.filter((serialLog: SerialLog) => {
+    if (
+      (serialLog["brand-id"] && serialLog["brand-id"].includes(filterQuery)) ||
+      (serialLog["model-name"] &&
+        serialLog["model-name"].includes(filterQuery)) ||
+      (serialLog.serial && serialLog.serial.includes(filterQuery))
+    ) {
+      return true;
+    }
+
+    return false;
+  });
+}
+
+const filteredSerialLogsListState = atom<Array<SerialLog>>((get) => {
+  const filter = get(serialLogsListFilterState);
+  const serialLogs = get(serialLogsListState);
+
+  return getFilteredSerialLogs(serialLogs, filter);
+});
+
+export {
+  serialLogsListState,
+  serialLogsListFilterState,
+  filteredSerialLogsListState,
+};

--- a/static/js/publisher/types/shared.ts
+++ b/static/js/publisher/types/shared.ts
@@ -188,3 +188,12 @@ export type Remodel = {
   "to-model": string;
   serials?: number;
 };
+
+export type SerialLog = {
+  "brand-id": string;
+  "created-at": string;
+  "model-name": string;
+  serial: string;
+  "serial-assertion"?: string;
+  "serial-sign-key-sha3-384"?: string;
+};

--- a/tests/endpoints/tests_models.py
+++ b/tests/endpoints/tests_models.py
@@ -344,13 +344,12 @@ class TestCreateRemodelAllowlist(TestModelServiceEndpoints):
         self.assertEqual(data["message"], "An error occurred")
 
 
-class TestGetSerialLog(TestModelServiceEndpoints):
+class TestGetSerialLogs(TestModelServiceEndpoints):
     @patch(
         "canonicalwebteam.store_api.publishergw.PublisherGW"
-        + ".get_store_model_serial_log"
+        + ".get_store_model_serial_logs"
     )
-    @patch("canonicalwebteam.store_api.dashboard.Dashboard.get_store")
-    def test_get_serial_log_success(self, mock_get_store, mock_get_serial_log):
+    def test_get_serial_logs_success(self, mock_get_serial_logs):
         mock_serial_log = [
             {
                 "brand-id": "test-brand-id",
@@ -359,8 +358,7 @@ class TestGetSerialLog(TestModelServiceEndpoints):
                 "serial": "test-serial",
             }
         ]
-        mock_get_serial_log.return_value = {"items": mock_serial_log}
-        mock_get_store.return_value = {"brand-id": "test-brand-id"}
+        mock_get_serial_logs.return_value = {"items": mock_serial_log}
 
         response = self.client.get("/api/store/1/models/test-model/serial-log")
         data = response.json
@@ -371,12 +369,10 @@ class TestGetSerialLog(TestModelServiceEndpoints):
 
     @patch(
         "canonicalwebteam.store_api.publishergw.PublisherGW"
-        + ".get_store_model_serial_log"
+        + ".get_store_model_serial_logs"
     )
-    @patch("canonicalwebteam.store_api.dashboard.Dashboard.get_store")
-    def test_get_serial_log_empty(self, mock_get_store, mock_get_serial_log):
-        mock_get_serial_log.return_value = {"items": []}
-        mock_get_store.return_value = {"brand-id": "test-brand-id"}
+    def test_get_serial_logs_empty(self, mock_get_serial_logs):
+        mock_get_serial_logs.return_value = {"items": []}
 
         response = self.client.get("/api/store/1/models/test-model/serial-log")
         data = response.json
@@ -387,16 +383,12 @@ class TestGetSerialLog(TestModelServiceEndpoints):
 
     @patch(
         "canonicalwebteam.store_api.publishergw.PublisherGW"
-        + ".get_store_model_serial_log"
+        + ".get_store_model_serial_logs"
     )
-    @patch("canonicalwebteam.store_api.dashboard.Dashboard.get_store")
-    def test_get_serial_log_unauthorized(
-        self, mock_get_store, mock_get_serial_log
-    ):
-        mock_get_serial_log.side_effect = StoreApiResponseErrorList(
+    def test_get_serial_logs_unauthorized(self, mock_get_serial_logs):
+        mock_get_serial_logs.side_effect = StoreApiResponseErrorList(
             "unauthorized", 401, [{"message": "unauthorized"}]
         )
-        mock_get_store.return_value = {"brand-id": "test-brand-id"}
 
         response = self.client.get("/api/store/1/models/test-model/serial-log")
         data = response.json
@@ -407,13 +399,13 @@ class TestGetSerialLog(TestModelServiceEndpoints):
 
     @patch(
         "canonicalwebteam.store_api.publishergw.PublisherGW"
-        + ".get_store_model_serial_log"
+        + ".get_store_model_serial_logs"
     )
     @patch("canonicalwebteam.store_api.dashboard.Dashboard.get_store")
-    def test_get_serial_log_store_not_found(
-        self, mock_get_store, mock_get_serial_log
+    def test_get_serial_logs_store_not_found(
+        self, mock_get_store, mock_get_serial_logs
     ):
-        mock_get_serial_log.side_effect = StoreApiResponseErrorList(
+        mock_get_serial_logs.side_effect = StoreApiResponseErrorList(
             "Store not found", 404, [{"message": "Store not found"}]
         )
         mock_get_store.return_value = {"brand-id": "test-brand-id"}
@@ -429,18 +421,14 @@ class TestGetSerialLog(TestModelServiceEndpoints):
 
     @patch(
         "canonicalwebteam.store_api.publishergw.PublisherGW"
-        + ".get_store_model_serial_log"
+        + ".get_store_model_serial_logs"
     )
-    @patch("canonicalwebteam.store_api.dashboard.Dashboard.get_store")
-    def test_get_serial_log_general_error(
-        self, mock_get_store, mock_get_serial_log
-    ):
-        mock_get_serial_log.side_effect = StoreApiResponseErrorList(
+    def test_get_serial_logs_general_error(self, mock_get_serial_logs):
+        mock_get_serial_logs.side_effect = StoreApiResponseErrorList(
             "Internal server error",
             500,
             [{"message": "Internal server error"}],
         )
-        mock_get_store.return_value = {"brand-id": "test-brand-id"}
 
         response = self.client.get("/api/store/1/models/test-model/serial-log")
         data = response.json

--- a/webapp/endpoints/models.py
+++ b/webapp/endpoints/models.py
@@ -352,14 +352,13 @@ def create_remodel_allowlist(store_id: str):
 @models.route("/api/store/<store_id>/models/<model_name>/serial-log")
 @login_required
 @exchange_required
-def get_serial_log(store_id: str, model_name: str):
+def get_serial_logs(store_id: str, model_name: str):
     res = {}
 
     try:
-        brand_id = get_brand_id(flask.session, store_id)
-        logs = publisher_gateway.get_store_model_serial_log(
+        logs = publisher_gateway.get_store_model_serial_logs(
             flask.session,
-            brand_id,
+            store_id,
             model_name,
         )
         res["data"] = logs["items"]


### PR DESCRIPTION
## Done
Adds the serial logs table to the models service

## How to QA
- Go to https://snapcraft-io-5636.demos.haus/admin/ahnuP3quahti9vis8aiw/models/test-superalpaca-00/serial-log
- Check that there is a table that displays serial logs
- **Note**: This isn't shown in the navigation as we don't want to surface it to users without access until we can figure out how to handle permissions

## Testing

- [x] This PR has tests
- [ ] No testing required (explain why):

## Security

- [ ] Security considerations for review (list them):
  - [ ] Examples:
  - [ ] Access control: users can only access their own data
  - [ ] Input: user input is validated and sanitised
  - [ ] Sensitive data: secret or private data is not exposed in any way
  - [ ] ...
- [x] This PR has no security considerations (explain why): No user input

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-35104

## Screenshots
<img width="1440" height="1364" alt="serial-logs" src="https://github.com/user-attachments/assets/39970131-21ea-418a-bbe2-21f389dafac2" />

## UX Approval

- [ ] This PR does not require UX approval
- [x] This PR does require UX approval (add context):
