### PR TITLE
feat: Use Store API pagination for remodels table

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ canonicalwebteam.discourse==7.2.0
 canonicalwebteam.blog==6.8.4
 canonicalwebteam.search==2.1.2
 canonicalwebteam.image-template==1.9.0
-canonicalwebteam.store-api==7.8.1
+canonicalwebteam.store-api==7.8.2
 canonicalwebteam.launchpad==0.9.0
 django-openid-auth==0.17
 Flask-OpenID==1.3.1

--- a/static/js/publisher/hooks/__tests__/useRemodels.test.tsx
+++ b/static/js/publisher/hooks/__tests__/useRemodels.test.tsx
@@ -72,8 +72,150 @@ afterAll(() => {
 
 describe("useRemodels", () => {
   test("returns remodels data", async () => {
+    const { result } = renderHook(() => useRemodels("test-brand-id"), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(result.current.data).toEqual({
+      data: remodelsResponse,
+      success: true,
+    });
+  });
+
+  test("returns remodels data with pageSize param", async () => {
+    server.use(
+      http.get(
+        "/api/store/test-brand-id/models/remodel-allowlist",
+        ({ request }) => {
+          const url = new URL(request.url);
+
+          expect(url.searchParams.get("page-size")).toBe("10");
+          return HttpResponse.json({
+            data: remodelsResponse,
+            success: true,
+          });
+        },
+      ),
+    );
+
     const { result } = renderHook(
-      () => useRemodels("test-brand-id", "test-to-model"),
+      () => useRemodels("test-brand-id", { pageSize: 10 }),
+      {
+        wrapper: createWrapper(),
+      },
+    );
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(result.current.data).toEqual({
+      data: remodelsResponse,
+      success: true,
+    });
+  });
+
+  test("returns remodels data with page param", async () => {
+    server.use(
+      http.get(
+        "/api/store/test-brand-id/models/remodel-allowlist",
+        ({ request }) => {
+          const url = new URL(request.url);
+
+          expect(url.searchParams.get("page")).toBe("next_cursor_value");
+          return HttpResponse.json({
+            data: remodelsResponse,
+            success: true,
+          });
+        },
+      ),
+    );
+
+    const { result } = renderHook(
+      () =>
+        useRemodels("test-brand-id", {
+          page: "next_cursor_value",
+        }),
+      {
+        wrapper: createWrapper(),
+      },
+    );
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(result.current.data).toEqual({
+      data: remodelsResponse,
+      success: true,
+    });
+  });
+
+  test("returns remodels data with fromModel param", async () => {
+    server.use(
+      http.get(
+        "/api/store/test-brand-id/models/remodel-allowlist",
+        ({ request }) => {
+          const url = new URL(request.url);
+
+          expect(url.searchParams.get("from-model")).toBe("test-from-model");
+          return HttpResponse.json({
+            data: remodelsResponse,
+            success: true,
+          });
+        },
+      ),
+    );
+
+    const { result } = renderHook(
+      () =>
+        useRemodels("test-brand-id", {
+          fromModel: "test-from-model",
+        }),
+      {
+        wrapper: createWrapper(),
+      },
+    );
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(result.current.data).toEqual({
+      data: remodelsResponse,
+      success: true,
+    });
+  });
+
+  test("returns remodels data with pageSize, page and fromModel param", async () => {
+    server.use(
+      http.get(
+        "/api/store/test-brand-id/models/remodel-allowlist",
+        ({ request }) => {
+          const url = new URL(request.url);
+
+          expect(url.searchParams.get("page-size")).toBe("25");
+          expect(url.searchParams.get("page")).toBe("cursor123");
+          expect(url.searchParams.get("from-model")).toBe("test-from-model");
+          return HttpResponse.json({
+            data: remodelsResponse,
+            success: true,
+          });
+        },
+      ),
+    );
+
+    const { result } = renderHook(
+      () =>
+        useRemodels("test-brand-id", {
+          pageSize: 25,
+          page: "cursor123",
+          fromModel: "test-from-model",
+        }),
       {
         wrapper: createWrapper(),
       },
@@ -90,12 +232,9 @@ describe("useRemodels", () => {
   });
 
   test("returns error if request fails", async () => {
-    const { result } = renderHook(
-      () => useRemodels("test-brand-id-fail", "test-to-model"),
-      {
-        wrapper: createWrapper(),
-      },
-    );
+    const { result } = renderHook(() => useRemodels("test-brand-id-fail"), {
+      wrapper: createWrapper(),
+    });
 
     await waitFor(() => {
       expect(result.current.isSuccess).toBe(true);
@@ -108,12 +247,9 @@ describe("useRemodels", () => {
   });
 
   test("returns error if network error", async () => {
-    const { result } = renderHook(
-      () => useRemodels("test-brand-id-error", "test-to-model"),
-      {
-        wrapper: createWrapper(),
-      },
-    );
+    const { result } = renderHook(() => useRemodels("test-brand-id-error"), {
+      wrapper: createWrapper(),
+    });
 
     await waitFor(() => {
       expect(result.current.isError).toBe(true);

--- a/static/js/publisher/hooks/useRemodels.ts
+++ b/static/js/publisher/hooks/useRemodels.ts
@@ -1,44 +1,46 @@
 import { useQuery, UseQueryResult } from "react-query";
-import type { Remodel, RemodelResponse, ApiResponse } from "../types/shared";
+import type { RemodelResponse, ApiResponse } from "../types/shared";
 
 const useRemodels = (
   brandId: string | undefined,
-  modelId: string | undefined,
+  urlSearchParams?: {
+    page?: string | null;
+    pageSize?: number;
+    fromModel?: string;
+  },
 ): UseQueryResult<ApiResponse<RemodelResponse>, Error> => {
+  const url = new URL(
+    `/api/store/${brandId}/models/remodel-allowlist`,
+    window.location.origin,
+  );
+
+  if (urlSearchParams) {
+    const { page, pageSize, fromModel } = urlSearchParams;
+
+    if (page) {
+      url.searchParams.set("page", page);
+    }
+
+    if (pageSize) {
+      url.searchParams.set("page-size", pageSize.toString());
+    }
+
+    if (fromModel) {
+      url.searchParams.set("from-model", fromModel);
+    }
+  }
+
   return useQuery<ApiResponse<RemodelResponse>, Error>({
-    queryKey: ["remodels", brandId, modelId],
+    queryKey: [
+      "remodels",
+      brandId,
+      urlSearchParams?.page,
+      urlSearchParams?.pageSize,
+      urlSearchParams?.fromModel,
+    ],
     queryFn: async () => {
-      const response = await fetch(
-        `/api/store/${brandId}/models/remodel-allowlist`,
-      );
-
+      const response = await fetch(url);
       const responseData = await response.json();
-
-      if (responseData.data?.allowlist) {
-        const remodelsForCurrentModel = responseData.data.allowlist.filter(
-          (remodel: Remodel) => {
-            return (
-              remodel["from-model"] === modelId ||
-              remodel["to-model"] === modelId
-            );
-          },
-        );
-
-        responseData.data.allowlist = remodelsForCurrentModel.sort(
-          (a: Remodel, b: Remodel) => {
-            if (a["created-at"] > b["created-at"]) {
-              return -1;
-            }
-
-            if (a["created-at"] < b["created-at"]) {
-              return 1;
-            }
-
-            return 0;
-          },
-        );
-      }
-
       return responseData;
     },
     enabled: !!brandId,

--- a/static/js/publisher/layouts/ModelDetailsPageLayout/ModelNav.tsx
+++ b/static/js/publisher/layouts/ModelDetailsPageLayout/ModelNav.tsx
@@ -7,7 +7,7 @@ import { brandIdState } from "../../state/brandStoreState";
 function ModelNav({ sectionName }: { sectionName: string }): React.JSX.Element {
   const { id, modelId } = useParams();
   const brandId = useAtomValue(brandIdState);
-  const { data: remodelsData } = useRemodels(brandId, modelId);
+  const { data: remodelsData } = useRemodels(brandId);
 
   return (
     <nav className="p-tabs">

--- a/static/js/publisher/pages/Remodel/Remodel.tsx
+++ b/static/js/publisher/pages/Remodel/Remodel.tsx
@@ -1,6 +1,12 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, useRef } from "react";
 import { useAtomValue, useSetAtom } from "jotai";
-import { useParams, Link, useNavigate, useLocation } from "react-router-dom";
+import {
+  useParams,
+  Link,
+  useNavigate,
+  useLocation,
+  useSearchParams,
+} from "react-router-dom";
 import { Notification, Icon, Row, Col } from "@canonical/react-components";
 
 import { useRemodels } from "../../hooks";
@@ -17,8 +23,17 @@ import type { Remodel, RemodelResponse, ApiResponse } from "../../types/shared";
 
 function Remodel(): React.JSX.Element {
   const { id, modelId } = useParams();
+  const [searchParams, setSearchParams] = useSearchParams();
   const location = useLocation();
   const brandId = useAtomValue(brandIdState);
+  const [currentCursor, setCurrentCursor] = useState<string | null>(null);
+  const [nextCursor, setNextCursor] = useState<string | null>(null);
+  const cursorHistory = useRef<Array<string | null>>([]);
+
+  const pageSizeParam = searchParams.get("page-size");
+  const parsedPageSize = pageSizeParam ? parseInt(pageSizeParam) : NaN;
+  const pageSize = Number.isInteger(parsedPageSize) ? parsedPageSize : 25;
+
   const {
     isLoading,
     isError,
@@ -27,7 +42,11 @@ function Remodel(): React.JSX.Element {
     refetch,
   }: UseQueryResult<ApiResponse<RemodelResponse>, Error> = useRemodels(
     brandId,
-    modelId,
+    {
+      fromModel: modelId,
+      pageSize: pageSize,
+      page: currentCursor,
+    },
   );
   const setRemodels = useSetAtom(remodelsListState);
   const [showNotification, setShowNotification] = useState(false);
@@ -36,13 +55,36 @@ function Remodel(): React.JSX.Element {
   const brandStore = useAtomValue(brandStoreState(id));
   const navigate = useNavigate();
 
+  const handlePageForward = () => {
+    cursorHistory.current.push(currentCursor);
+    setCurrentCursor(nextCursor);
+  };
+
+  const handlePageBack = () => {
+    const lastCursor = cursorHistory.current.pop();
+    setCurrentCursor(lastCursor || null);
+  };
+
+  const handlePageSizeChange = (newPageSize: number) => {
+    // Need to reset current page when changing page size
+    // because otherwise the cursor history gets out of sync
+    setCurrentCursor(null);
+    cursorHistory.current = [];
+    setSearchParams({ "page-size": newPageSize.toString() });
+  };
+
   brandStore
     ? setPageTitle(`Remodels in ${brandStore.name}`)
     : setPageTitle("Remodels");
 
   useEffect(() => {
-    if (!isLoading && !isError && data) {
+    if (isLoading || isError) {
+      return;
+    }
+
+    if (data) {
       setRemodels(data.data?.allowlist || []);
+      setNextCursor(data.data?.["next-cursor"] || null);
     }
   }, [isLoading, isError, data, brandId, id]);
 
@@ -76,7 +118,18 @@ function Remodel(): React.JSX.Element {
               </Col>
             </Row>
             <div className="u-flex-column u-flex-grow">
-              <RemodelTable />
+              {data && (
+                <RemodelTable
+                  handlePageForward={handlePageForward}
+                  handlePageBack={handlePageBack}
+                  handlePageSizeChange={handlePageSizeChange}
+                  forwardDisabled={!nextCursor}
+                  backDisabled={
+                    cursorHistory.current.length < 1 || currentCursor === null
+                  }
+                  pageSize={pageSize}
+                />
+              )}
             </div>
           </>
         )}

--- a/static/js/publisher/pages/Remodel/RemodelTable.tsx
+++ b/static/js/publisher/pages/Remodel/RemodelTable.tsx
@@ -1,30 +1,51 @@
 import { useAtomValue } from "jotai";
-import { MainTable, TablePagination } from "@canonical/react-components";
+import {
+  MainTable,
+  TablePaginationControls,
+} from "@canonical/react-components";
 import { format } from "date-fns";
 
 import { remodelsListState } from "../../state/remodelsState";
 
 import type { Remodel } from "../../types/shared";
 
-function RemodelTable(): React.JSX.Element {
+type Props = {
+  handlePageForward: () => void;
+  handlePageBack: () => void;
+  handlePageSizeChange: (arg: number) => void;
+  forwardDisabled: boolean;
+  backDisabled: boolean;
+  pageSize: number;
+};
+
+function RemodelTable({
+  handlePageForward,
+  handlePageBack,
+  handlePageSizeChange,
+  forwardDisabled,
+  backDisabled,
+  pageSize,
+}: Props): React.JSX.Element {
   const remodels = useAtomValue(remodelsListState);
 
   const headers = [
     {
       content: "Target model",
       style: { width: "250px" },
+      className: "u-truncate",
     },
     {
       content: "Original model",
       style: { width: "250px" },
+      className: "u-truncate",
     },
-    { content: "Serial" },
+    { content: "Serial", className: "u-truncate" },
     {
       content: "Created date",
-      className: "u-align--right",
+      className: "u-align--right u-truncate",
       style: { width: "130px" },
     },
-    { content: "Note" },
+    { content: "Note", className: "u-truncate" },
   ];
 
   const rows = remodels.map((remodel: Remodel) => {
@@ -46,17 +67,37 @@ function RemodelTable(): React.JSX.Element {
   });
 
   return (
-    <TablePagination
-      data={rows}
-      pageLimits={[25, 50, 100, 200]}
-      position="below"
-    >
+    <>
       <MainTable
         data-testid="remodel-table"
         emptyStateMsg="No remodels found"
         headers={headers}
+        rows={rows}
       />
-    </TablePagination>
+      <TablePaginationControls
+        // Although we don't know the current page as we don't know
+        // how many pages there are, the `currentPage` value is required, and
+        // must be > 0, to remove the "of more than x rows" in the visible
+        // count section. See:
+        // https://canonical.github.io/react-components/?path=/story/components-tablepagination--controls-with-partially-known-entries
+        currentPage={1}
+        itemName="remodel"
+        nextButtonProps={{
+          disabled: forwardDisabled,
+        }}
+        onNextPage={handlePageForward}
+        onPageSizeChange={handlePageSizeChange}
+        onPreviousPage={handlePageBack}
+        pageLimits={[10, 25, 50, 100, 500]}
+        pageSize={pageSize}
+        previousButtonProps={{
+          disabled: backDisabled,
+        }}
+        showPageInput={false}
+        visibleCount={rows.length}
+        className="table-pagination-controls"
+      />
+    </>
   );
 }
 

--- a/static/sass/_snapcraft_p-table-pagination-controls.scss
+++ b/static/sass/_snapcraft_p-table-pagination-controls.scss
@@ -1,0 +1,60 @@
+@mixin snapcraft-p-table-pagination-controls {
+  .table-pagination-controls {
+    align-items: baseline;
+    display: flex;
+    margin: $spv--large 0;
+
+    @media screen and (max-width: $breakpoint-small) {
+      justify-content: flex-end;
+    }
+
+    .description {
+      flex-grow: 1;
+
+      @media screen and (max-width: $breakpoint-small) {
+        display: none;
+      }
+    }
+
+    .back {
+      margin: 0 0 0 $spv--large;
+
+      .p-icon--chevron-down {
+        rotate: 90deg;
+      }
+    }
+
+    .next {
+      margin: 0 $spv--large 0 0;
+
+      .p-icon--chevron-down {
+        rotate: 270deg;
+      }
+    }
+
+    .pagination-input {
+      margin: 0 $spv--large;
+      min-width: 0;
+      width: 4rem;
+    }
+
+    .pagination-item-count {
+      margin: 0 $spv--large 0 0;
+    }
+
+    .pagination-select {
+      margin-bottom: 0;
+      margin-left: $spv--x-large;
+      min-width: 0;
+      width: 7rem;
+    }
+
+    @media screen and (max-width: $breakpoint-small) {
+      .back,
+      .next {
+        margin-left: 0;
+        margin-right: 0;
+      }
+    }
+  }
+}

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -184,6 +184,14 @@ $color-social-icon-foreground: $color-light;
 @import "snapcraft_p-combobox";
 @include snapcraft_p-combobox;
 
+// Needed when using the TablePaginationControls component
+// directly as it's primary purpose is to be wrapped by the
+// TablePagination component, so it doesn't import the styles
+// itself
+// https://canonical.github.io/react-components/?path=/story/components-tablepagination--controls-only
+@import "snapcraft_p-table-pagination-controls";
+@include snapcraft-p-table-pagination-controls;
+
 dl {
   margin-bottom: $spv--x-large;
 }
@@ -570,4 +578,3 @@ html {
   background-size: contain;
   padding: 67px;
 }
-

--- a/tests/endpoints/tests_models.py
+++ b/tests/endpoints/tests_models.py
@@ -262,6 +262,119 @@ class TestGetRemodelAllowlist(TestModelServiceEndpoints):
         self.assertFalse(data["success"])
         self.assertEqual(data["message"], "Internal server error")
 
+    @patch(
+        "canonicalwebteam.store_api.publishergw.PublisherGW"
+        + ".get_remodel_allowlist"
+    )
+    def test_get_remodel_allowlist_with_page_parameter(
+        self, mock_get_remodel_allowlist
+    ):
+        mock_get_remodel_allowlist.return_value = {"allowlist": []}
+
+        response = self.client.get(
+            "/api/store/1/models/remodel-allowlist?page=2"
+        )
+        data = response.json
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(data["success"])
+        mock_get_remodel_allowlist.assert_called_once_with(
+            mock_get_remodel_allowlist.call_args[0][0],  # flask.session
+            "1",  # store_id
+            {"cursor": "2", "from-model": None, "page-size": None},  # params
+        )
+
+    @patch(
+        "canonicalwebteam.store_api.publishergw.PublisherGW"
+        + ".get_remodel_allowlist"
+    )
+    def test_get_remodel_allowlist_with_from_model_parameter(
+        self, mock_get_remodel_allowlist
+    ):
+        mock_get_remodel_allowlist.return_value = {"allowlist": []}
+
+        response = self.client.get(
+            "/api/store/1/models/remodel-allowlist?from-model=test-model"
+        )
+        data = response.json
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(data["success"])
+        mock_get_remodel_allowlist.assert_called_once_with(
+            mock_get_remodel_allowlist.call_args[0][0],  # flask.session
+            "1",  # store_id
+            {"cursor": None, "from-model": "test-model", "page-size": None},
+        )
+
+    @patch(
+        "canonicalwebteam.store_api.publishergw.PublisherGW"
+        + ".get_remodel_allowlist"
+    )
+    def test_get_remodel_allowlist_with_page_size_parameter(
+        self, mock_get_remodel_allowlist
+    ):
+        mock_get_remodel_allowlist.return_value = {"allowlist": []}
+
+        response = self.client.get(
+            "/api/store/1/models/remodel-allowlist?page-size=50"
+        )
+        data = response.json
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(data["success"])
+        mock_get_remodel_allowlist.assert_called_once_with(
+            mock_get_remodel_allowlist.call_args[0][0],  # flask.session
+            "1",  # store_id
+            {"cursor": None, "from-model": None, "page-size": "50"},
+        )
+
+    @patch(
+        "canonicalwebteam.store_api.publishergw.PublisherGW"
+        + ".get_remodel_allowlist"
+    )
+    def test_get_remodel_allowlist_with_multiple_parameters(
+        self, mock_get_remodel_allowlist
+    ):
+        mock_get_remodel_allowlist.return_value = {"allowlist": []}
+
+        response = self.client.get(
+            "/api/store/1/models/remodel-allowlist"
+            "?page=3&from-model=ubuntu-core&page-size=25"
+        )
+        data = response.json
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(data["success"])
+        mock_get_remodel_allowlist.assert_called_once_with(
+            mock_get_remodel_allowlist.call_args[0][0],  # flask.session
+            "1",  # store_id
+            {
+                "cursor": "3",
+                "from-model": "ubuntu-core",
+                "page-size": "25",
+            },
+        )
+
+    @patch(
+        "canonicalwebteam.store_api.publishergw.PublisherGW"
+        + ".get_remodel_allowlist"
+    )
+    def test_get_remodel_allowlist_with_no_parameters(
+        self, mock_get_remodel_allowlist
+    ):
+        mock_get_remodel_allowlist.return_value = {"allowlist": []}
+
+        response = self.client.get("/api/store/1/models/remodel-allowlist")
+        data = response.json
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(data["success"])
+        mock_get_remodel_allowlist.assert_called_once_with(
+            mock_get_remodel_allowlist.call_args[0][0],  # flask.session
+            "1",  # store_id
+            {"cursor": None, "from-model": None, "page-size": None},
+        )
+
 
 class TestCreateRemodelAllowlist(TestModelServiceEndpoints):
     @patch(

--- a/webapp/endpoints/models.py
+++ b/webapp/endpoints/models.py
@@ -278,10 +278,18 @@ def get_remodel_allowlist(store_id: str):
         and data.
     """
 
+    params = {
+        # rename `cursor` to `page` on our side for clarity
+        "cursor": flask.request.args.get("page"),
+        "from-model": flask.request.args.get("from-model"),
+        "page-size": flask.request.args.get("page-size"),
+    }
+
     res = {}
+
     try:
         allowlist = publisher_gateway.get_remodel_allowlist(
-            flask.session, store_id
+            flask.session, store_id, params
         )
         res["success"] = True
         res["data"] = allowlist


### PR DESCRIPTION
## Done
Updated the remodels table to use the `next-cursor` pagination supplied by the Store API. This involved removing the ordering by date so as to retain the order returned from the API.

## How to QA
- Go to https://snapcraft-io-5681.demos.haus/admin/ahnuP3quahti9vis8aiw/models/testing-model-new2/remodel
- Check that you can navigate backwards and forwards with the pagination
- Check that you can change the number of results with the page size selector
- Check that the `page-size` query param is updated in the URL when using the page size selector

## Testing

- [x] This PR has tests
- [ ] No testing required (explain why):

## Security

- [ ] Security considerations for review (list them):
  - [ ] Examples:
  - [ ] Access control: users can only access their own data
  - [ ] Input: user input is validated and sanitised
  - [ ] Sensitive data: secret or private data is not exposed in any way
  - [ ] ...
- [x] This PR has no security considerations (explain why): No user input

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-36146

## Screenshots
n/a

## UX Approval

- [x] This PR does not require UX approval
- [ ] This PR does require UX approval (add context):
