### PR TITLE
WD-34913 - Add button to close arch automatically

### DIFF
--- a/static/js/publisher/pages/Releases/components/defaultTrackModifier.tsx
+++ b/static/js/publisher/pages/Releases/components/defaultTrackModifier.tsx
@@ -14,6 +14,7 @@ import type {
   ReleasesReduxState,
 } from "../../../types/releaseTypes";
 import type { AppDispatch } from "../store";
+import { clearDefaultTrack, setDefaultTrack } from "../slices/defaultTrack";
 
 interface StateProps {
   defaultTrack: string | null;
@@ -27,6 +28,8 @@ interface DispatchProps {
   openModal: (payload: ModalState) => void;
   showNotification: (payload: NotificationState) => void;
   hideNotification: () => void;
+  clearDefaultTrack: () => void;
+  setDefaultTrack: () => void;
 }
 
 type DefaultTrackModifierProps = StateProps & DispatchProps;
@@ -40,7 +43,7 @@ class DefaultTrackModifier extends Component<DefaultTrackModifierProps> {
   }
 
   clearDefaultTrackHandler() {
-    const { defaultTrack, openModal } = this.props;
+    const { clearDefaultTrack, defaultTrack, openModal } = this.props;
 
     openModal({
       title: "Clear default track",
@@ -49,7 +52,7 @@ class DefaultTrackModifier extends Component<DefaultTrackModifierProps> {
         {
           appearance: "positive",
           onClickAction: {
-            reduxAction: "clearDefaultTrack",
+            reduxAction: clearDefaultTrack,
           },
           label: `Clear ${defaultTrack} as default track`,
         },
@@ -65,7 +68,7 @@ class DefaultTrackModifier extends Component<DefaultTrackModifierProps> {
   }
 
   setDefaultTrackHandler() {
-    const { currentTrack, defaultTrack, openModal } = this.props;
+    const { currentTrack, defaultTrack, openModal, setDefaultTrack } = this.props;
 
     openModal({
       title: `Set default track to ${currentTrack}`,
@@ -74,7 +77,7 @@ class DefaultTrackModifier extends Component<DefaultTrackModifierProps> {
         {
           appearance: "positive",
           onClickAction: {
-            reduxAction: "setDefaultTrack",
+            reduxAction: setDefaultTrack,
           },
           label: `Set ${currentTrack} as default track`,
         },
@@ -166,6 +169,8 @@ const mapDispatchToProps = (dispatch: AppDispatch): DispatchProps => ({
   openModal: (payload) => dispatch(openModal(payload)),
   showNotification: (payload) => dispatch(showNotification(payload)),
   hideNotification: () => dispatch(hideNotification()),
+  clearDefaultTrack: () => dispatch(clearDefaultTrack()),
+  setDefaultTrack: () => dispatch(setDefaultTrack()),
 });
 
 export default connect(

--- a/static/js/publisher/pages/Releases/components/modal.tsx
+++ b/static/js/publisher/pages/Releases/components/modal.tsx
@@ -2,7 +2,6 @@ import { Component, ReactNode } from "react";
 import { connect } from "react-redux";
 
 import { CLOSE_MODAL_ACTION_NAME, closeModal } from "../slices/modal";
-import { setDefaultTrack, clearDefaultTrack } from "../slices/defaultTrack";
 import type { ReleasesReduxState } from "../../../types/releaseTypes";
 import type { AppDispatch } from "../store";
 
@@ -10,7 +9,7 @@ type ModalAction = {
   appearance: "positive" | "neutral" | "negative";
   onClickAction:
     | {
-        reduxAction: string;
+        reduxAction: () => void;
       }
     | {
         type: typeof CLOSE_MODAL_ACTION_NAME;
@@ -23,9 +22,6 @@ interface ModalActionButtonProps {
   appearance: ModalAction["appearance"];
   children: ReactNode;
   dispatch: AppDispatch;
-  setDefaultTrack?: () => void;
-  clearDefaultTrack?: () => void;
-  [key: string]: unknown; // For dynamic redux action props
 }
 
 interface ModalActionButtonState {
@@ -48,11 +44,7 @@ class ModalActionButton extends Component<ModalActionButtonProps, ModalActionBut
 
     if ("reduxAction" in onClickAction) {
       const { reduxAction } = onClickAction;
-      const reduxActionFn = this.props[reduxAction];
-      if (reduxActionFn && typeof reduxActionFn === "function") {
-        // If an action is passed, perform the specific action
-        (reduxActionFn as () => void)();
-      }
+      reduxAction();
     } else {
       // Otherwise dispatch the action object
       dispatch(onClickAction);
@@ -70,7 +62,6 @@ class ModalActionButton extends Component<ModalActionButtonProps, ModalActionBut
     const className = [
       `p-button--${appearance}`,
       "u-no-margin--bottom",
-      "u-float-right",
       ["positive", "negative"].indexOf(appearance) > -1 ? "is--dark" : "",
     ];
 
@@ -89,8 +80,6 @@ class ModalActionButton extends Component<ModalActionButtonProps, ModalActionBut
 
 const mapActionButtonDispatchToProps = (dispatch: AppDispatch) => ({
   dispatch,
-  setDefaultTrack: () => dispatch(setDefaultTrack()),
-  clearDefaultTrack: () => dispatch(clearDefaultTrack()),
 });
 
 const ModalActionButtonWrapped = connect(
@@ -131,15 +120,17 @@ const Modal = ({ title, content, actions = [], closeModal }: ModalProps) => {
           </button>
         </header>
         <p id="modal-description">{content}</p>
-        {actions.map((action, i) => (
-          <ModalActionButtonWrapped
-            key={`action-${i}`}
-            appearance={action.appearance}
-            onClickAction={action.onClickAction}
-          >
-            {action.label}
-          </ModalActionButtonWrapped>
-        ))}
+        <div className="u-align--right">
+          {actions.map((action, i) => (
+            <ModalActionButtonWrapped
+              key={`action-${i}`}
+              appearance={action.appearance}
+              onClickAction={action.onClickAction}
+            >
+              {action.label}
+            </ModalActionButtonWrapped>
+          ))}
+        </div>
       </div>
     </div>
   );

--- a/static/js/publisher/pages/Releases/components/releasesTable/cellViews.tsx
+++ b/static/js/publisher/pages/Releases/components/releasesTable/cellViews.tsx
@@ -11,6 +11,7 @@ import {
 } from "../../helpers";
 import { useDragging, Handle } from "../dnd";
 
+import CloseMenuItem from "./closeMenuItem";
 import ReleaseMenuItem from "./releaseMenuItem";
 import type { Revision, CPUArchitecture } from "../../../../types/releaseTypes";
 import type { DraggedItem } from "./types";
@@ -339,7 +340,7 @@ export const ReleasesTableCellView = (props: ReleasesTableCellViewProps) => {
           <>
             <ContextualMenu
               className="p-button is-small"
-              label={cellType === "revision" ? "Release" : "Promote"}
+              label={cellType === "revision" ? "Release" : "Promote/close"}
             >
               <span className="p-contextual-menu__group">
                 <span className="p-contextual-menu__item">
@@ -356,6 +357,9 @@ export const ReleasesTableCellView = (props: ReleasesTableCellViewProps) => {
                   );
                 })}
               </span>
+              { cellType === "release" &&
+                <CloseMenuItem item={item} current={current} arch={arch} />
+              }
             </ContextualMenu>
             <Handle />
           </>

--- a/static/js/publisher/pages/Releases/components/releasesTable/closeMenuItem.tsx
+++ b/static/js/publisher/pages/Releases/components/releasesTable/closeMenuItem.tsx
@@ -1,0 +1,57 @@
+import { connect } from "react-redux";
+
+import { closeRevision } from "../../slices/pendingChanges";
+import type {
+  Revision,
+  CPUArchitecture,
+} from "../../../../types/releaseTypes";
+import type { AppDispatch } from "../../store";
+import type { DraggedItem } from "./types";
+
+interface OwnProps {
+  item: DraggedItem;
+  current?: string;
+  arch?: CPUArchitecture;
+}
+
+interface DispatchProps {
+  closeRevision: (revision: Revision, targetChannel: string, arch: CPUArchitecture) => void;
+}
+
+type ReleaseMenuItemProps = OwnProps & DispatchProps;
+
+function CloseMenuItem(props: ReleaseMenuItemProps) {
+  return (props.current && props.arch &&
+    <span className="p-contextual-menu__group">
+      <a
+        className="p-contextual-menu__link"
+        href="#"
+        onClick={() => {
+          const revision = props.item.revisions.find(() => true);
+          if (revision) {
+            props.closeRevision(
+              revision,
+              props.current!,
+              props.arch!,
+            );
+          }
+        }}
+      >
+        Close {props.arch}
+      </a>
+    </span>
+  );
+}
+
+const mapDispatchToProps = (dispatch: AppDispatch): DispatchProps => {
+  return {
+    closeRevision: (revision: Revision, targetChannel: string, arch: CPUArchitecture) =>
+      dispatch(closeRevision(
+        revision,
+        targetChannel,
+        arch,
+      )),
+  };
+};
+
+export default connect(null, mapDispatchToProps)(CloseMenuItem);

--- a/static/js/publisher/pages/Releases/slices/__tests__/pendingChanges.test.ts
+++ b/static/js/publisher/pages/Releases/slices/__tests__/pendingChanges.test.ts
@@ -10,10 +10,13 @@ import reducer, {
   promoteChannel,
   undoRelease,
   closeChannel,
+  closeRevision,
   incrementOrderIndex,
 } from "../pendingChanges";
 import historyReducer from "../history";
+import { closeModal, CLOSE_MODAL_ACTION_NAME } from "../modal";
 import type {
+  CPUArchitecture,
   PendingChangesState,
   PendingReleaseItem,
   Progressive,
@@ -41,6 +44,13 @@ const emptyPendingReleaseItem: PendingReleaseItem = {
   channel: "",
   previousReleases: [],
 }
+
+const makeStore = () => {
+  const store = configureStore({
+    reducer: { pendingChanges: reducer, history: historyReducer },
+  });
+  return store as typeof store & { dispatch: AppDispatch };
+};
 
 const findPendingRelease = (state: PendingChangesState, revisionId: number) =>
   Object.values(state.pendingReleases).find((pr) => pr.revision.revision === revisionId);
@@ -645,13 +655,6 @@ describe("pendingChanges", () => {
   // ─── closeChannel thunk ─────────────────────────────────────────────────────
 
   describe("closeChannel thunk", () => {
-    const makeStore = () => {
-      const store = configureStore({
-        reducer: { pendingChanges: reducer, history: historyReducer },
-      });
-      return store as typeof store & { dispatch: AppDispatch };
-    };
-
     it("should add channel to pending closes", () => {
       const store = makeStore();
       store.dispatch(closeChannel("test/edge"));
@@ -682,6 +685,168 @@ describe("pendingChanges", () => {
       const store = makeStore();
       store.dispatch(closeChannel("test/edge"));
       expect(store.getState().history.isOpen).toBe(false);
+    });
+  });
+
+  // ─── closeRevision thunk ────────────────────────────────────────────────────
+
+  describe("closeRevision thunk", () => {
+    const revision = {
+      revision: 1,
+      architectures: ["test64"],
+    } as unknown as Revision;
+    const channel = "test/edge";
+    const arch = "test64" as CPUArchitecture;
+
+    const closeRevisionAndGetDispatch = (channelMap = {}) => {
+      const dispatch = vi.fn() as unknown as AppDispatch;
+      const getState = () => ({} as RootState);
+      vi.mocked(getPendingChannelMap).mockReturnValue(channelMap as any);
+      closeRevision(revision, channel, arch)(dispatch, getState);
+      return dispatch;
+    };
+
+    const extractProceed = (dispatch: AppDispatch) =>
+      // the dispatch to open the modal contains the proceed function we want to test
+      (dispatch as ReturnType<typeof vi.fn>).mock.calls[0][0].payload.actions[0]
+        .onClickAction.reduxAction as () => void;
+
+    describe("dispatched modal", () => {
+      it("should dispatch openModal", () => {
+        const dispatch = closeRevisionAndGetDispatch();
+        expect(dispatch).toHaveBeenCalledTimes(1);
+        expect((dispatch as ReturnType<typeof vi.fn>).mock.calls[0][0]).toMatchObject({
+          type: "modal/openModal",
+        });
+      });
+
+      it("should set the modal title to 'Attention'", () => {
+        const dispatch = closeRevisionAndGetDispatch();
+        expect((dispatch as ReturnType<typeof vi.fn>).mock.calls[0][0].payload.title).toBe(
+          "Attention",
+        );
+      });
+
+      it("should include arch and channel in the modal content", () => {
+        const dispatch = closeRevisionAndGetDispatch();
+        const content: string =
+          (dispatch as ReturnType<typeof vi.fn>).mock.calls[0][0].payload.content;
+        expect(content).toContain(arch);
+        expect(content).toContain(channel);
+      });
+
+      it("should provide Continue and Cancel actions", () => {
+        const dispatch = closeRevisionAndGetDispatch();
+        const actions =
+          (dispatch as ReturnType<typeof vi.fn>).mock.calls[0][0].payload.actions;
+        expect(actions).toHaveLength(2);
+        expect(actions[0].label).toBe("Continue");
+        expect(actions[1].label).toBe("Cancel");
+      });
+
+      it("should wire the Cancel action to close the modal", () => {
+        const dispatch = closeRevisionAndGetDispatch();
+        const cancelAction =
+          (dispatch as ReturnType<typeof vi.fn>).mock.calls[0][0].payload.actions[1];
+        expect(cancelAction.onClickAction).toEqual({ type: CLOSE_MODAL_ACTION_NAME });
+      });
+    });
+
+    describe("when the Continue action is executed (proceed)", () => {
+      it("should dispatch closeChannel for the given channel", () => {
+        const dispatch = closeRevisionAndGetDispatch();
+        extractProceed(dispatch)();
+        const calls = (dispatch as ReturnType<typeof vi.fn>).mock.calls;
+        expect(calls.length).toBeGreaterThan(1);
+        const closeChannelThunk = calls[1][0] as unknown as ReturnType<typeof closeChannel>;
+        // check that closeChannel is called with the appropriate parameter
+        expect(typeof closeChannelThunk).toBe("function");
+        const store = makeStore();
+        store.dispatch(closeChannelThunk);
+        expect(Object.values(store.getState().pendingChanges.pendingCloses))
+          .toContain(channel);
+      });
+
+      it("should dispatch closeModal", () => {
+        const dispatch = closeRevisionAndGetDispatch();
+        extractProceed(dispatch)();
+        expect(dispatch).toHaveBeenCalledWith(closeModal());
+      });
+
+      describe("when there are other revisions in the channel", () => {
+        it("should re-release those revisions", () => {
+          const otherRevision = {
+            revision: 2,
+            architectures: ["abc42"],
+          } as unknown as Revision;
+          const dispatch = closeRevisionAndGetDispatch({
+            [channel]: { test64: revision, abc42: otherRevision },
+          });
+
+          vi.mocked(getReleases).mockReturnValue([]);
+
+          extractProceed(dispatch)();
+          const calls = (dispatch as ReturnType<typeof vi.fn>).mock.calls;
+          // openModal + closeChannel thunk + releaseRevision thunk + closeModal
+          expect(calls.length).toBe(4);
+          const releaseRevisionThunk = calls[2][0] as unknown as ReturnType<typeof releaseRevision>;
+          expect(typeof releaseRevisionThunk).toBe("function");
+          const store = makeStore();
+          store.dispatch(releaseRevisionThunk);
+          const pendingReleases = Object.values(store.getState().pendingChanges.pendingReleases);
+          expect(pendingReleases).toHaveLength(1);
+          expect(pendingReleases[0].channel).toBe("test/edge");
+          expect(pendingReleases[0].revision.revision).toBe(2);
+          expect(pendingReleases[0].revision.architectures).toContainEqual("abc42");
+        });
+
+        it("should not re-release the revision being closed", () => {
+          const otherRevision = {
+            revision: 2,
+            architectures: ["abc42"],
+          } as unknown as Revision;
+          const dispatch = closeRevisionAndGetDispatch({
+            [channel]: { test64: revision, abc42: otherRevision },
+          });
+
+          vi.mocked(getReleases).mockReturnValue([]);
+
+          extractProceed(dispatch)();
+          const calls = (dispatch as ReturnType<typeof vi.fn>).mock.calls;
+          // openModal + closeChannel thunk + releaseRevision thunk + closeModal
+          expect(calls.length).toBe(4);
+          const thunkCalls = calls.filter((args: any[]) => typeof args[0] === "function")
+            .map((args) => args[0]);
+          // closeChannel + releaseRevision
+          expect(thunkCalls).toHaveLength(2);
+          // check that the releaseRevision is otherRevision
+          const store = makeStore();
+          thunkCalls.forEach((thunk) => store.dispatch(thunk));
+          const pendingReleases = Object.values(store.getState().pendingChanges.pendingReleases);
+          expect(pendingReleases).not.toEqual(
+            expect.arrayContaining([
+              expect.objectContaining({ revision: expect.objectContaining({ revision: 1 }) })
+            ])
+          );
+        });
+      });
+
+      describe("when the revision is the only one in the channel", () => {
+        it("should not dispatch releaseRevision for any other revisions", () => {
+          const dispatch = closeRevisionAndGetDispatch({ [channel]: { test64: revision } });
+          extractProceed(dispatch)();
+          const calls = (dispatch as ReturnType<typeof vi.fn>).mock.calls;
+          // openModal + closeChannel thunk + closeModal
+          expect(calls.length).toBe(3);
+          const thunkCalls = calls.filter((args: any[]) => typeof args[0] === "function")
+            .map((args) => args[0]);
+          // check releaseRevision has never been called
+          const store = makeStore();
+          thunkCalls.forEach((thunk) => store.dispatch(thunk));
+          const pendingReleases = Object.values(store.getState().pendingChanges.pendingReleases);
+          expect(pendingReleases).toHaveLength(0);
+        });
+      });
     });
   });
 });

--- a/static/js/publisher/pages/Releases/slices/pendingChanges.ts
+++ b/static/js/publisher/pages/Releases/slices/pendingChanges.ts
@@ -7,9 +7,14 @@ import type {
   Progressive,
   Revision,
   Release,
+  CPUArchitecture,
 } from "../../../types/releaseTypes";
-import type { AppDispatch, RootState } from "../store";
+import { AppAsyncThunkConfig, type AppDispatch, type RootState } from "../store";
 import { closeHistory } from "./history";
+import { showNotification } from "./notification";
+import { CLOSE_MODAL_ACTION_NAME, closeModal, openModal } from "./modal";
+
+const PENDING_CHANGES_SLICE_NAME = "pendingChanges";
 
 export function releaseRevision(
   revision: Revision,
@@ -59,6 +64,59 @@ export function releaseRevision(
       channel,
       progressive,
       previousReleases,
+    }));
+  };
+}
+
+export function closeRevision(
+  revision: Revision,
+  channel: string,
+  arch: CPUArchitecture,
+) {
+  return (dispatch: AppDispatch, getState: () => RootState) => {
+    const pendingChannelMap = getPendingChannelMap(getState());
+    const toReleaseAgain: Set<Revision> = new Set();
+    if (pendingChannelMap[channel]) {
+      Object.entries(pendingChannelMap[channel]).forEach(
+        ([_arch, rev]) => {
+          if (rev && rev?.revision !== revision.revision) {
+            toReleaseAgain.add(rev);
+          }
+        }
+      );
+    }
+
+    const proceed = () => {
+      dispatch(closeChannel(channel));
+      for (const rev of toReleaseAgain) {
+        dispatch(releaseRevision(rev, channel, undefined));
+      }
+      dispatch(closeModal());
+    }
+
+    // display notification with accept or cancel
+    dispatch(openModal({
+      title: "Attention",
+      content: `By closing an architecture release from a channel you will be `
+        + `executing the following actions: close the channel and release to the `
+        + `closed channel all the revisions again except the one being closed, `
+        + `${arch} from ${channel}. Would you like to proceed?`,
+      actions: [
+        {
+          appearance: "positive",
+          onClickAction: {
+            reduxAction: proceed,
+          },
+          label: `Continue`,
+        },
+        {
+          appearance: "neutral",
+          onClickAction: {
+            type: CLOSE_MODAL_ACTION_NAME,
+          },
+          label: "Cancel",
+        },
+      ],
     }));
   };
 }
@@ -195,8 +253,8 @@ export type RemoveRevisionPayload = {
   channel: string;
 }
 
-const pendingReleasesSlice = createSlice({
-  name: "pendingReleases",
+const pendingChangesSlice = createSlice({
+  name: PENDING_CHANGES_SLICE_NAME,
   initialState: {
     changeOrderIndex: 0,
     pendingCloses: {},
@@ -316,11 +374,11 @@ const pendingReleasesSlice = createSlice({
         }
       });
     },
-  }
+  },
 });
 
 // don't export addPendingClose to force using the thunk CloseChannel
-const { addPendingClose } = pendingReleasesSlice.actions;
+const { addPendingClose } = pendingChangesSlice.actions;
 
 export const {
   incrementOrderIndex,
@@ -329,5 +387,5 @@ export const {
   removePendingRelease,
   setProgressiveRelease,
   updateProgressiveRelease,
-} = pendingReleasesSlice.actions;
-export default pendingReleasesSlice.reducer;
+} = pendingChangesSlice.actions;
+export default pendingChangesSlice.reducer;

--- a/static/js/publisher/types/releaseTypes.ts
+++ b/static/js/publisher/types/releaseTypes.ts
@@ -301,7 +301,7 @@ export type ModalState = Partial<{
   actions: {
     appearance: "positive" | "neutral" | "negative";
     onClickAction:
-      | { reduxAction: string }
+      | { reduxAction: () => void }
       | { type: typeof CLOSE_MODAL_ACTION_NAME };
     label: string;
   }[];


### PR DESCRIPTION
## Done

Modified the `Promote` button in the releases cells to be `Promote/close` like for the channels.
This allows users to select the "Close <arch>"  option from the dropdown that automates the process to remove that architecture: first closes the channel, then re-releases all the other revisions.
When clicking on the close button a modal is displayed with a warning that tells the user what is going to happen under the hood. The user can accept or undo the change.

## How to QA

- Go to the "Releases" page of one of your snaps - [DEMO](https://snapcraft-io-5720.demos.haus)
- Try to find different cells of released revisions and click on "Promote/close" > "Close <arch>"
- Check that you get the modal warning about what is going to happen.
- Review and save changes
- Check that the revision for the selected architecture has disappeared from the Releases UI (while the rest of architectures in the channel are still there).

Finally, try to play around a bit with the Releases UI to make sure that everything still works as before.

## Testing

- [x] This PR has tests
- [ ] No testing required (explain why):

## Security

- [ ] Security considerations for review (list them):
  - [ ] Examples:
  - [ ] Access control: users can only access their own data
  - [ ] Input: user input is validated and sanitised
  - [ ] Sensitive data: secret or private data is not exposed in any way
  - [ ] ...
- [x] This PR has no security considerations (explain why): It's just a FE UX/UI improvement - backend services and requests remain the same as before.

## Issue / Card

Fixes [WD-34913](https://warthogs.atlassian.net/browse/WD-34913)

## UX Approval

- [ ] This PR does not require UX approval
- [x] This PR does require UX approval (add context): the Jira card details what is the problem the users have. The solution has been to condense all the actions the user was required to do under a single click (all of them are done programmatically under the hood). Is the button in the dropdown a good approach? Is the modal to warn the users about what it does the right approach?


[WD-34913]: https://warthogs.atlassian.net/browse/WD-34913?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ