### PR TITLE
WD-34912 - Close channel & re-add revisions

### DIFF
--- a/static/js/publisher/pages/Releases/components/defaultTrackModifier.tsx
+++ b/static/js/publisher/pages/Releases/components/defaultTrackModifier.tsx
@@ -14,6 +14,7 @@ import type {
   ReleasesReduxState,
 } from "../../../types/releaseTypes";
 import type { AppDispatch } from "../store";
+import { clearDefaultTrack, setDefaultTrack } from "../slices/defaultTrack";
 
 interface StateProps {
   defaultTrack: string | null;
@@ -27,6 +28,8 @@ interface DispatchProps {
   openModal: (payload: ModalState) => void;
   showNotification: (payload: NotificationState) => void;
   hideNotification: () => void;
+  clearDefaultTrack: () => void;
+  setDefaultTrack: () => void;
 }
 
 type DefaultTrackModifierProps = StateProps & DispatchProps;
@@ -40,7 +43,7 @@ class DefaultTrackModifier extends Component<DefaultTrackModifierProps> {
   }
 
   clearDefaultTrackHandler() {
-    const { defaultTrack, openModal } = this.props;
+    const { clearDefaultTrack, defaultTrack, openModal } = this.props;
 
     openModal({
       title: "Clear default track",
@@ -49,7 +52,7 @@ class DefaultTrackModifier extends Component<DefaultTrackModifierProps> {
         {
           appearance: "positive",
           onClickAction: {
-            reduxAction: "clearDefaultTrack",
+            reduxAction: clearDefaultTrack,
           },
           label: `Clear ${defaultTrack} as default track`,
         },
@@ -65,7 +68,7 @@ class DefaultTrackModifier extends Component<DefaultTrackModifierProps> {
   }
 
   setDefaultTrackHandler() {
-    const { currentTrack, defaultTrack, openModal } = this.props;
+    const { currentTrack, defaultTrack, openModal, setDefaultTrack } = this.props;
 
     openModal({
       title: `Set default track to ${currentTrack}`,
@@ -74,7 +77,7 @@ class DefaultTrackModifier extends Component<DefaultTrackModifierProps> {
         {
           appearance: "positive",
           onClickAction: {
-            reduxAction: "setDefaultTrack",
+            reduxAction: setDefaultTrack,
           },
           label: `Set ${currentTrack} as default track`,
         },
@@ -166,6 +169,8 @@ const mapDispatchToProps = (dispatch: AppDispatch): DispatchProps => ({
   openModal: (payload) => dispatch(openModal(payload)),
   showNotification: (payload) => dispatch(showNotification(payload)),
   hideNotification: () => dispatch(hideNotification()),
+  clearDefaultTrack: () => dispatch(clearDefaultTrack()),
+  setDefaultTrack: () => dispatch(setDefaultTrack()),
 });
 
 export default connect(

--- a/static/js/publisher/pages/Releases/components/modal.tsx
+++ b/static/js/publisher/pages/Releases/components/modal.tsx
@@ -2,7 +2,6 @@ import { Component, ReactNode } from "react";
 import { connect } from "react-redux";
 
 import { CLOSE_MODAL_ACTION_NAME, closeModal } from "../slices/modal";
-import { setDefaultTrack, clearDefaultTrack } from "../slices/defaultTrack";
 import type { ReleasesReduxState } from "../../../types/releaseTypes";
 import type { AppDispatch } from "../store";
 
@@ -10,7 +9,7 @@ type ModalAction = {
   appearance: "positive" | "neutral" | "negative";
   onClickAction:
     | {
-        reduxAction: string;
+        reduxAction: () => void;
       }
     | {
         type: typeof CLOSE_MODAL_ACTION_NAME;
@@ -23,9 +22,6 @@ interface ModalActionButtonProps {
   appearance: ModalAction["appearance"];
   children: ReactNode;
   dispatch: AppDispatch;
-  setDefaultTrack?: () => void;
-  clearDefaultTrack?: () => void;
-  [key: string]: unknown; // For dynamic redux action props
 }
 
 interface ModalActionButtonState {
@@ -48,11 +44,7 @@ class ModalActionButton extends Component<ModalActionButtonProps, ModalActionBut
 
     if ("reduxAction" in onClickAction) {
       const { reduxAction } = onClickAction;
-      const reduxActionFn = this.props[reduxAction];
-      if (reduxActionFn && typeof reduxActionFn === "function") {
-        // If an action is passed, perform the specific action
-        (reduxActionFn as () => void)();
-      }
+      reduxAction();
     } else {
       // Otherwise dispatch the action object
       dispatch(onClickAction);
@@ -70,7 +62,6 @@ class ModalActionButton extends Component<ModalActionButtonProps, ModalActionBut
     const className = [
       `p-button--${appearance}`,
       "u-no-margin--bottom",
-      "u-float-right",
       ["positive", "negative"].indexOf(appearance) > -1 ? "is--dark" : "",
     ];
 
@@ -89,8 +80,6 @@ class ModalActionButton extends Component<ModalActionButtonProps, ModalActionBut
 
 const mapActionButtonDispatchToProps = (dispatch: AppDispatch) => ({
   dispatch,
-  setDefaultTrack: () => dispatch(setDefaultTrack()),
-  clearDefaultTrack: () => dispatch(clearDefaultTrack()),
 });
 
 const ModalActionButtonWrapped = connect(
@@ -131,15 +120,17 @@ const Modal = ({ title, content, actions = [], closeModal }: ModalProps) => {
           </button>
         </header>
         <p id="modal-description">{content}</p>
-        {actions.map((action, i) => (
-          <ModalActionButtonWrapped
-            key={`action-${i}`}
-            appearance={action.appearance}
-            onClickAction={action.onClickAction}
-          >
-            {action.label}
-          </ModalActionButtonWrapped>
-        ))}
+        <div className="u-align--right">
+          {actions.map((action, i) => (
+            <ModalActionButtonWrapped
+              key={`action-${i}`}
+              appearance={action.appearance}
+              onClickAction={action.onClickAction}
+            >
+              {action.label}
+            </ModalActionButtonWrapped>
+          ))}
+        </div>
       </div>
     </div>
   );

--- a/static/js/publisher/pages/Releases/components/releasesConfirmDetails/closeChannelsRow.tsx
+++ b/static/js/publisher/pages/Releases/components/releasesConfirmDetails/closeChannelsRow.tsx
@@ -13,7 +13,7 @@ const CloseChannelsRow = ({ channels }: CloseChannelsRowProps) => {
   }
   return (
     <div className="p-release-details-row is-closing">
-      <span>Close</span>
+      <span>Close&nbsp;</span>
       <span>
         {group
           .map((channel) => <b key={channel}>{channel}</b>)

--- a/static/js/publisher/pages/Releases/components/releasesConfirmDetails/index.tsx
+++ b/static/js/publisher/pages/Releases/components/releasesConfirmDetails/index.tsx
@@ -76,6 +76,7 @@ const ReleasesConfirmDetails = ({
 
   return (
     <div className="p-releases-confirm__details">
+      {showPendingCloses && <CloseChannelsRow channels={pendingCloses} />}
       {showProgressiveReleases && (
         <ReleaseRowGroup releases={progressiveReleases} />
       )}
@@ -116,7 +117,6 @@ const ReleasesConfirmDetails = ({
           </Col>
         </Row>
       )}
-      {showPendingCloses && <CloseChannelsRow channels={pendingCloses} />}
     </div>
   );
 };

--- a/static/js/publisher/pages/Releases/components/releasesTable/cellViews.tsx
+++ b/static/js/publisher/pages/Releases/components/releasesTable/cellViews.tsx
@@ -11,6 +11,7 @@ import {
 } from "../../helpers";
 import { useDragging, Handle } from "../dnd";
 
+import CloseMenuItem from "./closeMenuItem";
 import ReleaseMenuItem from "./releaseMenuItem";
 import type { Revision, CPUArchitecture } from "../../../../types/releaseTypes";
 import type { DraggedItem } from "./types";
@@ -339,7 +340,7 @@ export const ReleasesTableCellView = (props: ReleasesTableCellViewProps) => {
           <>
             <ContextualMenu
               className="p-button is-small"
-              label={cellType === "revision" ? "Release" : "Promote"}
+              label={cellType === "revision" ? "Release" : "Promote/close"}
             >
               <span className="p-contextual-menu__group">
                 <span className="p-contextual-menu__item">
@@ -356,6 +357,9 @@ export const ReleasesTableCellView = (props: ReleasesTableCellViewProps) => {
                   );
                 })}
               </span>
+              { cellType === "release" &&
+                <CloseMenuItem item={item} current={current} arch={arch} />
+              }
             </ContextualMenu>
             <Handle />
           </>

--- a/static/js/publisher/pages/Releases/components/releasesTable/closeMenuItem.tsx
+++ b/static/js/publisher/pages/Releases/components/releasesTable/closeMenuItem.tsx
@@ -1,0 +1,57 @@
+import { connect } from "react-redux";
+
+import { closeRevision } from "../../slices/pendingChanges";
+import type {
+  Revision,
+  CPUArchitecture,
+} from "../../../../types/releaseTypes";
+import type { AppDispatch } from "../../store";
+import type { DraggedItem } from "./types";
+
+interface OwnProps {
+  item: DraggedItem;
+  current?: string;
+  arch?: CPUArchitecture;
+}
+
+interface DispatchProps {
+  closeRevision: (revision: Revision, targetChannel: string, arch: CPUArchitecture) => void;
+}
+
+type ReleaseMenuItemProps = OwnProps & DispatchProps;
+
+function CloseMenuItem(props: ReleaseMenuItemProps) {
+  return (props.current && props.arch &&
+    <span className="p-contextual-menu__group">
+      <a
+        className="p-contextual-menu__link"
+        href="#"
+        onClick={() => {
+          const revision = props.item.revisions.find(() => true);
+          if (revision) {
+            props.closeRevision(
+              revision,
+              props.current!,
+              props.arch!,
+            );
+          }
+        }}
+      >
+        Close {props.arch}
+      </a>
+    </span>
+  );
+}
+
+const mapDispatchToProps = (dispatch: AppDispatch): DispatchProps => {
+  return {
+    closeRevision: (revision: Revision, targetChannel: string, arch: CPUArchitecture) =>
+      dispatch(closeRevision(
+        revision,
+        targetChannel,
+        arch,
+      )),
+  };
+};
+
+export default connect(null, mapDispatchToProps)(CloseMenuItem);

--- a/static/js/publisher/pages/Releases/components/releasesTable/releaseCell.tsx
+++ b/static/js/publisher/pages/Releases/components/releasesTable/releaseCell.tsx
@@ -15,6 +15,7 @@ import {
   getFilteredAvailableRevisionsForArch,
   getProgressiveState,
   hasPendingRelease,
+  isArchPendingClose,
   type Branch,
   type ProgressiveState,
 } from "../../selectors";
@@ -32,7 +33,6 @@ import type {
   ReleasesReduxState,
   CPUArchitecture,
   ChannelArchitectureRevisionsMap,
-  Channel,
   Revision,
   FailedRevision,
 } from "../../../../types/releaseTypes";
@@ -53,7 +53,7 @@ interface OwnProps {
 interface StateProps {
   channelMap: ChannelArchitectureRevisionsMap;
   filters: ReleasesReduxState["history"]["filters"];
-  pendingCloses: Channel["name"][];
+  isArchPendingClose: boolean;
   failedRevisions: FailedRevision[];
   pendingChannelMap: ChannelArchitectureRevisionsMap;
   getAvailableCount: (arch: CPUArchitecture) => number;
@@ -82,7 +82,7 @@ const ReleasesTableReleaseCell = (props: ReleasesTableReleaseCellProps) => {
     branch,
     channelMap,
     pendingChannelMap,
-    pendingCloses,
+    isArchPendingClose,
     filters,
     isOverParent,
     getAvailableCount,
@@ -128,9 +128,9 @@ const ReleasesTableReleaseCell = (props: ReleasesTableReleaseCellProps) => {
     };
   }
 
-  const isChannelPendingClose = pendingCloses.includes(channel);
+  const pendingClose = isArchPendingClose;
   const isPending =
-    pendingRelease || isChannelPendingClose || pendingProgressiveState;
+    pendingRelease || pendingClose || pendingProgressiveState;
   const isUnassigned = risk === AVAILABLE;
   const isActive =
     filters &&
@@ -138,7 +138,7 @@ const ReleasesTableReleaseCell = (props: ReleasesTableReleaseCellProps) => {
     filters.risk === risk &&
     filters.branch === branchName;
   const isHighlighted = isPending || (isUnassigned && currentRevision);
-  const canDrag = (currentRevision && !isChannelPendingClose && releasable) || false;
+  const canDrag = (currentRevision && !pendingClose && releasable) || false;
 
 
   function handleHistoryIconClick(
@@ -185,7 +185,7 @@ const ReleasesTableReleaseCell = (props: ReleasesTableReleaseCellProps) => {
 
   let cellInfoNode = null;
 
-  if (isChannelPendingClose) {
+  if (pendingClose) {
     cellInfoNode = <CloseChannelInfo />;
   } else if (currentRevision) {
     cellInfoNode = (
@@ -209,7 +209,7 @@ const ReleasesTableReleaseCell = (props: ReleasesTableReleaseCellProps) => {
     );
   }
 
-  const showHistoryIcon = currentRevision || isUnassigned;
+  const showHistoryIcon = currentRevision || isUnassigned || pendingClose;
 
   return (
     <ReleasesTableCellView
@@ -237,11 +237,13 @@ const ReleasesTableReleaseCell = (props: ReleasesTableReleaseCellProps) => {
   );
 };
 
-const mapStateToProps = (state: ReleasesReduxState): StateProps => {
+const mapStateToProps = (state: ReleasesReduxState, ownProps: OwnProps): StateProps => {
+  const branchName = ownProps.branch ? ownProps.branch.branch : null;
+  const channel = getChannelName(ownProps.track, ownProps.risk, branchName);
   return {
     channelMap: state.channelMap,
     filters: state.history.filters,
-    pendingCloses: Object.values(state.pendingChanges.pendingCloses),
+    isArchPendingClose: isArchPendingClose(state, channel, ownProps.arch),
     failedRevisions: state.failedRevisions,
     pendingChannelMap: getPendingChannelMap(state),
     getAvailableCount: (arch: CPUArchitecture) =>

--- a/static/js/publisher/pages/Releases/selectors/__tests__/selectors.test.ts
+++ b/static/js/publisher/pages/Releases/selectors/__tests__/selectors.test.ts
@@ -1343,34 +1343,36 @@ describe("hasRelease", () => {
         ),
       };
 
+      const pendingReleasesProgressive = {
+        revision: 1,
+        channel: "latest/stable",
+        pendingReleaseItem: {
+          revision: createMockRevision({ revision: 1, architectures: ["amd64"] }),
+          progressive: {
+            "current-percentage": null,
+            percentage: null,
+            paused: null,
+          },
+          previousReleases: [
+            createMockRevision({ revision: 2 }),
+          ],
+        }
+      };
+
       const stateWithPendingReleaseToProgress: ReleasesReduxState = {
         ...stateWithFlagEnabled,
         pendingChanges: createMockPendingChanges(
-          [{
-            revision: 1,
-            channel: "latest/stable",
-            pendingReleaseItem: {
-              revision: createMockRevision({ revision: 1, architectures: ["amd64"] }),
-              progressive: {
-                "current-percentage": null,
-                percentage: null,
-                paused: null,
-              },
-              previousReleases: [
-                createMockRevision({ revision: 2 }),
-              ],
-            }
-          }],
+          [pendingReleasesProgressive],
           [],
         ),
-        releases: [
-          createMockRelease({
-            architecture: "amd64",
-            track: "latest",
-            risk: "stable",
-            revision: 2,
-          }),
-        ],
+      };
+
+      const stateWithPendingReleaseToClosedChannel: ReleasesReduxState = {
+        ...stateWithFlagEnabled,
+        pendingChanges: createMockPendingChanges(
+          [pendingReleasesProgressive],
+          ["latest/stable"],
+        ),
       };
 
       const stateWithPendingReleaseToCancel: ReleasesReduxState = {
@@ -1412,6 +1414,21 @@ describe("hasRelease", () => {
               stateWithPendingRelease
                 .pendingChanges
                 .pendingReleases["0"],
+          },
+          newReleasesToProgress: {},
+          cancelProgressive: {},
+        });
+      });
+
+      it("should return only new release if channel is closed", () => {
+        expect(
+          getSeparatePendingReleases(stateWithPendingReleaseToClosedChannel)
+        ).toEqual({
+          newReleases: {
+            "1-latest/stable":
+              stateWithPendingReleaseToClosedChannel
+                .pendingChanges
+                .pendingReleases["1"],
           },
           newReleasesToProgress: {},
           cancelProgressive: {},

--- a/static/js/publisher/pages/Releases/selectors/__tests__/selectors.test.ts
+++ b/static/js/publisher/pages/Releases/selectors/__tests__/selectors.test.ts
@@ -11,6 +11,7 @@ import {
   getSelectedRevisions,
   getSelectedArchitectures,
   getPendingChannelMap,
+  isArchPendingClose,
   hasDevmodeRevisions,
   hasPendingRelease,
   getFilteredAvailableRevisions,
@@ -339,18 +340,13 @@ describe("getPendingChannelMap", () => {
       changeOrderIndex: 1,
       pendingReleases: {
         0: {
-          revision: 2,
-          channels: {
-            "latest/stable": {
-              revision: createMockRevision({ revision: 2, architectures: ["test64"] }),
-              channel: "latest/stable",
-              previousReleases: [],
-              progressive: {
-                "current-percentage": null,
-                percentage: null,
-                paused: null,
-              }
-            },
+          revision: createMockRevision({ revision: 2, architectures: ["test64"] }),
+          channel: "latest/stable",
+          previousReleases: [],
+          progressive: {
+            "current-percentage": null,
+            percentage: null,
+            paused: null,
           },
         },
       },
@@ -385,13 +381,7 @@ describe("getPendingChannelMap", () => {
       expect(getPendingChannelMap(stateWithPendingReleases)).toEqual({
         ...stateWithPendingReleases.channelMap,
         "latest/stable": {
-          test64: {
-            ...stateWithPendingReleases
-              .pendingChanges
-              .pendingReleases["0"]
-              .channels["latest/stable"]
-              .revision,
-          },
+          test64: stateWithPendingReleases.pendingChanges.pendingReleases["0"].revision,
         },
       });
     });
@@ -401,30 +391,188 @@ describe("getPendingChannelMap", () => {
     it("should return channel map with pending revisions", () => {
       const stateWithWithOverrides = {
         ...stateWithPendingReleases,
-      };
-      stateWithWithOverrides.pendingChanges.pendingReleases["0"].channels["latest/stable"] = {
-        revision: createMockRevision({ revision: 2, architectures: ["test64"] }),
-        channel: "latest/stable",
-        previousReleases: [],
-        progressive: {
-          "current-percentage": null,
-          percentage: null,
-          paused: null,
-        }
+        pendingChanges: {
+          ...stateWithPendingReleases.pendingChanges,
+          pendingReleases: {
+            0: {
+              revision: createMockRevision({ revision: 2, architectures: ["test64"] }),
+              channel: "latest/stable",
+              previousReleases: [],
+              progressive: {
+                "current-percentage": null,
+                percentage: null,
+                paused: null,
+              },
+            },
+          },
+        },
       };
       expect(getPendingChannelMap(stateWithWithOverrides)).toEqual({
         ...stateWithWithOverrides.channelMap,
         "latest/stable": {
-          test64: {
-            ...stateWithWithOverrides
-              .pendingChanges
-              .pendingReleases["0"]
-              .channels["latest/stable"]
-              .revision,
-          },
+          test64: stateWithWithOverrides.pendingChanges.pendingReleases["0"].revision,
         },
       });
     });
+  });
+
+  describe("when there are pending closes", () => {
+    it("should clear the closed channel from the pending channel map", () => {
+      const stateWithPendingClose: ReleasesReduxState = {
+        ...initialState,
+        channelMap: {
+          "test/edge": { test64: createMockRevision({ revision: 1 }) },
+          "test/stable": { test64: createMockRevision({ revision: 2 }) },
+        },
+        pendingChanges: {
+          changeOrderIndex: 1,
+          pendingReleases: {},
+          pendingCloses: { 0: "test/edge" },
+        },
+      };
+
+      const result = getPendingChannelMap(stateWithPendingClose);
+      expect(result["test/edge"]).toBeUndefined();
+      expect(result["test/stable"]).toBeDefined();
+    });
+
+    it("should apply close and subsequent release in order — release wins per arch", () => {
+      const revision = createMockRevision({ revision: 3, architectures: ["test64"] });
+      const stateWithCloseAndRelease: ReleasesReduxState = {
+        ...initialState,
+        channelMap: {
+          "test/edge": { test64: createMockRevision({ revision: 1 }) },
+        },
+        pendingChanges: {
+          changeOrderIndex: 2,
+          pendingReleases: {
+            1: { revision, channel: "test/edge", previousReleases: [] },
+          },
+          pendingCloses: { 0: "test/edge" },
+        },
+      };
+
+      const result = getPendingChannelMap(stateWithCloseAndRelease);
+      expect(result["test/edge"]?.["test64"]).toEqual(revision);
+    });
+
+    it("should keep arch closed when close comes after a release for that arch", () => {
+      const revision = createMockRevision({ revision: 3, architectures: ["test64"] });
+      const stateWithReleaseAndClose: ReleasesReduxState = {
+        ...initialState,
+        channelMap: {
+          "test/edge": { test64: createMockRevision({ revision: 1 }) },
+        },
+        pendingChanges: {
+          changeOrderIndex: 2,
+          pendingReleases: {
+            0: { revision, channel: "test/edge", previousReleases: [] },
+          },
+          pendingCloses: { 1: "test/edge" },
+        },
+      };
+
+      const result = getPendingChannelMap(stateWithReleaseAndClose);
+      expect(result["test/edge"]).toBeUndefined();
+    });
+
+    it("should allow a release for one arch while keeping another arch closed", () => {
+      const amd64Revision = createMockRevision({ revision: 3, architectures: ["amd64"] });
+      const stateWithMixedArches: ReleasesReduxState = {
+        ...initialState,
+        channelMap: {
+          "test/edge": {
+            amd64: createMockRevision({ revision: 1, architectures: ["amd64"] }),
+            arm64: createMockRevision({ revision: 2, architectures: ["arm64"] }),
+          },
+        },
+        pendingChanges: {
+          changeOrderIndex: 2,
+          pendingReleases: {
+            1: { revision: amd64Revision, channel: "test/edge", previousReleases: [] },
+          },
+          pendingCloses: { 0: "test/edge" },
+        },
+      };
+
+      const result = getPendingChannelMap(stateWithMixedArches);
+      expect(result["test/edge"]?.["amd64"]).toEqual(amd64Revision);
+      expect(result["test/edge"]?.["arm64"]).toBeUndefined();
+    });
+  });
+});
+
+describe("isArchPendingClose", () => {
+  const initialState = getInitialState();
+
+  it("should return false when there are no pending closes", () => {
+    const state: ReleasesReduxState = {
+      ...initialState,
+      pendingChanges: {
+        changeOrderIndex: 0,
+        pendingReleases: {},
+        pendingCloses: {},
+      },
+    };
+    expect(isArchPendingClose(state, "test/edge", "amd64")).toBe(false);
+  });
+
+  it("should return true when the channel is pending close with no subsequent release for this arch", () => {
+    const state: ReleasesReduxState = {
+      ...initialState,
+      pendingChanges: {
+        changeOrderIndex: 1,
+        pendingReleases: {},
+        pendingCloses: { 0: "test/edge" },
+      },
+    };
+    expect(isArchPendingClose(state, "test/edge", "amd64")).toBe(true);
+  });
+
+  it("should return false when a release for this arch came after the close", () => {
+    const revision = createMockRevision({ revision: 1, architectures: ["amd64"] });
+    const state: ReleasesReduxState = {
+      ...initialState,
+      pendingChanges: {
+        changeOrderIndex: 2,
+        pendingReleases: {
+          1: { revision, channel: "test/edge", previousReleases: [] },
+        },
+        pendingCloses: { 0: "test/edge" },
+      },
+    };
+    expect(isArchPendingClose(state, "test/edge", "amd64")).toBe(false);
+  });
+
+  it("should return true for an arch that has no release after the close, even if another arch does", () => {
+    const amd64Revision = createMockRevision({ revision: 1, architectures: ["amd64"] });
+    const state: ReleasesReduxState = {
+      ...initialState,
+      pendingChanges: {
+        changeOrderIndex: 2,
+        pendingReleases: {
+          1: { revision: amd64Revision, channel: "test/edge", previousReleases: [] },
+        },
+        pendingCloses: { 0: "test/edge" },
+      },
+    };
+    expect(isArchPendingClose(state, "test/edge", "amd64")).toBe(false);
+    expect(isArchPendingClose(state, "test/edge", "arm64")).toBe(true);
+  });
+
+  it("should return true when a release came before the close", () => {
+    const revision = createMockRevision({ revision: 1, architectures: ["amd64"] });
+    const state: ReleasesReduxState = {
+      ...initialState,
+      pendingChanges: {
+        changeOrderIndex: 2,
+        pendingReleases: {
+          0: { revision, channel: "test/edge", previousReleases: [] },
+        },
+        pendingCloses: { 1: "test/edge" },
+      },
+    };
+    expect(isArchPendingClose(state, "test/edge", "amd64")).toBe(true);
   });
 });
 
@@ -1162,8 +1310,7 @@ describe("hasRelease", () => {
             "1-latest/stable":
               stateWithPendingReleaseToProgress
                 .pendingChanges
-                .pendingReleases["0"]
-                .channels["latest/stable"],
+                .pendingReleases["0"],
           },
           newReleasesToProgress: {},
           cancelProgressive: {},
@@ -1264,8 +1411,7 @@ describe("hasRelease", () => {
             "1-latest/stable":
               stateWithPendingRelease
                 .pendingChanges
-                .pendingReleases["0"]
-                .channels["latest/stable"],
+                .pendingReleases["0"],
           },
           newReleasesToProgress: {},
           cancelProgressive: {},
@@ -1281,8 +1427,7 @@ describe("hasRelease", () => {
             "1-latest/stable":
               stateWithPendingReleaseToProgress
                 .pendingChanges
-                .pendingReleases["0"]
-                .channels["latest/stable"],
+                .pendingReleases["0"],
           },
           cancelProgressive: {},
         });
@@ -1343,9 +1488,7 @@ describe("getPendingRelease", () => {
   it("should return the correct release", () => {
     const result = getPendingRelease(state, "latest/stable", "amd64");
 
-    expect(result).toEqual({
-      ...state.pendingChanges.pendingReleases["0"].channels["latest/stable"],
-    });
+    expect(result).toEqual(state.pendingChanges.pendingReleases["0"]);
   });
 
   it("should return null if no pendingRelease is found", () => {

--- a/static/js/publisher/pages/Releases/selectors/index.ts
+++ b/static/js/publisher/pages/Releases/selectors/index.ts
@@ -12,9 +12,9 @@ import type {
   AvailableRevisionsSelect,
   CPUArchitecture,
   LaunchpadBuildRevision,
+  PendingChangesState,
   PendingReleaseItem,
   Progressive,
-  ProgressiveChanges,
   Release,
   ReleasesReduxState,
   Revision,
@@ -126,16 +126,15 @@ export function getPendingChannelMap(state: ReleasesReduxState) {
     // ascending order to ensure that later changes overwrite the first ones
     .sort((a, b) => parseInt(a[0]) - parseInt(b[0]))
     .forEach(([_orderIndex, pendingRelease]) => {
-      Object.entries(pendingRelease.channels).forEach(([channel, channelItem]) => {
-        const revision = channelItem.revision;
+      const revision = pendingRelease.revision;
+      const channel = pendingRelease.channel;
 
-        if (!pendingChannelMap[channel]) {
-          pendingChannelMap[channel] = {} as ArchitectureRevisionsMap;
-        }
+      if (!pendingChannelMap[channel]) {
+        pendingChannelMap[channel] = {} as ArchitectureRevisionsMap;
+      }
 
-        revision.architectures.forEach((arch: CPUArchitecture) => {
-          pendingChannelMap[channel]![arch] = revision;
-        });
+      revision.architectures.forEach((arch: CPUArchitecture) => {
+        pendingChannelMap[channel]![arch] = revision;
       });
     });
 
@@ -313,6 +312,20 @@ export function getRevisionsFromBuild(
   );
 }
 
+function filterPendingReleases(
+  pendingReleases: PendingChangesState["pendingReleases"],
+  channel: string,
+  arch: CPUArchitecture,
+  revisionId?: number,
+): PendingReleaseItem[] {
+  return Object.values(pendingReleases)
+    .filter((pri) => pri.channel === channel)
+    .filter((pri) => pri.revision.architectures.includes(arch))
+    .filter((pri) => revisionId !== undefined 
+      ? pri.revision.revision === revisionId
+      : true); // if no revisionId was provided we don't do any filtering
+}
+
 type PreviousRevisionState = Partial<
   Pick<Revision, "attributes" | "confinement" | "releases" | "revision" | "version">
 >;
@@ -364,17 +377,15 @@ export function getProgressiveState(
       previousRevision = revisions[release.revision];
     }
 
-    let pendingMatch: PendingReleaseItem | undefined;
-
-    Object.values(pendingReleases).forEach((pendingRelease) => {
-      if (
-        pendingRelease.channels[channel] &&
-        pendingRelease.channels[channel].revision &&
-        pendingRelease.channels[channel].revision.architectures.includes(arch)
-      ) {
-        pendingMatch = pendingRelease.channels[channel];
-      }
-    });
+    const filteredPendingReleases = filterPendingReleases(
+      pendingReleases,
+      channel,
+      arch,
+    );
+    // there should be just one filtered pending release
+    let pendingMatch = filterPendingReleases.length > 0
+      ? filteredPendingReleases[0]
+      : undefined;
 
     if (pendingMatch) {
       if (
@@ -427,27 +438,26 @@ export function getSeparatePendingReleases(state: ReleasesReduxState): SeparateP
   const newReleasesToProgress: PendingReleaseMap = {};
   const cancelProgressive: PendingReleaseMap = {};
 
-  Object.values(pendingReleases).forEach((pendingRelease) => {
-    const revId = pendingRelease.revision;
-    Object.entries(pendingRelease.channels).forEach(([channel, pendingReleaseItem]) => {
-      const releaseCopy = structuredClone(pendingReleaseItem);
+  Object.values(pendingReleases).forEach((pendingReleaseItem) => {
+    const releaseCopy = structuredClone(pendingReleaseItem);
+    const revId = pendingReleaseItem.revision;
+    const channel = pendingReleaseItem.channel;
 
-      if (isProgressiveEnabled && pendingReleaseItem.replaces) {
-        const oldRelease = pendingReleaseItem.replaces;
-        cancelProgressive[`${oldRelease.revision.revision}-${channel}`] =
-          oldRelease;
-      } else if (
-        isProgressiveEnabled &&
-        pendingReleaseItem.progressive &&
-        pendingReleaseItem.previousReleases &&
-        pendingReleaseItem.previousReleases.length > 0 &&
-        pendingReleaseItem.previousReleases[0]
-      ) {
-        newReleasesToProgress[`${revId}-${channel}`] = releaseCopy;
-      } else {
-        newReleases[`${revId}-${channel}`] = releaseCopy;
-      }
-    });
+    if (isProgressiveEnabled && pendingReleaseItem.replaces) {
+      const oldRelease = pendingReleaseItem.replaces;
+      cancelProgressive[`${oldRelease.revision.revision}-${channel}`] =
+        oldRelease;
+    } else if (
+      isProgressiveEnabled &&
+      pendingReleaseItem.progressive &&
+      pendingReleaseItem.previousReleases &&
+      pendingReleaseItem.previousReleases.length > 0 &&
+      pendingReleaseItem.previousReleases[0]
+    ) {
+      newReleasesToProgress[`${revId}-${channel}`] = releaseCopy;
+    } else {
+      newReleases[`${revId}-${channel}`] = releaseCopy;
+    }
   });
 
   return {
@@ -461,19 +471,20 @@ export function getSeparatePendingReleases(state: ReleasesReduxState): SeparateP
 export function getPendingRelease(
   { pendingChanges }: ReleasesReduxState,
   channel: string,
-  arch: CPUArchitecture
-) {
-  const pendingReleases = pendingChanges.pendingReleases;
-  return Object.values(pendingReleases).map((pendingRelease) => {
-    if (
-      pendingRelease.channels[channel] &&
-      pendingRelease.channels[channel].revision.architectures.includes(arch)
-    ) {
-      return pendingRelease.channels[channel];
-    }
-
-    return null;
-  })[0];
+  arch: CPUArchitecture,
+  revisionId?: number,
+): PendingReleaseItem | null {
+  const filteredPendingReleases = filterPendingReleases(
+    pendingChanges.pendingReleases,
+    channel,
+    arch,
+    revisionId,
+  );
+  // there should be only one pendingRelease at most always
+  // because if there's another that goes to the same channel it should overwrite it
+  return filteredPendingReleases.length > 0
+    ? filteredPendingReleases[0]
+    : null;
 }
 
 // Get releases

--- a/static/js/publisher/pages/Releases/selectors/index.ts
+++ b/static/js/publisher/pages/Releases/selectors/index.ts
@@ -114,31 +114,70 @@ export function hasDevmodeRevisions(state: ReleasesReduxState) {
   });
 }
 
-// get channel map data updated with any pending releases
+// get channel map data updated with any pending releases and closes, applied in
+// change-order so later changes override earlier ones per cell (channel/arch).
+// A close clears the entire channel; a subsequent release re-populates only the
+// architectures carried by that revision.
 export function getPendingChannelMap(state: ReleasesReduxState) {
   const { channelMap, pendingChanges } = state;
   const pendingChannelMap = structuredClone(channelMap);
-  const pendingReleases = pendingChanges.pendingReleases;
+  const { pendingReleases, pendingCloses } = pendingChanges;
 
-  // for each release
-  Object.entries(pendingReleases)
-    // the first item of the entry is the number representing the order of the change
-    // ascending order to ensure that later changes overwrite the first ones
-    .sort((a, b) => parseInt(a[0]) - parseInt(b[0]))
-    .forEach(([_orderIndex, pendingRelease]) => {
-      const revision = pendingRelease.revision;
-      const channel = pendingRelease.channel;
+  type CloseChange = { orderIndex: number; type: "close"; channel: string };
+  type ReleaseChange = { orderIndex: number; type: "release"; pendingRelease: PendingReleaseItem };
 
+  const allChanges: Array<CloseChange | ReleaseChange> = [];
+
+  Object.entries(pendingCloses).forEach(([orderIndex, channel]) => {
+    allChanges.push({ orderIndex: parseInt(orderIndex), type: "close", channel });
+  });
+
+  Object.entries(pendingReleases).forEach(([orderIndex, pendingRelease]) => {
+    allChanges.push({ orderIndex: parseInt(orderIndex), type: "release", pendingRelease });
+  });
+
+  allChanges.sort((a, b) => a.orderIndex - b.orderIndex).forEach((change) => {
+    if (change.type === "close") {
+      delete pendingChannelMap[change.channel];
+    } else {
+      const { revision, channel } = change.pendingRelease;
       if (!pendingChannelMap[channel]) {
         pendingChannelMap[channel] = {} as ArchitectureRevisionsMap;
       }
-
       revision.architectures.forEach((arch: CPUArchitecture) => {
         pendingChannelMap[channel]![arch] = revision;
       });
-    });
+    }
+  });
 
   return pendingChannelMap;
+}
+
+// Returns true when a specific channel/arch cell is effectively "pending close":
+// the channel has a pending close with no later pending release for that arch.
+export function isArchPendingClose(
+  state: ReleasesReduxState,
+  channel: string,
+  arch: CPUArchitecture
+): boolean {
+  const { pendingReleases, pendingCloses } = state.pendingChanges;
+
+  const closeOrders = Object.entries(pendingCloses)
+    .filter(([_, ch]) => ch === channel)
+    .map(([orderIndex]) => parseInt(orderIndex));
+
+  if (closeOrders.length === 0) {
+    return false;
+  }
+
+  const latestCloseOrder = Math.max(...closeOrders);
+
+  return !Object.entries(pendingReleases).some(
+    ([orderIndex, release]) =>
+      parseInt(orderIndex) > latestCloseOrder &&
+      release.channel === channel &&
+      release.revision.architectures.includes(arch)
+  );
 }
 
 // get all revisions ordered from newest (based on revsion id)
@@ -440,7 +479,7 @@ export function getSeparatePendingReleases(state: ReleasesReduxState): SeparateP
 
   Object.values(pendingReleases).forEach((pendingReleaseItem) => {
     const releaseCopy = structuredClone(pendingReleaseItem);
-    const revId = pendingReleaseItem.revision;
+    const revId = pendingReleaseItem.revision.revision;
     const channel = pendingReleaseItem.channel;
 
     if (isProgressiveEnabled && pendingReleaseItem.replaces) {

--- a/static/js/publisher/pages/Releases/selectors/index.ts
+++ b/static/js/publisher/pages/Releases/selectors/index.ts
@@ -470,8 +470,9 @@ export type SeparatePendingReleases = Record<
 
 // Separate pendingRelease actions
 export function getSeparatePendingReleases(state: ReleasesReduxState): SeparatePendingReleases {
-  const { pendingReleases } = state.pendingChanges;
+  const { pendingReleases, pendingCloses } = state.pendingChanges;
   const isProgressiveEnabled = isProgressiveReleaseEnabled(state);
+  const closedChannels = Object.values(pendingCloses);
 
   const newReleases: PendingReleaseMap = {};
   const newReleasesToProgress: PendingReleaseMap = {};
@@ -488,6 +489,7 @@ export function getSeparatePendingReleases(state: ReleasesReduxState): SeparateP
         oldRelease;
     } else if (
       isProgressiveEnabled &&
+      !closedChannels.includes(channel) &&
       pendingReleaseItem.progressive &&
       pendingReleaseItem.previousReleases &&
       pendingReleaseItem.previousReleases.length > 0 &&

--- a/static/js/publisher/pages/Releases/selectors/index.ts
+++ b/static/js/publisher/pages/Releases/selectors/index.ts
@@ -422,7 +422,7 @@ export function getProgressiveState(
       arch,
     );
     // there should be just one filtered pending release
-    let pendingMatch = filterPendingReleases.length > 0
+    let pendingMatch = filteredPendingReleases.length > 0
       ? filteredPendingReleases[0]
       : undefined;
 

--- a/static/js/publisher/pages/Releases/slices/__tests__/pendingChanges.test.ts
+++ b/static/js/publisher/pages/Releases/slices/__tests__/pendingChanges.test.ts
@@ -43,7 +43,7 @@ const emptyPendingReleaseItem: PendingReleaseItem = {
 }
 
 const findPendingRelease = (state: PendingChangesState, revisionId: number) =>
-  Object.values(state.pendingReleases).find((pr) => pr.revision === revisionId);
+  Object.values(state.pendingReleases).find((pr) => pr.revision.revision === revisionId);
 
 describe("pendingChanges", () => {
   it("should return the initial state", () => {
@@ -76,8 +76,7 @@ describe("pendingChanges", () => {
       it("should add the revision to pending releases", () => {
         const result = reducer(initialState, addPendingRelease({ revision, channel }));
         const pr = findPendingRelease(result, 1);
-        expect(pr).toBeDefined();
-        expect(pr!.channels[channel]).toMatchObject({ revision, channel });
+        expect(pr).toMatchObject({ revision, channel });
       });
     });
 
@@ -87,14 +86,9 @@ describe("pendingChanges", () => {
         pendingCloses: {},
         pendingReleases: {
           0: {
-            revision: 1,
-            channels: {
-              "other/edge": {
-                ...emptyPendingReleaseItem,
-                revision: createMockRevision({ revision: 1, architectures: ["abc42", "test64"] }),
-                channel: "other/edge",
-              },
-            },
+            ...emptyPendingReleaseItem,
+            revision: createMockRevision({ revision: 1, architectures: ["abc42", "test64"] }),
+            channel: "other/edge",
           },
         },
       };
@@ -104,9 +98,10 @@ describe("pendingChanges", () => {
           stateWithSamePendingRevision,
           addPendingRelease({ revision, channel }),
         );
-        const pr = findPendingRelease(result, 1);
-        expect(pr!.channels["other/edge"]).toBeDefined();
-        expect(pr!.channels[channel]).toMatchObject({ revision, channel });
+        const pr = Object.values(result.pendingReleases).find(
+          (pr) => pr.revision.revision === 1 && pr.channel === channel
+        );
+        expect(pr).toMatchObject({ revision, channel });
       });
     });
 
@@ -120,35 +115,19 @@ describe("pendingChanges", () => {
         pendingCloses: {},
         pendingReleases: {
           0: {
-            revision: 2,
-            channels: {
-              "other/edge": {
-                ...emptyPendingReleaseItem,
-                revision: createMockRevision({ revision: 2, architectures: ["test64"] }),
-                channel: "other/edge",
-                
-              },
-            },
+            ...emptyPendingReleaseItem,
+            revision: createMockRevision({ revision: 2, architectures: ["test64"] }),
+            channel: "other/edge",
           },
           1: {
-            revision: 3,
-            channels: {
-              [channel]: {
-                ...emptyPendingReleaseItem,
-                revision: createMockRevision({ revision: 3, architectures: ["armf"] }),
-                channel,
-              },
-            },
+            ...emptyPendingReleaseItem,
+            revision: createMockRevision({ revision: 3, architectures: ["armf"] }),
+            channel,
           },
           2: {
-            revision: 4,
-            channels: {
-              [channel]: {
-                ...emptyPendingReleaseItem,
-                revision: conflictingRevision,
-                channel,
-              },
-            },
+            ...emptyPendingReleaseItem,
+            revision: conflictingRevision,
+            channel,
           },
         },
       };
@@ -157,9 +136,8 @@ describe("pendingChanges", () => {
         const result = reducer(stateWithConflict, addPendingRelease({ revision, channel }));
         const pendingRelease = findPendingRelease(result, 1);
         expect(pendingRelease).toBeDefined();
-        expect(pendingRelease!.revision).toEqual(1);
-        expect(Object.keys(pendingRelease!.channels)).toHaveLength(1);
-        expect(pendingRelease!.channels[channel].channel).toEqual(channel);
+        expect(pendingRelease!.revision).toMatchObject(revision);
+        expect(pendingRelease!.channel).toEqual(channel);
       });
 
       it("should remove the conflicting pending release for the same arch and channel", () => {
@@ -179,7 +157,7 @@ describe("pendingChanges", () => {
           addPendingRelease({ revision, channel, previousReleases }),
         );
         const pr = findPendingRelease(result, 1);
-        expect(pr!.channels[channel].previousReleases).toEqual(previousReleases);
+        expect(pr!.previousReleases).toEqual(previousReleases);
       });
     });
 
@@ -195,7 +173,28 @@ describe("pendingChanges", () => {
           addPendingRelease({ revision, channel, progressive }),
         );
         const pr = findPendingRelease(result, 1);
-        expect(pr!.channels[channel].progressive).toEqual(progressive);
+        expect(pr!.progressive).toEqual(progressive);
+      });
+    });
+
+    describe("when channel is pending close", () => {
+      it("should NOT cancel the pending close when releasing to the same channel", () => {
+        const revision = {
+          revision: 1,
+          architectures: ["test64"],
+        } as unknown as Revision;
+        const channel = "test/edge";
+        const stateWithPendingClose: PendingChangesState = {
+          changeOrderIndex: 1,
+          pendingCloses: { 0: channel },
+          pendingReleases: {},
+        };
+
+        const result = reducer(
+          stateWithPendingClose,
+          addPendingRelease({ revision, channel }),
+        );
+        expect(Object.values(result.pendingCloses)).toContain(channel);
       });
     });
   });
@@ -219,23 +218,18 @@ describe("pendingChanges", () => {
     describe("when revision has pending releases in multiple channels", () => {
       it("should remove only the given channel from pending releases", () => {
         const stateWithRevisionInMultipleChannels: PendingChangesState = {
-          changeOrderIndex: 1,
+          changeOrderIndex: 2,
           pendingCloses: {},
           pendingReleases: {
             0: {
-              revision: 1,
-              channels: {
-                [channel]: {
-                  ...emptyPendingReleaseItem,
-                  revision,
-                  channel
-                },
-                "latest/beta": {
-                  ...emptyPendingReleaseItem,
-                  revision,
-                  channel: "latest/beta"
-                },
-              },
+              ...emptyPendingReleaseItem,
+              revision,
+              channel,
+            },
+            1: {
+              ...emptyPendingReleaseItem,
+              revision,
+              channel: "latest/beta",
             },
           },
         };
@@ -244,10 +238,16 @@ describe("pendingChanges", () => {
           stateWithRevisionInMultipleChannels,
           removePendingRelease({ revision, channel }),
         );
-        const pr = findPendingRelease(result, 1);
-        expect(pr).toBeDefined();
-        expect(pr!.channels[channel]).toBeUndefined();
-        expect(pr!.channels["latest/beta"]).toBeDefined();
+        expect(
+          Object.values(result.pendingReleases).find(
+            (pr) => pr.revision.revision === 1 && pr.channel === channel
+          )
+        ).toBeUndefined();
+        expect(
+          Object.values(result.pendingReleases).find(
+            (pr) => pr.revision.revision === 1 && pr.channel === "latest/beta"
+          )
+        ).toBeDefined();
       });
     });
 
@@ -258,14 +258,9 @@ describe("pendingChanges", () => {
           pendingCloses: {},
           pendingReleases: {
             0: {
-              revision: 1,
-              channels: {
-                [channel]: {
-                  ...emptyPendingReleaseItem,
-                  revision,
-                  channel
-                }
-              },
+              ...emptyPendingReleaseItem,
+              revision,
+              channel,
             },
           },
         };
@@ -293,24 +288,14 @@ describe("pendingChanges", () => {
         pendingCloses: {},
         pendingReleases: {
           0: {
-            revision: 1,
-            channels: {
-              "latest/beta": {
-                ...emptyPendingReleaseItem,
-                revision: createMockRevision({ revision: 1 }),
-                channel: "latest/beta",
-              },
-            },
+            ...emptyPendingReleaseItem,
+            revision: createMockRevision({ revision: 1 }),
+            channel: "latest/beta",
           },
           1: {
-            revision: 2,
-            channels: {
-              "latest/stable": {
-                ...emptyPendingReleaseItem,
-                revision: createMockRevision({ revision: 2 }),
-                channel: "latest/stable",
-              },
-            },
+            ...emptyPendingReleaseItem,
+            revision: createMockRevision({ revision: 2 }),
+            channel: "latest/stable",
           },
         },
       };
@@ -356,21 +341,16 @@ describe("pendingChanges", () => {
           pendingCloses: {},
           pendingReleases: {
             0: {
-              revision: 1,
-              channels: {
-                "test/edge": {
-                  ...emptyPendingReleaseItem,
-                  revision: createMockRevision({ revision: 1, architectures: ["abc42"] }),
-                  channel: "test/edge",
-                },
-              },
+              ...emptyPendingReleaseItem,
+              revision: createMockRevision({ revision: 1, architectures: ["abc42"] }),
+              channel: "test/edge",
             },
           },
         };
 
         const result = reducer(stateWithPendingRevision, setProgressiveRelease(progressive));
         const pr = findPendingRelease(result, 1);
-        expect(pr!.channels["test/edge"].progressive).toBeUndefined();
+        expect(pr!.progressive).toBeUndefined();
       });
     });
 
@@ -380,17 +360,12 @@ describe("pendingChanges", () => {
         pendingCloses: {},
         pendingReleases: {
           0: {
-            revision: 1,
-            channels: {
-              "test/edge": {
-                ...emptyPendingReleaseItem,
-                revision: createMockRevision({ revision: 1, architectures: ["abc42", "test64"] }),
-                channel: "test/edge",
-                previousReleases: [
-                  createMockRevision({ revision: 0, architectures: ["abc42"] }),
-                ],
-              },
-            },
+            ...emptyPendingReleaseItem,
+            revision: createMockRevision({ revision: 1, architectures: ["abc42", "test64"] }),
+            channel: "test/edge",
+            previousReleases: [
+              createMockRevision({ revision: 0, architectures: ["abc42"] }),
+            ],
           },
         },
       };
@@ -398,7 +373,7 @@ describe("pendingChanges", () => {
       it("should add progressive state to the pending release", () => {
         const result = reducer(stateWithPreviousReleases, setProgressiveRelease(progressive));
         const pr = findPendingRelease(result, 1);
-        expect(pr!.channels["test/edge"].progressive).toEqual(progressive);
+        expect(pr!.progressive).toEqual(progressive);
       });
     });
 
@@ -414,22 +389,17 @@ describe("pendingChanges", () => {
           pendingCloses: {},
           pendingReleases: {
             0: {
-              revision: 1,
-              channels: {
-                "test/edge": {
-                  ...emptyPendingReleaseItem,
-                  revision: createMockRevision({ revision: 1, architectures: ["abc42", "test64"] }),
-                  channel: "test/edge",
-                  progressive: existingProgressive,
-                },
-              },
+              ...emptyPendingReleaseItem,
+              revision: createMockRevision({ revision: 1, architectures: ["abc42", "test64"] }),
+              channel: "test/edge",
+              progressive: existingProgressive,
             },
           },
         };
 
         const result = reducer(stateWithProgressiveRelease, setProgressiveRelease(progressive));
         const pr = findPendingRelease(result, 1);
-        expect(pr!.channels["test/edge"].progressive).toEqual(existingProgressive);
+        expect(pr!.progressive).toEqual(existingProgressive);
       });
     });
   });
@@ -457,21 +427,16 @@ describe("pendingChanges", () => {
           pendingCloses: {},
           pendingReleases: {
             0: {
-              revision: 1,
-              channels: {
-                "test/edge": {
-                  ...emptyPendingReleaseItem,
-                  revision: createMockRevision({ revision: 1 }),
-                  channel: "test/edge",
-                },
-              },
+              ...emptyPendingReleaseItem,
+              revision: createMockRevision({ revision: 1 }),
+              channel: "test/edge",
             },
           },
         };
 
         const result = reducer(stateWithoutProgressive, updateProgressiveRelease(newProgressive));
         const pr = findPendingRelease(result, 1);
-        expect(pr!.channels["test/edge"].progressive).toBeUndefined();
+        expect(pr!.progressive).toBeUndefined();
       });
     });
 
@@ -482,18 +447,13 @@ describe("pendingChanges", () => {
           pendingCloses: {},
           pendingReleases: {
             0: {
-              revision: 1,
-              channels: {
-                "test/edge": {
-                  ...emptyPendingReleaseItem,
-                  revision: createMockRevision({ revision: 1 }),
-                  channel: "test/edge",
-                  progressive: {
-                    "current-percentage": null,
-                    percentage: 10,
-                    paused: null,
-                  },
-                },
+              ...emptyPendingReleaseItem,
+              revision: createMockRevision({ revision: 1 }),
+              channel: "test/edge",
+              progressive: {
+                "current-percentage": null,
+                percentage: 10,
+                paused: null,
               },
             },
           },
@@ -502,8 +462,8 @@ describe("pendingChanges", () => {
         const result = reducer(stateWithProgressive, updateProgressiveRelease(newProgressive));
         const pr = findPendingRelease(result, 1);
         expect(pr).toBeDefined();
-        expect(pr!.channels["test/edge"].progressive!.percentage).toEqual(50);
-        expect(pr!.channels["test/edge"].progressive!["current-percentage"]).toEqual(10);
+        expect(pr!.progressive!.percentage).toEqual(50);
+        expect(pr!.progressive!["current-percentage"]).toEqual(10);
       });
     });
   });
@@ -715,7 +675,7 @@ describe("pendingChanges", () => {
       store.dispatch(addPendingRelease({ revision, channel: "test/edge" }));
       store.dispatch(closeChannel("test/edge"));
       const pr = findPendingRelease(store.getState().pendingChanges, 1);
-      expect(pr?.channels["test/edge"]).toBeUndefined();
+      expect(pr).toBeUndefined();
     });
 
     it("should close the history panel", () => {

--- a/static/js/publisher/pages/Releases/slices/__tests__/pendingChanges.test.ts
+++ b/static/js/publisher/pages/Releases/slices/__tests__/pendingChanges.test.ts
@@ -10,10 +10,13 @@ import reducer, {
   promoteChannel,
   undoRelease,
   closeChannel,
+  closeRevision,
   incrementOrderIndex,
 } from "../pendingChanges";
 import historyReducer from "../history";
+import { closeModal, CLOSE_MODAL_ACTION_NAME } from "../modal";
 import type {
+  CPUArchitecture,
   PendingChangesState,
   PendingReleaseItem,
   Progressive,
@@ -41,6 +44,13 @@ const emptyPendingReleaseItem: PendingReleaseItem = {
   channel: "",
   previousReleases: [],
 }
+
+const makeStore = () => {
+  const store = configureStore({
+    reducer: { pendingChanges: reducer, history: historyReducer },
+  });
+  return store as typeof store & { dispatch: AppDispatch };
+};
 
 const findPendingRelease = (state: PendingChangesState, revisionId: number) =>
   Object.values(state.pendingReleases).find((pr) => pr.revision.revision === revisionId);
@@ -645,13 +655,6 @@ describe("pendingChanges", () => {
   // ─── closeChannel thunk ─────────────────────────────────────────────────────
 
   describe("closeChannel thunk", () => {
-    const makeStore = () => {
-      const store = configureStore({
-        reducer: { pendingChanges: reducer, history: historyReducer },
-      });
-      return store as typeof store & { dispatch: AppDispatch };
-    };
-
     it("should add channel to pending closes", () => {
       const store = makeStore();
       store.dispatch(closeChannel("test/edge"));
@@ -682,6 +685,168 @@ describe("pendingChanges", () => {
       const store = makeStore();
       store.dispatch(closeChannel("test/edge"));
       expect(store.getState().history.isOpen).toBe(false);
+    });
+  });
+
+  // ─── closeRevision thunk ────────────────────────────────────────────────────
+
+  describe("closeRevision thunk", () => {
+    const revision = {
+      revision: 1,
+      architectures: ["test64"],
+    } as unknown as Revision;
+    const channel = "test/edge";
+    const arch = "test64" as CPUArchitecture;
+
+    const closeRevisionAndGetDispatch = (channelMap = {}) => {
+      const dispatch = vi.fn() as unknown as AppDispatch;
+      const getState = () => ({} as RootState);
+      vi.mocked(getPendingChannelMap).mockReturnValue(channelMap as any);
+      closeRevision(revision, channel, arch)(dispatch, getState);
+      return dispatch;
+    };
+
+    const extractProceed = (dispatch: AppDispatch) =>
+      // the dispatch to open the modal contains the proceed function we want to test
+      (dispatch as ReturnType<typeof vi.fn>).mock.calls[0][0].payload.actions[0]
+        .onClickAction.reduxAction as () => void;
+
+    describe("dispatched modal", () => {
+      it("should dispatch openModal", () => {
+        const dispatch = closeRevisionAndGetDispatch();
+        expect(dispatch).toHaveBeenCalledTimes(1);
+        expect((dispatch as ReturnType<typeof vi.fn>).mock.calls[0][0]).toMatchObject({
+          type: "modal/openModal",
+        });
+      });
+
+      it("should set the modal title to 'Attention'", () => {
+        const dispatch = closeRevisionAndGetDispatch();
+        expect((dispatch as ReturnType<typeof vi.fn>).mock.calls[0][0].payload.title).toBe(
+          "Attention",
+        );
+      });
+
+      it("should include arch and channel in the modal content", () => {
+        const dispatch = closeRevisionAndGetDispatch();
+        const content: string =
+          (dispatch as ReturnType<typeof vi.fn>).mock.calls[0][0].payload.content;
+        expect(content).toContain(arch);
+        expect(content).toContain(channel);
+      });
+
+      it("should provide Continue and Cancel actions", () => {
+        const dispatch = closeRevisionAndGetDispatch();
+        const actions =
+          (dispatch as ReturnType<typeof vi.fn>).mock.calls[0][0].payload.actions;
+        expect(actions).toHaveLength(2);
+        expect(actions[0].label).toBe("Continue");
+        expect(actions[1].label).toBe("Cancel");
+      });
+
+      it("should wire the Cancel action to close the modal", () => {
+        const dispatch = closeRevisionAndGetDispatch();
+        const cancelAction =
+          (dispatch as ReturnType<typeof vi.fn>).mock.calls[0][0].payload.actions[1];
+        expect(cancelAction.onClickAction).toEqual({ type: CLOSE_MODAL_ACTION_NAME });
+      });
+    });
+
+    describe("when the Continue action is executed (proceed)", () => {
+      it("should dispatch closeChannel for the given channel", () => {
+        const dispatch = closeRevisionAndGetDispatch();
+        extractProceed(dispatch)();
+        const calls = (dispatch as ReturnType<typeof vi.fn>).mock.calls;
+        expect(calls.length).toBeGreaterThan(1);
+        const closeChannelThunk = calls[1][0] as unknown as ReturnType<typeof closeChannel>;
+        // check that closeChannel is called with the appropriate parameter
+        expect(typeof closeChannelThunk).toBe("function");
+        const store = makeStore();
+        store.dispatch(closeChannelThunk);
+        expect(Object.values(store.getState().pendingChanges.pendingCloses))
+          .toContain(channel);
+      });
+
+      it("should dispatch closeModal", () => {
+        const dispatch = closeRevisionAndGetDispatch();
+        extractProceed(dispatch)();
+        expect(dispatch).toHaveBeenCalledWith(closeModal());
+      });
+
+      describe("when there are other revisions in the channel", () => {
+        it("should re-release those revisions", () => {
+          const otherRevision = {
+            revision: 2,
+            architectures: ["abc42"],
+          } as unknown as Revision;
+          const dispatch = closeRevisionAndGetDispatch({
+            [channel]: { test64: revision, abc42: otherRevision },
+          });
+
+          vi.mocked(getReleases).mockReturnValue([]);
+
+          extractProceed(dispatch)();
+          const calls = (dispatch as ReturnType<typeof vi.fn>).mock.calls;
+          // openModal + closeChannel thunk + releaseRevision thunk + closeModal
+          expect(calls.length).toBe(4);
+          const releaseRevisionThunk = calls[2][0] as unknown as ReturnType<typeof releaseRevision>;
+          expect(typeof releaseRevisionThunk).toBe("function");
+          const store = makeStore();
+          store.dispatch(releaseRevisionThunk);
+          const pendingReleases = Object.values(store.getState().pendingChanges.pendingReleases);
+          expect(pendingReleases).toHaveLength(1);
+          expect(pendingReleases[0].channel).toBe("test/edge");
+          expect(pendingReleases[0].revision.revision).toBe(2);
+          expect(pendingReleases[0].revision.architectures).toContainEqual("abc42");
+        });
+
+        it("should not re-release the revision being closed", () => {
+          const otherRevision = {
+            revision: 2,
+            architectures: ["abc42"],
+          } as unknown as Revision;
+          const dispatch = closeRevisionAndGetDispatch({
+            [channel]: { test64: revision, abc42: otherRevision },
+          });
+
+          vi.mocked(getReleases).mockReturnValue([]);
+
+          extractProceed(dispatch)();
+          const calls = (dispatch as ReturnType<typeof vi.fn>).mock.calls;
+          // openModal + closeChannel thunk + releaseRevision thunk + closeModal
+          expect(calls.length).toBe(4);
+          const thunkCalls = calls.filter((args: any[]) => typeof args[0] === "function")
+            .map((args) => args[0]);
+          // closeChannel + releaseRevision
+          expect(thunkCalls).toHaveLength(2);
+          // check that the releaseRevision is otherRevision
+          const store = makeStore();
+          thunkCalls.forEach((thunk) => store.dispatch(thunk));
+          const pendingReleases = Object.values(store.getState().pendingChanges.pendingReleases);
+          expect(pendingReleases).not.toEqual(
+            expect.arrayContaining([
+              expect.objectContaining({ revision: expect.objectContaining({ revision: 1 }) })
+            ])
+          );
+        });
+      });
+
+      describe("when the revision is the only one in the channel", () => {
+        it("should not dispatch releaseRevision for any other revisions", () => {
+          const dispatch = closeRevisionAndGetDispatch({ [channel]: { test64: revision } });
+          extractProceed(dispatch)();
+          const calls = (dispatch as ReturnType<typeof vi.fn>).mock.calls;
+          // openModal + closeChannel thunk + closeModal
+          expect(calls.length).toBe(3);
+          const thunkCalls = calls.filter((args: any[]) => typeof args[0] === "function")
+            .map((args) => args[0]);
+          // check releaseRevision has never been called
+          const store = makeStore();
+          thunkCalls.forEach((thunk) => store.dispatch(thunk));
+          const pendingReleases = Object.values(store.getState().pendingChanges.pendingReleases);
+          expect(pendingReleases).toHaveLength(0);
+        });
+      });
     });
   });
 });

--- a/static/js/publisher/pages/Releases/slices/__tests__/releases.test.ts
+++ b/static/js/publisher/pages/Releases/slices/__tests__/releases.test.ts
@@ -28,8 +28,8 @@ import { updateArchitectures } from "../architectures";
 import { updateFailedRevisions } from "../failedRevisions";
 import { DEFAULT_ERROR_MESSAGE as ERROR_MESSAGE } from "../../constants";
 import {
-  fetchReleases,
-  fetchCloses,
+  fetchRelease,
+  fetchClose,
   fetchSnapReleaseStatus,
 } from "../../api/releases";
 import {
@@ -39,8 +39,8 @@ import {
 } from "../../releasesState";
 
 vi.mock("../../api/releases", () => ({
-  fetchReleases: vi.fn(),
-  fetchCloses: vi.fn(),
+  fetchRelease: vi.fn(),
+  fetchClose: vi.fn(),
   fetchSnapReleaseStatus: vi.fn(),
 }));
 
@@ -131,8 +131,17 @@ describe("releases", () => {
 
     beforeEach(() => {
       vi.clearAllMocks();
-      vi.mocked(fetchReleases).mockResolvedValue(undefined);
-      vi.mocked(fetchCloses).mockResolvedValue(undefined);
+      vi.mocked(fetchRelease).mockResolvedValue({
+        success: true,
+        channel_map: [],
+        channel_map_tree: {},
+        opened_channels: [],
+      });
+      vi.mocked(fetchClose).mockResolvedValue({
+        success: true,
+        channel_maps: makeArchitectureReleaseChannelMap(),
+        closed_channels: [],
+      });
       vi.mocked(fetchSnapReleaseStatus).mockResolvedValue(
         {} as ReleasesAPIResponse
       );
@@ -157,11 +166,7 @@ describe("releases", () => {
 
         await releaseRevisions()(dispatch, makeGetState(emptyPendingChanges), undefined);
 
-        expect(fetchReleases).toHaveBeenCalledWith(
-          expect.any(Function),
-          [],
-          snapName
-        );
+        expect(fetchRelease).not.toHaveBeenCalled();
       });
 
       it("should not dispatch any releaseRevisionSuccess", async () => {
@@ -208,11 +213,7 @@ describe("releases", () => {
       };
 
       beforeEach(() => {
-        vi.mocked(fetchReleases).mockImplementation(async (onComplete, releases) => {
-          for (const release of releases) {
-            onComplete(successResponse, release);
-          }
-        });
+        vi.mocked(fetchRelease).mockResolvedValue(successResponse);
       });
 
       it("should call fetchRelease for each pending release", async () => {
@@ -224,10 +225,11 @@ describe("releases", () => {
           undefined
         );
 
-        expect(fetchReleases).toHaveBeenCalledWith(
-          expect.any(Function),
-          [expect.objectContaining({ id: 1 })],
-          snapName
+        expect(fetchRelease).toHaveBeenCalledWith(
+          snapName,
+          1,
+          ["latest/stable"],
+          null
         );
       });
 
@@ -246,7 +248,7 @@ describe("releases", () => {
       });
 
       it("should dispatch an error notification if a fetchRelease fails", async () => {
-        vi.mocked(fetchReleases).mockRejectedValue(new Error("API error"));
+        vi.mocked(fetchRelease).mockRejectedValue(new Error("API error"));
         const dispatch = vi.fn() as unknown as AppDispatch;
 
         await releaseRevisions()(dispatch, makeGetState(pendingChanges), undefined);
@@ -289,16 +291,13 @@ describe("releases", () => {
           undefined
         );
 
-        // Both channels for revision 1 are deduplicated into a single fetchReleases call
-        expect(fetchReleases).toHaveBeenCalledWith(
-          expect.any(Function),
-          [
-            expect.objectContaining({
-              id: 1,
-              channels: expect.arrayContaining(["latest/stable", "latest/edge"]),
-            }),
-          ],
-          snapName
+        // Both channels for revision 1 are deduplicated into a single fetchRelease call
+        expect(fetchRelease).toHaveBeenCalledTimes(1);
+        expect(fetchRelease).toHaveBeenCalledWith(
+          snapName,
+          1,
+          expect.arrayContaining(["latest/stable", "latest/edge"]),
+          null
         );
       });
 
@@ -318,11 +317,7 @@ describe("releases", () => {
           },
           opened_channels: [],
         };
-        vi.mocked(fetchReleases).mockImplementation(async (onComplete, releases) => {
-          for (const release of releases) {
-            onComplete(successResponse, release);
-          }
-        });
+        vi.mocked(fetchRelease).mockResolvedValue(successResponse);
         const dispatch = vi.fn() as unknown as AppDispatch;
 
         await releaseRevisions()(
@@ -331,8 +326,8 @@ describe("releases", () => {
           undefined
         );
 
-        // Only one fetchReleases call for the deduplicated release
-        expect(fetchReleases).toHaveBeenCalledTimes(1);
+        // Only one fetchRelease call for the deduplicated release
+        expect(fetchRelease).toHaveBeenCalledTimes(1);
         // And one releaseRevisionSuccess per channel/arch combo in the response
         const releaseSuccessActions = vi
           .mocked(dispatch)
@@ -360,9 +355,7 @@ describe("releases", () => {
       };
 
       beforeEach(() => {
-        vi.mocked(fetchCloses).mockImplementation(async (onComplete) => {
-          onComplete(closeResponse);
-        });
+        vi.mocked(fetchClose).mockResolvedValue(closeResponse);
       });
 
       it("should call fetchClose for each pending close channel", async () => {
@@ -374,8 +367,7 @@ describe("releases", () => {
           undefined
         );
 
-        expect(fetchCloses).toHaveBeenCalledWith(
-          expect.any(Function),
+        expect(fetchClose).toHaveBeenCalledWith(
           snapName,
           ["latest/stable"]
         );
@@ -394,7 +386,7 @@ describe("releases", () => {
       });
 
       it("should dispatch an error notification if a fetchClose fails", async () => {
-        vi.mocked(fetchCloses).mockRejectedValue(new Error("Close error"));
+        vi.mocked(fetchClose).mockRejectedValue(new Error("Close error"));
         const dispatch = vi.fn() as unknown as AppDispatch;
 
         await releaseRevisions()(

--- a/static/js/publisher/pages/Releases/slices/__tests__/releases.test.ts
+++ b/static/js/publisher/pages/Releases/slices/__tests__/releases.test.ts
@@ -282,7 +282,7 @@ describe("releases", () => {
         },
       };
 
-      it("should call fetchRelease for each unique pending release", async () => {
+      it("should call fetchRelease for each pending release", async () => {
         const dispatch = vi.fn() as unknown as AppDispatch;
 
         await releaseRevisions()(
@@ -291,17 +291,12 @@ describe("releases", () => {
           undefined
         );
 
-        // Both channels for revision 1 are deduplicated into a single fetchRelease call
-        expect(fetchRelease).toHaveBeenCalledTimes(1);
-        expect(fetchRelease).toHaveBeenCalledWith(
-          snapName,
-          1,
-          expect.arrayContaining(["latest/stable", "latest/edge"]),
-          null
-        );
+        expect(fetchRelease).toHaveBeenCalledTimes(2);
+        expect(fetchRelease).toHaveBeenNthCalledWith(1, snapName, 1, ["latest/stable"], null);
+        expect(fetchRelease).toHaveBeenNthCalledWith(2, snapName, 1, ["latest/edge"], null);
       });
 
-      it("should dispatch a releaseRevisionSuccess for each unique pending release", async () => {
+      it("should dispatch a releaseRevisionSuccess for each pending release", async () => {
         const successResponse: FetchReleaseResponse = {
           success: true,
           channel_map: [],
@@ -326,9 +321,7 @@ describe("releases", () => {
           undefined
         );
 
-        // Only one fetchRelease call for the deduplicated release
-        expect(fetchRelease).toHaveBeenCalledTimes(1);
-        // And one releaseRevisionSuccess per channel/arch combo in the response
+        expect(fetchRelease).toHaveBeenCalledTimes(2);
         const releaseSuccessActions = vi
           .mocked(dispatch)
           .mock.calls.filter(
@@ -337,7 +330,7 @@ describe("releases", () => {
               typeof action === "object" &&
               (action as { type?: string }).type === releaseRevisionSuccess.type
           );
-        expect(releaseSuccessActions).toHaveLength(1);
+        expect(releaseSuccessActions).toHaveLength(2);
       });
     });
 

--- a/static/js/publisher/pages/Releases/slices/__tests__/releases.test.ts
+++ b/static/js/publisher/pages/Releases/slices/__tests__/releases.test.ts
@@ -184,14 +184,9 @@ describe("releases", () => {
         pendingCloses: {},
         pendingReleases: {
           0: {
-            revision: 1,
-            channels: {
-              "latest/stable": {
-                revision: pendingRevision,
-                channel: "latest/stable",
-                previousReleases: [],
-              } as unknown as PendingReleaseItem,
-            },
+            revision: pendingRevision,
+            channel: "latest/stable",
+            previousReleases: [],
           },
         },
       };
@@ -269,23 +264,18 @@ describe("releases", () => {
     describe("when there are duplicate pending releases", () => {
       const pendingRevision = makeRevision(1);
       const pendingChangesWithDuplicates: PendingChangesState = {
-        changeOrderIndex: 1,
+        changeOrderIndex: 2,
         pendingCloses: {},
         pendingReleases: {
           0: {
-            revision: 1,
-            channels: {
-              "latest/stable": {
-                revision: pendingRevision,
-                channel: "latest/stable",
-                previousReleases: [],
-              } as unknown as PendingReleaseItem,
-              "latest/edge": {
-                revision: pendingRevision,
-                channel: "latest/edge",
-                previousReleases: [],
-              } as unknown as PendingReleaseItem,
-            },
+            revision: pendingRevision,
+            channel: "latest/stable",
+            previousReleases: [],
+          },
+          1: {
+            revision: pendingRevision,
+            channel: "latest/edge",
+            previousReleases: [],
           },
         },
       };

--- a/static/js/publisher/pages/Releases/slices/pendingChanges.ts
+++ b/static/js/publisher/pages/Releases/slices/pendingChanges.ts
@@ -7,9 +7,14 @@ import type {
   Progressive,
   Revision,
   Release,
+  CPUArchitecture,
 } from "../../../types/releaseTypes";
-import type { AppDispatch, RootState } from "../store";
+import { AppAsyncThunkConfig, type AppDispatch, type RootState } from "../store";
 import { closeHistory } from "./history";
+import { showNotification } from "./notification";
+import { CLOSE_MODAL_ACTION_NAME, closeModal, openModal } from "./modal";
+
+const PENDING_CHANGES_SLICE_NAME = "pendingChanges";
 
 export function releaseRevision(
   revision: Revision,
@@ -59,6 +64,59 @@ export function releaseRevision(
       channel,
       progressive,
       previousReleases,
+    }));
+  };
+}
+
+export function closeRevision(
+  revision: Revision,
+  channel: string,
+  arch: CPUArchitecture,
+) {
+  return (dispatch: AppDispatch, getState: () => RootState) => {
+    const pendingChannelMap = getPendingChannelMap(getState());
+    const toReleaseAgain: Set<Revision> = new Set();
+    if (pendingChannelMap[channel]) {
+      Object.entries(pendingChannelMap[channel]).forEach(
+        ([_arch, rev]) => {
+          if (rev && rev?.revision !== revision.revision) {
+            toReleaseAgain.add(rev);
+          }
+        }
+      );
+    }
+
+    const proceed = () => {
+      dispatch(closeChannel(channel));
+      for (const rev of toReleaseAgain) {
+        dispatch(releaseRevision(rev, channel, undefined));
+      }
+      dispatch(closeModal());
+    }
+
+    // display notification with accept or cancel
+    dispatch(openModal({
+      title: "Attention",
+      content: `By closing an architecture release from a channel you will be `
+        + `executing the following actions: close the channel and release to the `
+        + `closed channel all the revisions again except the one being closed, `
+        + `${arch} from ${channel}. Would you like to proceed?`,
+      actions: [
+        {
+          appearance: "positive",
+          onClickAction: {
+            reduxAction: proceed,
+          },
+          label: `Continue`,
+        },
+        {
+          appearance: "neutral",
+          onClickAction: {
+            type: CLOSE_MODAL_ACTION_NAME,
+          },
+          label: "Cancel",
+        },
+      ],
     }));
   };
 }
@@ -195,8 +253,8 @@ export type RemoveRevisionPayload = {
   channel: string;
 }
 
-const pendingReleasesSlice = createSlice({
-  name: "pendingReleases",
+const pendingChangesSlice = createSlice({
+  name: PENDING_CHANGES_SLICE_NAME,
   initialState: {
     changeOrderIndex: 0,
     pendingCloses: {},
@@ -316,11 +374,11 @@ const pendingReleasesSlice = createSlice({
         }
       });
     },
-  }
+  },
 });
 
 // don't export addPendingClose to force using the thunk CloseChannel
-const { addPendingClose } = pendingReleasesSlice.actions;
+const { addPendingClose } = pendingChangesSlice.actions;
 
 export const {
   incrementOrderIndex,
@@ -329,5 +387,5 @@ export const {
   removePendingRelease,
   setProgressiveRelease,
   updateProgressiveRelease,
-} = pendingReleasesSlice.actions;
-export default pendingReleasesSlice.reducer;
+} = pendingChangesSlice.actions;
+export default pendingChangesSlice.reducer;

--- a/static/js/publisher/pages/Releases/slices/pendingChanges.ts
+++ b/static/js/publisher/pages/Releases/slices/pendingChanges.ts
@@ -3,7 +3,6 @@ import { getPendingChannelMap, getReleases } from "../selectors";
 import { triggerGAEvent } from "../analytics";
 import type {
   PendingChangesState,
-  PendingRelease,
   PendingReleaseItem,
   Progressive,
   Revision,
@@ -41,16 +40,10 @@ export function releaseRevision(
 
       // If there's already a "null" release in staging that is progressive
       // assign that value to subsequent progressive releases
-      Object.keys(pendingReleases).forEach((orderIndex) => {
-        const numericOrderIndex = Number(orderIndex);
-        const channels = pendingReleases[numericOrderIndex].channels;
-        Object.keys(channels).forEach((channel) => {
-          const release = channels[channel];
-
-          if (release.progressive && percentage === 100) {
-            percentage = release.progressive.percentage;
-          }
-        });
+      Object.values(pendingReleases).forEach((pendingReleaseItem) => {
+        if (pendingReleaseItem.progressive && percentage === 100) {
+          percentage = pendingReleaseItem.progressive.percentage;
+        }
       });
 
       // this is the exact payload expected by the Store API BE
@@ -145,12 +138,22 @@ export function closeChannel(channel: string) {
 
 function _getPendingReleaseByRevision(
   state: Draft<PendingChangesState>,
-  revision: number
-): Draft<[number, PendingRelease]> | null {
-  const entry = Object.entries(state.pendingReleases).find(
-    ([_orderKeyStr, pendingRelValue]) => pendingRelValue.revision === revision
-  );
-  if (entry) {
+  revision: number,
+  channel?: string
+): Draft<[number, PendingReleaseItem]> | null {
+  let entries = Object.entries(state.pendingReleases)
+    .filter(
+      ([_orderKeyStr, pendingRelItem]) => pendingRelItem.revision.revision === revision
+    );
+  
+  if (channel) {
+    entries.filter(
+      ([_orderKeyStr, pendingRelItem]) => pendingRelItem.channel === channel
+    );
+  }
+
+  if (entries.length > 0) {
+    const entry = entries[0];
     return [parseInt(entry[0]), entry[1]];
   }
   return null;
@@ -163,36 +166,17 @@ function _removePendingRelease(
 ) {
   const pendingReleaseEntry = _getPendingReleaseByRevision(state, revision.revision);
   if (pendingReleaseEntry) {
-    const [ orderKey, pendingRelease ] = pendingReleaseEntry;
-    if (pendingRelease.channels[channel]) {
-      delete pendingRelease.channels[channel];
-    }
-    if (Object.keys(pendingRelease.channels).length === 0) {
+    const [ orderKey, pendingReleaseItem ] = pendingReleaseEntry;
+    if (pendingReleaseItem.channel === channel) {
       delete state.pendingReleases[orderKey];
     }
   }
 }
 
 /*
-revisions to be released:
-key is the id of revision to release
-value is object containing release object and channels to release to
-{
-  <revisionId>: {
-    <channel>: {
-      revision: { revision: <revisionId>, version, ... },
-      channel: <channel>,
-      progressive: { percentage, current-percentage },
-      previousReleases: {
-        <arch>: { revision: <revisionId>, version, ... }
-      },
-      replaces: <revision>
-    }
-  }
-}
-we should prevent duplication of revison data.
-TODO: remove `revision` from here, use only data from `revisions` state
-TODO: remove `revision` from the PendingReleaseItem type
+TODO: We should prevent duplication of revison data.
+Remove `revision` from the PendingReleaseItem type,
+and use only data from `revisions` state
 */
 
 export type ReleaseRevisionPayload = {
@@ -230,10 +214,10 @@ const pendingReleasesSlice = createSlice({
 
       const channel = action.payload;
       Object.values(state.pendingReleases).forEach((pendingRelease) => {
-        if (pendingRelease.channels[channel]) {
+        if (pendingRelease.channel === channel) {
           _removePendingRelease(
             state,
-            pendingRelease.channels[channel].revision,
+            pendingRelease.revision,
             channel
           );
         }
@@ -262,81 +246,68 @@ const pendingReleasesSlice = createSlice({
       revision.architectures.forEach((arch) => {
         Object.values(state.pendingReleases).forEach((pendingRelease) => {
           if (
-            pendingRelease.revision !== revision.revision &&
-            pendingRelease.channels[channel] &&
-            pendingRelease.channels[channel].revision.architectures.includes(arch)
+            pendingRelease.revision.revision !== revision.revision &&
+            pendingRelease.revision.architectures.includes(arch)
           ) {
             _removePendingRelease(
               state,
-              pendingRelease.channels[channel].revision,
+              pendingRelease.revision,
               channel
             );
           }
         });
       });
 
-      const pendingReleaseEntry = _getPendingReleaseByRevision(state, revision.revision);
+      const pendingReleaseEntry = _getPendingReleaseByRevision(
+        state, revision.revision, channel);
+      let pendingReleaseItem: Draft<PendingReleaseItem>;
       let releaseOrder: number;
-      let pendingRelease: Draft<PendingRelease>;
       let newChangeOrderIndex = state.changeOrderIndex;
-      if (!pendingReleaseEntry) {
+      if (pendingReleaseEntry) {
+        [releaseOrder, pendingReleaseItem] = pendingReleaseEntry;
+        pendingReleaseItem.previousReleases = previousReleases ?? [];
+        pendingReleaseItem.progressive = progressive;
+      } else {
         releaseOrder = state.changeOrderIndex;
-        pendingRelease = {
-          revision: revision.revision,
-          channels: {}
+        pendingReleaseItem = {
+          revision: revision,
+          channel: channel,
+          previousReleases: previousReleases ?? [],
+          progressive: progressive,
         };
         newChangeOrderIndex = state.changeOrderIndex + 1;
-      } else {
-        [releaseOrder, pendingRelease] = pendingReleaseEntry;
       }
 
-      if (!pendingRelease.channels[channel]) {
-        pendingRelease.channels[channel] = {
-          revision,
-          channel,
-        } as PendingReleaseItem;
-      }
-      if (previousReleases) {
-        pendingRelease.channels[channel].previousReleases = previousReleases;
-      }
-      if (progressive && !pendingRelease.channels[channel].progressive) {
-        pendingRelease.channels[channel].progressive = progressive;
-      }
-
+      state.pendingReleases[releaseOrder] = pendingReleaseItem;
       state.changeOrderIndex = newChangeOrderIndex;
-      state.pendingReleases[releaseOrder] = pendingRelease;
     },
     removePendingRelease(state, action: PayloadAction<RemoveRevisionPayload>) {
       _removePendingRelease(state, action.payload.revision, action.payload.channel);
     },
     setProgressiveRelease(state, action: PayloadAction<Progressive>) {
       const progressive = action.payload;
-      Object.values(state.pendingReleases).forEach((pendingRelease) => {
-        Object.values(pendingRelease.channels).forEach((channel) => {
-          const hasPreviousReleases =
-            channel.previousReleases &&
-            Object.keys(channel.previousReleases).length > 0;
-          if (
-            hasPreviousReleases &&
-            !channel.progressive &&
-            progressive.percentage &&
-            progressive.percentage < 100
-          ) {
-            channel.progressive = { ...progressive };
-          }
-        });
+      Object.values(state.pendingReleases).forEach((pendingReleaseItem) => {
+        const hasPreviousReleases =
+          pendingReleaseItem.previousReleases &&
+          pendingReleaseItem.previousReleases.length > 0;
+        if (
+          hasPreviousReleases &&
+          !pendingReleaseItem.progressive &&
+          progressive.percentage &&
+          progressive.percentage < 100
+        ) {
+          pendingReleaseItem.progressive = { ...progressive };
+        }
       });
     },
     updateProgressiveRelease(state, action: PayloadAction<Progressive>) {
       const progressive = action.payload;
-      Object.values(state.pendingReleases).forEach((pendingRelease) => {
-        Object.values(pendingRelease.channels).forEach((channel) => {
-          if (channel.progressive) {
-            channel.progressive.percentage = progressive.percentage;
-            channel.progressive["current-percentage"] = progressive["current-percentage"];
-            channel.progressive.paused = progressive.paused;
-          }
-        });
+      Object.values(state.pendingReleases).forEach((pendingReleaseItem) => {
+        if (pendingReleaseItem.progressive) {
+          pendingReleaseItem.progressive.percentage = progressive.percentage;
+          pendingReleaseItem.progressive["current-percentage"] = progressive["current-percentage"];
+          pendingReleaseItem.progressive.paused = progressive.paused;
+        }
       });
     },
   }

--- a/static/js/publisher/pages/Releases/slices/pendingChanges.ts
+++ b/static/js/publisher/pages/Releases/slices/pendingChanges.ts
@@ -164,7 +164,11 @@ function _removePendingRelease(
   revision: Draft<Revision>,
   channel: string
 ) {
-  const pendingReleaseEntry = _getPendingReleaseByRevision(state, revision.revision);
+  const pendingReleaseEntry = _getPendingReleaseByRevision(
+    state,
+    revision.revision,
+    channel
+  );
   if (pendingReleaseEntry) {
     const [ orderKey, pendingReleaseItem ] = pendingReleaseEntry;
     if (pendingReleaseItem.channel === channel) {
@@ -174,7 +178,7 @@ function _removePendingRelease(
 }
 
 /*
-TODO: We should prevent duplication of revison data.
+TODO: We should prevent duplication of revision data.
 Remove `revision` from the PendingReleaseItem type,
 and use only data from `revisions` state
 */
@@ -248,6 +252,7 @@ const pendingReleasesSlice = createSlice({
         Object.values(state.pendingReleases).forEach((pendingRelease) => {
           if (
             pendingRelease.revision.revision !== revision.revision &&
+            pendingRelease.channel === channel &&
             pendingRelease.revision.architectures.includes(arch)
           ) {
             _removePendingRelease(

--- a/static/js/publisher/pages/Releases/slices/pendingChanges.ts
+++ b/static/js/publisher/pages/Releases/slices/pendingChanges.ts
@@ -147,7 +147,7 @@ function _getPendingReleaseByRevision(
     );
   
   if (channel) {
-    entries.filter(
+    entries = entries.filter(
       ([_orderKeyStr, pendingRelItem]) => pendingRelItem.channel === channel
     );
   }
@@ -204,24 +204,25 @@ const pendingReleasesSlice = createSlice({
     },
     addPendingClose(state, action: PayloadAction<string>) {
       const pendingCloses = state.pendingCloses;
+      const channel = action.payload;
       const alreadyExistingChannel = Object.entries(pendingCloses).find(
         ([_orderIndex, channel]) => channel === action.payload
       );
-      // channel is already in pendingCloses so we just return the state
-      if (alreadyExistingChannel) {
-        return;
-      }
 
-      const channel = action.payload;
-      Object.values(state.pendingReleases).forEach((pendingRelease) => {
-        if (pendingRelease.channel === channel) {
-          _removePendingRelease(
-            state,
-            pendingRelease.revision,
-            channel
-          );
-        }
-      });
+      if (alreadyExistingChannel) {
+        const index = parseInt(alreadyExistingChannel[0]);
+        delete state.pendingCloses[index];
+      } else {
+        Object.values(state.pendingReleases).forEach((pendingRelease) => {
+          if (pendingRelease.channel === channel) {
+            _removePendingRelease(
+              state,
+              pendingRelease.revision,
+              channel
+            );
+          }
+        });
+      }
 
       state.pendingCloses[state.changeOrderIndex] = channel;
       state.changeOrderIndex += 1;

--- a/static/js/publisher/pages/Releases/slices/releases.ts
+++ b/static/js/publisher/pages/Releases/slices/releases.ts
@@ -187,26 +187,19 @@ function dedupeReleases(
 ): FetchReleasePayload[] {
   const progressiveReleases: FetchReleasePayload[] = [];
   const regularReleases: FetchReleasePayload[] = [];
-  Object.keys(pendingReleases).forEach((orderIndex) => {
-    const numericOrderIndex = Number(orderIndex);
-    const revId = pendingReleases[numericOrderIndex].revision;
-    const channels = pendingReleases[numericOrderIndex].channels;
-    Object.keys(channels).forEach((channel) => {
-      const pendingRelease = channels[channel];
-      if (pendingRelease.progressive) {
-        // first move progressive releases out
-        progressiveReleases.push(mapToRelease(pendingRelease));
+  Object.values(pendingReleases).forEach((pendingReleaseItem) => {
+    if (pendingReleaseItem.progressive) {
+      progressiveReleases.push(mapToRelease(pendingReleaseItem));
+    } else {
+      const releaseIndex = regularReleases.findIndex(
+        (release) => release.revision.revision === pendingReleaseItem.revision.revision
+      );
+      if (releaseIndex === -1) {
+        regularReleases.push(mapToRelease(pendingReleaseItem));
       } else {
-        const releaseIndex = regularReleases.findIndex(
-          (release) => release.revision.revision === revId
-        );
-        if (releaseIndex === -1) {
-          regularReleases.push(mapToRelease(pendingRelease));
-        } else {
-          regularReleases[releaseIndex].channels.push(pendingRelease.channel);
-        }
+        regularReleases[releaseIndex].channels.push(pendingReleaseItem.channel);
       }
-    });
+    }
   });
   return [...progressiveReleases, ...regularReleases];
 }
@@ -228,6 +221,15 @@ export const releaseRevisions = createAsyncThunk<
     // should we display a loading state in the UI ?
 
     try {
+      // for (let index = 0; index < pendingChanges.changeOrderIndex; ++index) {
+      //   if (pendingChanges.pendingCloses[index]) {
+      //     // fetch close
+      //     const response = await fetchRelease()
+      //   } else {
+      //     // fetch release
+      //   }
+      // }
+
       await fetchReleases(
         (json, release) => handleReleaseResponse(dispatch, json, release, revisions),
         releases,

--- a/static/js/publisher/pages/Releases/slices/releases.ts
+++ b/static/js/publisher/pages/Releases/slices/releases.ts
@@ -193,15 +193,13 @@ export const releaseRevisions = createAsyncThunk<
     const { pendingChanges, revisions, options } = getState();
     const { snapName } = options;
     const pendingCloses = pendingChanges.pendingCloses;
-    const releases = Object.values(pendingChanges.pendingReleases)
-      .map((pendingReleaseItem) => mapToRelease(pendingReleaseItem));
     dispatch(hideNotification());
     // TODO: we're doing a lot of sequential network requests
     // should we display a loading state in the UI ?
 
     try {
-      const sentReleases = new Set<FetchReleasePayload>();
-      // send the requests in order
+      // send the requests in order — later changes can overwrite earlier ones,
+      // so each pending release must be sent individually without deduplication
       for (let index = 0; index < pendingChanges.changeOrderIndex; ++index) {
         const pendingClose = pendingCloses[index];
         if (pendingClose) {
@@ -214,24 +212,14 @@ export const releaseRevisions = createAsyncThunk<
           if (!pendingRelease) {
             continue;
           }
-          // fetch release
-          const release = releases.find(
-            (releasePayload) =>
-              releasePayload.id === pendingRelease.revision.revision,
+          const release = mapToRelease(pendingRelease);
+          const json = await fetchRelease(
+            snapName,
+            release.id,
+            release.channels,
+            release.progressive
           );
-          if (release && !sentReleases.has(release)) {
-            sentReleases.add(release);
-            const json = await fetchRelease(
-              snapName,
-              release.id,
-              release.channels,
-              release.progressive
-            );
-            handleReleaseResponse(dispatch, json, release, revisions);
-          } else if (!release) {
-            // this should never happen
-            console.warn("pending release mismatch");
-          }
+          handleReleaseResponse(dispatch, json, release, revisions);
         }
       }
 

--- a/static/js/publisher/pages/Releases/slices/releases.ts
+++ b/static/js/publisher/pages/Releases/slices/releases.ts
@@ -16,8 +16,8 @@ import { closeHistory } from "./history";
 import { releasesReady } from "./options";
 import {
   fetchSnapReleaseStatus,
-  fetchReleases,
-  fetchCloses,
+  fetchRelease,
+  fetchClose,
 } from "../api/releases";
 import {
   getReleaseDataFromChannelMap,
@@ -221,25 +221,39 @@ export const releaseRevisions = createAsyncThunk<
     // should we display a loading state in the UI ?
 
     try {
-      // for (let index = 0; index < pendingChanges.changeOrderIndex; ++index) {
-      //   if (pendingChanges.pendingCloses[index]) {
-      //     // fetch close
-      //     const response = await fetchRelease()
-      //   } else {
-      //     // fetch release
-      //   }
-      // }
+      const sentReleases = new Set<FetchReleasePayload>();
+      // the the requests in order
+      for (let index = 0; index < pendingChanges.changeOrderIndex; ++index) {
+        if (pendingChanges.pendingCloses[index]) {
+          // fetch close
+          const json = await fetchClose(
+            snapName,
+            [pendingChanges.pendingCloses[index]]
+          );
+          handleCloseResponse(dispatch, json, pendingCloses)
+        } else {
+          // fetch release
+          const release = releases.find(
+            (releasePayload) =>
+              releasePayload.id ===
+              pendingChanges.pendingReleases[index].revision.revision,
+          );
+          if (release && !sentReleases.has(release)) {
+            sentReleases.add(release);
+            const json = await fetchRelease(
+              snapName,
+              release.id,
+              release.channels,
+              release.progressive
+            );
+            handleReleaseResponse(dispatch, json, release, revisions);
+          } else if (!release) {
+            // this should never happen
+            console.warn("pending release mismatch");
+          }
+        }
+      }
 
-      await fetchReleases(
-        (json, release) => handleReleaseResponse(dispatch, json, release, revisions),
-        releases,
-        snapName,
-      );
-      await fetchCloses(
-        (json) => handleCloseResponse(dispatch, json, pendingCloses),
-        snapName,
-        getArrayOfChannelNames(pendingCloses),
-      )
       const jsonData = await fetchSnapReleaseStatus(snapName);
       dispatch(updateReleasesUI(jsonData));
       dispatch(cancelPendingChanges());

--- a/static/js/publisher/pages/Releases/slices/releases.ts
+++ b/static/js/publisher/pages/Releases/slices/releases.ts
@@ -182,28 +182,6 @@ function mapToRelease(
   };
 };
 
-function dedupeReleases(
-  pendingReleases: PendingChangesState["pendingReleases"]
-): FetchReleasePayload[] {
-  const progressiveReleases: FetchReleasePayload[] = [];
-  const regularReleases: FetchReleasePayload[] = [];
-  Object.values(pendingReleases).forEach((pendingReleaseItem) => {
-    if (pendingReleaseItem.progressive) {
-      progressiveReleases.push(mapToRelease(pendingReleaseItem));
-    } else {
-      const releaseIndex = regularReleases.findIndex(
-        (release) => release.revision.revision === pendingReleaseItem.revision.revision
-      );
-      if (releaseIndex === -1) {
-        regularReleases.push(mapToRelease(pendingReleaseItem));
-      } else {
-        regularReleases[releaseIndex].channels.push(pendingReleaseItem.channel);
-      }
-    }
-  });
-  return [...progressiveReleases, ...regularReleases];
-}
-
 // async thunk method to push all the pending changes to the Store backend
 export const releaseRevisions = createAsyncThunk<
   void,
@@ -215,28 +193,31 @@ export const releaseRevisions = createAsyncThunk<
     const { pendingChanges, revisions, options } = getState();
     const { snapName } = options;
     const pendingCloses = pendingChanges.pendingCloses;
-    const releases = dedupeReleases(pendingChanges.pendingReleases);
+    const releases = Object.values(pendingChanges.pendingReleases)
+      .map((pendingReleaseItem) => mapToRelease(pendingReleaseItem));
     dispatch(hideNotification());
     // TODO: we're doing a lot of sequential network requests
     // should we display a loading state in the UI ?
 
     try {
       const sentReleases = new Set<FetchReleasePayload>();
-      // the the requests in order
+      // send the requests in order
       for (let index = 0; index < pendingChanges.changeOrderIndex; ++index) {
-        if (pendingChanges.pendingCloses[index]) {
-          // fetch close
-          const json = await fetchClose(
-            snapName,
-            [pendingChanges.pendingCloses[index]]
-          );
-          handleCloseResponse(dispatch, json, pendingCloses)
+        const pendingClose = pendingCloses[index];
+        if (pendingClose) {
+          const json = await fetchClose(snapName, [pendingClose]);
+          handleCloseResponse(dispatch, json, pendingCloses);
         } else {
+          const pendingRelease = pendingChanges.pendingReleases[index];
+          // some changes could have been removed by the user and the index
+          // will be undefined
+          if (!pendingRelease) {
+            continue;
+          }
           // fetch release
           const release = releases.find(
             (releasePayload) =>
-              releasePayload.id ===
-              pendingChanges.pendingReleases[index].revision.revision,
+              releasePayload.id === pendingRelease.revision.revision,
           );
           if (release && !sentReleases.has(release)) {
             sentReleases.add(release);

--- a/static/js/publisher/test-utils/mockPendingChanges.ts
+++ b/static/js/publisher/test-utils/mockPendingChanges.ts
@@ -1,6 +1,5 @@
 import type {
   PendingChangesState,
-  PendingRelease,
   PendingReleaseItem,
   Progressive,
   Revision,
@@ -44,46 +43,23 @@ export function createMockPendingCloses(
 }
 
 type PendingReleases = {
-  [order: number]: PendingRelease;
+  [order: number]: PendingReleaseItem;
 };
 
 export function createMockPendingReleases(
   partialPendingReleases: PartialPendingRelease[],
   startIndex = 0,
 ) {
-  // first sort the pending releases passed by revision
-  partialPendingReleases.sort((a, b) => a.revision - b.revision);
   const result: PendingReleases = {};
-  // there are no revisions with negative numbers, so the first iteration
-  // will always enter the if and increase the index back to its original value
-  let previousRevision = -1;
-  --startIndex;
 
-  for (const pendingRelease of partialPendingReleases) {
+  for (const partialPendingRelease of partialPendingReleases) {
     const channel =
-      pendingRelease.pendingReleaseItem.channel || "latest/stable";
-    if (pendingRelease.revision !== previousRevision) {
-      // if it's the same revision then the changes go into the same index
-      ++startIndex;
-    }
-    if (result[startIndex]) {
-      result[startIndex].channels = {
-        ...result[startIndex].channels,
-        [channel]: createMockPendingReleaseItem(
-          pendingRelease.pendingReleaseItem,
-        ),
-      };
-    } else {
-      result[startIndex] = {
-        revision: pendingRelease.revision,
-        channels: {
-          [channel]: createMockPendingReleaseItem(
-            pendingRelease.pendingReleaseItem,
-          ),
-        },
-      };
-    }
-    previousRevision = pendingRelease.revision;
+      partialPendingRelease.pendingReleaseItem.channel ?? partialPendingRelease.channel;
+    result[startIndex] = createMockPendingReleaseItem({
+      ...partialPendingRelease.pendingReleaseItem,
+      channel,
+    });
+    startIndex++;
   }
 
   return result;

--- a/static/js/publisher/test-utils/mockPendingChanges.ts
+++ b/static/js/publisher/test-utils/mockPendingChanges.ts
@@ -54,7 +54,8 @@ export function createMockPendingReleases(
 
   for (const partialPendingRelease of partialPendingReleases) {
     const channel =
-      partialPendingRelease.pendingReleaseItem.channel ?? partialPendingRelease.channel;
+      partialPendingRelease.pendingReleaseItem.channel ??
+      partialPendingRelease.channel;
     result[startIndex] = createMockPendingReleaseItem({
       ...partialPendingRelease.pendingReleaseItem,
       channel,

--- a/static/js/publisher/types/releaseTypes.ts
+++ b/static/js/publisher/types/releaseTypes.ts
@@ -313,7 +313,7 @@ export type PendingChangesState = {
     [order: number]: Channel["name"]; // TODO: are there any constraints on this?
   };
   pendingReleases: {
-    [order: number]: PendingRelease;
+    [order: number]: PendingReleaseItem;
   };
 };
 export type ReleasesState = Release[];
@@ -383,7 +383,7 @@ export type PendingReleaseItem = {
   channel: Channel["name"];
   previousReleases: Revision[];
   progressive?: Progressive;
-  replaces?: PendingReleaseItem;
+  replaces?: PendingReleaseItem; // TODO: remove because it is never set
 };
 
 /**

--- a/static/js/publisher/types/releaseTypes.ts
+++ b/static/js/publisher/types/releaseTypes.ts
@@ -301,7 +301,7 @@ export type ModalState = Partial<{
   actions: {
     appearance: "positive" | "neutral" | "negative";
     onClickAction:
-      | { reduxAction: string }
+      | { reduxAction: () => void }
       | { type: typeof CLOSE_MODAL_ACTION_NAME };
     label: string;
   }[];

--- a/static/sass/_snapcraft_release.scss
+++ b/static/sass/_snapcraft_release.scss
@@ -562,6 +562,11 @@
         display: none;
       }
     }
+
+    &.is-over.is-highlighted {
+      background: $colors--theme--border-low-contrast;
+      border-color: $colors--theme--border-low-contrast;
+    }
   }
 
   .p-releases-table__arch {


### PR DESCRIPTION
## Done

Modified releases UI to be able to re-add revisions on top of a closed channel.
This allows users to close a channel and re-open it without including some of the revisions (effectively "deleting them").

## How to QA

- Go to the "Releases" page of one of your snaps - [DEMO](https://snapcraft-io-5715.demos.haus/).
- Close a channel.
- Drag a revision on top of the closed channel.
- Click on "Save changes".
- The list should include:
    - Close channel "your channel"
    - Release Revision X to "your channel"
- Confirm changes and check that there are no errors and changes are applied properly.

In addition, try to play around the Releases UI to make sure nothing else got broken.

## Testing

- [x] This PR has tests
- [ ] No testing required (explain why):

## Security

- [ ] Security considerations for review (list them):
  - [ ] Examples:
  - [ ] Access control: users can only access their own data
  - [ ] Input: user input is validated and sanitised
  - [ ] Sensitive data: secret or private data is not exposed in any way
  - [ ] ...
- [x] This PR has no security considerations (explain why): It's just a FE UX/UI improvement - backend services and requests remain the same as before.

## Issue / Card

Fixes [WD-34912](https://warthogs.atlassian.net/browse/WD-34912)

## UX Approval

- [ ] This PR does not require UX approval
- [x] This PR does require UX approval (add context): as explained above the PR contains a very simple change regarding the possibility to drop releases on top of an already closed channel, but I guess a UX approval makes sense (?)


[WD-34912]: https://warthogs.atlassian.net/browse/WD-34912?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ