### PR TITLE
Add delete action for remodel allowlists

### DIFF
--- a/static/js/publisher/pages/Remodel/ConfigureRemodelForm.tsx
+++ b/static/js/publisher/pages/Remodel/ConfigureRemodelForm.tsx
@@ -18,6 +18,7 @@ import { setPageTitle } from "../../utils";
 
 type Props = {
   setShowNotification: Dispatch<SetStateAction<boolean>>;
+  setNotificationMessage: Dispatch<SetStateAction<string>>;
   setShowErrorNotification: Dispatch<SetStateAction<boolean>>;
   refetch: () => void;
   setErrorMessage: Dispatch<SetStateAction<string>>;
@@ -26,6 +27,7 @@ type Props = {
 function ConfigureRemodelForm({
   refetch,
   setShowNotification,
+  setNotificationMessage,
   setShowErrorNotification,
   setErrorMessage,
 }: Props): React.JSX.Element {
@@ -155,6 +157,7 @@ function ConfigureRemodelForm({
         setErrorMessage(errorMessage);
         setShowErrorNotification(true);
       } else {
+        setNotificationMessage("New remodel configured");
         setShowNotification(true);
         refetch();
       }

--- a/static/js/publisher/pages/Remodel/Remodel.tsx
+++ b/static/js/publisher/pages/Remodel/Remodel.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState, useRef } from "react";
 import { useAtomValue, useSetAtom } from "jotai";
+import { useQueryClient } from "react-query";
 import {
   useParams,
   Link,
@@ -26,6 +27,8 @@ function Remodel(): React.JSX.Element {
   const [searchParams, setSearchParams] = useSearchParams();
   const location = useLocation();
   const brandId = useAtomValue(brandIdState);
+  const remodels = useAtomValue(remodelsListState);
+  const queryClient = useQueryClient();
   const [currentCursor, setCurrentCursor] = useState<string | null>(null);
   const [nextCursor, setNextCursor] = useState<string | null>(null);
   const cursorHistory = useRef<Array<string | null>>([]);
@@ -50,10 +53,63 @@ function Remodel(): React.JSX.Element {
   );
   const setRemodels = useSetAtom(remodelsListState);
   const [showNotification, setShowNotification] = useState(false);
+  const [notificationMessage, setNotificationMessage] = useState(
+    "New remodel configured",
+  );
   const [showErrorNotification, setShowErrorNotification] = useState(false);
   const [errorMessage, setErrorMessage] = useState("");
+  const [isDeleting, setIsDeleting] = useState(false);
   const brandStore = useAtomValue(brandStoreState(id));
   const navigate = useNavigate();
+
+  const handleDeleteRemodel = async (remodel: Remodel) => {
+    setIsDeleting(true);
+    const deletePayload = {
+      "from-model": remodel["from-model"],
+      "to-model": remodel["to-model"],
+      "from-serial": remodel["from-serial"],
+    };
+
+    try {
+      const response = await fetch(
+        `/api/store/${brandId}/models/remodel-allowlist`,
+        {
+          method: "DELETE",
+          body: JSON.stringify(deletePayload),
+          headers: {
+            "Content-Type": "application/json",
+            "X-CSRF-Token": window.CSRF_TOKEN,
+          },
+        },
+      );
+      const responseData = await response.json();
+
+      if (!response.ok || !responseData.success) {
+        throw new Error(responseData.message || "Unable to delete remodel");
+      }
+
+      setNotificationMessage("Remodel deleted");
+      setShowNotification(true);
+
+      await queryClient.invalidateQueries({ queryKey: ["remodels"] });
+
+      setTimeout(() => {
+        setShowNotification(false);
+      }, 5000);
+    } catch (error) {
+      setErrorMessage(
+        error instanceof Error ? error.message : "Unable to delete remodel",
+      );
+      setShowErrorNotification(true);
+      setTimeout(() => {
+        setShowErrorNotification(false);
+      }, 5000);
+
+      throw error;
+    } finally {
+      setIsDeleting(false);
+    }
+  };
 
   const handlePageForward = () => {
     cursorHistory.current.push(currentCursor);
@@ -123,6 +179,7 @@ function Remodel(): React.JSX.Element {
             <div className="u-flex-column u-flex-grow">
               {data && (
                 <RemodelTable
+                  remodels={remodels}
                   handlePageForward={handlePageForward}
                   handlePageBack={handlePageBack}
                   handlePageSizeChange={handlePageSizeChange}
@@ -131,6 +188,8 @@ function Remodel(): React.JSX.Element {
                     cursorHistory.current.length < 1 || currentCursor === null
                   }
                   pageSize={pageSize}
+                  isDeleting={isDeleting}
+                  onDeleteRemodel={handleDeleteRemodel}
                 />
               )}
             </div>
@@ -147,7 +206,7 @@ function Remodel(): React.JSX.Element {
                 setShowNotification(false);
               }}
             >
-              New remodel configured
+              {notificationMessage}
             </Notification>
           </div>
         )}
@@ -191,6 +250,7 @@ function Remodel(): React.JSX.Element {
           <ConfigureRemodelForm
             refetch={refetch}
             setShowNotification={setShowNotification}
+            setNotificationMessage={setNotificationMessage}
             setShowErrorNotification={setShowErrorNotification}
             setErrorMessage={setErrorMessage}
           />

--- a/static/js/publisher/pages/Remodel/RemodelTable.tsx
+++ b/static/js/publisher/pages/Remodel/RemodelTable.tsx
@@ -1,32 +1,54 @@
-import { useAtomValue } from "jotai";
+import { useState } from "react";
 import {
+  Button,
+  Icon,
   MainTable,
+  Modal,
   TablePaginationControls,
 } from "@canonical/react-components";
 import { format } from "date-fns";
 
-import { remodelsListState } from "../../state/remodelsState";
-
 import type { Remodel } from "../../types/shared";
 
 type Props = {
+  remodels: Remodel[];
   handlePageForward: () => void;
   handlePageBack: () => void;
   handlePageSizeChange: (arg: number) => void;
   forwardDisabled: boolean;
   backDisabled: boolean;
   pageSize: number;
+  isDeleting: boolean;
+  onDeleteRemodel: (remodel: Remodel) => Promise<void>;
 };
 
 function RemodelTable({
+  remodels,
   handlePageForward,
   handlePageBack,
   handlePageSizeChange,
   forwardDisabled,
   backDisabled,
   pageSize,
+  isDeleting,
+  onDeleteRemodel,
 }: Props): React.JSX.Element {
-  const remodels = useAtomValue(remodelsListState);
+  const [showDeleteModal, setShowDeleteModal] = useState(false);
+  const [selectedRemodel, setSelectedRemodel] = useState<Remodel | null>(null);
+
+  const handleDeleteConfirm = async () => {
+    if (!selectedRemodel) {
+      return;
+    }
+
+    try {
+      await onDeleteRemodel(selectedRemodel);
+      setShowDeleteModal(false);
+      setSelectedRemodel(null);
+    } catch {
+      // Keep modal open so user can retry or cancel.
+    }
+  };
 
   const headers = [
     {
@@ -46,6 +68,7 @@ function RemodelTable({
       style: { width: "130px" },
     },
     { content: "Note", className: "u-truncate" },
+    { content: "Actions", className: "u-align--right" },
   ];
 
   const rows = remodels.map((remodel: Remodel) => {
@@ -62,6 +85,22 @@ function RemodelTable({
           className: "u-align--right",
         },
         { content: remodel["description"] },
+        {
+          content: (
+            <Button
+              className="u-no-margin--bottom u-no-margin--right"
+              dense
+              disabled={isDeleting}
+              onClick={() => {
+                setSelectedRemodel(remodel);
+                setShowDeleteModal(true);
+              }}
+            >
+              Delete
+            </Button>
+          ),
+          className: "u-align--right",
+        },
       ],
     };
   });
@@ -97,6 +136,54 @@ function RemodelTable({
         visibleCount={rows.length}
         className="table-pagination-controls"
       />
+      {showDeleteModal && selectedRemodel && (
+        <Modal
+          close={() => {
+            if (!isDeleting) {
+              setShowDeleteModal(false);
+              setSelectedRemodel(null);
+            }
+          }}
+          title="Delete remodel"
+          buttonRow={
+            <>
+              <Button
+                className="u-no-margin--bottom"
+                disabled={isDeleting}
+                onClick={() => {
+                  setShowDeleteModal(false);
+                  setSelectedRemodel(null);
+                }}
+              >
+                Cancel
+              </Button>
+              <Button
+                className="u-no-margin--bottom u-no-margin--right"
+                appearance="positive"
+                disabled={isDeleting}
+                onClick={() => {
+                  void handleDeleteConfirm();
+                }}
+              >
+                {isDeleting ? (
+                  <>
+                    <Icon name="spinner" className="u-animation--spin" />
+                    &nbsp;Deleting...
+                  </>
+                ) : (
+                  "Delete"
+                )}
+              </Button>
+            </>
+          }
+        >
+          <p>
+            Are you sure you want to delete this remodel?
+            <br />
+            This action cannot be undone.
+          </p>
+        </Modal>
+      )}
     </>
   );
 }

--- a/static/js/publisher/pages/Remodel/RemodelTable.tsx
+++ b/static/js/publisher/pages/Remodel/RemodelTable.tsx
@@ -159,7 +159,7 @@ function RemodelTable({
               </Button>
               <Button
                 className="u-no-margin--bottom u-no-margin--right"
-                appearance="positive"
+                appearance="negative"
                 disabled={isDeleting}
                 onClick={() => {
                   void handleDeleteConfirm();
@@ -167,7 +167,10 @@ function RemodelTable({
               >
                 {isDeleting ? (
                   <>
-                    <Icon name="spinner" className="u-animation--spin" />
+                    <Icon
+                      name="spinner"
+                      className="u-animation--spin is-light"
+                    />
                     &nbsp;Deleting...
                   </>
                 ) : (

--- a/static/js/publisher/pages/Remodel/__tests__/Remodel.test.tsx
+++ b/static/js/publisher/pages/Remodel/__tests__/Remodel.test.tsx
@@ -1,7 +1,8 @@
 import { BrowserRouter } from "react-router-dom";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { vi } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 
 import "@testing-library/jest-dom";
 
@@ -72,6 +73,29 @@ const useRemodelsPermissions = {
   isError: false,
 } as unknown as UseQueryResult<ApiResponse<RemodelResponse>, Error>;
 
+const useRemodelsWithData = {
+  data: {
+    data: {
+      allowlist: [
+        {
+          "created-at": "2026-03-27T14:34:23.666Z",
+          "created-by": "test-user",
+          "from-model": "from-model-a",
+          "from-serial": "serial-1",
+          "modified-at": null,
+          "modified-by": null,
+          "to-model": "to-model-a",
+          description: "test remodel",
+        },
+      ],
+      "next-cursor": null,
+    },
+    success: true,
+  },
+  isLoading: false,
+  isError: false,
+} as unknown as UseQueryResult<ApiResponse<RemodelResponse>, Error>;
+
 const mockUseModels = vi.mocked(useModels);
 mockUseModels.mockReturnValue({
   data: [],
@@ -128,5 +152,61 @@ describe("Remodel", () => {
     expect(
       screen.getByRole("link", { name: "Configure remodels" }),
     ).toBeInTheDocument();
+  });
+
+  it("deletes remodel and shows success notification", async () => {
+    const invalidateQueriesSpy = vi
+      .spyOn(queryClient, "invalidateQueries")
+      .mockResolvedValue(undefined);
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ success: true }),
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    mockUseRemodels.mockReturnValue(useRemodelsWithData);
+    renderComponent();
+    const user = userEvent.setup();
+
+    await user.click(screen.getByRole("button", { name: "Delete" }));
+    await user.click(screen.getAllByRole("button", { name: "Delete" })[1]);
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        expect.stringContaining("/models/remodel-allowlist"),
+        expect.objectContaining({
+          method: "DELETE",
+          body: JSON.stringify({
+            "from-model": "from-model-a",
+            "to-model": "to-model-a",
+            "from-serial": "serial-1",
+          }),
+          headers: {
+            "Content-Type": "application/json",
+            "X-CSRF-Token": undefined,
+          },
+        }),
+      );
+    });
+    expect(await screen.findByText("Remodel deleted")).toBeInTheDocument();
+    expect(invalidateQueriesSpy).toHaveBeenCalledWith({ queryKey: ["remodels"] });
+  });
+
+  it("shows error notification when delete fails", async () => {
+    const errorMessage = "Unable to delete remodel from API";
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ success: false, message: errorMessage }),
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    mockUseRemodels.mockReturnValue(useRemodelsWithData);
+    renderComponent();
+    const user = userEvent.setup();
+
+    await user.click(screen.getByRole("button", { name: "Delete" }));
+    await user.click(screen.getAllByRole("button", { name: "Delete" })[1]);
+
+    expect(await screen.findByText(errorMessage)).toBeInTheDocument();
   });
 });

--- a/static/js/publisher/pages/Remodel/__tests__/Remodel.test.tsx
+++ b/static/js/publisher/pages/Remodel/__tests__/Remodel.test.tsx
@@ -189,7 +189,9 @@ describe("Remodel", () => {
       );
     });
     expect(await screen.findByText("Remodel deleted")).toBeInTheDocument();
-    expect(invalidateQueriesSpy).toHaveBeenCalledWith({ queryKey: ["remodels"] });
+    expect(invalidateQueriesSpy).toHaveBeenCalledWith({
+      queryKey: ["remodels"],
+    });
   });
 
   it("shows error notification when delete fails", async () => {

--- a/static/js/publisher/pages/Remodel/__tests__/RemodelTable.test.tsx
+++ b/static/js/publisher/pages/Remodel/__tests__/RemodelTable.test.tsx
@@ -1,9 +1,11 @@
 import { BrowserRouter } from "react-router-dom";
 import { QueryClientProvider, QueryClient } from "react-query";
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom";
 
 import RemodelTable from "../RemodelTable";
+import type { Remodel } from "../../../types/shared";
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -14,17 +16,36 @@ const queryClient = new QueryClient({
   },
 });
 
-const renderComponent = () => {
+const remodels: Remodel[] = [
+  {
+    "created-at": "2026-03-27T14:34:23.666Z",
+    "created-by": "test-user",
+    "from-model": "from-model-a",
+    "from-serial": "serial-1",
+    "modified-at": null,
+    "modified-by": null,
+    "to-model": "to-model-a",
+    description: "test remodel",
+  },
+];
+
+const renderComponent = (
+  onDeleteRemodel: (remodel: Remodel) => Promise<void> = vi.fn(async () => {}),
+  isDeleting = false,
+) => {
   return render(
     <BrowserRouter>
       <QueryClientProvider client={queryClient}>
         <RemodelTable
+          remodels={remodels}
           handlePageForward={vi.fn()}
           handlePageBack={vi.fn()}
           handlePageSizeChange={vi.fn()}
           forwardDisabled={false}
           backDisabled={true}
           pageSize={10}
+          isDeleting={isDeleting}
+          onDeleteRemodel={onDeleteRemodel}
         />
       </QueryClientProvider>
     </BrowserRouter>,
@@ -59,5 +80,36 @@ describe("RemodelTable", () => {
     expect(
       screen.getByRole("columnheader", { name: "Note" }),
     ).toBeInTheDocument();
+
+    expect(
+      screen.getByRole("columnheader", { name: "Actions" }),
+    ).toBeInTheDocument();
+  });
+
+  it("opens the delete modal and closes it when cancel is clicked", async () => {
+    renderComponent();
+    const user = userEvent.setup();
+
+    await user.click(screen.getByRole("button", { name: "Delete" }));
+
+    expect(screen.getByText("Delete remodel")).toBeInTheDocument();
+    expect(
+      screen.getByText(/Are you sure you want to delete this remodel/),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(screen.queryByText("Delete remodel")).not.toBeInTheDocument();
+  });
+
+  it("calls onDeleteRemodel with the selected remodel", async () => {
+    const onDeleteRemodel = vi.fn(async () => {});
+    renderComponent(onDeleteRemodel);
+    const user = userEvent.setup();
+
+    await user.click(screen.getByRole("button", { name: "Delete" }));
+    await user.click(screen.getAllByRole("button", { name: "Delete" })[1]);
+
+    expect(onDeleteRemodel).toHaveBeenCalledWith(remodels[0]);
   });
 });


### PR DESCRIPTION
## Done
- Added a Delete action on each row in the remodel allowlist table.
- Added a confirmation modal with Cancel and Delete actions.
- Wired delete to /api/store/<store_id>/models/remodel-allowlist.
- Updated delete payload to include only from-model, to-model, and from-serial.
- On successful delete, refreshes remodel list data and shows a success notification.
- On delete failure, shows an error notification.
- Added coverage for remodel table delete interactions.

## How to QA
1. Go to https://snapcraft-io-5729.demos.haus/admin/ahnuP3quahti9vis8aiw/models/testing-model-new-2/remodel
3. Verify each row has a Delete button.
4. Click Delete on a row and verify a confirmation modal appears.
5. Verify modal text and buttons: Cancel and Delete.
6. Click Cancel and verify nothing changes.
7. Click Delete again and confirm.
9. Verify the table refreshes with latest data after successful deletion.
10. Verify a success notification appears.

## Testing
- [x] This PR has tests
- [ ] No testing required (explain why):

## Security
- [ ] Security considerations for review (list them):
  - [ ] Examples:
  - [ ] Access control: users can only access their own data
  - [ ] Input: user input is validated and sanitised
  - [ ] Sensitive data: secret or private data is not exposed in any way
  - [ ] ...
- [x] This PR has no security considerations (explain why):
  - Frontend-only UX/action wiring to an existing authenticated endpoint; no new auth surface or sensitive data handling added.

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-36948

## Screenshots

n/a

## UX Approval

- [ ] This PR does not require UX approval
- [x] This PR does require UX approval (add context):

Currently the users are not able to delete remodel allowlists via the UI, however the API does support this. This PR adds the ability for the user to do this.
