### PR TITLE
feat: Add endpoints to update and delete remodel allowlists

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ canonicalwebteam.discourse==7.2.0
 canonicalwebteam.blog==6.8.4
 canonicalwebteam.search==2.1.2
 canonicalwebteam.image-template==1.9.0
-canonicalwebteam.store-api==7.7.0
+canonicalwebteam.store-api==7.8.1
 canonicalwebteam.launchpad==0.9.0
 django-openid-auth==0.17
 Flask-OpenID==1.3.1

--- a/tests/endpoints/tests_models.py
+++ b/tests/endpoints/tests_models.py
@@ -344,6 +344,434 @@ class TestCreateRemodelAllowlist(TestModelServiceEndpoints):
         self.assertEqual(data["message"], "An error occurred")
 
 
+class TestUpdateRemodelAllowlist(TestModelServiceEndpoints):
+    @patch(
+        "canonicalwebteam.store_api.publishergw.PublisherGW"
+        + ".update_remodel_allowlist"
+    )
+    def test_update_remodel_allowlist_success(
+        self, mock_update_remodel_allowlist
+    ):
+        mock_update_remodel_allowlist.return_value = None
+
+        payload = {
+            "description": "Updated remodel allowlist",
+            "from-model": "updated-from-model",
+            "from-serial": "updated-from-serial",
+            "to-model": "updated-to-model",
+        }
+
+        response = self.client.patch(
+            "/api/store/1/models/remodel-allowlist", json=payload
+        )
+        data = response.json
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(data["success"])
+        # Verify dict payload was wrapped in a list
+        mock_update_remodel_allowlist.assert_called_once_with(
+            mock_update_remodel_allowlist.call_args[0][0],  # flask.session
+            "1",  # store_id
+            [payload],  # Dict should be wrapped in a list
+        )
+
+    @patch(
+        "canonicalwebteam.store_api.publishergw.PublisherGW"
+        + ".update_remodel_allowlist"
+    )
+    def test_update_remodel_allowlist_store_not_found(
+        self, mock_update_remodel_allowlist
+    ):
+        mock_update_remodel_allowlist.side_effect = StoreApiResponseErrorList(
+            "Store not found", 404, [{"message": "Store not found"}]
+        )
+
+        payload = {
+            "description": "Updated remodel allowlist",
+            "from-model": "updated-from-model",
+            "to-model": "updated-to-model",
+        }
+
+        response = self.client.patch(
+            "/api/store/999/models/remodel-allowlist", json=payload
+        )
+        data = response.json
+
+        self.assertEqual(response.status_code, 404)
+        self.assertFalse(data["success"])
+        self.assertEqual(data["message"], "Store not found")
+
+    @patch(
+        "canonicalwebteam.store_api.publishergw.PublisherGW"
+        + ".update_remodel_allowlist"
+    )
+    def test_update_remodel_allowlist_models_not_found(
+        self, mock_update_remodel_allowlist
+    ):
+        mock_update_remodel_allowlist.side_effect = StoreApiResourceNotFound(
+            "Remodel allowlist not found",
+            404,
+            [{"message": "Remodel allowlist not found"}],
+        )
+
+        payload = {
+            "description": "Updated remodel allowlist",
+            "from-model": "updated-from-model",
+            "to-model": "updated-to-model",
+        }
+
+        response = self.client.patch(
+            "/api/store/1/models/remodel-allowlist", json=payload
+        )
+        data = response.json
+
+        self.assertEqual(response.status_code, 404)
+        self.assertFalse(data["success"])
+        self.assertEqual(data["message"], "Remodel allowlist not found")
+
+    @patch(
+        "canonicalwebteam.store_api.publishergw.PublisherGW"
+        + ".update_remodel_allowlist"
+    )
+    def test_update_remodel_allowlist_api_error(
+        self, mock_update_remodel_allowlist
+    ):
+        mock_update_remodel_allowlist.side_effect = StoreApiResponseErrorList(
+            "Internal server error",
+            500,
+            [{"message": "An error occurred"}],
+        )
+
+        payload = {
+            "description": "Updated remodel allowlist",
+            "from-model": "updated-from-model",
+            "to-model": "updated-to-model",
+        }
+
+        response = self.client.patch(
+            "/api/store/1/models/remodel-allowlist", json=payload
+        )
+        data = response.json
+
+        self.assertEqual(response.status_code, 500)
+        self.assertFalse(data["success"])
+        self.assertEqual(data["message"], "An error occurred")
+
+    @patch(
+        "canonicalwebteam.store_api.publishergw.PublisherGW"
+        + ".update_remodel_allowlist"
+    )
+    def test_update_remodel_allowlist_general_exception(
+        self, mock_update_remodel_allowlist
+    ):
+        mock_update_remodel_allowlist.side_effect = Exception(
+            "Unexpected error"
+        )
+
+        payload = {
+            "description": "Updated remodel allowlist",
+            "from-model": "updated-from-model",
+            "to-model": "updated-to-model",
+            "from-serial": "test-serial",
+        }
+
+        response = self.client.patch(
+            "/api/store/1/models/remodel-allowlist", json=payload
+        )
+        data = response.json
+
+        self.assertEqual(response.status_code, 500)
+        self.assertFalse(data["success"])
+        self.assertEqual(data["message"], "An error occurred")
+
+    def test_update_remodel_allowlist_missing_json_payload(self):
+        """Test update remodel allowlist with missing JSON payload."""
+        response = self.client.patch(
+            "/api/store/1/models/remodel-allowlist",
+            headers={"Content-Type": "application/json"},
+            data="",
+        )
+        data = response.json
+
+        self.assertEqual(response.status_code, 400)
+        self.assertFalse(data["success"])
+        self.assertEqual(data["message"], "Missing or invalid JSON payload")
+
+    def test_update_remodel_allowlist_invalid_json_payload(self):
+        """Test update remodel allowlist with invalid JSON payload."""
+        response = self.client.patch(
+            "/api/store/1/models/remodel-allowlist",
+            headers={"Content-Type": "application/json"},
+            data="{invalid json}",
+        )
+        data = response.json
+
+        self.assertEqual(response.status_code, 400)
+        self.assertFalse(data["success"])
+        self.assertEqual(data["message"], "Missing or invalid JSON payload")
+
+    def test_update_remodel_allowlist_no_content_type(self):
+        """Test update remodel allowlist without content-type header."""
+        response = self.client.patch(
+            "/api/store/1/models/remodel-allowlist", data='{"test": "data"}'
+        )
+        data = response.json
+
+        self.assertEqual(response.status_code, 400)
+        self.assertFalse(data["success"])
+        self.assertEqual(data["message"], "Missing or invalid JSON payload")
+
+    @patch(
+        "canonicalwebteam.store_api.publishergw.PublisherGW"
+        + ".update_remodel_allowlist"
+    )
+    def test_update_remodel_allowlist_with_list_payload(
+        self, mock_update_remodel_allowlist
+    ):
+        mock_update_remodel_allowlist.return_value = None
+
+        payload = [
+            {
+                "description": "Updated remodel allowlist 1",
+                "from-model": "updated-from-model-1",
+                "from-serial": "updated-from-serial-1",
+                "to-model": "updated-to-model-1",
+            },
+            {
+                "description": "Updated remodel allowlist 2",
+                "from-model": "updated-from-model-2",
+                "from-serial": "updated-from-serial-2",
+                "to-model": "updated-to-model-2",
+            },
+        ]
+
+        response = self.client.patch(
+            "/api/store/1/models/remodel-allowlist", json=payload
+        )
+        data = response.json
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(data["success"])
+        # Verify the list was passed as-is, not wrapped in another list
+        mock_update_remodel_allowlist.assert_called_once_with(
+            mock_update_remodel_allowlist.call_args[0][0],  # flask.session
+            "1",  # store_id
+            payload,  # Should be the original list, not [payload]
+        )
+
+
+class TestDeleteRemodelAllowlist(TestModelServiceEndpoints):
+    @patch(
+        "canonicalwebteam.store_api.publishergw.PublisherGW"
+        + ".delete_remodel_allowlist"
+    )
+    def test_delete_remodel_allowlist_success(
+        self, mock_delete_remodel_allowlist
+    ):
+        mock_delete_remodel_allowlist.return_value = None
+
+        payload = {
+            "from-model": "test-from-model",
+            "from-serial": "test-from-serial",
+            "to-model": "test-to-model",
+        }
+
+        response = self.client.delete(
+            "/api/store/1/models/remodel-allowlist", json=payload
+        )
+        data = response.json
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(data["success"])
+        # Verify dict payload was wrapped in a list
+        mock_delete_remodel_allowlist.assert_called_once_with(
+            mock_delete_remodel_allowlist.call_args[0][0],  # flask.session
+            "1",  # store_id
+            [payload],  # Dict should be wrapped in a list
+        )
+
+    @patch(
+        "canonicalwebteam.store_api.publishergw.PublisherGW"
+        + ".delete_remodel_allowlist"
+    )
+    def test_delete_remodel_allowlist_store_not_found(
+        self, mock_delete_remodel_allowlist
+    ):
+        mock_delete_remodel_allowlist.side_effect = StoreApiResponseErrorList(
+            "Store not found", 404, [{"message": "Store not found"}]
+        )
+
+        payload = {
+            "from-model": "test-from-model",
+            "from-serial": "test-from-serial",
+            "to-model": "test-to-model",
+        }
+
+        response = self.client.delete(
+            "/api/store/999/models/remodel-allowlist", json=payload
+        )
+        data = response.json
+
+        self.assertEqual(response.status_code, 404)
+        self.assertFalse(data["success"])
+        self.assertEqual(data["message"], "Store not found")
+
+    @patch(
+        "canonicalwebteam.store_api.publishergw.PublisherGW"
+        + ".delete_remodel_allowlist"
+    )
+    def test_delete_remodel_allowlist_allowlist_not_found(
+        self, mock_delete_remodel_allowlist
+    ):
+        mock_delete_remodel_allowlist.side_effect = StoreApiResourceNotFound(
+            "Remodel allowlist not found",
+            404,
+            [{"message": "Remodel allowlist not found"}],
+        )
+
+        payload = {
+            "from-model": "test-from-model",
+            "from-serial": "test-from-serial",
+            "to-model": "test-to-model",
+        }
+
+        response = self.client.delete(
+            "/api/store/1/models/remodel-allowlist", json=payload
+        )
+        data = response.json
+
+        self.assertEqual(response.status_code, 404)
+        self.assertFalse(data["success"])
+        self.assertEqual(data["message"], "Remodel allowlist not found")
+
+    @patch(
+        "canonicalwebteam.store_api.publishergw.PublisherGW"
+        + ".delete_remodel_allowlist"
+    )
+    def test_delete_remodel_allowlist_api_error(
+        self, mock_delete_remodel_allowlist
+    ):
+        mock_delete_remodel_allowlist.side_effect = StoreApiResponseErrorList(
+            "Internal server error",
+            500,
+            [{"message": "An error occurred"}],
+        )
+
+        payload = {
+            "from-model": "test-from-model",
+            "from-serial": "test-from-serial",
+            "to-model": "test-to-model",
+        }
+
+        response = self.client.delete(
+            "/api/store/1/models/remodel-allowlist", json=payload
+        )
+        data = response.json
+
+        self.assertEqual(response.status_code, 500)
+        self.assertFalse(data["success"])
+        self.assertEqual(data["message"], "An error occurred")
+
+    @patch(
+        "canonicalwebteam.store_api.publishergw.PublisherGW"
+        + ".delete_remodel_allowlist"
+    )
+    def test_delete_remodel_allowlist_general_exception(
+        self, mock_delete_remodel_allowlist
+    ):
+        mock_delete_remodel_allowlist.side_effect = Exception(
+            "Unexpected error"
+        )
+
+        payload = {
+            "from-model": "test-from-model",
+            "from-serial": "test-serial",
+            "to-model": "test-to-model",
+        }
+
+        response = self.client.delete(
+            "/api/store/1/models/remodel-allowlist", json=payload
+        )
+        data = response.json
+
+        self.assertEqual(response.status_code, 500)
+        self.assertFalse(data["success"])
+        self.assertEqual(data["message"], "An error occurred")
+
+    def test_delete_remodel_allowlist_missing_json_payload(self):
+        """Test delete remodel allowlist with missing JSON payload."""
+        response = self.client.delete(
+            "/api/store/1/models/remodel-allowlist",
+            headers={"Content-Type": "application/json"},
+            data="",
+        )
+        data = response.json
+
+        self.assertEqual(response.status_code, 400)
+        self.assertFalse(data["success"])
+        self.assertEqual(data["message"], "Missing or invalid JSON payload")
+
+    def test_delete_remodel_allowlist_invalid_json_payload(self):
+        """Test delete remodel allowlist with invalid JSON payload."""
+        response = self.client.delete(
+            "/api/store/1/models/remodel-allowlist",
+            headers={"Content-Type": "application/json"},
+            data="{invalid json}",
+        )
+        data = response.json
+
+        self.assertEqual(response.status_code, 400)
+        self.assertFalse(data["success"])
+        self.assertEqual(data["message"], "Missing or invalid JSON payload")
+
+    def test_delete_remodel_allowlist_no_content_type(self):
+        """Test delete remodel allowlist without content-type header."""
+        response = self.client.delete(
+            "/api/store/1/models/remodel-allowlist", data='{"test": "data"}'
+        )
+        data = response.json
+
+        self.assertEqual(response.status_code, 400)
+        self.assertFalse(data["success"])
+        self.assertEqual(data["message"], "Missing or invalid JSON payload")
+
+    @patch(
+        "canonicalwebteam.store_api.publishergw.PublisherGW"
+        + ".delete_remodel_allowlist"
+    )
+    def test_delete_remodel_allowlist_with_list_payload(
+        self, mock_delete_remodel_allowlist
+    ):
+        mock_delete_remodel_allowlist.return_value = None
+
+        payload = [
+            {
+                "from-model": "test-from-model-1",
+                "from-serial": "test-from-serial-1",
+                "to-model": "test-to-model-1",
+            },
+            {
+                "from-model": "test-from-model-2",
+                "from-serial": "test-from-serial-2",
+                "to-model": "test-to-model-2",
+            },
+        ]
+
+        response = self.client.delete(
+            "/api/store/1/models/remodel-allowlist", json=payload
+        )
+        data = response.json
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(data["success"])
+        # Verify the list was passed as-is, not wrapped in another list
+        mock_delete_remodel_allowlist.assert_called_once_with(
+            mock_delete_remodel_allowlist.call_args[0][0],  # flask.session
+            "1",  # store_id
+            payload,  # Should be the original list, not [payload]
+        )
+
+
 class TestGetSerialLog(TestModelServiceEndpoints):
     @patch(
         "canonicalwebteam.store_api.publishergw.PublisherGW"

--- a/webapp/endpoints/models.py
+++ b/webapp/endpoints/models.py
@@ -349,6 +349,118 @@ def create_remodel_allowlist(store_id: str):
     return make_response(res, 500)
 
 
+@models.route(
+    "/api/store/<store_id>/models/remodel-allowlist", methods=["PATCH"]
+)
+@login_required
+@exchange_required
+def update_remodel_allowlist(store_id: str):
+    """
+    Update a remodel allowlist for a given store.
+
+    Args:
+        store_id (str): The ID of the store.
+
+    Returns:
+        dict: A dictionary containing the response message and success
+        status.
+    """
+    res = {}
+
+    try:
+        allowlist = flask.request.get_json(silent=True)
+        if allowlist is None:
+            res["success"] = False
+            res["message"] = "Missing or invalid JSON payload"
+            return make_response(res, 400)
+
+        # Only wrap in list if payload is a dict, not already a list
+        allowlist_param = (
+            [allowlist] if isinstance(allowlist, dict) else allowlist
+        )
+        publisher_gateway.update_remodel_allowlist(
+            flask.session, store_id, allowlist_param
+        )
+
+        res["success"] = True
+        return make_response(res, 200)
+    except StoreApiResponseErrorList as error_list:
+        res["success"] = False
+        messages = [
+            f"{error.get('message', 'An error occurred')}"
+            for error in error_list.errors
+        ]
+        res["message"] = " ".join(messages)
+        return make_response(res, error_list.status_code)
+
+    except StoreApiResourceNotFound:
+        res["success"] = False
+        res["message"] = "Remodel allowlist not found"
+        return make_response(res, 404)
+
+    except Exception:
+        res["success"] = False
+        res["message"] = "An error occurred"
+
+    return make_response(res, 500)
+
+
+@models.route(
+    "/api/store/<store_id>/models/remodel-allowlist", methods=["DELETE"]
+)
+@login_required
+@exchange_required
+def delete_remodel_allowlist(store_id: str):
+    """
+    Delete a remodel allowlist for a given store.
+
+    Args:
+        store_id (str): The ID of the store.
+
+    Returns:
+        dict: A dictionary containing the response message and success
+        status.
+    """
+    res = {}
+
+    try:
+        allowlist = flask.request.get_json(silent=True)
+        if allowlist is None:
+            res["success"] = False
+            res["message"] = "Missing or invalid JSON payload"
+            return make_response(res, 400)
+
+        # Only wrap in list if payload is a dict, not already a list
+        allowlist_param = (
+            [allowlist] if isinstance(allowlist, dict) else allowlist
+        )
+        publisher_gateway.delete_remodel_allowlist(
+            flask.session, store_id, allowlist_param
+        )
+
+        res["success"] = True
+        return make_response(res, 200)
+    except StoreApiResponseErrorList as error_list:
+        res["success"] = False
+        messages = [
+            f"{error.get('message', 'An error occurred')}"
+            for error in error_list.errors
+        ]
+        res["message"] = " ".join(messages)
+        return make_response(res, error_list.status_code)
+
+    except StoreApiResourceNotFound:
+        res["success"] = False
+        res["message"] = "Remodel allowlist not found"
+        return make_response(res, 404)
+
+    except Exception:
+        res["success"] = False
+        res["message"] = "An error occurred"
+
+    return make_response(res, 500)
+
+
 @models.route("/api/store/<store_id>/models/<model_name>/serial-log")
 @login_required
 @exchange_required


### PR DESCRIPTION
## Done

Adds endpoints to update and delete remodels

## How to QA

Run the site locally

### To update a model

Make a `PATCH` request in Postman using the following:

URL: http://localhost:8004/api/store/njwQYXFnS7ppo7LaGxoh7aqVZc1CPi26/models/remodel-allowlist

In the "Body" tab select "raw" and "JSON" and put the following using the data from one of the models from [the remodel allowlist](http://localhost:8004/api/store/njwQYXFnS7ppo7LaGxoh7aqVZc1CPi26/models/remodel-allowlist) _(make sure to use a different description as that is the field that can be updated)_

```json
{
  "from-model": "example-test-model",
  "to-model": "example-to-model",
  "from-serial": "example-from-serial",
  "description": "New description to update"
}
```

In the "Headers" section set:

- "Content-Type" to "application/json"
- "X-Csrftoken" to the value of `window.CSRF_TOKEN` in the browser console
- "Cookie" to the value of your cookie which you can find in the browser dev tools

The request should be successful and when you check the [allowlist response](http://localhost:8004/api/store/njwQYXFnS7ppo7LaGxoh7aqVZc1CPi26/models/remodel-allowlist) you should see that your chosen remodel has the updated description

### To delete a model

Use the same process as above except remove the `description` field from the JSON you are sending in the request and change `PATCH` to `DELETE`

```json
{
  "from-model": "example-test-model",
  "to-model": "example-to-model",
  "from-serial": "example-from-serial",
}
```

The request should be successful and the remodel should no longer be in the [allowlist response](http://localhost:8004/api/store/njwQYXFnS7ppo7LaGxoh7aqVZc1CPi26/models/remodel-allowlist)


## Testing

- [x] This PR has tests
- [ ] No testing required (explain why):

## Security

- [ ] Security considerations for review (list them):
  - [ ] Examples:
  - [ ] Access control: users can only access their own data
  - [ ] Input: user input is validated and sanitised
  - [ ] Sensitive data: secret or private data is not exposed in any way
  - [ ] ...
- [x] This PR has no security considerations (explain why):

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-36211

## Screenshots
n/a

## UX Approval

- [x] This PR does not require UX approval
- [ ] This PR does require UX approval (add context):
