### PR TITLE
feat: Add edit description to remodel table

### DIFF
--- a/static/js/publisher/pages/Remodel/Remodel.tsx
+++ b/static/js/publisher/pages/Remodel/Remodel.tsx
@@ -22,6 +22,11 @@ import ConfigureRemodelForm from "./ConfigureRemodelForm";
 import type { UseQueryResult } from "react-query";
 import type { Remodel, RemodelResponse, ApiResponse } from "../../types/shared";
 
+const getRemodelRowId = (remodel: Remodel): string => {
+  const serial = remodel["from-serial"] ?? "all-serials";
+  return `${remodel["from-model"]}:${remodel["to-model"]}:${serial}`;
+};
+
 function Remodel(): React.JSX.Element {
   const { id, modelId } = useParams();
   const [searchParams, setSearchParams] = useSearchParams();
@@ -59,8 +64,27 @@ function Remodel(): React.JSX.Element {
   const [showErrorNotification, setShowErrorNotification] = useState(false);
   const [errorMessage, setErrorMessage] = useState("");
   const [isDeleting, setIsDeleting] = useState(false);
+  const [isSavingEdit, setIsSavingEdit] = useState(false);
+  const [editedDescriptions, setEditedDescriptions] = useState<
+    Record<string, string>
+  >({});
   const brandStore = useAtomValue(brandStoreState(id));
   const navigate = useNavigate();
+
+  const handleEditChange = (rowId: string, value: string) => {
+    setEditedDescriptions((previous) => ({
+      ...previous,
+      [rowId]: value,
+    }));
+  };
+
+  const handleEditCancel = (rowId: string) => {
+    setEditedDescriptions((previous) => {
+      const updated = { ...previous };
+      delete updated[rowId];
+      return updated;
+    });
+  };
 
   const handleDeleteRemodel = async (remodel: Remodel) => {
     setIsDeleting(true);
@@ -108,6 +132,63 @@ function Remodel(): React.JSX.Element {
       throw error;
     } finally {
       setIsDeleting(false);
+    }
+  };
+
+  const handleUpdateRemodel = async (remodel: Remodel) => {
+    const rowId = getRemodelRowId(remodel);
+    const description = editedDescriptions[rowId] ?? remodel["description"];
+
+    setIsSavingEdit(true);
+
+    const patchPayload = {
+      "from-model": remodel["from-model"],
+      "to-model": remodel["to-model"],
+      "from-serial": remodel["from-serial"],
+      description,
+    };
+
+    try {
+      const response = await fetch(
+        `/api/store/${brandId}/models/remodel-allowlist`,
+        {
+          method: "PATCH",
+          body: JSON.stringify(patchPayload),
+          headers: {
+            "Content-Type": "application/json",
+            "X-CSRF-Token": window.CSRF_TOKEN,
+          },
+        },
+      );
+      const responseData = await response.json();
+
+      if (!response.ok || !responseData.success) {
+        throw new Error(responseData.message || "Unable to update remodel");
+      }
+
+      setNotificationMessage("Remodel updated");
+      setShowNotification(true);
+      setEditedDescriptions((previous) => {
+        const updated = { ...previous };
+        delete updated[rowId];
+        return updated;
+      });
+
+      await queryClient.invalidateQueries({ queryKey: ["remodels"] });
+
+      setTimeout(() => {
+        setShowNotification(false);
+      }, 5000);
+    } catch (error) {
+      setErrorMessage(
+        error instanceof Error ? error.message : "Unable to update remodel",
+      );
+      setShowErrorNotification(true);
+      setTimeout(() => {
+        setShowErrorNotification(false);
+      }, 5000);
+    } finally {
+      setIsSavingEdit(false);
     }
   };
 
@@ -189,7 +270,12 @@ function Remodel(): React.JSX.Element {
                   }
                   pageSize={pageSize}
                   isDeleting={isDeleting}
+                  isSavingEdit={isSavingEdit}
+                  editedDescriptions={editedDescriptions}
                   onDeleteRemodel={handleDeleteRemodel}
+                  onEditChange={handleEditChange}
+                  onEditSave={handleUpdateRemodel}
+                  onEditCancel={handleEditCancel}
                 />
               )}
             </div>

--- a/static/js/publisher/pages/Remodel/RemodelTable.tsx
+++ b/static/js/publisher/pages/Remodel/RemodelTable.tsx
@@ -5,6 +5,7 @@ import {
   MainTable,
   Modal,
   TablePaginationControls,
+  Input,
 } from "@canonical/react-components";
 import { format } from "date-fns";
 
@@ -19,7 +20,17 @@ type Props = {
   backDisabled: boolean;
   pageSize: number;
   isDeleting: boolean;
+  isSavingEdit: boolean;
+  editedDescriptions: Record<string, string>;
   onDeleteRemodel: (remodel: Remodel) => Promise<void>;
+  onEditChange: (rowId: string, value: string) => void;
+  onEditSave: (remodel: Remodel) => Promise<void>;
+  onEditCancel: (rowId: string) => void;
+};
+
+const getRemodelRowId = (remodel: Remodel): string => {
+  const serial = remodel["from-serial"] ?? "all-serials";
+  return `${remodel["from-model"]}:${remodel["to-model"]}:${serial}`;
 };
 
 function RemodelTable({
@@ -31,10 +42,16 @@ function RemodelTable({
   backDisabled,
   pageSize,
   isDeleting,
+  isSavingEdit,
+  editedDescriptions,
   onDeleteRemodel,
+  onEditChange,
+  onEditSave,
+  onEditCancel,
 }: Props): React.JSX.Element {
   const [showDeleteModal, setShowDeleteModal] = useState(false);
   const [selectedRemodel, setSelectedRemodel] = useState<Remodel | null>(null);
+  const isBusy = isDeleting || isSavingEdit;
 
   const handleDeleteConfirm = async () => {
     if (!selectedRemodel) {
@@ -57,25 +74,35 @@ function RemodelTable({
       className: "u-truncate",
     },
     {
-      content: "Original model",
-      style: { width: "250px" },
+      content: "Serial",
       className: "u-truncate",
+      style: { width: "200px" },
     },
-    { content: "Serial", className: "u-truncate" },
     {
       content: "Created date",
       className: "u-align--right u-truncate",
       style: { width: "130px" },
     },
     { content: "Note", className: "u-truncate" },
-    { content: "Actions", className: "u-align--right" },
+    {
+      content: "Actions",
+      style: { width: "100px" },
+      className: "u-align--right",
+    },
   ];
 
   const rows = remodels.map((remodel: Remodel) => {
+    const rowId = getRemodelRowId(remodel);
+    const currentValue =
+      editedDescriptions[rowId] ?? remodel["description"] ?? "";
+    const originalValue = remodel["description"] ?? "";
+    const isDirty =
+      editedDescriptions[rowId] !== undefined &&
+      editedDescriptions[rowId] !== originalValue;
+
     return {
       columns: [
         { content: remodel["to-model"], className: "u-truncate" },
-        { content: remodel["from-model"], className: "u-truncate" },
         {
           content: remodel["from-serial"] || "All serial policies",
           className: "u-truncate",
@@ -84,22 +111,64 @@ function RemodelTable({
           content: format(new Date(remodel["created-at"]), "dd/MM/yyyy"),
           className: "u-align--right",
         },
-        { content: remodel["description"] },
         {
+          content: (
+            <>
+              <Input
+                type="text"
+                value={currentValue}
+                onChange={(event) => {
+                  onEditChange(rowId, event.target.value);
+                }}
+                disabled={isBusy}
+                className={!isDirty ? "u-no-margin--bottom" : ""}
+              />
+              {isDirty && (
+                <div className="u-align--right">
+                  <Button disabled={isBusy} onClick={() => onEditCancel(rowId)}>
+                    Revert
+                  </Button>
+                  <Button
+                    appearance="positive"
+                    disabled={isBusy}
+                    className="u-no-margin--right"
+                    onClick={() => {
+                      onEditSave(remodel);
+                    }}
+                  >
+                    Save
+                    {isSavingEdit && (
+                      <>
+                        &nbsp;
+                        <Icon
+                          name="spinner"
+                          light
+                          className="u-animation--spin"
+                        />
+                      </>
+                    )}
+                  </Button>
+                </div>
+              )}
+            </>
+          ),
+        },
+        {
+          className: "u-align--right",
           content: (
             <Button
               className="u-no-margin--bottom u-no-margin--right"
-              dense
-              disabled={isDeleting}
+              appearance="base"
+              disabled={isBusy}
               onClick={() => {
                 setSelectedRemodel(remodel);
                 setShowDeleteModal(true);
               }}
             >
-              Delete
+              <Icon name="delete" />
+              <span className="u-off-screen">Delete</span>
             </Button>
           ),
-          className: "u-align--right",
         },
       ],
     };
@@ -140,7 +209,7 @@ function RemodelTable({
       {showDeleteModal && selectedRemodel && (
         <Modal
           close={() => {
-            if (!isDeleting) {
+            if (!isBusy) {
               setShowDeleteModal(false);
               setSelectedRemodel(null);
             }
@@ -150,7 +219,7 @@ function RemodelTable({
             <>
               <Button
                 className="u-no-margin--bottom"
-                disabled={isDeleting}
+                disabled={isBusy}
                 onClick={() => {
                   setShowDeleteModal(false);
                   setSelectedRemodel(null);
@@ -161,7 +230,7 @@ function RemodelTable({
               <Button
                 className="u-no-margin--bottom u-no-margin--right"
                 appearance="negative"
-                disabled={isDeleting}
+                disabled={isBusy}
                 onClick={() => {
                   void handleDeleteConfirm();
                 }}

--- a/static/js/publisher/pages/Remodel/__tests__/Remodel.test.tsx
+++ b/static/js/publisher/pages/Remodel/__tests__/Remodel.test.tsx
@@ -110,6 +110,10 @@ mockUseSortTableData.mockReturnValue({
 const mockUseRemodels = vi.mocked(useRemodels);
 
 describe("Remodel", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it("displays message if user has no remodels access", () => {
     mockUseRemodels.mockReturnValue(useRemodelsNoPermissions);
     renderComponent();
@@ -208,6 +212,87 @@ describe("Remodel", () => {
 
     await user.click(screen.getByRole("button", { name: "Delete" }));
     await user.click(screen.getAllByRole("button", { name: "Delete" })[1]);
+
+    expect(await screen.findByText(errorMessage)).toBeInTheDocument();
+  });
+
+  it("updates remodel and shows success notification", async () => {
+    const invalidateQueriesSpy = vi
+      .spyOn(queryClient, "invalidateQueries")
+      .mockResolvedValue(undefined);
+    const fetchMock = vi.fn(async (_url: string, options?: RequestInit) => {
+      if (options?.method === "PATCH") {
+        return {
+          ok: true,
+          json: async () => ({ success: true }),
+        };
+      }
+
+      return {
+        ok: true,
+        json: async () => ({ success: true }),
+      };
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    mockUseRemodels.mockReturnValue(useRemodelsWithData);
+    renderComponent();
+    const user = userEvent.setup();
+
+    const input = screen.getByDisplayValue("test remodel");
+    await user.clear(input);
+    await user.type(input, "updated remodel");
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        expect.stringContaining("/models/remodel-allowlist"),
+        expect.objectContaining({
+          method: "PATCH",
+          body: JSON.stringify({
+            "from-model": "from-model-a",
+            "to-model": "to-model-a",
+            "from-serial": "serial-1",
+            description: "updated remodel",
+          }),
+          headers: {
+            "Content-Type": "application/json",
+            "X-CSRF-Token": undefined,
+          },
+        }),
+      );
+    });
+
+    expect(await screen.findByText("Remodel updated")).toBeInTheDocument();
+    expect(invalidateQueriesSpy).toHaveBeenCalledWith({
+      queryKey: ["remodels"],
+    });
+  });
+
+  it("shows error notification when update fails", async () => {
+    const errorMessage = "Unable to update remodel from API";
+    const fetchMock = vi.fn(async (_url: string, options?: RequestInit) => {
+      if (options?.method === "PATCH") {
+        return {
+          ok: true,
+          json: async () => ({ success: false, message: errorMessage }),
+        };
+      }
+
+      return {
+        ok: true,
+        json: async () => ({ success: true }),
+      };
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    mockUseRemodels.mockReturnValue(useRemodelsWithData);
+    renderComponent();
+    const user = userEvent.setup();
+
+    const input = screen.getByDisplayValue("test remodel");
+    await user.type(input, " edited");
+    await user.click(screen.getByRole("button", { name: "Save" }));
 
     expect(await screen.findByText(errorMessage)).toBeInTheDocument();
   });

--- a/static/js/publisher/pages/Remodel/__tests__/RemodelTable.test.tsx
+++ b/static/js/publisher/pages/Remodel/__tests__/RemodelTable.test.tsx
@@ -27,11 +27,38 @@ const remodels: Remodel[] = [
     "to-model": "to-model-a",
     description: "test remodel",
   },
+  {
+    "created-at": "2026-03-28T14:34:23.666Z",
+    "created-by": "test-user",
+    "from-model": "from-model-b",
+    "from-serial": "serial-2",
+    "modified-at": null,
+    "modified-by": null,
+    "to-model": "to-model-b",
+    description: "second remodel",
+  },
 ];
+
+const firstRowId = "from-model-a:to-model-a:serial-1";
+const secondRowId = "from-model-b:to-model-b:serial-2";
 
 const renderComponent = (
   onDeleteRemodel: (remodel: Remodel) => Promise<void> = vi.fn(async () => {}),
-  isDeleting = false,
+  {
+    isDeleting = false,
+    isSavingEdit = false,
+    editedDescriptions = {},
+    onEditChange = vi.fn(),
+    onEditSave = vi.fn(async () => {}),
+    onEditCancel = vi.fn(),
+  }: {
+    isDeleting?: boolean;
+    isSavingEdit?: boolean;
+    editedDescriptions?: Record<string, string>;
+    onEditChange?: (rowId: string, value: string) => void;
+    onEditSave?: (remodel: Remodel) => Promise<void>;
+    onEditCancel?: (rowId: string) => void;
+  } = {},
 ) => {
   return render(
     <BrowserRouter>
@@ -45,7 +72,12 @@ const renderComponent = (
           backDisabled={true}
           pageSize={10}
           isDeleting={isDeleting}
+          isSavingEdit={isSavingEdit}
+          editedDescriptions={editedDescriptions}
           onDeleteRemodel={onDeleteRemodel}
+          onEditChange={onEditChange}
+          onEditSave={onEditSave}
+          onEditCancel={onEditCancel}
         />
       </QueryClientProvider>
     </BrowserRouter>,
@@ -63,10 +95,6 @@ describe("RemodelTable", () => {
 
     expect(
       screen.getByRole("columnheader", { name: "Target model" }),
-    ).toBeInTheDocument();
-
-    expect(
-      screen.getByRole("columnheader", { name: "Original model" }),
     ).toBeInTheDocument();
 
     expect(
@@ -90,7 +118,7 @@ describe("RemodelTable", () => {
     renderComponent();
     const user = userEvent.setup();
 
-    await user.click(screen.getByRole("button", { name: "Delete" }));
+    await user.click(screen.getAllByRole("button", { name: "Delete" })[0]);
 
     expect(screen.getByText("Delete remodel")).toBeInTheDocument();
     expect(
@@ -107,9 +135,119 @@ describe("RemodelTable", () => {
     renderComponent(onDeleteRemodel);
     const user = userEvent.setup();
 
-    await user.click(screen.getByRole("button", { name: "Delete" }));
-    await user.click(screen.getAllByRole("button", { name: "Delete" })[1]);
+    await user.click(screen.getAllByRole("button", { name: "Delete" })[0]);
+    const deleteButtons = screen.getAllByRole("button", { name: "Delete" });
+    await user.click(deleteButtons[deleteButtons.length - 1]);
 
     expect(onDeleteRemodel).toHaveBeenCalledWith(remodels[0]);
+  });
+
+  it("shows input fields for all descriptions", () => {
+    renderComponent();
+
+    const inputs = screen.getAllByRole("textbox");
+    expect(inputs).toHaveLength(2);
+    expect(inputs[0]).toHaveValue("test remodel");
+    expect(inputs[1]).toHaveValue("second remodel");
+  });
+
+  it("does not show save/cancel buttons when value is unchanged", () => {
+    renderComponent();
+
+    expect(
+      screen.queryByRole("button", { name: "Save" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Revert" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows save/cancel buttons when value differs from original", () => {
+    renderComponent(undefined, {
+      editedDescriptions: { [firstRowId]: "modified description" },
+    });
+
+    expect(screen.getByRole("button", { name: "Save" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Revert" })).toBeInTheDocument();
+  });
+
+  it("supports multiple rows with pending edits simultaneously", () => {
+    renderComponent(undefined, {
+      editedDescriptions: {
+        [firstRowId]: "modified first",
+        [secondRowId]: "modified second",
+      },
+    });
+
+    const saveButtons = screen.getAllByRole("button", {
+      name: "Save",
+    });
+    const cancelButtons = screen.getAllByRole("button", {
+      name: "Revert",
+    });
+
+    expect(saveButtons).toHaveLength(2);
+    expect(cancelButtons).toHaveLength(2);
+  });
+
+  it("calls onEditSave with active row remodel when save is clicked", async () => {
+    const user = userEvent.setup();
+    const onEditSave = vi.fn(async () => {});
+
+    renderComponent(undefined, {
+      editedDescriptions: { [firstRowId]: "modified description" },
+      onEditSave,
+    });
+
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(onEditSave).toHaveBeenCalledWith(remodels[0]);
+  });
+
+  it("calls onEditChange when editing note text", async () => {
+    const user = userEvent.setup();
+    const onEditChange = vi.fn();
+
+    renderComponent(undefined, {
+      onEditChange,
+    });
+
+    const inputs = screen.getAllByRole("textbox");
+    await user.clear(inputs[0]);
+    await user.type(inputs[0], "updated note");
+
+    expect(onEditChange).toHaveBeenCalled();
+  });
+
+  it("calls onEditCancel with rowId when cancel button is clicked", async () => {
+    const user = userEvent.setup();
+    const onEditCancel = vi.fn();
+
+    renderComponent(undefined, {
+      editedDescriptions: { [firstRowId]: "modified description" },
+      onEditCancel,
+    });
+
+    await user.click(screen.getByRole("button", { name: "Revert" }));
+
+    expect(onEditCancel).toHaveBeenCalledWith(firstRowId);
+  });
+
+  it("delete buttons are always visible", () => {
+    renderComponent();
+
+    const deleteButtons = screen.getAllByRole("button", { name: "Delete" });
+    expect(deleteButtons).toHaveLength(2);
+  });
+
+  it("disables delete buttons when busy", () => {
+    renderComponent(undefined, {
+      isDeleting: true,
+    });
+
+    const deleteButtons = screen.getAllByRole("button", { name: "Delete" });
+    deleteButtons.forEach((button) => {
+      expect(button).toHaveAttribute("aria-disabled", "true");
+    });
   });
 });


### PR DESCRIPTION
## Done
Adds the option to add/edit the description field of a remodel allowlist

## How to QA
- Go to https://snapcraft-io-5756.demos.haus/admin/ahnuP3quahti9vis8aiw/models/testing-model-new-2/remodel
- Click the pencil/edit icon to edit a field
- Check that you can add a note to a remodel that doesn't have one
- Check that you can edit the note of a remodel that already has one
- Check that you can remove the note of a remodel (by leaving it blank)

## Testing

- [x] This PR has tests
- [ ] No testing required (explain why):

## Security

- [ ] Security considerations for review (list them):
  - [ ] Examples:
  - [ ] Access control: users can only access their own data
  - [ ] Input: user input is validated and sanitised
  - [ ] Sensitive data: secret or private data is not exposed in any way
  - [ ] ...
- [x] This PR has no security considerations (explain why): Input is escaped

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-36949

## Screenshots
n/a

## UX Approval

- [ ] This PR does not require UX approval
- [x] This PR does require UX approval (add context):
