### PR TITLE
Add banner to admin template

### DIFF
--- a/templates/admin/admin.html
+++ b/templates/admin/admin.html
@@ -2,7 +2,18 @@
 {% set show_header = False %}
 {% extends "_base-layout.html" %}
 {% block body_class %}{% endblock %}
+{% block banner %}{% endblock %}
 {% block content %}
+<div id="status-banner" class="p-strip is-shallow" style="position: fixed; bottom: 0; left: 0; right: 0; z-index: 1000;">
+  <div class="p-notification--caution u-fixed-width u-no-margin--bottom">
+    <div class="p-notification__content">
+      <h5 class="p-notification__title">Temporary performance degradation</h5>
+      <p class="p-notification__message">We are currently experiencing service degradation and working on resolving this. Thank you for your patience and understanding.</p>
+    </div>
+    <button class="p-notification__close" aria-controls="status-banner" onclick="document.getElementById('status-banner').remove()">Close</button>
+  </div>
+</div>
+
 <div id="root">
 </div>
 


### PR DESCRIPTION
## Done

Added the same banner as for publisher layout for consistency in admin views.

## How to QA

Go to a store admin view: https://snapcraft-io-5704.demos.haus/admin/nah4ahShap8aefie6pha/snaps (go to link directly, not through SPA publisher view)

Make sure it shows notice banner floating at the bottom of the app layout.

## Testing

- [ ] This PR has tests
- [x] No testing required (explain why): visual change

## Security

- [x] This PR has no security considerations (explain why): visual change only

