### PR TITLE
fix: block list-parser rule bypass

### DIFF
--- a/tests/tests_markdown_parser.py
+++ b/tests/tests_markdown_parser.py
@@ -175,3 +175,34 @@ class TestMarkdownParser(unittest.TestCase):
         expected_result = "<p>" + markdown + "</p>\n"
 
         self.assertEqual(result, expected_result)
+
+    def test_list_followed_by_heading_does_not_render_heading(self):
+        markdown = "- a\n# Title"
+        expected = "<ul>\n<li>a</li>\n</ul>\n<p># Title</p>\n"
+        self.assertEqual(parse_markdown_description(markdown), expected)
+
+    def test_list_followed_by_blockquote_does_not_render_blockquote(self):
+        markdown = "- a\n> quoted"
+        expected = "<ul>\n<li>a</li>\n</ul>\n<p>&gt; quoted</p>\n"
+        self.assertEqual(parse_markdown_description(markdown), expected)
+
+    def test_list_followed_by_fence_does_not_render_code_block(self):
+        markdown = "- a\n```\ncode\n```"
+        expected = (
+            "<ul>\n<li>a</li>\n</ul>\n<p>```\ncode\n```</p>\n"
+        )
+        self.assertEqual(parse_markdown_description(markdown), expected)
+
+    def test_intro_paragraph_before_list_stays_separate_from_heading(self):
+        markdown = "intro\n- a\n# title"
+        expected = (
+            "<p>intro</p>\n<ul>\n<li>a</li>\n</ul>\n<p># title</p>\n"
+        )
+        self.assertEqual(parse_markdown_description(markdown), expected)
+
+    def test_parse_auto_email(self):
+        markdown = "<me@example.com>"
+        expected = (
+            '<p><a href="mailto:me@example.com">me@example.com</a></p>\n'
+        )
+        self.assertEqual(parse_markdown_description(markdown), expected)

--- a/tests/tests_markdown_parser.py
+++ b/tests/tests_markdown_parser.py
@@ -188,16 +188,12 @@ class TestMarkdownParser(unittest.TestCase):
 
     def test_list_followed_by_fence_does_not_render_code_block(self):
         markdown = "- a\n```\ncode\n```"
-        expected = (
-            "<ul>\n<li>a</li>\n</ul>\n<p>```\ncode\n```</p>\n"
-        )
+        expected = "<ul>\n<li>a</li>\n</ul>\n<p>```\ncode\n```</p>\n"
         self.assertEqual(parse_markdown_description(markdown), expected)
 
     def test_intro_paragraph_before_list_stays_separate_from_heading(self):
         markdown = "intro\n- a\n# title"
-        expected = (
-            "<p>intro</p>\n<ul>\n<li>a</li>\n</ul>\n<p># title</p>\n"
-        )
+        expected = "<p>intro</p>\n<ul>\n<li>a</li>\n</ul>\n<p># title</p>\n"
         self.assertEqual(parse_markdown_description(markdown), expected)
 
     def test_parse_auto_email(self):

--- a/webapp/endpoints/publisher/register.py
+++ b/webapp/endpoints/publisher/register.py
@@ -52,9 +52,7 @@ def post_register_name():
 
         if api_response_error_list.status_code == 400:
             res["data"]["error_code"] = "no-permission"
-            res[
-                "message"
-            ] = """You don't have permission
+            res["message"] = """You don't have permission
                 to register a snap in this store.
                 Please see store administrator."""
 

--- a/webapp/endpoints/publisher/register.py
+++ b/webapp/endpoints/publisher/register.py
@@ -52,7 +52,9 @@ def post_register_name():
 
         if api_response_error_list.status_code == 400:
             res["data"]["error_code"] = "no-permission"
-            res["message"] = """You don't have permission
+            res[
+                "message"
+            ] = """You don't have permission
                 to register a snap in this store.
                 Please see store administrator."""
 

--- a/webapp/markdown.py
+++ b/webapp/markdown.py
@@ -45,6 +45,19 @@ class SnapcraftBlockParser(BlockParser):
         )
         return m.end()
 
+    def parse_method(self, m, state):
+        # mistune's list parser invokes parse_method for rules outside
+        # DEFAULT_RULES (atx_heading, block_quote, ...) render those as
+        # paragraph text instead of letting the inherited methods run.
+        if m.lastgroup not in self.DEFAULT_RULES:
+            end_pos = state.find_line_end()
+            state.append_token(
+                {"type": "paragraph", "text": state.get_text(end_pos)}
+            )
+            state.cursor = end_pos
+            return end_pos
+        return super().parse_method(m, state)
+
 
 class SnapcraftInlineParser(InlineParser):
     SPECIFICATION = {
@@ -57,6 +70,7 @@ class SnapcraftInlineParser(InlineParser):
     DEFAULT_RULES = (
         "escape",
         "auto_link",
+        "auto_email",
         "emphasis",
         "codespan",
         "linebreak",


### PR DESCRIPTION
## Done
- Stopped the mistune 3 upgrade from re-enabling h1, blockquote, and pre code rendering when a list is followed by # heading, > quote, or a triple-backtick fence (``` some code ```). mistune 3's list parser was calling restricted parse methods directly, bypassing our reduced rule set.
- Added four regression tests covering the leak scenarios and one for the email autolink.

## How to QA
- go to https://snapcraft-io-5714.demos.haus/ilayda-test-hello
- Find the line that reads # 
  - This should NOT be a heading.
  - It should be the same font size and weight as the surrounding paragraph text
- Find > This should NOT be a blockquote.
  - It should sit flush-left like normal text, not indented and not in a grey/bordered quote box.
- Find the this should not be a code block line.
  - It should be plain paragraph text with literal backticks visible around it. It should not be inside a grey monospace box.
- On the line with "bold and italic and code and strike"
  - Verify bold is in bold, italic is in italics, code is in a monospace inline span, strike is ~~struck through~~.
- The "one / two / three" block should appear as a bulleted list with visible bullet points, not as three separate lines of plain text.
- https://snapcraft.io in the "Visit ... for more." sentence should be a clickable blue link.
- The three-space indented code line should appear inside a grey monospace  box.

## Testing

- [x] This PR has tests
- [ ] No testing required (explain why):

## Security

- [ ] Security considerations for review (list them):
  - [ ] Output tags allowlist: the fix narrows what HTML the parser can emit. Anything outside the allowlist is now coerced into a paragraph whose contents flow through HTML escaping, so injected <script>, <style>, etc. stay escaped.
  - [ ]  mailto autolink: auto_email was re-enabled, but the regex only matches email-shaped input (no : in the local part), so alternate schemes like javascript: cannot be smuggled in. The URL goes through mistune's escape_url and the renderer's safe_url (which already blocks harmful protocols).
  - [ ] No new user-input sinks, no new outbound calls, no auth/permission changes.

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-36737

