### PR TITLE
feat: Add featured snaps to explore page

### DIFF
--- a/templates/explore/_snaps-list.html
+++ b/templates/explore/_snaps-list.html
@@ -12,12 +12,12 @@
       {% if loop.index <= 8 %}
         <div class="grid-col-2 grid-col-medium-2">
           <div class="p-strip is-shallow u-no-padding--top">
-            <a href="{{ snap.details.name }}">
+            <a href="/{{ snap.details.name }}">
               <img src="{{ snap.details.icon }}" alt="{{ snap.details.title }}" width="48" height="48">
             </a>
             <div style="min-width: 0">
               <h3 class="p-heading--5 u-no-margin--bottom u-truncate">
-                <a href="{{ snap.details.name }}">{{ snap.details.title }}</a>
+                <a href="/{{ snap.details.name }}">{{ snap.details.title }}</a>
               </h3>
               <p class="u-text--muted">
                 <small>{{ snap.details.publisher }}</small>

--- a/templates/explore/index.html
+++ b/templates/explore/index.html
@@ -22,11 +22,22 @@
     </div>
   </section>
 
+  {% if featured_snaps %}
+    {% with
+      snaps_list = featured_snaps,
+      title = "Featured snaps",
+      has_summary = True
+    %}
+      {% include "explore/_snaps-list.html" %}
+    {% endwith %}
+  {% endif %}
+
   {% if recent_snaps %}
     {% with
       snaps_list = recent_snaps,
       title = "Recently updated snaps",
-      has_summary = True
+      has_summary = True,
+      has_rule = True
     %}
       {% include "explore/_snaps-list.html" %}
     {% endwith %}

--- a/tests/store/tests_details.py
+++ b/tests/store/tests_details.py
@@ -10,6 +10,7 @@ RECENT_PATH = "webapp.store.views.snap_recommendations.get_recent"
 TREND_PATH = "webapp.store.views.snap_recommendations.get_trending"
 TOP_PATH = "webapp.store.views.snap_recommendations.get_top_rated"
 CATEGORIES_PATH = "webapp.store.views.device_gateway.get_categories"
+FEATURED_PATH = "webapp.store.views.device_gateway.get_featured_snaps"
 
 
 EMPTY_EXTRA_DETAILS_PAYLOAD = {"aliases": None, "package_name": "vault"}
@@ -488,7 +489,7 @@ class GetDetailsPageTest(TestCase):
     @responses.activate
     def test_explore_uses_redis_cache(self):
         """When Redis has cached explore data, the recommendation APIs
-        and device gateway should not be called and the view should
+        and category lookup should not be called and the view should
         return successfully using the cached values.
         """
         # seed redis
@@ -541,6 +542,32 @@ class GetDetailsPageTest(TestCase):
             }
         ]
         categories = [{"slug": "cat1", "name": "Cat 1"}]
+        featured = {
+            "_embedded": {
+                "clickindex:package": [
+                    {
+                        "developer_validation": True,
+                        "media": [],
+                        "publisher": "Featured Pub",
+                        "package_name": "featured-snap",
+                        "summary": "Featured snap",
+                        "title": "Featured Snap",
+                    }
+                ]
+            }
+        }
+        expected_featured = [
+            {
+                "details": {
+                    "developer_validation": True,
+                    "icon": "",
+                    "publisher": "Featured Pub",
+                    "name": "featured-snap",
+                    "summary": "Featured snap",
+                    "title": "Featured Snap",
+                }
+            }
+        ]
 
         redis_cache.set("explore:popular-snaps", popular, ttl=3600)
         redis_cache.set("explore:recent-snaps", recent, ttl=3600)
@@ -553,15 +580,28 @@ class GetDetailsPageTest(TestCase):
                 with patch(TREND_PATH) as mock_trending:
                     with patch(TOP_PATH) as mock_top_rated:
                         with patch(CATEGORIES_PATH) as mock_categories:
-                            response = self.client.get("/explore")
+                            with patch(
+                                FEATURED_PATH, return_value=featured
+                            ) as mock_featured:
+                                response = self.client.get("/explore")
 
-                            self.assert200(response)
+                                self.assert200(response)
+                                self.assert_context(
+                                    "featured_snaps", expected_featured
+                                )
 
-                            mock_popular.assert_not_called()
-                            mock_recent.assert_not_called()
-                            mock_trending.assert_not_called()
-                            mock_top_rated.assert_not_called()
-                            mock_categories.assert_not_called()
+                                mock_popular.assert_not_called()
+                                mock_recent.assert_not_called()
+                                mock_trending.assert_not_called()
+                                mock_top_rated.assert_not_called()
+                                mock_categories.assert_not_called()
+                                mock_featured.assert_called_once_with(
+                                    fields=(
+                                        "developer_validation,media,"
+                                        "package_name,publisher,summary,"
+                                        "title"
+                                    )
+                                )
 
     @responses.activate
     def test_explore_populates_cache_when_empty(self):
@@ -569,6 +609,32 @@ class GetDetailsPageTest(TestCase):
         should be called and their results stored in Redis for subsequent
         requests.
         """
+        featured = {
+            "_embedded": {
+                "clickindex:package": [
+                    {
+                        "developer_validation": None,
+                        "media": [],
+                        "publisher": "Featured Pub",
+                        "package_name": "featured-snap",
+                        "summary": "Featured snap",
+                        "title": "Featured Snap",
+                    }
+                ]
+            }
+        }
+        expected_featured = [
+            {
+                "details": {
+                    "developer_validation": None,
+                    "icon": "",
+                    "publisher": "Featured Pub",
+                    "name": "featured-snap",
+                    "summary": "Featured snap",
+                    "title": "Featured Snap",
+                }
+            }
+        ]
 
         with patch(
             POPULAR_PATH,
@@ -634,38 +700,45 @@ class GetDetailsPageTest(TestCase):
                             CATEGORIES_PATH,
                             return_value=[{"slug": "c1", "name": "C1"}],
                         ) as mock_categories:
-                            response = self.client.get("/explore")
+                            with patch(
+                                FEATURED_PATH, return_value=featured
+                            ) as mock_featured:
+                                response = self.client.get("/explore")
 
-                            self.assert200(response)
+                                self.assert200(response)
+                                self.assert_context(
+                                    "featured_snaps", expected_featured
+                                )
 
-                            # ensure the methods were called to populate cache
-                            self.assertTrue(mock_popular.called)
-                            self.assertTrue(mock_recent.called)
-                            self.assertTrue(mock_trending.called)
-                            self.assertTrue(mock_top_rated.called)
-                            self.assertTrue(mock_categories.called)
-                            # cached values should now exist
-                            pop_cached = redis_cache.get(
-                                "explore:popular-snaps"
-                            )
-                            recent_cached = redis_cache.get(
-                                "explore:recent-snaps"
-                            )
-                            trend_cached = redis_cache.get(
-                                "explore:trending-snaps"
-                            )
-                            top_cached = redis_cache.get(
-                                "explore:top-rated-snaps"
-                            )
-                            categories_cached = redis_cache.get(
-                                "explore:categories"
-                            )
+                                # cache-populating methods were called
+                                self.assertTrue(mock_popular.called)
+                                self.assertTrue(mock_recent.called)
+                                self.assertTrue(mock_trending.called)
+                                self.assertTrue(mock_top_rated.called)
+                                self.assertTrue(mock_categories.called)
+                                self.assertTrue(mock_featured.called)
+                                # cached values should now exist
+                                pop_cached = redis_cache.get(
+                                    "explore:popular-snaps"
+                                )
+                                recent_cached = redis_cache.get(
+                                    "explore:recent-snaps"
+                                )
+                                trend_cached = redis_cache.get(
+                                    "explore:trending-snaps"
+                                )
+                                top_cached = redis_cache.get(
+                                    "explore:top-rated-snaps"
+                                )
+                                categories_cached = redis_cache.get(
+                                    "explore:categories"
+                                )
 
-                            assert pop_cached is not None
-                            assert recent_cached is not None
-                            assert trend_cached is not None
-                            assert top_cached is not None
-                            assert categories_cached is not None
+                                assert pop_cached is not None
+                                assert recent_cached is not None
+                                assert trend_cached is not None
+                                assert top_cached is not None
+                                assert categories_cached is not None
 
 
 if __name__ == "__main__":

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -189,6 +189,40 @@ def store_blueprint(store_query=None):
             key=lambda category: category["slug"],
         )
 
+        featured_snaps_fields = ",".join(
+            [
+                "developer_validation",
+                "media",
+                "package_name",
+                "publisher",
+                "summary",
+                "title",
+            ]
+        )
+
+        try:
+            featured_snaps = device_gateway.get_featured_snaps(
+                fields=featured_snaps_fields
+            )
+        except (StoreApiError, api_requests.exceptions.RequestException):
+            featured_snaps = {}
+
+        currently_featured_snaps = [
+            {
+                "details": {
+                    "developer_validation": snap["developer_validation"],
+                    "icon": helpers.get_icon(snap["media"]),
+                    "publisher": snap["publisher"],
+                    "name": snap["package_name"],
+                    "summary": snap["summary"],
+                    "title": snap["title"],
+                }
+            }
+            for snap in featured_snaps.get("_embedded", {}).get(
+                "clickindex:package", []
+            )
+        ]
+
         return flask.render_template(
             "explore/index.html",
             categories=categories,
@@ -196,6 +230,7 @@ def store_blueprint(store_query=None):
             recent_snaps=recent_snaps,
             trending_snaps=trending_snaps,
             top_rated_snaps=top_rated_snaps,
+            featured_snaps=currently_featured_snaps,
         )
 
     @store.route("/publisher/<regex('[a-z0-9-]*[a-z][a-z0-9-]*'):publisher>")


### PR DESCRIPTION
## Done
Adds featured snaps to the explore page

## How to QA
- Go to https://snapcraft-io-5730.demos.haus/explore
- Check that there is a "Featured snaps" section at the top of the page

## Testing

- [x] This PR has tests
- [ ] No testing required (explain why):

## Security

- [ ] Security considerations for review (list them):
  - [ ] Examples:
  - [ ] Access control: users can only access their own data
  - [ ] Input: user input is validated and sanitised
  - [ ] Sensitive data: secret or private data is not exposed in any way
  - [ ] ...
- [x] This PR has no security considerations (explain why): Visual change

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-36971

## Screenshots
n/a

## UX Approval

- [x] This PR does not require UX approval
- [ ] This PR does require UX approval (add context):
