### PR TITLE
fix: change marketo form submission URL

### DIFF
--- a/templates/partials/_newsletter-signup.html
+++ b/templates/partials/_newsletter-signup.html
@@ -2,7 +2,7 @@
   <h5 class="p-muted-heading">Newsletter Signup</h5>
   <hr class="u-sv1" />
     <div class="p-card__content js-newsletter-signup">
-        <form action="https://pages.canonical.com/index.php/leadCapture/save" method="post" class="p-form" id="mktoForm_3376">
+        <form action="https://ubuntu.com/marketo/submit" method="post" class="p-form" id="mktoForm_3376">
             <div class="p-form__group">
                 <label for="Email" class="u-no-padding--top">Email:*</label>
                 <input id="Email" name="Email" maxlength="255" type="email" required />
@@ -28,7 +28,7 @@
             <input type="hidden" name="subId" value="" />
             <input type="hidden" name="munchkinId" value="066-EOV-335" />
             <input type="hidden" name="lpurl" value="" />
-            <input type="hidden" name="ret" value="{{host_url[:-1]}}{{path}}?newsletter=true" />
+            <input type="hidden" name="returnURL" value="{{host_url[:-1]}}{{path}}?newsletter=true" />
             <input type="hidden" name="cr" value="" />
             <input type="hidden" name="kw" value="" />
             <input type="hidden" name="q" value="" />


### PR DESCRIPTION
## Done
- fixed submissions for the blog newsletter form
  - changed submit endpoint (`https://ubuntu.com/marketo/submit`)
  - changed returnURL parameter name to match what the new endpoint expects

## How to QA
- go to https://snapcraft-io-5668.demos.haus/blog
- subscribe to the newsletter
- the page should refresh and show a success message at the top 
<img width="371" height="226" alt="immagine" src="https://github.com/user-attachments/assets/272e9b0f-919d-422d-95b9-ca6da3058206" />


## Testing

- [ ] This PR has tests
- [x] No testing required (explain why): can't test marketo

## Security

- [ ] Security considerations for review (list them):
  - [ ] Examples:
  - [ ] Access control: users can only access their own data
  - [ ] Input: user input is validated and sanitised
  - [ ] Sensitive data: secret or private data is not exposed in any way
  - [ ] ...
- [x] This PR has no security considerations (explain why): it's a subscription form that only accepts emails

## Issue / Card

Fixes WD-35855

## Screenshots

## UX Approval

- [x] This PR does not require UX approval
- [ ] This PR does require UX approval (add context):
