### PR TITLE
Remove major updates grouping from Renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,10 +7,6 @@
 
   "packageRules": [
     {
-      "matchUpdateTypes": ["major"],
-      "groupName": null
-    },
-    {
       "matchUpdateTypes": ["minor"],
       "groupName": "minor updates"
     },


### PR DESCRIPTION
## Done
- Removes major updates grouping so that they are not omitted
