### PR TITLE
align header variables to match charmhub

### DIFF
--- a/templates/store/package_header/_package_header.html
+++ b/templates/store/package_header/_package_header.html
@@ -22,8 +22,8 @@ Other:
 {%- from 'store/package_header/_package_header_data.html' import package_header_data, package_icon -%}
 
 {%- macro package_header() -%}
-  {%- set buttons_content = caller('buttons') -%}
-  {%- set has_buttons_content = buttons_content|trim|length > 0 -%}
+  {%- set additional_info_content = caller('additional_info') -%}
+  {%- set has_additional_info_content = additional_info_content|trim|length > 0 -%}
   <div class="grid-row">
     <div class="grid-col-2 grid-col-medium-1 grid-col-small-1">
       {{ package_icon(icon_url, image) }}
@@ -40,9 +40,14 @@ Other:
           developer_validation=developer_validation,
           STAR_DEVELOPER=STAR_DEVELOPER,
           VERIFIED_PUBLISHER=VERIFIED_PUBLISHER) }}
-      {%- if has_buttons_content -%}
-      <div class="p-section--shallow">{{ buttons_content }}</div>
-      {%- endif -%}
     </div>
   </div>
+  {%- if has_additional_info_content -%}
+  <div class="grid-row">
+    <div class="grid-col-2 grid-col-medium-1 grid-col-small-1"></div>
+    <div class="grid-col-6 grid-col-medium-3 grid-col-small-3">
+      <div class="p-section--shallow">{{ additional_info_content }}</div>
+    </div>
+  </div>
+  {%- endif -%}
 {%- endmacro -%}

--- a/templates/store/snap-details.html
+++ b/templates/store/snap-details.html
@@ -89,7 +89,7 @@
       </div>
     {% endif %}
       {%- call(slot) package_header() -%}
-        {%- if slot == 'buttons' -%}
+        {%- if slot == 'additional_info' -%}
           <div class="p-cta-block u-no-padding--bottom">
             <button
               class="p-button{% if is_preview %} p-tooltip p-tooltip--btm-right{% endif %}"

--- a/templates/store/snap-distro-install.html
+++ b/templates/store/snap-distro-install.html
@@ -101,7 +101,7 @@
         <div class="row">
           <div class="details-block">
             {%- call(slot) package_header() -%}
-              {%- if slot == 'buttons' -%}
+              {%- if slot == 'additional_info' -%}
                 <a class="p-button--positive js-install" href="#install" data-scroll-to="#install">
                   Install
                 </a>


### PR DESCRIPTION
## Done
- Modifies variables in package details header to align with charmhub.io changes [here](https://github.com/canonical/charmhub.io/pull/2313)

## How to QA
- Go to a package (e.g. https://snapcraft-io-5678.demos.haus/artikulate)
- Make sure the header looks the same as on prod (no visual changes)

## Testing

- [ ] This PR has tests
- [x] No testing required (explain why): no change in behaviour

## Security

- [ ] Security considerations for review (list them):
  - [ ] Examples:
  - [ ] Access control: users can only access their own data
  - [ ] Input: user input is validated and sanitised
  - [ ] Sensitive data: secret or private data is not exposed in any way
  - [ ] ...
- [x] This PR has no security considerations (explain why): only variable name changing

## UX Approval

- [x] This PR does not require UX approval: no visual changes
- [ ] This PR does require UX approval (add context):
