### PR TITLE
chore: Update Mozilla logo on homepage

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -22,7 +22,7 @@
         <a href="/firefox">
           {{
             image(
-              url="https://assets.ubuntu.com/v1/aae93857-logo-mozilla--snapcraft-homepage.svg",
+              url="https://assets.ubuntu.com/v1/6eec0a35-logo_mozilla_snapcraft_homepage.svg",
               alt="Mozilla",
               width="146",
               height="145",


### PR DESCRIPTION
## Done

Replaced the Mozilla logo on the homepage with the latest version

## How to QA
- Go to https://snapcraft-io-5711.demos.haus/
- Check that the Mozilla logo in the "Official snaps from major publishers" section matches the current version which can be seen on the Mozilla homepage header

## Testing

- [ ] This PR has tests
- [x] No testing required (explain why): Visual/content change

## Security

- [ ] Security considerations for review (list them):
  - [ ] Examples:
  - [ ] Access control: users can only access their own data
  - [ ] Input: user input is validated and sanitised
  - [ ] Sensitive data: secret or private data is not exposed in any way
  - [ ] ...
- [x] This PR has no security considerations (explain why): Visual/content change

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-36601

## Screenshots

<img width="2656" height="542" alt="Screenshot 2026-05-20 at 15 10 52" src="https://github.com/user-attachments/assets/e6882416-0fa6-49e3-9a43-867f4a7933f6" />


## UX Approval

- [x] This PR does not require UX approval
- [ ] This PR does require UX approval (add context):
