### PR TITLE
Revert dep updates

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -194,7 +194,7 @@ jobs:
         run: dotrun test-python-job
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v7
+        uses: codecov/codecov-action@v6
         with:
           flags: python
 
@@ -219,7 +219,7 @@ jobs:
           yarn test-js --coverage
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v7
+        uses: codecov/codecov-action@v6
         with:
           flags: javascript
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ canonicalwebteam.discourse==7.2.0
 canonicalwebteam.blog==6.8.4
 canonicalwebteam.search==2.1.2
 canonicalwebteam.image-template==1.9.0
-canonicalwebteam.store-api==8.1.0
+canonicalwebteam.store-api==7.8.3
 canonicalwebteam.launchpad==0.9.0
 django-openid-auth==0.17
 Flask-OpenID==1.3.1

--- a/tests/publisher/snaps/tests_post_release.py
+++ b/tests/publisher/snaps/tests_post_release.py
@@ -100,7 +100,7 @@ class PostDataReleasePage(BaseTestCases.EndpointLoggedIn):
 
     @responses.activate
     def test_return_error(self):
-        payload = {"error_list": [{"code": "code", "name": ["message"]}]}
+        payload = {"success": False, "errors": [{"name": ["message"]}]}
 
         responses.add(responses.POST, self.api_url, json=payload, status=400)
 
@@ -113,6 +113,4 @@ class PostDataReleasePage(BaseTestCases.EndpointLoggedIn):
             },
         )
 
-        expected_response = {"errors": [{"code": "code", "name": ["message"]}]}
-        assert response.status_code == 400
-        assert response.json == expected_response
+        assert response.json == payload

--- a/yarn.lock
+++ b/yarn.lock
@@ -8635,9 +8635,9 @@ tldts@^7.0.5:
     tldts-core "^7.0.24"
 
 tmp@~0.2.4:
-  version "0.2.7"
-  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.2.7.tgz#26f4db11d1601ce8012dcb8a798ece1c06a99059"
-  integrity sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==
+  version "0.2.5"
+  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.2.5.tgz#b06bcd23f0f3c8357b426891726d16015abfd8f8"
+  integrity sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==
 
 to-regex-range@^5.0.1:
   version "5.0.1"


### PR DESCRIPTION
## Done

Reverts dependency change updates as they break publisher pages

## How to QA
- Go to https://snapcraft-io-5752.demos.haus/snaps
- It should load correctly
- Click around logged in pages and check that work

## Testing

- [ ] This PR has tests
- [ ] No testing required (explain why):

## Security

- [ ] Security considerations for review (list them):
  - [ ] Examples:
  - [ ] Access control: users can only access their own data
  - [ ] Input: user input is validated and sanitised
  - [ ] Sensitive data: secret or private data is not exposed in any way
  - [ ] ...
- [ ] This PR has no security considerations (explain why):

## Issue / Card

Fixes #

## Screenshots

## UX Approval

- [ ] This PR does not require UX approval
- [ ] This PR does require UX approval (add context):
