### PR TITLE
add turnstile CAPTCHA to snap reports

### DIFF
--- a/konf/site.yaml
+++ b/konf/site.yaml
@@ -91,6 +91,15 @@ env: &env
       key: report-sheet-url
       name: snapcraft-io
 
+  - name: TURNSTILE_SITE_KEY
+    secretKeyRef:
+      key: turnstile-site-key
+      name: snapcraft-io
+  - name: TURNSTILE_SECRET_KEY
+    secretKeyRef:
+      key: turnstile-secret-key
+      name: snapcraft-io
+
 memoryLimit: 256Mi
 
 extraHosts:

--- a/static/js/global.d.ts
+++ b/static/js/global.d.ts
@@ -30,6 +30,18 @@ declare interface Window {
   Sentry: Record<string, unknown>;
   COMMIT_ID: string;
   ENVIRONMENT: string;
+  turnstile?: {
+    render: (
+      container: HTMLElement,
+      options: {
+        sitekey: string;
+        callback: () => void;
+        "expired-callback": () => void;
+        "error-callback": () => void;
+      },
+    ) => string | number;
+    reset: (widgetId?: string | number) => void;
+  };
 }
 
 declare module "@canonical/cookie-policy";

--- a/static/js/public/snap-details/__tests__/reportSnap.test.ts
+++ b/static/js/public/snap-details/__tests__/reportSnap.test.ts
@@ -24,6 +24,7 @@ describe("report snap modal", () => {
 
   afterEach(() => {
     document.body.innerHTML = "";
+    document.body.classList.remove("vbox-open");
     vi.restoreAllMocks();
     delete window.turnstile;
   });

--- a/static/js/public/snap-details/__tests__/reportSnap.test.ts
+++ b/static/js/public/snap-details/__tests__/reportSnap.test.ts
@@ -1,0 +1,127 @@
+import "@testing-library/jest-dom";
+import { waitFor } from "@testing-library/dom";
+import userEvent from "@testing-library/user-event";
+import { vi } from "vitest";
+
+// @ts-expect-error importing the HTML template as a string
+import REPORT_SNAP_MODAL from "../../../../../templates/store/snap-details/_report_snap_modal.html?raw";
+
+const TOGGLE_SELECTOR = ".js-modal-open";
+const MODAL_SELECTOR = "#report-snap-modal";
+const FORM_URL = "/report";
+
+describe("report snap modal", () => {
+  let initReportSnap: typeof import("../reportSnap").default;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    ({ default: initReportSnap } = await import("../reportSnap"));
+    document.body.innerHTML = `
+      <a class="js-modal-open" href="#report-snap-modal">Report this Snap</a>
+      ${REPORT_SNAP_MODAL}
+    `;
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+    vi.restoreAllMocks();
+    delete window.turnstile;
+  });
+
+  function setupTurnstileMock() {
+    const render = vi.fn(() => 42);
+    const reset = vi.fn();
+
+    const appendSpy = vi
+      .spyOn(document.head, "appendChild")
+      .mockImplementation((node: Node) => {
+        if (node instanceof HTMLScriptElement) {
+          Object.defineProperty(window, "turnstile", {
+            value: { render, reset },
+            configurable: true,
+          });
+          node.onload?.(new Event("load"));
+        }
+
+        return node;
+      });
+
+    return { appendSpy, render, reset };
+  }
+
+  test("loads Turnstile only when the modal opens", async () => {
+    const user = userEvent.setup();
+    const { appendSpy, render } = setupTurnstileMock();
+
+    initReportSnap(TOGGLE_SELECTOR, MODAL_SELECTOR, FORM_URL);
+
+    expect(appendSpy).not.toHaveBeenCalled();
+
+    await user.click(
+      document.querySelector<HTMLAnchorElement>(TOGGLE_SELECTOR)!,
+    );
+
+    await waitFor(() => expect(render).toHaveBeenCalledTimes(1));
+    expect(appendSpy).toHaveBeenCalledTimes(1);
+    expect((appendSpy.mock.calls[0][0] as HTMLScriptElement).src).toContain(
+      "https://challenges.cloudflare.com/turnstile/v0/api.js",
+    );
+  });
+
+  test("keeps submit disabled until Turnstile verifies", async () => {
+    const user = userEvent.setup();
+    const { render, reset } = setupTurnstileMock();
+
+    initReportSnap(TOGGLE_SELECTOR, MODAL_SELECTOR, FORM_URL);
+
+    await user.click(
+      document.querySelector<HTMLAnchorElement>(TOGGLE_SELECTOR)!,
+    );
+    await waitFor(() => expect(render).toHaveBeenCalledTimes(1));
+
+    const submitButton = document.querySelector<HTMLButtonElement>(
+      "#report-snap-modal button[type=submit]",
+    )!;
+    const [, options] = render.mock.calls[0];
+
+    expect(submitButton).toBeDisabled();
+
+    options.callback();
+    expect(submitButton).not.toBeDisabled();
+
+    options["expired-callback"]();
+    expect(submitButton).toBeDisabled();
+
+    await user.click(
+      document.querySelector<HTMLButtonElement>(
+        "#report-snap-modal .js-modal-close",
+      )!,
+    );
+    await user.click(
+      document.querySelector<HTMLAnchorElement>(TOGGLE_SELECTOR)!,
+    );
+
+    expect(reset).toHaveBeenCalledWith(42);
+    expect(submitButton).toBeDisabled();
+  });
+
+  test("restores the submit label when reopening after loading", async () => {
+    const user = userEvent.setup();
+    setupTurnstileMock();
+
+    initReportSnap(TOGGLE_SELECTOR, MODAL_SELECTOR, FORM_URL);
+
+    const submitButton = document.querySelector<HTMLButtonElement>(
+      "#report-snap-modal button[type=submit]",
+    )!;
+    submitButton.disabled = true;
+    submitButton.innerHTML = "Submitting…";
+
+    await user.click(
+      document.querySelector<HTMLAnchorElement>(TOGGLE_SELECTOR)!,
+    );
+
+    expect(submitButton).toHaveTextContent("Submit report");
+    expect(submitButton).toBeDisabled();
+  });
+});

--- a/static/js/public/snap-details/reportSnap.ts
+++ b/static/js/public/snap-details/reportSnap.ts
@@ -1,7 +1,49 @@
 import { buttonEnabled, buttonLoading } from "../../libs/formHelpers";
 
+const TURNSTILE_SCRIPT_SRC =
+  "https://challenges.cloudflare.com/turnstile/v0/api.js";
+const SUBMIT_TEXT = "Submit report";
+
 const showEl = (el: HTMLElement) => el.classList.remove("u-hide");
 const hideEl = (el: HTMLElement) => el.classList.add("u-hide");
+
+let turnstileScriptPromise: Promise<void> | null = null;
+let turnstileSetupPromise: Promise<void> | null = null;
+let turnstileWidgetId: string | number | null = null;
+
+function loadTurnstileScript(): Promise<void> {
+  if (window.turnstile) {
+    return Promise.resolve();
+  }
+
+  if (!turnstileScriptPromise) {
+    turnstileScriptPromise = new Promise((resolve, reject) => {
+      const script = document.createElement("script");
+
+      script.src = TURNSTILE_SCRIPT_SRC;
+      script.async = true;
+      script.defer = true;
+      script.onload = () => resolve();
+      script.onerror = () =>
+        reject(new Error("Turnstile script failed to load"));
+
+      document.head.appendChild(script);
+    }).finally(() => {
+      turnstileScriptPromise = null;
+    });
+  }
+
+  return turnstileScriptPromise;
+}
+
+function disableSubmitButton(button: HTMLButtonElement): void {
+  buttonEnabled(button, SUBMIT_TEXT);
+  button.disabled = true;
+}
+
+function resetSubmitButton(button: HTMLButtonElement): void {
+  buttonEnabled(button, SUBMIT_TEXT);
+}
 
 function toggleModal(modal: HTMLElement, show?: boolean): void {
   if (typeof show === "undefined") {
@@ -16,11 +58,68 @@ function toggleModal(modal: HTMLElement, show?: boolean): void {
   }
 }
 
+function setupTurnstile(modal: HTMLElement): void {
+  const turnstile = modal.querySelector(
+    ".js-report-snap-turnstile",
+  ) as HTMLElement | null;
+  const submitButton = modal.querySelector(
+    "button[type=submit]",
+  ) as HTMLButtonElement | null;
+
+  if (!turnstile || !submitButton) {
+    return;
+  }
+
+  disableSubmitButton(submitButton);
+
+  if (turnstileWidgetId !== null && window.turnstile) {
+    window.turnstile.reset(turnstileWidgetId);
+    return;
+  }
+
+  if (turnstileSetupPromise) {
+    return;
+  }
+
+  turnstileSetupPromise = loadTurnstileScript()
+    .then(() => {
+      if (!window.turnstile) {
+        return;
+      }
+
+      const sitekey = turnstile.dataset.sitekey;
+      if (!sitekey) {
+        return;
+      }
+
+      turnstileWidgetId = window.turnstile.render(turnstile, {
+        sitekey,
+        callback: () => resetSubmitButton(submitButton),
+        "expired-callback": () => disableSubmitButton(submitButton),
+        "error-callback": () => disableSubmitButton(submitButton),
+      });
+    })
+    .catch(() => {
+      disableSubmitButton(submitButton);
+    })
+    .finally(() => {
+      turnstileSetupPromise = null;
+    });
+}
+
 function initForm(modal: HTMLElement): void {
-  buttonEnabled(
-    modal.querySelector("button[type=submit]") as HTMLButtonElement,
-    "Submit report",
+  const submitButton = modal.querySelector(
+    "button[type=submit]",
+  ) as HTMLButtonElement;
+  const hasTurnstile = Boolean(
+    modal.querySelector(".js-report-snap-turnstile"),
   );
+
+  if (hasTurnstile) {
+    setupTurnstile(modal);
+  } else {
+    resetSubmitButton(submitButton);
+  }
 
   showEl(modal.querySelector(".js-report-snap-form") as HTMLElement);
   hideEl(modal.querySelector(".js-report-snap-success") as HTMLElement);

--- a/static/js/public/snap-details/reportSnap.ts
+++ b/static/js/public/snap-details/reportSnap.ts
@@ -53,8 +53,10 @@ function toggleModal(modal: HTMLElement, show?: boolean): void {
   if (show) {
     initForm(modal);
     showEl(modal);
+    document.body.classList.add("vbox-open");
   } else {
     hideEl(modal);
+    document.body.classList.remove("vbox-open");
   }
 }
 

--- a/templates/store/snap-details.html
+++ b/templates/store/snap-details.html
@@ -344,9 +344,6 @@
 {% endblock %}
 
 {% block scripts_includes %}
-  {% if turnstile_site_key %}
-    <script src="https://challenges.cloudflare.com/turnstile/v0/api.js" async defer></script>
-  {% endif %}
   {{ vite_import('static/js/public/store-details.ts') }}
 {% endblock %}
 

--- a/templates/store/snap-details.html
+++ b/templates/store/snap-details.html
@@ -344,6 +344,9 @@
 {% endblock %}
 
 {% block scripts_includes %}
+  {% if turnstile_site_key %}
+    <script src="https://challenges.cloudflare.com/turnstile/v0/api.js" async defer></script>
+  {% endif %}
   {{ vite_import('static/js/public/store-details.ts') }}
 {% endblock %}
 

--- a/templates/store/snap-details/_report_snap_modal.html
+++ b/templates/store/snap-details/_report_snap_modal.html
@@ -50,6 +50,9 @@
 
         <label for="report-snap-email">Your email (optional)</label>
         <input id="report-snap-email" type="email" name="email" placeholder="email@example.com" />
+        {% if turnstile_site_key %}
+          <div class="cf-turnstile" data-sitekey="{{ turnstile_site_key }}"></div>
+        {% endif %}
         <div class="u-off-screen">
           <label for="report-snap-confirm" aria-hidden="true">I agree</label>
           <input id="report-snap-confirm" type="checkbox" name="confirm" aria-hidden="true" />

--- a/templates/store/snap-details/_report_snap_modal.html
+++ b/templates/store/snap-details/_report_snap_modal.html
@@ -51,7 +51,7 @@
         <label for="report-snap-email">Your email (optional)</label>
         <input id="report-snap-email" type="email" name="email" placeholder="email@example.com" />
         {% if turnstile_site_key %}
-          <div class="cf-turnstile" data-sitekey="{{ turnstile_site_key }}"></div>
+          <div class="cf-turnstile js-report-snap-turnstile" data-sitekey="{{ turnstile_site_key }}"></div>
         {% endif %}
         <div class="u-off-screen">
           <label for="report-snap-confirm" aria-hidden="true">I agree</label>
@@ -61,7 +61,7 @@
         <div class="u-align--right">
           <button type="button" class="js-modal-close u-no-margin--bottom">Cancel</button>
           {# use --dark fake class for spinner icon to be rendered correctly... #}
-          <button type="submit" type="submit" class="--dark u-no-margin--bottom">Submit report</button>
+          <button type="submit" type="submit" class="--dark u-no-margin--bottom"{% if turnstile_site_key %} disabled{% endif %}>Submit report</button>
         </div>
       </form>
     </div>

--- a/tests/store/tests_report.py
+++ b/tests/store/tests_report.py
@@ -1,0 +1,131 @@
+import responses
+from flask_testing import TestCase
+
+from webapp.app import create_app
+
+
+class ReportSnapTest(TestCase):
+    def create_app(self):
+        app = create_app(testing=True)
+        app.secret_key = "secret_key"
+        app.config["WTF_CSRF_METHODS"] = []
+        app.config["REPORT_SHEET_URL"] = "https://example.com/report"
+        app.config["TURNSTILE_VERIFY_URL"] = "https://example.com/turnstile"
+        app.config["TURNSTILE_SECRET_KEY"] = ""
+        return app
+
+    @responses.activate
+    def test_report_without_turnstile_secret(self):
+        responses.add(
+            responses.Response(
+                method="POST",
+                url=self.app.config["REPORT_SHEET_URL"],
+                status=200,
+            )
+        )
+
+        response = self.client.post(
+            "/report",
+            data={
+                "snap_name": "test-snap",
+                "reason": "Snap Store terms of service violation",
+                "comment": "A test report",
+            },
+        )
+
+        assert response.status_code == 200
+        assert response.get_json() == {"ok": True}
+        assert len(responses.calls) == 1
+        assert (
+            responses.calls[0].request.url
+            == self.app.config["REPORT_SHEET_URL"]
+        )
+
+    def test_report_rejects_missing_turnstile_token(self):
+        self.app.config["TURNSTILE_SECRET_KEY"] = "test-secret"
+
+        response = self.client.post(
+            "/report",
+            data={
+                "snap_name": "test-snap",
+                "reason": "Snap Store terms of service violation",
+                "comment": "A test report",
+            },
+        )
+
+        assert response.status_code == 400
+        assert response.get_json() == {"error": "turnstile_failed"}
+
+    @responses.activate
+    def test_report_rejects_invalid_turnstile_token(self):
+        self.app.config["TURNSTILE_SECRET_KEY"] = "test-secret"
+        responses.add(
+            responses.Response(
+                method="POST",
+                url=self.app.config["TURNSTILE_VERIFY_URL"],
+                json={
+                    "success": False,
+                    "error-codes": ["invalid-input-response"],
+                },
+                status=200,
+            )
+        )
+
+        response = self.client.post(
+            "/report",
+            data={
+                "snap_name": "test-snap",
+                "reason": "Snap Store terms of service violation",
+                "comment": "A test report",
+                "cf-turnstile-response": "invalid-token",
+            },
+        )
+
+        assert response.status_code == 400
+        assert response.get_json() == {"error": "turnstile_failed"}
+        assert len(responses.calls) == 1
+        assert (
+            responses.calls[0].request.url
+            == self.app.config["TURNSTILE_VERIFY_URL"]
+        )
+
+    @responses.activate
+    def test_report_submits_when_turnstile_token_is_valid(self):
+        self.app.config["TURNSTILE_SECRET_KEY"] = "test-secret"
+        responses.add(
+            responses.Response(
+                method="POST",
+                url=self.app.config["TURNSTILE_VERIFY_URL"],
+                json={"success": True},
+                status=200,
+            )
+        )
+        responses.add(
+            responses.Response(
+                method="POST",
+                url=self.app.config["REPORT_SHEET_URL"],
+                status=200,
+            )
+        )
+
+        response = self.client.post(
+            "/report",
+            data={
+                "snap_name": "test-snap",
+                "reason": "Snap Store terms of service violation",
+                "comment": "A test report",
+                "cf-turnstile-response": "valid-token",
+            },
+        )
+
+        assert response.status_code == 200
+        assert response.get_json() == {"ok": True}
+        assert len(responses.calls) == 2
+        assert (
+            responses.calls[0].request.url
+            == self.app.config["TURNSTILE_VERIFY_URL"]
+        )
+        assert (
+            responses.calls[1].request.url
+            == self.app.config["REPORT_SHEET_URL"]
+        )

--- a/webapp/config.py
+++ b/webapp/config.py
@@ -53,3 +53,9 @@ APP_NAME = "snapcraft"
 ANALYTICS_ENDPOINT = os.getenv("ANALYTICS_ENDPOINT", "").strip()
 
 REPORT_SHEET_URL = os.getenv("REPORT_SHEET_URL", "").strip()
+TURNSTILE_SITE_KEY = os.getenv("TURNSTILE_SITE_KEY", "").strip()
+TURNSTILE_SECRET_KEY = os.getenv("TURNSTILE_SECRET_KEY", "").strip()
+TURNSTILE_VERIFY_URL = os.getenv(
+    "TURNSTILE_VERIFY_URL",
+    "https://challenges.cloudflare.com/turnstile/v0/siteverify",
+).strip()

--- a/webapp/handlers.py
+++ b/webapp/handlers.py
@@ -70,6 +70,7 @@ CSP = {
         "w.usabilla.com",
         "connect.facebook.net",
         "snap.licdn.com",
+        "challenges.cloudflare.com",
         # This is necessary for Google Tag Manager to function properly.
         "'unsafe-inline'",
     ],
@@ -95,6 +96,7 @@ CSP = {
         "*.snapcraftcontent.com",
         "marketplace-analytics.staging.canonical.com",
         "marketplace-analytics.canonical.com",
+        "challenges.cloudflare.com",
         "www.google.com",
     ],
     "frame-src": [
@@ -106,6 +108,7 @@ CSP = {
         "player.vimeo.com",
         "snapcraft.io",
         "www.facebook.com",
+        "challenges.cloudflare.com",
         "snap:",
     ],
     "style-src": [

--- a/webapp/store/snap_details_views.py
+++ b/webapp/store/snap_details_views.py
@@ -227,8 +227,10 @@ def snap_details_views(store):
             "links": details["snap"].get("links"),
             "updates": updates,
             "revisions": revisions,
-            "turnstile_site_key": flask.current_app.config.get(
-                "TURNSTILE_SITE_KEY", ""
+            "turnstile_site_key": (
+                flask.current_app.config.get("TURNSTILE_SITE_KEY", "")
+                if flask.current_app.config.get("TURNSTILE_SECRET_KEY")
+                else ""
             ),
         }
         return context

--- a/webapp/store/snap_details_views.py
+++ b/webapp/store/snap_details_views.py
@@ -227,8 +227,55 @@ def snap_details_views(store):
             "links": details["snap"].get("links"),
             "updates": updates,
             "revisions": revisions,
+            "turnstile_site_key": flask.current_app.config.get(
+                "TURNSTILE_SITE_KEY", ""
+            ),
         }
         return context
+
+    def verify_turnstile(turnstile_response, remote_ip):
+        turnstile_secret = flask.current_app.config.get(
+            "TURNSTILE_SECRET_KEY", ""
+        )
+        if not turnstile_secret:
+            return True
+
+        if not turnstile_response:
+            logger.warning("Turnstile token missing from report form")
+            return False
+
+        payload = {
+            "secret": turnstile_secret,
+            "response": turnstile_response,
+        }
+        if remote_ip:
+            payload["remoteip"] = remote_ip
+
+        try:
+            response = requests.post(
+                flask.current_app.config["TURNSTILE_VERIFY_URL"],
+                data=payload,
+                timeout=10,
+            )
+            if not response.ok:
+                logger.warning(
+                    "Turnstile verification returned %s",
+                    response.status_code,
+                )
+                return False
+            verification = response.json()
+        except (requests.RequestException, ValueError):
+            logger.exception("Turnstile verification failed")
+            return False
+
+        if not verification.get("success"):
+            logger.warning(
+                "Turnstile verification denied report: %s",
+                verification.get("error-codes", []),
+            )
+            return False
+
+        return True
 
     def snap_has_sboms(revisions, snap_id):
         if not revisions:
@@ -568,6 +615,13 @@ def snap_details_views(store):
         # silently reject to avoid spam
         if "confirm" in fields:
             return flask.jsonify({"ok": True}), 200
+
+        if not verify_turnstile(
+            fields.get("cf-turnstile-response", ""),
+            flask.request.remote_addr,
+        ):
+            return flask.jsonify({"error": "turnstile_failed"}), 400
+
         payload = {
             "snap_name": fields.get("snap_name", ""),
             "reason": fields.get("reason", ""),

--- a/webapp/store/snap_details_views.py
+++ b/webapp/store/snap_details_views.py
@@ -235,7 +235,7 @@ def snap_details_views(store):
         }
         return context
 
-    def verify_turnstile(turnstile_response, remote_ip):
+    def verify_turnstile(turnstile_response):
         turnstile_secret = flask.current_app.config.get(
             "TURNSTILE_SECRET_KEY", ""
         )
@@ -250,8 +250,6 @@ def snap_details_views(store):
             "secret": turnstile_secret,
             "response": turnstile_response,
         }
-        if remote_ip:
-            payload["remoteip"] = remote_ip
 
         try:
             response = requests.post(
@@ -618,10 +616,7 @@ def snap_details_views(store):
         if "confirm" in fields:
             return flask.jsonify({"ok": True}), 200
 
-        if not verify_turnstile(
-            fields.get("cf-turnstile-response", ""),
-            flask.request.remote_addr,
-        ):
+        if not verify_turnstile(fields.get("cf-turnstile-response", "")):
             return flask.jsonify({"error": "turnstile_failed"}), 400
 
         payload = {


### PR DESCRIPTION
## Done
- Add turnstile user verification to snap reports modal
## How to QA
- go to any snap page
- report a snap after checking the CAPTCHA checkbox, it should work
- try being a suspicious clanker, it should fail, also hitting the API endpoint directly should fail
## Testing

- [x] This PR has tests
- [ ] No testing required (explain why):


