### PR TITLE
fix: Update Thunderbird screenshot on homepage

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -127,7 +127,7 @@
     <div class="u-fixed-width">
       {{
         image(
-          url="https://assets.ubuntu.com/v1/4c8b43dc-thunderbird-snap-page.png",
+          url="https://assets.ubuntu.com/v1/a0501ed2-thunderbird_snap_page.png",
           alt="Snap details page",
           width="2216",
           height="1591",


### PR DESCRIPTION
## Done
Updates the screenshot of Thunderbird on the homepage

## How to QA
- Go to https://snapcraft-io-5759.demos.haus/
- Scroll down to the "Showcase to millions" section
- Check that the Thunderbird screenshot has been updated to show the latests publisher page layout

## Testing

- [ ] This PR has tests
- [x] No testing required (explain why):

## Security

- [ ] Security considerations for review (list them):
  - [ ] Examples:
  - [ ] Access control: users can only access their own data
  - [ ] Input: user input is validated and sanitised
  - [ ] Sensitive data: secret or private data is not exposed in any way
  - [ ] ...
- [x] This PR has no security considerations (explain why):

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-37102

## Screenshots

## UX Approval

- [x] This PR does not require UX approval
- [ ] This PR does require UX approval (add context):
