### PR TITLE
Add status banner to layouts

### DIFF
--- a/templates/_base-layout.html
+++ b/templates/_base-layout.html
@@ -73,6 +73,17 @@
     {% endif %}
     {% endblock %}
 
+    {% block banner %}
+      <div class="p-strip is-shallow">
+        <div class="p-notification--caution u-fixed-width u-no-margin--bottom">
+          <div class="p-notification__content">
+            <h5 class="p-notification__title">Temporary performance degradation</h5>
+            <p class="p-notification__message">We are currently experiencing service degradation and working on resolving this. Thank you for your patience and understanding.</p>
+          </div>
+        </div>
+      </div>
+    {% endblock %}
+
     {% block content %}{% endblock %}
 
     {% block footer %}

--- a/templates/store/publisher.html
+++ b/templates/store/publisher.html
@@ -1,7 +1,17 @@
 {% set show_header = False %}
 {% extends "_base-layout.html" %}
 {% block body_class %}{% endblock %}
+{% block banner %}{% endblock %}
 {% block content %}
+<div id="status-banner" class="p-strip is-shallow" style="position: fixed; bottom: 0; left: 0; right: 0; z-index: 1000;">
+  <div class="p-notification--caution u-fixed-width u-no-margin--bottom">
+    <div class="p-notification__content">
+      <h5 class="p-notification__title">Temporary performance degradation</h5>
+      <p class="p-notification__message">We are currently experiencing service degradation and working on resolving this. Thank you for your patience and understanding.</p>
+    </div>
+    <button class="p-notification__close" aria-controls="status-banner" onclick="document.getElementById('status-banner').remove()">Close</button>
+  </div>
+</div>
 <div id="root">
 </div>
 <script>


### PR DESCRIPTION
## Done

Adds status banner to layouts.
Equivalent of https://github.com/canonical/charmhub.io/pull/2319

## How to QA

## Testing

- [ ] This PR has tests
- [x] No testing required (explain why): visual change

## Security

- [ ] Security considerations for review (list them):
- [x] This PR has no security considerations (explain why): visual change


## Screenshots
<img width="1519" height="282" alt="image" src="https://github.com/user-attachments/assets/c3e5f5c3-15e2-4260-98cb-148ea7e30e84" />

<img width="2102" height="1020" alt="image" src="https://github.com/user-attachments/assets/f0b7f4f5-6af5-4af8-a24c-85ac3a474c59" />


## UX Approval

- [x] This PR does not require UX approval
- [ ] This PR does require UX approval (add context):
