### PR TITLE
chore: Align search and store page search headers

### DIFF
--- a/static/js/store/components/Banner/Banner.tsx
+++ b/static/js/store/components/Banner/Banner.tsx
@@ -10,10 +10,10 @@ type Props = {
 
 function Banner({ searchRef, searchSummaryRef }: Props): React.JSX.Element {
   return (
-    <Strip type="dark">
+    <Strip>
       <Row>
-        <Col size={6} className="col-start-large-4">
-          <h1 className="p-heading--2">The app store for Linux</h1>
+        <Col size={9} className="col-start-large-4">
+          <h1>The app store for Linux</h1>
           <SearchInput
             searchRef={searchRef}
             searchSummaryRef={searchSummaryRef}

--- a/static/js/store/components/PackageList/PackageList.tsx
+++ b/static/js/store/components/PackageList/PackageList.tsx
@@ -98,7 +98,7 @@ function PackageList({
 
   return (
     <>
-      <Strip>
+      <Strip className="u-no-padding--top">
         <Row>
           <Col size={3}>
             <PackageFilter data={data} disabled={isFetching} />


### PR DESCRIPTION
## Done

Updates the search header on the /search page so it matches the new search header on the /store page

## How to QA
- Go to https://snapcraft-io-5739.demos.haus/search
- Check that the search header section is the same as the one on https://snapcraft-io-5739.demos.haus/store

## Testing

- [ ] This PR has tests
- [x] No testing required (explain why): Visual change

## Security

- [ ] Security considerations for review (list them):
  - [ ] Examples:
  - [ ] Access control: users can only access their own data
  - [ ] Input: user input is validated and sanitised
  - [ ] Sensitive data: secret or private data is not exposed in any way
  - [ ] ...
- [x] This PR has no security considerations (explain why): Visual change

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-37051

## Screenshots

Before:

<img width="3452" height="1082" alt="Screenshot 2026-06-10 at 15 59 31" src="https://github.com/user-attachments/assets/59df8d52-7b70-4252-ac0a-b344b259e139" />

After:

<img width="3440" height="902" alt="Screenshot 2026-06-10 at 15 59 18" src="https://github.com/user-attachments/assets/afebbcce-c7c0-4269-b565-f492a09ce6c2" />


## UX Approval

- [x] This PR does not require UX approval
- [ ] This PR does require UX approval (add context):
