### PR TITLE
WD-34910 - Fix dropdown overflow hidden bug in releases UI

### DIFF
--- a/static/js/publisher/pages/Releases/components/contextualMenu.tsx
+++ b/static/js/publisher/pages/Releases/components/contextualMenu.tsx
@@ -46,12 +46,48 @@ export default class ContextualMenu extends Component<ContextualMenuProps> {
     if (isClosed && dropdownEl) {
       dropdownEl.setAttribute("aria-hidden", "false");
 
+      requestAnimationFrame(() => {
+        this.positionDropdown(event.target as HTMLElement, dropdownEl);
+      });
+
       if (tooltipMessage) {
         tooltipMessage.classList.add("u-hide");
       }
     }
 
     event.stopPropagation();
+  }
+
+  positionDropdown(trigger: HTMLElement, menu: HTMLElement) {
+    // Reset direction first so previous state doesn't interfere
+    menu.classList.remove("opens-up");
+
+    const clippingParent = this.getClippingParent(trigger);
+    const triggerRect = trigger.getBoundingClientRect();
+    const menuRect = menu.getBoundingClientRect();
+
+    const boundaryBottom = clippingParent
+      ? clippingParent.getBoundingClientRect().bottom
+      : window.innerHeight;
+    const spaceBelow = boundaryBottom - triggerRect.bottom;
+
+    if (spaceBelow < menuRect.height) {
+      menu.classList.add("opens-up");
+    }
+  }
+
+  getClippingParent(el: HTMLElement): HTMLElement | null {
+    let parent = el.parentElement;
+
+    while (parent) {
+      const { overflow } = window.getComputedStyle(parent);
+      if (overflow === "hidden") {
+        return parent;
+      }
+      parent = parent.parentElement;
+    }
+
+    return null;
   }
 
   closeAllDropdowns() {

--- a/static/js/publisher/pages/Releases/components/contextualMenu.tsx
+++ b/static/js/publisher/pages/Releases/components/contextualMenu.tsx
@@ -33,7 +33,8 @@ export default class ContextualMenu extends Component<ContextualMenuProps> {
   }
 
   dropdownButtonClick(event: React.MouseEvent<HTMLButtonElement>) {
-    const dropdownEl = (event.target as HTMLButtonElement).nextSibling as HTMLElement | null;
+    const button = event.currentTarget as HTMLButtonElement;
+    const dropdownEl = button.nextElementSibling as HTMLElement | null;
     const isClosed = dropdownEl?.getAttribute("aria-hidden") === "true";
     const tooltipMessage = dropdownEl?.parentNode?.previousSibling as HTMLElement | null;
 
@@ -47,7 +48,7 @@ export default class ContextualMenu extends Component<ContextualMenuProps> {
       dropdownEl.setAttribute("aria-hidden", "false");
 
       requestAnimationFrame(() => {
-        this.positionDropdown(event.target as HTMLElement, dropdownEl);
+        this.positionDropdown(button, dropdownEl);
       });
 
       if (tooltipMessage) {

--- a/static/sass/_snapcraft_release.scss
+++ b/static/sass/_snapcraft_release.scss
@@ -400,6 +400,11 @@
     .p-tooltip {
       display: block;
     }
+
+    &.opens-up {
+      top: auto;
+      bottom: 100%;
+    }
   }
 
   .is-grabbing,

--- a/static/sass/_snapcraft_release.scss
+++ b/static/sass/_snapcraft_release.scss
@@ -343,6 +343,10 @@
     font-size: 0.8rem;
     line-height: 0.8rem;
     position: absolute;
+
+    .is-dark & {
+      color: $color-light;
+    }
   }
 
   .p-releases-table__branches {
@@ -800,6 +804,10 @@
 
     color: $color-dark;
 
+    .is-dark & {
+      color: $color-light;
+    }
+
     &:hover {
       background: transparent;
       cursor: default;
@@ -814,6 +822,10 @@
     margin-bottom: $sp-x-small;
     margin-top: $sp-x-small;
     white-space: normal;
+
+    .is-dark & {
+      color: $color-light;
+    }
   }
 
   .p-tooltip__group {

--- a/static/sass/_snapcraft_release.scss
+++ b/static/sass/_snapcraft_release.scss
@@ -402,8 +402,8 @@
     }
 
     &.opens-up {
-      top: auto;
       bottom: 100%;
+      top: auto;
     }
   }
 


### PR DESCRIPTION
## Done

- Add function to position the contextual menus (dropdowns) in Releases UI.
  - The function checks if the HTMLElement has enough space below.
  - If it doesn't adds a CSS class "opens-up".
- Add CSS rules for "opens-up" which display the dropdown on top of the button instead of below.

## How to QA

- Go to [DEMOS](https://snapcraft-io-5741.demos.haus/) and log in.
- Go to any snap and to the Releases UI tab in desktop view - [example](https://snapcraft-io-5741.demos.haus/amateo-hello/releases).
- Click on the dropdown to close/promote the last channel.
- Check that the contents of the dropdown are fully displayed (the dropdown should display top of the button instead of bottom, due to the lack of space).

## Testing

- [ ] This PR has tests
- [ ] No testing required (explain why):

## Security

- [ ] Security considerations for review (list them):
  - [ ] Examples:
  - [ ] Access control: users can only access their own data
  - [ ] Input: user input is validated and sanitised
  - [ ] Sensitive data: secret or private data is not exposed in any way
  - [ ] ...
- [x] This PR has no security considerations (explain why): Just a visual UI change

## Issue / Card

Fixes [WD-34910](https://warthogs.atlassian.net/browse/WD-34910)

## UX Approval

- [ ] This PR does not require UX approval
- [x] This PR does require UX approval (add context): Check if the dropdown displayed on top of the button is a good approach. 


[WD-34910]: https://warthogs.atlassian.net/browse/WD-34910?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ