### PR TITLE
feat: Switch remodel and serial log permission checks with HEAD requests

### DIFF
--- a/static/js/publisher/hooks/__tests__/useEndpointAvailability.test.ts
+++ b/static/js/publisher/hooks/__tests__/useEndpointAvailability.test.ts
@@ -1,0 +1,238 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { afterAll, beforeAll, vi } from "vitest";
+import "@testing-library/jest-dom";
+
+import useEndpointAvailability from "../useEndpointAvailability";
+
+const mockFetch = vi.fn();
+
+describe("useEndpointAvailability", () => {
+  beforeAll(() => {
+    vi.stubGlobal("fetch", mockFetch);
+  });
+
+  afterAll(() => {
+    vi.unstubAllGlobals();
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFetch.mockClear();
+  });
+
+  it("returns false for both endpoints when brandId is undefined", async () => {
+    mockFetch.mockResolvedValue({ ok: false });
+
+    const { result } = renderHook(() =>
+      useEndpointAvailability(undefined, "test-model-id"),
+    );
+
+    await waitFor(() => {
+      expect(result.current.isRemodelAvailable).toBe(false);
+      expect(result.current.isSerialLogAvailable).toBe(false);
+    });
+
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(mockFetch).toHaveBeenCalledWith(
+      "/api/store/undefined/models/remodel-allowlist",
+      expect.objectContaining({
+        method: "HEAD",
+        signal: expect.any(AbortSignal),
+      }),
+    );
+    expect(mockFetch).toHaveBeenCalledWith(
+      "/api/store/undefined/models/test-model-id/serial-log",
+      expect.objectContaining({
+        method: "HEAD",
+        signal: expect.any(AbortSignal),
+      }),
+    );
+  });
+
+  it("returns false for both endpoints when both brandId and modelId are undefined", async () => {
+    const { result } = renderHook(() =>
+      useEndpointAvailability(undefined, undefined),
+    );
+
+    await waitFor(() => {
+      expect(result.current.isRemodelAvailable).toBe(false);
+      expect(result.current.isSerialLogAvailable).toBe(false);
+    });
+
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("returns false for serial log when modelId is undefined", async () => {
+    mockFetch.mockResolvedValue({ ok: true });
+
+    const { result } = renderHook(() =>
+      useEndpointAvailability("test-brand-id", undefined),
+    );
+
+    await waitFor(() => {
+      expect(result.current.isRemodelAvailable).toBe(true);
+      expect(result.current.isSerialLogAvailable).toBe(false);
+    });
+
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(mockFetch).toHaveBeenCalledWith(
+      "/api/store/test-brand-id/models/remodel-allowlist",
+      expect.objectContaining({
+        method: "HEAD",
+        signal: expect.any(AbortSignal),
+      }),
+    );
+    expect(mockFetch).toHaveBeenCalledWith(
+      "/api/store/test-brand-id/models/undefined/serial-log",
+      expect.objectContaining({
+        method: "HEAD",
+        signal: expect.any(AbortSignal),
+      }),
+    );
+  });
+
+  it("makes HEAD requests to both endpoints when both IDs are provided", async () => {
+    mockFetch.mockResolvedValue({ ok: true });
+
+    const { result } = renderHook(() =>
+      useEndpointAvailability("test-brand-id", "test-model-id"),
+    );
+
+    await waitFor(() => {
+      expect(result.current.isRemodelAvailable).toBe(true);
+      expect(result.current.isSerialLogAvailable).toBe(true);
+    });
+
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(mockFetch).toHaveBeenCalledWith(
+      "/api/store/test-brand-id/models/remodel-allowlist",
+      expect.objectContaining({
+        method: "HEAD",
+        signal: expect.any(AbortSignal),
+      }),
+    );
+    expect(mockFetch).toHaveBeenCalledWith(
+      "/api/store/test-brand-id/models/test-model-id/serial-log",
+      expect.objectContaining({
+        method: "HEAD",
+        signal: expect.any(AbortSignal),
+      }),
+    );
+  });
+
+  it("handles remodel endpoint failure", async () => {
+    mockFetch
+      .mockResolvedValueOnce({ ok: false })
+      .mockResolvedValueOnce({ ok: true });
+
+    const { result } = renderHook(() =>
+      useEndpointAvailability("test-brand-id", "test-model-id"),
+    );
+
+    await waitFor(() => {
+      expect(result.current.isRemodelAvailable).toBe(false);
+      expect(result.current.isSerialLogAvailable).toBe(true);
+    });
+  });
+
+  it("handles serial log endpoint failure", async () => {
+    mockFetch
+      .mockResolvedValueOnce({ ok: true })
+      .mockResolvedValueOnce({ ok: false });
+
+    const { result } = renderHook(() =>
+      useEndpointAvailability("test-brand-id", "test-model-id"),
+    );
+
+    await waitFor(() => {
+      expect(result.current.isRemodelAvailable).toBe(true);
+      expect(result.current.isSerialLogAvailable).toBe(false);
+    });
+  });
+
+  it("handles fetch errors gracefully", async () => {
+    mockFetch
+      .mockRejectedValueOnce(new Error("Network error"))
+      .mockRejectedValueOnce(new Error("Network error"));
+
+    const { result } = renderHook(() =>
+      useEndpointAvailability("test-brand-id", "test-model-id"),
+    );
+
+    await waitFor(() => {
+      expect(result.current.isRemodelAvailable).toBe(false);
+      expect(result.current.isSerialLogAvailable).toBe(false);
+    });
+  });
+
+  it("re-runs checks when brandId changes", async () => {
+    mockFetch.mockResolvedValue({ ok: true });
+
+    const { result, rerender } = renderHook(
+      ({ brandId, modelId }) => useEndpointAvailability(brandId, modelId),
+      {
+        initialProps: { brandId: "brand-1", modelId: "model-1" },
+      },
+    );
+
+    await waitFor(() => {
+      expect(result.current.isRemodelAvailable).toBe(true);
+    });
+
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+
+    // Change brandId
+    rerender({ brandId: "brand-2", modelId: "model-1" });
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledTimes(4);
+    });
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "/api/store/brand-2/models/remodel-allowlist",
+      expect.objectContaining({
+        method: "HEAD",
+        signal: expect.any(AbortSignal),
+      }),
+    );
+    expect(mockFetch).toHaveBeenCalledWith(
+      "/api/store/brand-2/models/model-1/serial-log",
+      expect.objectContaining({
+        method: "HEAD",
+        signal: expect.any(AbortSignal),
+      }),
+    );
+  });
+
+  it("re-runs checks when modelId changes", async () => {
+    mockFetch.mockResolvedValue({ ok: true });
+
+    const { result, rerender } = renderHook(
+      ({ brandId, modelId }) => useEndpointAvailability(brandId, modelId),
+      {
+        initialProps: { brandId: "brand-1", modelId: "model-1" },
+      },
+    );
+
+    await waitFor(() => {
+      expect(result.current.isSerialLogAvailable).toBe(true);
+    });
+
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+
+    // Change modelId
+    rerender({ brandId: "brand-1", modelId: "model-2" });
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledTimes(4);
+    });
+
+    expect(mockFetch).toHaveBeenLastCalledWith(
+      "/api/store/brand-1/models/model-2/serial-log",
+      expect.objectContaining({
+        method: "HEAD",
+        signal: expect.any(AbortSignal),
+      }),
+    );
+  });
+});

--- a/static/js/publisher/hooks/index.ts
+++ b/static/js/publisher/hooks/index.ts
@@ -17,6 +17,7 @@ import useSortTableData from "./useSortTableData";
 import useAccountKeys from "./useAccountKeys";
 import useRemodels from "./useRemodels";
 import useSerialLogs from "./useSerialLogs";
+import useEndpointAvailability from "./useEndpointAvailability";
 
 export {
   useValidationSets,
@@ -38,4 +39,5 @@ export {
   useAccountKeys,
   useRemodels,
   useSerialLogs,
+  useEndpointAvailability,
 };

--- a/static/js/publisher/hooks/useEndpointAvailability.ts
+++ b/static/js/publisher/hooks/useEndpointAvailability.ts
@@ -1,0 +1,71 @@
+import { useState, useEffect } from "react";
+
+const useEndpointAvailability = (
+  brandId: string | undefined,
+  modelId: string | undefined,
+): {
+  isRemodelAvailable: boolean;
+  isSerialLogAvailable: boolean;
+} => {
+  const [isRemodelAvailable, setIsRemodelAvailable] = useState(false);
+  const [isSerialLogAvailable, setIsSerialLogAvailable] = useState(false);
+
+  useEffect(() => {
+    const abortController = new AbortController();
+    const signal = abortController.signal;
+
+    const checkEndpointAvailability = async () => {
+      if (!brandId && !modelId) {
+        if (!signal.aborted) {
+          setIsRemodelAvailable(false);
+          setIsSerialLogAvailable(false);
+        }
+
+        return;
+      }
+
+      const remodelUrl = `/api/store/${brandId}/models/remodel-allowlist`;
+      const serialLogUrl = `/api/store/${brandId}/models/${modelId}/serial-log`;
+
+      const remodelPromise = fetch(remodelUrl, { method: "HEAD", signal })
+        .then((response) => ({ success: true, ok: response.ok }))
+        .catch(() => ({ success: false, ok: false }));
+
+      const serialLogPromise = fetch(serialLogUrl, { method: "HEAD", signal })
+        .then((response) => ({ success: true, ok: response.ok }))
+        .catch(() => ({ success: false, ok: false }));
+
+      const results = await Promise.allSettled([
+        remodelPromise,
+        serialLogPromise,
+      ]);
+
+      if (!signal.aborted) {
+        const remodelResult =
+          results[0].status === "fulfilled"
+            ? results[0].value
+            : { success: false, ok: false };
+        const serialLogResult =
+          results[1].status === "fulfilled"
+            ? results[1].value
+            : { success: false, ok: false };
+
+        setIsRemodelAvailable(remodelResult.ok);
+        setIsSerialLogAvailable(modelId ? serialLogResult.ok : false);
+      }
+    };
+
+    checkEndpointAvailability();
+
+    return () => {
+      abortController.abort();
+    };
+  }, [brandId, modelId]);
+
+  return {
+    isRemodelAvailable,
+    isSerialLogAvailable,
+  };
+};
+
+export default useEndpointAvailability;

--- a/static/js/publisher/layouts/ModelDetailsPageLayout/ModelNav.tsx
+++ b/static/js/publisher/layouts/ModelDetailsPageLayout/ModelNav.tsx
@@ -1,14 +1,16 @@
 import { Link, useParams } from "react-router-dom";
 import { useAtomValue } from "jotai";
 
-import { useRemodels, useSerialLogs } from "../../hooks";
+import { useEndpointAvailability } from "../../hooks";
 import { brandIdState } from "../../state/brandStoreState";
 
 function ModelNav({ sectionName }: { sectionName: string }): React.JSX.Element {
   const { id, modelId } = useParams();
   const brandId = useAtomValue(brandIdState);
-  const { data: remodelsData } = useRemodels(brandId);
-  const { data: serialLogsData } = useSerialLogs(brandId, modelId);
+  const { isRemodelAvailable, isSerialLogAvailable } = useEndpointAvailability(
+    brandId,
+    modelId,
+  );
 
   return (
     <nav className="p-tabs">
@@ -33,7 +35,7 @@ function ModelNav({ sectionName }: { sectionName: string }): React.JSX.Element {
             Policies
           </Link>
         </li>
-        {remodelsData?.success && (
+        {isRemodelAvailable && (
           <li className="p-tabs__item">
             <Link
               to={`/admin/${id}/models/${modelId}/remodel`}
@@ -45,7 +47,7 @@ function ModelNav({ sectionName }: { sectionName: string }): React.JSX.Element {
             </Link>
           </li>
         )}
-        {serialLogsData?.success && (
+        {isSerialLogAvailable && (
           <li className="p-tabs__item">
             <Link
               to={`/admin/${id}/models/${modelId}/serial-log`}

--- a/static/js/publisher/layouts/ModelDetailsPageLayout/__tests__/ModelNav.test.tsx
+++ b/static/js/publisher/layouts/ModelDetailsPageLayout/__tests__/ModelNav.test.tsx
@@ -5,19 +5,19 @@ import { vi } from "vitest";
 import "@testing-library/jest-dom";
 
 import ModelNav from "../ModelNav";
-import { useRemodels, useSerialLogs } from "../../../hooks";
-
-import type { UseQueryResult } from "react-query";
-import type {
-  ApiResponse,
-  RemodelResponse,
-  SerialLogResponse,
-} from "../../../types/shared";
+import { useEndpointAvailability } from "../../../hooks";
 
 vi.mock("../../../hooks", () => ({
-  useRemodels: vi.fn(),
-  useSerialLogs: vi.fn(),
+  useEndpointAvailability: vi.fn(),
 }));
+
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual("react-router-dom");
+  return {
+    ...actual,
+    useParams: vi.fn(() => ({ id: "test-id", modelId: "test-model-id" })),
+  };
+});
 
 vi.mock("../../../state/brandStoreState", () => ({
   brandIdState: "mock-brand-id",
@@ -40,28 +40,16 @@ const renderComponent = (sectionName: string) => {
 };
 
 describe("ModelNav", () => {
-  it("highlights the correct navigation item", () => {
-    const mockUseRemodels = vi.mocked(useRemodels);
-    mockUseRemodels.mockReturnValue({
-      data: {
-        success: true,
-        data: {
-          allowlist: [],
-          "next-cursor": null,
-        },
-      },
-    } as unknown as UseQueryResult<ApiResponse<RemodelResponse>, Error>);
+  const mockUseEndpointAvailability = vi.mocked(useEndpointAvailability);
 
-    const mockUseSerialLogs = vi.mocked(useSerialLogs);
-    mockUseSerialLogs.mockReturnValue({
-      data: {
-        success: true,
-        data: {
-          items: [],
-          "next-cursor": null,
-        },
-      },
-    } as unknown as UseQueryResult<ApiResponse<SerialLogResponse>, Error>);
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+  it("highlights the correct navigation item", () => {
+    mockUseEndpointAvailability.mockReturnValue({
+      isRemodelAvailable: true,
+      isSerialLogAvailable: true,
+    });
 
     renderComponent("policies");
     const currentLink = screen.getByRole("tab", { name: "Policies" });
@@ -69,83 +57,31 @@ describe("ModelNav", () => {
   });
 
   it("doesn't highlight other navigation links", () => {
-    const mockUseRemodels = vi.mocked(useRemodels);
-    mockUseRemodels.mockReturnValue({
-      data: {
-        success: true,
-        data: {
-          allowlist: [],
-          "next-cursor": null,
-        },
-      },
-    } as unknown as UseQueryResult<ApiResponse<RemodelResponse>, Error>);
-
-    const mockUseSerialLogs = vi.mocked(useSerialLogs);
-    mockUseSerialLogs.mockReturnValue({
-      data: {
-        success: true,
-        data: {
-          items: [],
-          "next-cursor": null,
-        },
-      },
-    } as unknown as UseQueryResult<ApiResponse<SerialLogResponse>, Error>);
+    mockUseEndpointAvailability.mockReturnValue({
+      isRemodelAvailable: true,
+      isSerialLogAvailable: true,
+    });
 
     renderComponent("policies");
     const currentLink = screen.getByRole("tab", { name: "Overview" });
     expect(currentLink.getAttribute("aria-selected")).toBe("false");
   });
 
-  it("shows Remodel tab when useRemodels returns success: true", () => {
-    const mockUseRemodels = vi.mocked(useRemodels);
-    mockUseRemodels.mockReturnValue({
-      data: {
-        success: true,
-        data: {
-          allowlist: [],
-          "next-cursor": null,
-        },
-      },
-    } as unknown as UseQueryResult<ApiResponse<RemodelResponse>, Error>);
-
-    const mockUseSerialLogs = vi.mocked(useSerialLogs);
-    mockUseSerialLogs.mockReturnValue({
-      data: {
-        success: true,
-        data: {
-          items: [],
-          "next-cursor": null,
-        },
-      },
-    } as unknown as UseQueryResult<ApiResponse<SerialLogResponse>, Error>);
+  it("shows Remodel tab when endpoint is available", () => {
+    mockUseEndpointAvailability.mockReturnValue({
+      isRemodelAvailable: true,
+      isSerialLogAvailable: false,
+    });
 
     renderComponent("overview");
     expect(screen.getByRole("tab", { name: "Remodel" })).toBeInTheDocument();
   });
 
-  it("hides Remodel tab when useRemodels returns success: false", () => {
-    const mockUseRemodels = vi.mocked(useRemodels);
-    mockUseRemodels.mockReturnValue({
-      data: {
-        success: false,
-        message: "Remodeling not available",
-        data: {
-          allowlist: [],
-          "next-cursor": null,
-        },
-      },
-    } as unknown as UseQueryResult<ApiResponse<RemodelResponse>, Error>);
-
-    const mockUseSerialLogs = vi.mocked(useSerialLogs);
-    mockUseSerialLogs.mockReturnValue({
-      data: {
-        success: false,
-        data: {
-          items: [],
-          "next-cursor": null,
-        },
-      },
-    } as unknown as UseQueryResult<ApiResponse<SerialLogResponse>, Error>);
+  it("hides Remodel tab when endpoint is not available", () => {
+    mockUseEndpointAvailability.mockReturnValue({
+      isRemodelAvailable: false,
+      isSerialLogAvailable: false,
+    });
 
     renderComponent("overview");
     expect(
@@ -153,20 +89,25 @@ describe("ModelNav", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("hides Remodel tab when useRemodels returns no data", () => {
-    const mockUseRemodels = vi.mocked(useRemodels);
-    mockUseRemodels.mockReturnValue({
-      data: undefined,
-    } as unknown as UseQueryResult<ApiResponse<RemodelResponse>, Error>);
+  it("shows Serial log tab when endpoint is available", () => {
+    mockUseEndpointAvailability.mockReturnValue({
+      isRemodelAvailable: false,
+      isSerialLogAvailable: true,
+    });
 
-    const mockUseSerialLogs = vi.mocked(useSerialLogs);
-    mockUseSerialLogs.mockReturnValue({
-      data: undefined,
-    } as unknown as UseQueryResult<ApiResponse<SerialLogResponse>, Error>);
+    renderComponent("overview");
+    expect(screen.getByRole("tab", { name: "Serial log" })).toBeInTheDocument();
+  });
+
+  it("hides Serial log tab when endpoint is not available", () => {
+    mockUseEndpointAvailability.mockReturnValue({
+      isRemodelAvailable: false,
+      isSerialLogAvailable: false,
+    });
 
     renderComponent("overview");
     expect(
-      screen.queryByRole("tab", { name: "Remodel" }),
+      screen.queryByRole("tab", { name: "Serial log" }),
     ).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Done
Replaces the requests to check for remodel and serial log permissions with a custom hook which makes a `HEAD` request which is more performant as the remodels and serial logs data isn't required at that point.

## How to QA
- Go to https://snapcraft-io-5687.demos.haus/admin/ahnuP3quahti9vis8aiw/models/testing-model-new2
- Check that "Remodel" and "Serial log" appear in the horizontal navigation
- Go to https://snapcraft-io-5687.demos.haus/admin/nah4ahShap8aefie6pha/models/steve-test
- Check that "Remodel" and "Serial log" _don't_ appear in the horizontal navigation

## Testing

- [x] This PR has tests
- [ ] No testing required (explain why):

## Security

- [ ] Security considerations for review (list them):
  - [ ] Examples:
  - [ ] Access control: users can only access their own data
  - [ ] Input: user input is validated and sanitised
  - [ ] Sensitive data: secret or private data is not exposed in any way
  - [ ] ...
- [x] This PR has no security considerations (explain why): No user input

## Issue / Card

n/a

## Screenshots
n/a

## UX Approval

- [x] This PR does not require UX approval
- [ ] This PR does require UX approval (add context):
