### PR TITLE
fix tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ canonicalwebteam.discourse==7.2.0
 canonicalwebteam.blog==6.8.4
 canonicalwebteam.search==2.1.2
 canonicalwebteam.image-template==1.9.0
-canonicalwebteam.store-api==7.8.3
+canonicalwebteam.store-api==8.1.0
 canonicalwebteam.launchpad==0.9.0
 django-openid-auth==0.17
 Flask-OpenID==1.3.1

--- a/tests/publisher/snaps/tests_post_release.py
+++ b/tests/publisher/snaps/tests_post_release.py
@@ -100,7 +100,7 @@ class PostDataReleasePage(BaseTestCases.EndpointLoggedIn):
 
     @responses.activate
     def test_return_error(self):
-        payload = {"success": False, "errors": [{"name": ["message"]}]}
+        payload = {"error_list": [{"code": "code", "name": ["message"]}]}
 
         responses.add(responses.POST, self.api_url, json=payload, status=400)
 
@@ -113,4 +113,6 @@ class PostDataReleasePage(BaseTestCases.EndpointLoggedIn):
             },
         )
 
-        assert response.json == payload
+        expected_response = {"errors": [{"code": "code", "name": ["message"]}]}
+        assert response.status_code == 400
+        assert response.json == expected_response


### PR DESCRIPTION
## Done
Fix tests that are broken because of the store-api upgrade.

store-api v8 is just stricter about errors. real release errors already worked the same way in v7 and v8 so the app behaves exactly as before. Only one test was using a fake error format that v8 no longer accepts so thee test is fixed. 

## How to QA
- Go to https://snapcraft-io-5744.demos.haus/<snap>/releases
- promote a release, click around
- verify everything works as expected
- logout
- login
- verify you can login
- Go to https://snapcraft-io-5744.demos.haus/<snap>/listing
- Verify page loads
- Go to https://snapcraft-io-5744.demos.haus/<snap>/metrics
- Verify page loads
- Go to https://snapcraft-io-5744.demos.haus/<snap>/builds
- Verify page loads
- Go to https://snapcraft-io-5744.demos.haus/<snap>/settings
- Verify page loads
- Go to https://snapcraft-io-5744.demos.haus/code
- VErify all items loads
-  Go to https://snapcraft-io-5744.demos.haus/this-snap-does-not-exist
- Should throw 404 not 502

## Testing

- [x] This PR has tests
- [ ] No testing required (explain why):

## Security

- [ ] Security considerations for review (list them):
  - [ ] Examples:
  - [ ] Access control: users can only access their own data
  - [ ] Input: user input is validated and sanitised
  - [ ] Sensitive data: secret or private data is not exposed in any way
  - [ ] ...
- [x] This PR has no security considerations (explain why):

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-37176

