### PR TITLE
Revert python to 3.10 in test coverage workflow

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Python 3.10
         uses: actions/setup-python@v6
         with:
-          python-version: "3.14"
+          python-version: "3.10"
           cache: "pip"
 
       - name: Set up Node.js
@@ -127,7 +127,7 @@ jobs:
       - name: Set up Python 3.10
         uses: actions/setup-python@v6
         with:
-          python-version: "3.14"
+          python-version: "3.10"
           cache: "pip"
 
       - name: Set up Node.js


### PR DESCRIPTION
## Done

Attempts to fix broken Test coverage workflow by reverting back python version to 3.10

## How to QA

After merging, run the workflow

## Testing

- [ ] This PR has tests
- [x] No testing required (explain why): workflow change

## Security

- [x] This PR has no security considerations (explain why): reverting back version of python in workflow

