### PR TITLE
Increase k8s memory limits (PS5 only)

### DIFF
--- a/konf/site.yaml
+++ b/konf/site.yaml
@@ -100,7 +100,7 @@ env: &env
       key: turnstile-secret-key
       name: snapcraft-io
 
-memoryLimit: 256Mi
+memoryLimit: 512Mi
 
 extraHosts:
   - domain: docs.snapcraft.io
@@ -129,7 +129,7 @@ production:
       app_name: snapcraft.io-discourse
       image: prod-comms.ps5.docker-registry.canonical.com/snapcraft.io
       replicas: 5
-      memoryLimit: 256Mi
+      memoryLimit: 512Mi
       env: *env
 
     - paths: [/blog]
@@ -137,7 +137,7 @@ production:
       app_name: snapcraft.io-blog
       image: prod-comms.ps5.docker-registry.canonical.com/snapcraft.io
       replicas: 3
-      memoryLimit: 256Mi
+      memoryLimit: 512Mi
       env: *env
 
 # Overrides for staging


### PR DESCRIPTION
## Done
gunicorn workers keep getting killed by the OOM killer and recreated by gunicorn causing log spam and potentially dropping requests. in the current configuration there are two workers that have to share 256MB of memory, but each worker consumes about 100MB at idle, putting the container under memory pressure.
this PR increases the k8s memory limits to 512MB in an attempt to mitigate the issue

## How to QA
can't QA, it can only be tested after deploying

## Testing

- [ ] This PR has tests
- [x] No testing required (explain why): can't test

## Security

- [ ] Security considerations for review (list them):
  - [ ] Examples:
  - [ ] Access control: users can only access their own data
  - [ ] Input: user input is validated and sanitised
  - [ ] Sensitive data: secret or private data is not exposed in any way
  - [ ] ...
- [x] This PR has no security considerations (explain why): increasing memory limits has no impact on security

## Issue / Card

Fixes #

## Screenshots

## UX Approval

- [x] This PR does not require UX approval
- [ ] This PR does require UX approval (add context):
