### PR TITLE
feat: Add date selectors to the serial log UI

### DIFF
--- a/static/js/publisher/hooks/__tests__/useRemodels.test.tsx
+++ b/static/js/publisher/hooks/__tests__/useRemodels.test.tsx
@@ -7,6 +7,8 @@ import useRemodels from "../useRemodels";
 
 import type { ReactNode } from "react";
 
+let requestCount = 0;
+
 const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
@@ -39,18 +41,21 @@ const remodelsResponse = {
 
 const handlers = [
   http.get("/api/store/test-brand-id/models/remodel-allowlist", () => {
+    requestCount += 1;
     return HttpResponse.json({
       data: remodelsResponse,
       success: true,
     });
   }),
   http.get("/api/store/test-brand-id-fail/models/remodel-allowlist", () => {
+    requestCount += 1;
     return HttpResponse.json({
       message: "There was a problem fetching remodels",
       success: false,
     });
   }),
   http.get("/api/store/test-brand-id-error/models/remodel-allowlist", () => {
+    requestCount += 1;
     return HttpResponse.error();
   }),
 ];
@@ -64,6 +69,7 @@ beforeAll(() => {
 afterEach(() => {
   server.resetHandlers();
   queryClient.clear();
+  requestCount = 0;
 });
 
 afterAll(() => {
@@ -256,5 +262,16 @@ describe("useRemodels", () => {
     });
 
     expect(result.current.data).toBeUndefined();
+    expect(requestCount).toBe(1);
+  });
+
+  test("does not request remodels until brandId exists", async () => {
+    renderHook(() => useRemodels(undefined), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(requestCount).toBe(0);
+    });
   });
 });

--- a/static/js/publisher/hooks/__tests__/useSerialLogs.test.tsx
+++ b/static/js/publisher/hooks/__tests__/useSerialLogs.test.tsx
@@ -7,6 +7,8 @@ import useSerialLogs from "../useSerialLogs";
 
 import type { ReactNode } from "react";
 
+let requestCount = 0;
+
 const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
@@ -37,12 +39,14 @@ const serialLogsResponse = {
 
 const handlers = [
   http.get("/api/store/test-brand-id/models/test-model/serial-log", () => {
+    requestCount += 1;
     return HttpResponse.json({
       data: serialLogsResponse,
       success: true,
     });
   }),
   http.get("/api/store/test-brand-id-fail/models/test-model/serial-log", () => {
+    requestCount += 1;
     return HttpResponse.json({
       message: "There was a problem fetching serial logs",
       success: false,
@@ -51,6 +55,7 @@ const handlers = [
   http.get(
     "/api/store/test-brand-id-error/models/test-model/serial-log",
     () => {
+      requestCount += 1;
       return HttpResponse.error();
     },
   ),
@@ -65,6 +70,7 @@ beforeAll(() => {
 afterEach(() => {
   server.resetHandlers();
   queryClient.clear();
+  requestCount = 0;
 });
 
 afterAll(() => {
@@ -283,5 +289,16 @@ describe("useSerialLogs", () => {
     });
 
     expect(result.current.data).toBeUndefined();
+    expect(requestCount).toBe(1);
+  });
+
+  test("does not request serial logs until both brandId and modelId exist", async () => {
+    renderHook(() => useSerialLogs("test-brand-id", undefined), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(requestCount).toBe(0);
+    });
   });
 });

--- a/static/js/publisher/hooks/useRemodels.ts
+++ b/static/js/publisher/hooks/useRemodels.ts
@@ -43,7 +43,8 @@ const useRemodels = (
       const responseData = await response.json();
       return responseData;
     },
-    enabled: !!brandId,
+    enabled: Boolean(brandId),
+    retry: false,
   });
 };
 

--- a/static/js/publisher/hooks/useSerialLogs.ts
+++ b/static/js/publisher/hooks/useSerialLogs.ts
@@ -50,7 +50,8 @@ const useSerialLogs = (
 
       return responseData;
     },
-    enabled: !!brandId,
+    enabled: Boolean(brandId && modelId),
+    retry: false,
   });
 };
 

--- a/static/js/publisher/pages/SerialLog/SerialLog.tsx
+++ b/static/js/publisher/pages/SerialLog/SerialLog.tsx
@@ -8,6 +8,7 @@ import { serialLogsListState } from "../../state/serialLogsState";
 import { brandIdState, brandStoreState } from "../../state/brandStoreState";
 import { setPageTitle } from "../../utils";
 
+import SerialLogDateSelectors from "./SerialLogDateSelectors";
 import SerialLogTable from "./SerialLogTable";
 
 import type { UseQueryResult } from "react-query";
@@ -27,7 +28,7 @@ function SerialLog(): React.JSX.Element {
   const endTime = searchParams.get("end-time");
   const pageSize = Number.isInteger(parsedPageSize) ? parsedPageSize : 25;
   const params = {
-    pageSize: pageSize,
+    pageSize,
     page: currentCursor,
     ...(startTime && endTime && { interval: { startTime, endTime } }),
   };
@@ -66,6 +67,11 @@ function SerialLog(): React.JSX.Element {
     });
   };
 
+  const handleDateRangeApply = () => {
+    setCurrentCursor(null);
+    cursorHistory.current = [];
+  };
+
   brandStore
     ? setPageTitle(`Serial logs in ${brandStore.name}`)
     : setPageTitle("Serial logs");
@@ -94,22 +100,26 @@ function SerialLog(): React.JSX.Element {
             <Icon name="spinner" className="u-animation--spin" />
             &nbsp;Fetching serial logs...
           </p>
-        ) : data && data.success === false ? (
-          <Notification severity="caution">
-            {data.message || "Unable to fetch serial logs"}
-          </Notification>
         ) : (
           <div className="u-flex-column u-flex-grow">
-            <SerialLogTable
-              handlePageForward={handlePageForward}
-              handlePageBack={handlePageBack}
-              handlePageSizeChange={handlePageSizeChange}
-              forwardDisabled={!nextCursor}
-              backDisabled={
-                cursorHistory.current.length < 1 || currentCursor === null
-              }
-              pageSize={pageSize}
-            />
+            {data && data.success === false && (
+              <Notification severity="caution">
+                {data.message || "Unable to fetch serial logs"}
+              </Notification>
+            )}
+            <SerialLogDateSelectors onApplyDateRange={handleDateRangeApply} />
+            {data && data.success !== false && (
+              <SerialLogTable
+                handlePageForward={handlePageForward}
+                handlePageBack={handlePageBack}
+                handlePageSizeChange={handlePageSizeChange}
+                forwardDisabled={!nextCursor}
+                backDisabled={
+                  cursorHistory.current.length < 1 || currentCursor === null
+                }
+                pageSize={pageSize}
+              />
+            )}
           </div>
         )}
       </div>

--- a/static/js/publisher/pages/SerialLog/SerialLogDateSelectors.tsx
+++ b/static/js/publisher/pages/SerialLog/SerialLogDateSelectors.tsx
@@ -1,0 +1,257 @@
+import { useEffect, useState } from "react";
+import { useLocation, useNavigate, useSearchParams } from "react-router-dom";
+import { Button, Notification, Row, Col } from "@canonical/react-components";
+import { differenceInCalendarDays, format, parseISO, subDays } from "date-fns";
+
+type Props = {
+  onApplyDateRange: () => void;
+};
+
+const DEFAULT_START_TIME = "00:00:00";
+const DEFAULT_END_TIME = "23:59:59";
+
+function formatDateInputValue(date: Date): string {
+  return format(date, "yyyy-MM-dd");
+}
+
+function formatTimeInputValue(date: Date): string {
+  return format(date, "HH:mm:ss");
+}
+
+function getDefaultDateRange(): { startDate: string; endDate: string } {
+  const today = new Date();
+
+  return {
+    startDate: formatDateInputValue(subDays(today, 29)),
+    endDate: formatDateInputValue(today),
+  };
+}
+
+function formatReadableDate(dateValue: string): string {
+  const date = parseISO(dateValue);
+
+  return format(date, "d MMMM, yyyy");
+}
+
+function buildTimestampRange(
+  startDate: string,
+  startTime: string,
+  endDate: string,
+  endTime: string,
+): {
+  startTime: string;
+  endTime: string;
+} {
+  const startTimeValue = parseISO(`${startDate}T${startTime}`).toISOString();
+  const endTimeValue = parseISO(`${endDate}T${endTime}`).toISOString();
+
+  return { startTime: startTimeValue, endTime: endTimeValue };
+}
+
+function buildSearchString(searchParams: URLSearchParams): string[] {
+  const preservedParams = Array.from(searchParams.entries()).filter(
+    ([key]) => !["page", "page-size", "start-time", "end-time"].includes(key),
+  );
+
+  return preservedParams.map(
+    ([key, value]) => `${encodeURIComponent(key)}=${encodeURIComponent(value)}`,
+  );
+}
+
+function buildAppliedSearchString(
+  searchParams: URLSearchParams,
+  startTime: string,
+  endTime: string,
+): string {
+  const queryParts = buildSearchString(searchParams);
+
+  queryParts.push(`start-time=${startTime}`);
+  queryParts.push(`end-time=${endTime}`);
+
+  return `?${queryParts.join("&")}`;
+}
+
+function buildClearedSearchString(searchParams: URLSearchParams): string {
+  const queryParts = buildSearchString(searchParams);
+
+  return queryParts.length > 0 ? `?${queryParts.join("&")}` : "";
+}
+
+function SerialLogDateSelectors({
+  onApplyDateRange,
+}: Props): React.JSX.Element {
+  const { pathname } = useLocation();
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const queryStartTime = searchParams.get("start-time");
+  const queryEndTime = searchParams.get("end-time");
+  const shouldStartOpen = Boolean(queryStartTime && queryEndTime);
+  const defaultDateRange = getDefaultDateRange();
+  const [isOpen, setIsOpen] = useState(shouldStartOpen);
+  const [startDate, setStartDate] = useState(
+    (queryStartTime ? formatDateInputValue(parseISO(queryStartTime)) : "") ||
+      defaultDateRange.startDate,
+  );
+  const [endDate, setEndDate] = useState(
+    (queryEndTime ? formatDateInputValue(parseISO(queryEndTime)) : "") ||
+      defaultDateRange.endDate,
+  );
+  const [startTimeValue, setStartTimeValue] = useState(
+    (queryStartTime ? formatTimeInputValue(parseISO(queryStartTime)) : "") ||
+      DEFAULT_START_TIME,
+  );
+  const [endTimeValue, setEndTimeValue] = useState(
+    (queryEndTime ? formatTimeInputValue(parseISO(queryEndTime)) : "") ||
+      DEFAULT_END_TIME,
+  );
+
+  useEffect(() => {
+    if (queryStartTime && queryEndTime) {
+      setIsOpen(true);
+      setStartDate(formatDateInputValue(parseISO(queryStartTime)));
+      setEndDate(formatDateInputValue(parseISO(queryEndTime)));
+      setStartTimeValue(formatTimeInputValue(parseISO(queryStartTime)));
+      setEndTimeValue(formatTimeInputValue(parseISO(queryEndTime)));
+    }
+  }, [queryStartTime, queryEndTime]);
+
+  const hasBothDates = Boolean(startDate && endDate);
+  const hasBothTimes = Boolean(startTimeValue && endTimeValue);
+  const hasValidDateOrder =
+    hasBothDates &&
+    parseISO(startDate).getTime() <= parseISO(endDate).getTime();
+  const hasValidTimeOrder =
+    startDate !== endDate || startTimeValue <= endTimeValue;
+  const hasValidOrder = hasValidDateOrder && hasValidTimeOrder;
+  const exceedsThirtyDays =
+    hasValidDateOrder &&
+    differenceInCalendarDays(parseISO(endDate), parseISO(startDate)) > 29;
+  const showValidationError =
+    hasBothDates && (!hasValidOrder || exceedsThirtyDays);
+  const selectedDateRangeLabel =
+    hasBothDates && hasValidOrder
+      ? `Showing serial logs between ${formatReadableDate(startDate)} and ${formatReadableDate(endDate)}`
+      : "Showing serial logs between selected dates";
+
+  const handleApply = (): void => {
+    if (!hasBothDates || !hasBothTimes || !hasValidOrder || exceedsThirtyDays) {
+      return;
+    }
+
+    const { startTime, endTime } = buildTimestampRange(
+      startDate,
+      startTimeValue,
+      endDate,
+      endTimeValue,
+    );
+
+    onApplyDateRange();
+    navigate({
+      pathname,
+      search: buildAppliedSearchString(searchParams, startTime, endTime),
+    });
+  };
+
+  const handleClose = (): void => {
+    setIsOpen(false);
+    setStartDate(defaultDateRange.startDate);
+    setEndDate(defaultDateRange.endDate);
+    setStartTimeValue(DEFAULT_START_TIME);
+    setEndTimeValue(DEFAULT_END_TIME);
+    onApplyDateRange();
+    navigate({
+      pathname,
+      search: buildClearedSearchString(searchParams),
+    });
+  };
+
+  return (
+    <>
+      {!isOpen ? (
+        <Row>
+          <Col size={6} medium={3}>
+            <p>Showing serial logs for the past 30 days</p>
+          </Col>
+          <Col size={6} medium={3} className="u-align--right">
+            <Button onClick={() => setIsOpen(true)}>
+              Select custom date range
+            </Button>
+          </Col>
+        </Row>
+      ) : (
+        <div className="p-strip is-shallow u-no-padding--top">
+          <p>{selectedDateRangeLabel}</p>
+          {showValidationError && (
+            <Notification severity="caution">
+              {exceedsThirtyDays
+                ? "The selected date range cannot exceed 30 days."
+                : hasValidDateOrder
+                  ? "The start time must be on or before the end time when using the same date."
+                  : "The start date must be on or before the end date."}
+            </Notification>
+          )}
+          <Row>
+            <Col size={3} medium={3}>
+              <label htmlFor="serial-log-start-date">Start date</label>
+              <input
+                id="serial-log-start-date"
+                name="serial-log-start-date"
+                type="date"
+                value={startDate}
+                max={endDate}
+                onChange={(event) => setStartDate(event.target.value)}
+              />
+            </Col>
+            <Col size={3} medium={3}>
+              <label htmlFor="serial-log-start-time">Start time</label>
+              <input
+                id="serial-log-start-time"
+                name="serial-log-start-time"
+                type="time"
+                step={1}
+                value={startTimeValue}
+                onChange={(event) => setStartTimeValue(event.target.value)}
+              />
+            </Col>
+            <Row>
+              <Col size={3} medium={3}>
+                <label htmlFor="serial-log-end-date">End date</label>
+                <input
+                  id="serial-log-end-date"
+                  name="serial-log-end-date"
+                  type="date"
+                  value={endDate}
+                  min={startDate}
+                  onChange={(event) => setEndDate(event.target.value)}
+                />
+              </Col>
+              <Col size={3} medium={3}>
+                <label htmlFor="serial-log-end-time">End time</label>
+                <input
+                  id="serial-log-end-time"
+                  name="serial-log-end-time"
+                  type="time"
+                  step={1}
+                  value={endTimeValue}
+                  onChange={(event) => setEndTimeValue(event.target.value)}
+                />
+              </Col>
+            </Row>
+          </Row>
+          <div className="p-strip is-shallow u-no-padding--bottom">
+            <Button
+              appearance="positive"
+              onClick={handleApply}
+              disabled={showValidationError}
+            >
+              Apply date range
+            </Button>
+            <Button onClick={handleClose}>Close</Button>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}
+
+export default SerialLogDateSelectors;

--- a/static/js/publisher/pages/SerialLog/SerialLogTable.tsx
+++ b/static/js/publisher/pages/SerialLog/SerialLogTable.tsx
@@ -37,7 +37,7 @@ function SerialLogTable({
     { content: "Model", className: "u-truncate" },
     { content: "Serial", className: "u-truncate" },
     {
-      content: "Created date",
+      content: "Created at",
       className: "u-align--right u-truncate",
     },
   ];
@@ -49,7 +49,10 @@ function SerialLogTable({
         { content: serialLog["model-name"] },
         { content: serialLog.serial },
         {
-          content: format(new Date(serialLog["created-at"]), "dd/MM/yyyy"),
+          content: format(
+            new Date(serialLog["created-at"]),
+            "dd/MM/yyyy HH:mm:ss",
+          ),
           className: "u-align--right",
         },
       ],

--- a/static/js/publisher/pages/SerialLog/__tests__/SerialLog.test.tsx
+++ b/static/js/publisher/pages/SerialLog/__tests__/SerialLog.test.tsx
@@ -1,7 +1,9 @@
 import { BrowserRouter } from "react-router-dom";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { vi } from "vitest";
+import { format, parseISO } from "date-fns";
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 
 import "@testing-library/jest-dom";
 
@@ -16,10 +18,17 @@ import type {
 } from "../../../types/shared";
 
 const mockFilterQuery = "test-model";
+const mockSetSearchParams = vi.fn();
+const mockNavigate = vi.fn();
+const mockPathname = "/admin/test-store-id/models/test-model/serial-log";
+
+let mockSearchParams = new URLSearchParams({ filter: mockFilterQuery });
 
 vi.mock("react-router-dom", async (importOriginal) => ({
   ...(await importOriginal()),
-  useSearchParams: () => [new URLSearchParams({ filter: mockFilterQuery })],
+  useSearchParams: () => [mockSearchParams, mockSetSearchParams],
+  useNavigate: () => mockNavigate,
+  useLocation: () => ({ pathname: mockPathname }),
 }));
 
 vi.mock("../../Portals/Portals", async (importOriginal) => ({
@@ -54,6 +63,14 @@ function renderComponent() {
   );
 }
 
+function renderWithSearchParams(searchParams: Record<string, string> = {}) {
+  mockSearchParams = new URLSearchParams(searchParams);
+  mockSetSearchParams.mockClear();
+  mockNavigate.mockClear();
+
+  return renderComponent();
+}
+
 const useSerialLogsNoPermissions = {
   data: {
     message: "There was a problem fetching serial logs",
@@ -86,6 +103,18 @@ mockUseSortTableData.mockReturnValue({
 const mockuseSerialLogs = vi.mocked(useSerialLogs);
 
 describe("SerialLog", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-02T14:34:23.666Z"));
+    mockSearchParams = new URLSearchParams({ filter: mockFilterQuery });
+    mockSetSearchParams.mockClear();
+    mockNavigate.mockClear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it("displays message if user has no serial logs access", () => {
     mockuseSerialLogs.mockReturnValue(useSerialLogsNoPermissions);
     renderComponent();
@@ -100,6 +129,18 @@ describe("SerialLog", () => {
     expect(screen.queryByTestId("serial-log-table")).not.toBeInTheDocument();
   });
 
+  it("keeps date selector controls visible if user has no serial logs access", () => {
+    mockuseSerialLogs.mockReturnValue(useSerialLogsNoPermissions);
+    renderComponent();
+
+    expect(
+      screen.getByText("Showing serial logs for the past 30 days"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Select custom date range" }),
+    ).toBeInTheDocument();
+  });
+
   it("doesn't display message if user has serial logs access", () => {
     mockuseSerialLogs.mockReturnValue(useSerialLogsPermissions);
     renderComponent();
@@ -112,5 +153,207 @@ describe("SerialLog", () => {
     mockuseSerialLogs.mockReturnValue(useSerialLogsPermissions);
     renderComponent();
     expect(screen.getByTestId("serial-log-table")).toBeInTheDocument();
+  });
+
+  it("passes default page size 25 to useSerialLogs when none is set", () => {
+    mockuseSerialLogs.mockReturnValue(useSerialLogsPermissions);
+
+    renderWithSearchParams();
+
+    expect(mockuseSerialLogs).toHaveBeenCalled();
+    expect(mockuseSerialLogs.mock.calls[0][2]).toEqual({
+      pageSize: 25,
+      page: null,
+    });
+  });
+
+  it("shows the default serial log date selector summary and button", () => {
+    mockuseSerialLogs.mockReturnValue(useSerialLogsPermissions);
+
+    renderWithSearchParams();
+
+    expect(
+      screen.getByText("Showing serial logs for the past 30 days"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Select custom date range" }),
+    ).toBeInTheDocument();
+    expect(screen.queryByLabelText("Start date")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("End date")).not.toBeInTheDocument();
+  });
+
+  it("opens the date selector panel with query string values on load", () => {
+    mockuseSerialLogs.mockReturnValue(useSerialLogsPermissions);
+
+    const startTime = "2026-05-01T12:13:14.000Z";
+    const endTime = "2026-05-10T20:21:22.000Z";
+
+    renderWithSearchParams({
+      "start-time": startTime,
+      "end-time": endTime,
+    });
+
+    expect(screen.getByLabelText("Start date")).toHaveAttribute("type", "date");
+    expect(screen.getByLabelText("Start date")).toHaveValue(
+      format(parseISO(startTime), "yyyy-MM-dd"),
+    );
+    expect(screen.getByLabelText("End date")).toHaveAttribute("type", "date");
+    expect(screen.getByLabelText("End date")).toHaveValue(
+      format(parseISO(endTime), "yyyy-MM-dd"),
+    );
+    expect(screen.getByLabelText("Start time")).toHaveAttribute("type", "time");
+    expect(screen.getByLabelText("Start time")).toHaveValue(
+      format(parseISO(startTime), "HH:mm:ss"),
+    );
+    expect(screen.getByLabelText("End time")).toHaveAttribute("type", "time");
+    expect(screen.getByLabelText("End time")).toHaveValue(
+      format(parseISO(endTime), "HH:mm:ss"),
+    );
+    expect(
+      screen.getByText(
+        "Showing serial logs between 1 May, 2026 and 10 May, 2026",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("shows default start and end time values when opening the selector", async () => {
+    mockuseSerialLogs.mockReturnValue(useSerialLogsPermissions);
+
+    renderWithSearchParams();
+    vi.useRealTimers();
+    const user = userEvent.setup();
+
+    await user.click(
+      screen.getByRole("button", { name: "Select custom date range" }),
+    );
+
+    expect(screen.getByLabelText("Start time")).toHaveValue("00:00:00");
+    expect(screen.getByLabelText("End time")).toHaveValue("23:59:59");
+  });
+
+  it("shows a default date range of exactly 30 inclusive days", async () => {
+    mockuseSerialLogs.mockReturnValue(useSerialLogsPermissions);
+
+    renderWithSearchParams();
+    vi.useRealTimers();
+    const user = userEvent.setup();
+
+    await user.click(
+      screen.getByRole("button", { name: "Select custom date range" }),
+    );
+
+    expect(screen.getByLabelText("Start date")).toHaveValue("2026-05-04");
+    expect(screen.getByLabelText("End date")).toHaveValue("2026-06-02");
+  });
+
+  it("applies a valid custom date range", async () => {
+    mockuseSerialLogs.mockReturnValue(useSerialLogsPermissions);
+
+    renderWithSearchParams();
+    vi.useRealTimers();
+    const user = userEvent.setup();
+
+    await user.click(
+      screen.getByRole("button", { name: "Select custom date range" }),
+    );
+    await user.clear(screen.getByLabelText("Start date"));
+    await user.type(screen.getByLabelText("Start date"), "2026-05-01");
+    await user.clear(screen.getByLabelText("End date"));
+    await user.type(screen.getByLabelText("End date"), "2026-05-10");
+    await user.click(screen.getByRole("button", { name: "Apply date range" }));
+
+    expect(mockNavigate).toHaveBeenCalledWith({
+      pathname: mockPathname,
+      search:
+        "?start-time=2026-05-01T00:00:00.000Z&end-time=2026-05-10T23:59:59.000Z",
+    });
+  });
+
+  it("blocks applying a date range over 30 inclusive days", async () => {
+    mockuseSerialLogs.mockReturnValue(useSerialLogsPermissions);
+
+    renderWithSearchParams();
+    vi.useRealTimers();
+    const user = userEvent.setup();
+
+    await user.click(
+      screen.getByRole("button", { name: "Select custom date range" }),
+    );
+    await user.clear(screen.getByLabelText("Start date"));
+    await user.type(screen.getByLabelText("Start date"), "2026-05-01");
+    await user.clear(screen.getByLabelText("End date"));
+    await user.type(screen.getByLabelText("End date"), "2026-05-31");
+
+    expect(
+      screen.getByText("The selected date range cannot exceed 30 days."),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Apply date range" }),
+    ).toHaveAttribute("aria-disabled", "true");
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it("blocks applying when start date is after end date", async () => {
+    mockuseSerialLogs.mockReturnValue(useSerialLogsPermissions);
+
+    renderWithSearchParams();
+    vi.useRealTimers();
+    const user = userEvent.setup();
+
+    await user.click(
+      screen.getByRole("button", { name: "Select custom date range" }),
+    );
+    await user.clear(screen.getByLabelText("Start date"));
+    await user.type(screen.getByLabelText("Start date"), "2026-05-02");
+    await user.clear(screen.getByLabelText("End date"));
+    await user.type(screen.getByLabelText("End date"), "2026-05-01");
+
+    expect(
+      screen.getByText("The start date must be on or before the end date."),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Apply date range" }),
+    ).toHaveAttribute("aria-disabled", "true");
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it("blocks applying when start time is after end time on the same day", async () => {
+    mockuseSerialLogs.mockReturnValue(useSerialLogsPermissions);
+
+    renderWithSearchParams({
+      "start-time": "2026-05-10T22:00:00.000Z",
+      "end-time": "2026-05-10T01:00:00.000Z",
+    });
+    vi.useRealTimers();
+
+    expect(
+      screen.getByText(
+        "The start time must be on or before the end time when using the same date.",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Apply date range" }),
+    ).toHaveAttribute("aria-disabled", "true");
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it("removes date range query params when closing the panel", async () => {
+    mockuseSerialLogs.mockReturnValue(useSerialLogsPermissions);
+
+    renderWithSearchParams({
+      "start-time": "2026-05-01T00:00:00.000Z",
+      "end-time": "2026-05-10T23:59:59.000Z",
+      "page-size": "50",
+      page: "cursor",
+    });
+    vi.useRealTimers();
+    const user = userEvent.setup();
+
+    await user.click(screen.getByRole("button", { name: "Close" }));
+
+    expect(mockNavigate).toHaveBeenCalledWith({
+      pathname: mockPathname,
+      search: "",
+    });
   });
 });

--- a/static/js/publisher/pages/SerialLog/__tests__/SerialLogTable.test.tsx
+++ b/static/js/publisher/pages/SerialLog/__tests__/SerialLogTable.test.tsx
@@ -53,7 +53,7 @@ describe("SerialLogTable", () => {
     ).toBeInTheDocument();
 
     expect(
-      screen.getByRole("columnheader", { name: "Created date" }),
+      screen.getByRole("columnheader", { name: "Created at" }),
     ).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Done
Adds date filters to the serial logs view as currently it only shows the past 30 days of logs

## How to QA
- Go to https://snapcraft-io-5727.demos.haus/admin/ahnuP3quahti9vis8aiw/models/test-superalpaca-00/serial-log
- Click "Select custom date range"
- Choose a 30 day time period which includes 23rd March (these are the only serial logs we have)
- Check that the serial log table is populated
- Reload the page
- Check that the custom range panel is open and that the start and end values are still populated
- Close the panel
- Check that the start and end have reverted to the current 30 day period
- Try expanding the date range to more than 30 days
- Check that there is a notification that warns you about this

## Testing

- [x] This PR has tests
- [ ] No testing required (explain why):

## Security

- [ ] Security considerations for review (list them):
  - [ ] Examples:
  - [ ] Access control: users can only access their own data
  - [ ] Input: user input is validated and sanitised
  - [ ] Sensitive data: secret or private data is not exposed in any way
  - [ ] ...
- [x] This PR has no security considerations (explain why): User input is escaped

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-35106

## Screenshots
n/a

## UX Approval

- [ ] This PR does not require UX approval
- [x] This PR does require UX approval (add context):

The serial log API only shows results for up to a 30 day period, and by default it returns data for the previous 30 days. Currently the user has no way to select a time period of logs to view. This PR implements a panel where a user can specify a time period to view.