### PR TITLE
fix: Fix text overflow issue on details page

### DIFF
--- a/templates/store/snap-details/_details.html
+++ b/templates/store/snap-details/_details.html
@@ -16,10 +16,10 @@
   <h3 class="p-muted-heading">Last updated</h3>
   <ul class="p-list">
     {% if updates[0] %}
-      <li>{{ updates[0]["released-at-display"] }} - <small>{{ updates[0]["track"] }}/{{ updates[0]["risk"] }}</small></li>
+      <li class="">{{ updates[0]["released-at-display"] }} - <small>{{ updates[0]["track"] }}/{{ updates[0]["risk"] }}</small></li>
     {% endif %}
     {% if updates[1] %}
-      <li>{{ updates[1]["released-at-display"] }} - <small>{{ updates[1]["track"] }}/{{ updates[1]["risk"] }}</small></li>
+      <li class="u-text-wrap">{{ updates[1]["released-at-display"] }} - <small>{{ updates[1]["track"] }}/{{ updates[1]["risk"] }}</small></li>
     {% endif %}
   </ul>
   {% if is_snap_old %}
@@ -41,7 +41,7 @@
       {% for link in links["website"] %}
         {% if format_link(link) != None %}
         <li {% if loop.index == 1 %}data-js="primary-domain"{% endif %}>
-          <a class="js-external-link" title="{{ link }}" href="{{ link }}" aria-controls="modal">{{ format_link(link) }}</a>
+          <a class="js-external-link u-text-wrap" title="{{ link }}" href="{{ link }}" aria-controls="modal">{{ format_link(link) }}</a>
         </li>
         {% endif %}
       {% endfor %}
@@ -55,7 +55,7 @@
       {% for link in links["contact"] %}
         {% if format_link(link) != None %}
         <li>
-          <a class="js-external-link" title="{{ link }}" href="{{ link }}" aria-controls="modal">{{ format_link(link) }}</a>
+          <a class="js-external-link u-text-wrap" title="{{ link }}" href="{{ link }}" aria-controls="modal">{{ format_link(link) }}</a>
         </li>
         {% endif %}
       {% endfor %}
@@ -69,7 +69,7 @@
       {% for link in links["donations"] %}
         {% if format_link(link) != None %}
         <li>
-          <a class="js-external-link" title="{{ link }}" href="{{ link }}" aria-controls="modal">{{ format_link(link) }}</a>
+          <a class="js-external-link u-text-wrap" title="{{ link }}" href="{{ link }}" aria-controls="modal">{{ format_link(link) }}</a>
         </li>
         {% endif %}
       {% endfor %}
@@ -83,7 +83,7 @@
       {% for link in links["source"] %}
         {% if format_link(link) != None %}
         <li>
-          <a class="js-external-link" title="{{ link }}" href="{{ link }}" aria-controls="modal">{{ format_link(link) }}</a>
+          <a class="js-external-link u-text-wrap" title="{{ link }}" href="{{ link }}" aria-controls="modal">{{ format_link(link) }}</a>
         </li>
         {% endif %}
       {% endfor %}


### PR DESCRIPTION
## Done
Fixes overflowing links that are too long on the snap details metadata section

## How to QA
- Go to https://snapcraft-io-5738.demos.haus/directory-parser
- Check that the "Websites" link isn't breaking out of its column (Compare to [live](https://snapcraft.io/directory-parser))

## Testing

- [ ] This PR has tests
- [x] No testing required (explain why): Visual change

## Security

- [ ] Security considerations for review (list them):
  - [ ] Examples:
  - [ ] Access control: users can only access their own data
  - [ ] Input: user input is validated and sanitised
  - [ ] Sensitive data: secret or private data is not exposed in any way
  - [ ] ...
- [x] This PR has no security considerations (explain why): Visual change

## Issue / Card

Fixes #5737

## Screenshots

Before:

<img width="1010" height="460" alt="Screenshot 2026-06-10 at 11 07 58" src="https://github.com/user-attachments/assets/1567f466-1933-45be-aa0e-4901bb35e6a7" />

After:

<img width="874" height="386" alt="Screenshot 2026-06-10 at 11 07 39" src="https://github.com/user-attachments/assets/0e61a350-3379-4b92-aa18-ed2777eb8b5a" />

## UX Approval

- [x] This PR does not require UX approval
- [ ] This PR does require UX approval (add context):
