### PR TITLE
Fix parsing links nested in emphasis after mistune v3 upgrade

### DIFF
--- a/tests/tests_markdown_parser.py
+++ b/tests/tests_markdown_parser.py
@@ -202,3 +202,13 @@ class TestMarkdownParser(unittest.TestCase):
             '<p><a href="mailto:me@example.com">me@example.com</a></p>\n'
         )
         self.assertEqual(parse_markdown_description(markdown), expected)
+
+    def test_bold_text_with_square_brackets_does_not_crash(self):
+        markdown = "**[Recommended] Below**"
+        expected = "<p><strong>[Recommended] Below</strong></p>\n"
+        self.assertEqual(parse_markdown_description(markdown), expected)
+
+    def test_italic_text_with_square_brackets_does_not_crash(self):
+        markdown = "_[Recommended] Below_"
+        expected = "<p><em>[Recommended] Below</em></p>\n"
+        self.assertEqual(parse_markdown_description(markdown), expected)

--- a/tests/tests_markdown_parser.py
+++ b/tests/tests_markdown_parser.py
@@ -212,3 +212,12 @@ class TestMarkdownParser(unittest.TestCase):
         markdown = "_[Recommended] Below_"
         expected = "<p><em>[Recommended] Below</em></p>\n"
         self.assertEqual(parse_markdown_description(markdown), expected)
+
+    def test_emphasis_with_markdown_link_keeps_url_autolink(self):
+        markdown = "**[toto](https://toto.space)**"
+        expected = (
+            "<p><strong>"
+            '[toto](<a href="https://toto.space">https://toto.space</a>)'
+            "</strong></p>\n"
+        )
+        self.assertEqual(parse_markdown_description(markdown), expected)

--- a/webapp/markdown.py
+++ b/webapp/markdown.py
@@ -74,6 +74,9 @@ class SnapcraftInlineParser(InlineParser):
         "emphasis",
         "codespan",
         "linebreak",
+        # Keep rule enabled for mistune precedence compatibility;
+        # parse_link below turns markdown [text](url) syntax into literal text.
+        "link",
     )
 
     def __init__(self):
@@ -82,6 +85,17 @@ class SnapcraftInlineParser(InlineParser):
         # literal characters in the output
         if "softbreak" in self.rules:
             self.rules.remove("softbreak")
+
+    def parse_link(self, m, state):
+        # Keep markdown link syntax as literal text instead of creating links.
+        #
+        # Supported Mistune v3 customization point:
+        # - Inline parser methods can be overridden (see InlineParser API).
+        #   https://mistune.lepture.com/en/latest/api.html#mistune.InlineParser
+        # - Default link behavior lives in InlineParser.parse_link.
+        #   https://raw.githubusercontent.com/lepture/mistune/v3.2.1/src/mistune/inline_parser.py
+        state.append_token({"type": "text", "raw": m.group(0)})
+        return m.end()
 
 
 renderer = HTMLRenderer()


### PR DESCRIPTION
## Done

Recent mistune update #5696  caused a regression error in parsing links (because of our limitations on markdown syntax). This fixes it.

## How to QA

Go to demo: https://snapcraft-io-5723.demos.haus/whatsapp-linux-app
Make sure it loads propery and has description shown with Markdown links like `[Recommended]` not parsed

## Testing

- [x] This PR has tests
- [ ] No testing required (explain why):

## Security

- [x] This PR has no security considerations (explain why): update to markdown parsing

