### PR TITLE
force renovate to open smaller prs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,22 @@
 {
   "extends": [
     "github>canonical/renovate-websites"
+  ],
+
+  "prConcurrentLimit": 3,
+
+  "packageRules": [
+    {
+      "matchUpdateTypes": ["major"],
+      "groupName": null
+    },
+    {
+      "matchUpdateTypes": ["minor"],
+      "groupName": "minor updates"
+    },
+    {
+      "matchUpdateTypes": ["patch"],
+      "groupName": "patch updates"
+    }
   ]
 }


### PR DESCRIPTION
## Done
- Limited Renovate to at most 3 open PRs at once. Without this renovate might open 20+ prs simultaneously.
- If its a major update:  do NOT group major updates together, create separate PRs per dependency.
- Groups all minor updates into one PR.
- Groups all patch updates into one PR.
## How to QA
x
## Testing

- [ ] This PR has tests
- [ ] No testing required (explain why):

## Security

- [ ] Security considerations for review (list them):
  - [ ] Examples:
  - [ ] Access control: users can only access their own data
  - [ ] Input: user input is validated and sanitised
  - [ ] Sensitive data: secret or private data is not exposed in any way
  - [ ] ...
- [ ] This PR has no security considerations (explain why):

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-36541

## Screenshots

## UX Approval

- [ ] This PR does not require UX approval
- [ ] This PR does require UX approval (add context):
