### PR TITLE
fix: Only show remodels to users with permissions

### DIFF
--- a/static/js/publisher/hooks/__tests__/useRemodels.test.tsx
+++ b/static/js/publisher/hooks/__tests__/useRemodels.test.tsx
@@ -34,19 +34,18 @@ const remodelsResponse = {
       "to-model": "test-to-model",
     },
   ],
+  "next-cursor": null,
 };
 
 const handlers = [
   http.get("/api/store/test-brand-id/models/remodel-allowlist", () => {
     return HttpResponse.json({
       data: remodelsResponse,
-      message: "",
       success: true,
     });
   }),
   http.get("/api/store/test-brand-id-fail/models/remodel-allowlist", () => {
     return HttpResponse.json({
-      data: [],
       message: "There was a problem fetching remodels",
       success: false,
     });
@@ -84,7 +83,10 @@ describe("useRemodels", () => {
       expect(result.current.isSuccess).toBe(true);
     });
 
-    expect(result.current.data).toEqual(remodelsResponse.allowlist);
+    expect(result.current.data).toEqual({
+      data: remodelsResponse,
+      success: true,
+    });
   });
 
   test("returns error if request fails", async () => {
@@ -96,10 +98,13 @@ describe("useRemodels", () => {
     );
 
     await waitFor(() => {
-      expect(result.current.isError).toBe(true);
+      expect(result.current.isSuccess).toBe(true);
     });
 
-    expect(result.current.data).toBeUndefined();
+    expect(result.current.data).toEqual({
+      message: "There was a problem fetching remodels",
+      success: false,
+    });
   });
 
   test("returns error if network error", async () => {

--- a/static/js/publisher/hooks/useRemodels.ts
+++ b/static/js/publisher/hooks/useRemodels.ts
@@ -1,46 +1,45 @@
 import { useQuery, UseQueryResult } from "react-query";
-import type { Remodel } from "../types/shared";
+import type { Remodel, RemodelResponse, ApiResponse } from "../types/shared";
 
 const useRemodels = (
   brandId: string | undefined,
   modelId: string | undefined,
-): UseQueryResult<Remodel[], Error> => {
-  return useQuery<Remodel[], Error>({
+): UseQueryResult<ApiResponse<RemodelResponse>, Error> => {
+  return useQuery<ApiResponse<RemodelResponse>, Error>({
     queryKey: ["remodels", brandId, modelId],
     queryFn: async () => {
       const response = await fetch(
         `/api/store/${brandId}/models/remodel-allowlist`,
       );
 
-      if (!response.ok) {
-        throw new Error("There was a problem fetching remodels");
+      const responseData = await response.json();
+
+      if (responseData.data?.allowlist) {
+        const remodelsForCurrentModel = responseData.data.allowlist.filter(
+          (remodel: Remodel) => {
+            return (
+              remodel["from-model"] === modelId ||
+              remodel["to-model"] === modelId
+            );
+          },
+        );
+
+        responseData.data.allowlist = remodelsForCurrentModel.sort(
+          (a: Remodel, b: Remodel) => {
+            if (a["created-at"] > b["created-at"]) {
+              return -1;
+            }
+
+            if (a["created-at"] < b["created-at"]) {
+              return 1;
+            }
+
+            return 0;
+          },
+        );
       }
 
-      const data = await response.json();
-
-      if (!data.success) {
-        throw new Error(data.message);
-      }
-
-      const remodelsForCurrentModel = data.data.allowlist.filter(
-        (remodel: Remodel) => {
-          return (
-            remodel["from-model"] === modelId || remodel["to-model"] === modelId
-          );
-        },
-      );
-
-      return remodelsForCurrentModel.sort((a: Remodel, b: Remodel) => {
-        if (a["created-at"] > b["created-at"]) {
-          return -1;
-        }
-
-        if (a["created-at"] < b["created-at"]) {
-          return 1;
-        }
-
-        return 0;
-      });
+      return responseData;
     },
     enabled: !!brandId,
   });

--- a/static/js/publisher/layouts/ModelDetailsPageLayout/ModelNav.tsx
+++ b/static/js/publisher/layouts/ModelDetailsPageLayout/ModelNav.tsx
@@ -1,7 +1,13 @@
 import { Link, useParams } from "react-router-dom";
+import { useAtomValue } from "jotai";
+
+import { useRemodels } from "../../hooks";
+import { brandIdState } from "../../state/brandStoreState";
 
 function ModelNav({ sectionName }: { sectionName: string }): React.JSX.Element {
   const { id, modelId } = useParams();
+  const brandId = useAtomValue(brandIdState);
+  const { data } = useRemodels(brandId, modelId);
 
   return (
     <nav className="p-tabs">
@@ -26,6 +32,18 @@ function ModelNav({ sectionName }: { sectionName: string }): React.JSX.Element {
             Policies
           </Link>
         </li>
+        {data?.success && (
+          <li className="p-tabs__item">
+            <Link
+              to={`/admin/${id}/models/${modelId}/remodel`}
+              className="p-tabs__link"
+              aria-selected={sectionName === "remodel"}
+              role="tab"
+            >
+              Remodel
+            </Link>
+          </li>
+        )}
       </ul>
     </nav>
   );

--- a/static/js/publisher/layouts/ModelDetailsPageLayout/__tests__/ModelNav.test.tsx
+++ b/static/js/publisher/layouts/ModelDetailsPageLayout/__tests__/ModelNav.test.tsx
@@ -1,27 +1,118 @@
 import { BrowserRouter } from "react-router-dom";
+import { QueryClient, QueryClientProvider } from "react-query";
 import { render, screen } from "@testing-library/react";
+import { vi } from "vitest";
 import "@testing-library/jest-dom";
 
 import ModelNav from "../ModelNav";
+import { useRemodels } from "../../../hooks";
 
-const renderComponent = () => {
+import type { UseQueryResult } from "react-query";
+import type { ApiResponse, RemodelResponse } from "../../../types/shared";
+
+vi.mock("../../../hooks", () => ({
+  useRemodels: vi.fn(),
+}));
+
+vi.mock("../../../state/brandStoreState", () => ({
+  brandIdState: "mock-brand-id",
+}));
+
+vi.mock("jotai", () => ({
+  useAtomValue: vi.fn(() => "mock-brand-id"),
+}));
+
+const queryClient = new QueryClient();
+
+const renderComponent = (sectionName: string) => {
   return render(
     <BrowserRouter>
-      <ModelNav sectionName="policies" />
+      <QueryClientProvider client={queryClient}>
+        <ModelNav sectionName={sectionName} />
+      </QueryClientProvider>
     </BrowserRouter>,
   );
 };
 
 describe("ModelNav", () => {
   it("highlights the correct navigation item", () => {
-    renderComponent();
+    const mockUseRemodels = vi.mocked(useRemodels);
+    mockUseRemodels.mockReturnValue({
+      data: {
+        success: true,
+        data: {
+          allowlist: [],
+          "next-cursor": null,
+        },
+      },
+    } as unknown as UseQueryResult<ApiResponse<RemodelResponse>, Error>);
+
+    renderComponent("policies");
     const currentLink = screen.getByRole("tab", { name: "Policies" });
     expect(currentLink.getAttribute("aria-selected")).toBe("true");
   });
 
   it("doesn't highlight other navigation links", () => {
-    renderComponent();
+    const mockUseRemodels = vi.mocked(useRemodels);
+    mockUseRemodels.mockReturnValue({
+      data: {
+        success: true,
+        data: {
+          allowlist: [],
+          "next-cursor": null,
+        },
+      },
+    } as unknown as UseQueryResult<ApiResponse<RemodelResponse>, Error>);
+
+    renderComponent("policies");
     const currentLink = screen.getByRole("tab", { name: "Overview" });
     expect(currentLink.getAttribute("aria-selected")).toBe("false");
+  });
+
+  it("shows Remodel tab when useRemodels returns success: true", () => {
+    const mockUseRemodels = vi.mocked(useRemodels);
+    mockUseRemodels.mockReturnValue({
+      data: {
+        success: true,
+        data: {
+          allowlist: [],
+          "next-cursor": null,
+        },
+      },
+    } as unknown as UseQueryResult<ApiResponse<RemodelResponse>, Error>);
+
+    renderComponent("overview");
+    expect(screen.getByRole("tab", { name: "Remodel" })).toBeInTheDocument();
+  });
+
+  it("hides Remodel tab when useRemodels returns success: false", () => {
+    const mockUseRemodels = vi.mocked(useRemodels);
+    mockUseRemodels.mockReturnValue({
+      data: {
+        success: false,
+        message: "Remodeling not available",
+        data: {
+          allowlist: [],
+          "next-cursor": null,
+        },
+      },
+    } as unknown as UseQueryResult<ApiResponse<RemodelResponse>, Error>);
+
+    renderComponent("overview");
+    expect(
+      screen.queryByRole("tab", { name: "Remodel" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("hides Remodel tab when useRemodels returns no data", () => {
+    const mockUseRemodels = vi.mocked(useRemodels);
+    mockUseRemodels.mockReturnValue({
+      data: undefined,
+    } as unknown as UseQueryResult<ApiResponse<RemodelResponse>, Error>);
+
+    renderComponent("overview");
+    expect(
+      screen.queryByRole("tab", { name: "Remodel" }),
+    ).not.toBeInTheDocument();
   });
 });

--- a/static/js/publisher/pages/Remodel/Remodel.tsx
+++ b/static/js/publisher/pages/Remodel/Remodel.tsx
@@ -22,7 +22,7 @@ import RemodelTable from "./RemodelTable";
 import ConfigureRemodelForm from "./ConfigureRemodelForm";
 
 import type { UseQueryResult } from "react-query";
-import type { Remodel } from "../../types/shared";
+import type { Remodel, RemodelResponse, ApiResponse } from "../../types/shared";
 
 function Remodel(): React.JSX.Element {
   const { id, modelId } = useParams();
@@ -33,7 +33,10 @@ function Remodel(): React.JSX.Element {
     error,
     data,
     refetch,
-  }: UseQueryResult<Remodel[], Error> = useRemodels(brandId, modelId);
+  }: UseQueryResult<ApiResponse<RemodelResponse>, Error> = useRemodels(
+    brandId,
+    modelId,
+  );
   const setRemodels = useSetAtom(remodelsListState);
   const setFilter = useSetAtom(remodelsListFilterState);
   const [showNotification, setShowNotification] = useState(false);
@@ -49,7 +52,7 @@ function Remodel(): React.JSX.Element {
 
   useEffect(() => {
     if (!isLoading && !isError && data) {
-      setRemodels(data);
+      setRemodels(data.data?.allowlist || []);
       setFilter(searchParams.get("filter") || "");
     }
   }, [isLoading, error, data, brandId, id]);
@@ -67,6 +70,10 @@ function Remodel(): React.JSX.Element {
             <Icon name="spinner" className="u-animation--spin" />
             &nbsp;Fetching remodels...
           </p>
+        ) : data && data.success === false ? (
+          <Notification severity="caution">
+            {data.message || "Unable to fetch remodels"}
+          </Notification>
         ) : (
           <>
             <Row>

--- a/static/js/publisher/pages/Remodel/__tests__/Remodel.test.tsx
+++ b/static/js/publisher/pages/Remodel/__tests__/Remodel.test.tsx
@@ -1,10 +1,19 @@
 import { BrowserRouter } from "react-router-dom";
 import { QueryClient, QueryClientProvider } from "react-query";
+import { vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 
 import "@testing-library/jest-dom";
 
 import Remodel from "../Remodel";
+import { useRemodels, useModels, useSortTableData } from "../../../hooks";
+
+import type { UseQueryResult } from "react-query";
+import type {
+  ApiResponse,
+  RemodelResponse,
+  Model,
+} from "../../../types/shared";
 
 const mockFilterQuery = "test-model";
 
@@ -18,6 +27,12 @@ vi.mock("../../Portals/Portals", async (importOriginal) => ({
   PortalEntrance: ({ children }: { children: React.ReactNode }) => (
     <>{children}</>
   ),
+}));
+
+vi.mock("../../../hooks", () => ({
+  useRemodels: vi.fn(),
+  useModels: vi.fn(),
+  useSortTableData: vi.fn(),
 }));
 
 const queryClient = new QueryClient({
@@ -39,16 +54,91 @@ function renderComponent() {
   );
 }
 
+const useRemodelsNoPermissions = {
+  data: {
+    message: "There was a problem fetching remodels",
+    success: false,
+  },
+  isLoading: false,
+  isError: false,
+} as UseQueryResult<ApiResponse<RemodelResponse>, Error>;
+
+const useRemodelsPermissions = {
+  data: {
+    data: { allowlist: [], "next-cursor": null },
+    success: true,
+  },
+  isLoading: false,
+  isError: false,
+} as unknown as UseQueryResult<ApiResponse<RemodelResponse>, Error>;
+
+const mockUseModels = vi.mocked(useModels);
+mockUseModels.mockReturnValue({
+  data: [],
+} as unknown as UseQueryResult<Model[], Error>);
+
+const mockUseSortTableData = vi.mocked(useSortTableData);
+mockUseSortTableData.mockReturnValue({
+  rows: [],
+  updateSort: vi.fn(),
+});
+
+const mockUseRemodels = vi.mocked(useRemodels);
+
 describe("Remodel", () => {
-  it("displays a filter input", () => {
+  it("displays message if user has no remodels access", () => {
+    mockUseRemodels.mockReturnValue(useRemodelsNoPermissions);
+    renderComponent();
+    expect(
+      screen.getByText("There was a problem fetching remodels"),
+    ).toBeInTheDocument();
+  });
+
+  it("doesn't display filter if user has no remodels access", () => {
+    mockUseRemodels.mockReturnValue(useRemodelsNoPermissions);
+    renderComponent();
+    expect(screen.queryByLabelText("Search remodels")).not.toBeInTheDocument();
+  });
+
+  it("doesn't display table if user has no remodels access", () => {
+    mockUseRemodels.mockReturnValue(useRemodelsNoPermissions);
+    renderComponent();
+    expect(screen.queryByTestId("remodel-table")).not.toBeInTheDocument();
+  });
+
+  it("doesn't display 'Configure' button if user has no remodels access", () => {
+    mockUseRemodels.mockReturnValue(useRemodelsNoPermissions);
+    renderComponent();
+    expect(
+      screen.queryByRole("link", { name: "Configure remodels" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("doesn't display message if user has remodels access", () => {
+    mockUseRemodels.mockReturnValue(useRemodelsPermissions);
+    renderComponent();
+    expect(
+      screen.queryByText("There was a problem fetching remodels"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("displays filter if user has remodels access", () => {
+    mockUseRemodels.mockReturnValue(useRemodelsPermissions);
     renderComponent();
     expect(screen.getByLabelText("Search remodels")).toBeInTheDocument();
   });
 
-  it("populates filter with the filter query parameter", () => {
+  it("displays table if user has remodels access", () => {
+    mockUseRemodels.mockReturnValue(useRemodelsPermissions);
     renderComponent();
-    expect(screen.getByLabelText("Search remodels")).toHaveValue(
-      mockFilterQuery,
-    );
+    expect(screen.getByTestId("remodel-table")).toBeInTheDocument();
+  });
+
+  it("displays 'Configure' button if user has remodels access", () => {
+    mockUseRemodels.mockReturnValue(useRemodelsPermissions);
+    renderComponent();
+    expect(
+      screen.getByRole("link", { name: "Configure remodels" }),
+    ).toBeInTheDocument();
   });
 });

--- a/static/js/publisher/types/shared.ts
+++ b/static/js/publisher/types/shared.ts
@@ -188,3 +188,14 @@ export type Remodel = {
   "to-model": string;
   serials?: number;
 };
+
+export type RemodelResponse = {
+  allowlist: Remodel[];
+  "next-cursor": string | null;
+};
+
+export type ApiResponse<T> = {
+  data?: T;
+  success: boolean;
+  message?: string;
+};


### PR DESCRIPTION
## Done
- Only displays "Remodels" tab if user has permissions
- Shows message to user without permissions if they happen to get to the remodels page
- Creates an `ApiResonse` type for reuse across custom `useQuery` hooks

## How to QA
- Go to https://snapcraft-io-5669.demos.haus/admin/ahnuP3quahti9vis8aiw/models/test-superalpaca-00
- Check that there is a "Remodel" tab in the horizontal navigation
- Go to https://snapcraft-io-5669.demos.haus/admin/ahnuP3quahti9vis8aiw/models/test-superalpaca-00/remodel
- Check that there is a table of remodels
- Go to https://snapcraft-io-5669.demos.haus/admin/nah4ahShap8aefie6pha/models/steve-test
- Check that there is **NOT** a "Remodel" tab in the horizontal navigation
- Go to https://snapcraft-io-5669.demos.haus/admin/nah4ahShap8aefie6pha/models/steve-test/remodel
- Check that there is a notification telling the user they don't have permissions

## Testing

- [x] This PR has tests
- [ ] No testing required (explain why):

## Security

- [ ] Security considerations for review (list them):
  - [ ] Examples:
  - [ ] Access control: users can only access their own data
  - [ ] Input: user input is validated and sanitised
  - [ ] Sensitive data: secret or private data is not exposed in any way
  - [ ] ...
- [x] This PR has no security considerations (explain why): No user input

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-35865

## Screenshots
n/a

## UX Approval

- [x] This PR does not require UX approval
- [ ] This PR does require UX approval (add context):
