### PR TITLE
fix: Remove remodel link from model navigation

### DIFF
--- a/static/js/publisher/layouts/ModelDetailsPageLayout/ModelNav.tsx
+++ b/static/js/publisher/layouts/ModelDetailsPageLayout/ModelNav.tsx
@@ -26,16 +26,6 @@ function ModelNav({ sectionName }: { sectionName: string }): React.JSX.Element {
             Policies
           </Link>
         </li>
-        <li className="p-tabs__item">
-          <Link
-            to={`/admin/${id}/models/${modelId}/remodel`}
-            className="p-tabs__link"
-            aria-selected={sectionName === "remodel"}
-            role="tab"
-          >
-            Remodel
-          </Link>
-        </li>
       </ul>
     </nav>
   );


### PR DESCRIPTION
## Done
Removes "Remodels" link from the models navigation as the majority of users currently don't have access to these.

## How to QA
- Go to https://snapcraft-io-5665.demos.haus/admin/ahnuP3quahti9vis8aiw/models/test-superalpaca-00
- Check that there is no link to "Remodels" in the horizontal navigation
- Go to https://snapcraft-io-5665.demos.haus/admin/ahnuP3quahti9vis8aiw/models/test-superalpaca-00/remodel
- Check that the remodel page is still there (there is a bug where the remodels aren't showing in the table which I'll address separately: https://warthogs.atlassian.net/browse/WD-35858)

## Testing

- [ ] This PR has tests
- [x] No testing required (explain why):

## Security

- [ ] Security considerations for review (list them):
  - [ ] Examples:
  - [ ] Access control: users can only access their own data
  - [ ] Input: user input is validated and sanitised
  - [ ] Sensitive data: secret or private data is not exposed in any way
  - [ ] ...
- [ ] This PR has no security considerations (explain why):

## Issue / Card

Fixes #

## Screenshots

## UX Approval

- [ ] This PR does not require UX approval
- [ ] This PR does require UX approval (add context):
