### PR TITLE
chore: refactor login and macaroon auth

### DIFF
--- a/tests/login/tests_login_handler.py
+++ b/tests/login/tests_login_handler.py
@@ -23,8 +23,7 @@ class LoginHandlerTest(TestCase):
     def test_redirect_user_logged_in(self):
         with self.client.session_transaction() as s:
             s["publisher"] = "openid"
-            s["macaroon_root"] = "macaroon_root"
-            s["macaroon_discharge"] = "macaroon_discharge"
+            s["macaroon_exchanged"] = "macaroon_exchanged"
 
         response = self.client.get(self.endpoint_url)
         assert response.status_code == 302
@@ -33,8 +32,7 @@ class LoginHandlerTest(TestCase):
     def test_redirect_user_logged_in_next_url(self):
         with self.client.session_transaction() as s:
             s["publisher"] = "openid"
-            s["macaroon_root"] = "macaroon_root"
-            s["macaroon_discharge"] = "macaroon_discharge"
+            s["macaroon_exchanged"] = "macaroon_exchanged"
 
         response = self.client.get(self.endpoint_url + "?next=/test")
         assert response.status_code == 302
@@ -119,6 +117,17 @@ class AfterLoginHandlerTest(TestCase):
     def prepare_mock_response(
         self, mock_get_account, email="test@test.com", groups=[]
     ):
+        root = Macaroon(location="store", identifier="root", key="root-key")
+        root.add_third_party_caveat(
+            "login.ubuntu.com", "caveat-key", "caveat-id"
+        )
+        self.root_macaroon = root.serialize()
+        discharge = Macaroon(
+            location="login.ubuntu.com",
+            identifier="caveat-id",
+            key="caveat-key",
+        ).serialize()
+
         self.mock_resp = MagicMock()
         self.mock_resp.nickname = "test"
         self.mock_resp.identity_url = "https://login.ubuntu.com/test"
@@ -126,7 +135,7 @@ class AfterLoginHandlerTest(TestCase):
         self.mock_resp.image = "test.png"
         self.mock_resp.email = email
         self.mock_resp.extensions = {
-            "macaroon": MagicMock(discharge="some-discharge"),
+            "macaroon": MagicMock(discharge=discharge),
             "lp": MagicMock(is_member=groups),
         }
 
@@ -143,6 +152,10 @@ class AfterLoginHandlerTest(TestCase):
     @patch(
         "webapp.login.views.dashboard.get_validation_sets", return_value=None
     )
+    @patch(
+        "webapp.login.views.publisher_gateway.exchange_dashboard_macaroons",
+        return_value="exchanged-macaroon",
+    )
     @patch("webapp.login.views.dashboard.get_account")
     def test_is_canonical_true_if_email_ends_with_canonical_on_staging(
         self,
@@ -155,6 +168,40 @@ class AfterLoginHandlerTest(TestCase):
             mock_get_account, email="test@canonical.com", groups=[]
         )
 
+        with self.client.session_transaction() as s:
+            s["macaroon_root"] = self.root_macaroon
+        self.client.get("/_test_after_login")
+
+        with self.client.session_transaction() as s:
+            publisher = s.get("publisher")
+            assert publisher is not None
+            assert publisher["is_canonical"] is True
+            assert s["macaroon_exchanged"] == "exchanged-macaroon"
+            assert "macaroon_root" not in s
+            assert "macaroon_discharge" not in s
+
+    @patch("webapp.login.views.ENVIRONMENT", "production")
+    @patch("webapp.login.views.dashboard.get_stores", return_value=[])
+    @patch("webapp.login.views.logic.get_stores", return_value=[])
+    @patch(
+        "webapp.login.views.dashboard.get_validation_sets", return_value=None
+    )
+    @patch(
+        "webapp.login.views.publisher_gateway.exchange_dashboard_macaroons",
+        return_value="exchanged-macaroon",
+    )
+    @patch("webapp.login.views.dashboard.get_account")
+    def test_is_canonical_true_if_member_of_team_on_production(
+        self,
+        mock_get_account,
+        *_,
+    ):
+        # on production, we treat publisher's account as "canonical"
+        # if they are a member of the canonical team
+        self.prepare_mock_response(mock_get_account, groups=["canonical"])
+
+        with self.client.session_transaction() as s:
+            s["macaroon_root"] = self.root_macaroon
         self.client.get("/_test_after_login")
 
         with self.client.session_transaction() as s:
@@ -168,28 +215,9 @@ class AfterLoginHandlerTest(TestCase):
     @patch(
         "webapp.login.views.dashboard.get_validation_sets", return_value=None
     )
-    @patch("webapp.login.views.dashboard.get_account")
-    def test_is_canonical_true_if_member_of_team_on_production(
-        self,
-        mock_get_account,
-        *_,
-    ):
-        # on production, we treat publisher's account as "canonical"
-        # if they are a member of the canonical team
-        self.prepare_mock_response(mock_get_account, groups=["canonical"])
-
-        self.client.get("/_test_after_login")
-
-        with self.client.session_transaction() as s:
-            publisher = s.get("publisher")
-            assert publisher is not None
-            assert publisher["is_canonical"] is True
-
-    @patch("webapp.login.views.ENVIRONMENT", "production")
-    @patch("webapp.login.views.dashboard.get_stores", return_value=[])
-    @patch("webapp.login.views.logic.get_stores", return_value=[])
     @patch(
-        "webapp.login.views.dashboard.get_validation_sets", return_value=None
+        "webapp.login.views.publisher_gateway.exchange_dashboard_macaroons",
+        return_value="exchanged-macaroon",
     )
     @patch("webapp.login.views.dashboard.get_account")
     def test_is_canonical_false_if_not_member_of_team_on_production(
@@ -203,9 +231,49 @@ class AfterLoginHandlerTest(TestCase):
             mock_get_account, email="test@canonical.com", groups=[]
         )
 
+        with self.client.session_transaction() as s:
+            s["macaroon_root"] = self.root_macaroon
         self.client.get("/_test_after_login")
 
         with self.client.session_transaction() as s:
             publisher = s.get("publisher")
             assert publisher is not None
             assert publisher["is_canonical"] is False
+
+    def test_after_login_exchanges_macaroons_and_clears_root_and_discharge(
+        self,
+    ):
+        self.prepare_mock_response(MagicMock(), groups=["canonical"])
+
+        with patch(
+            "webapp.login.views.dashboard.get_account",
+            return_value={
+                "username": "test",
+                "displayname": "Test",
+                "email": "test@test.com",
+                "stores": [],
+            },
+        ), patch(
+            "webapp.login.views.dashboard.get_validation_sets",
+            return_value=None,
+        ), patch(
+            "webapp.login.views.dashboard.get_stores", return_value=[]
+        ), patch(
+            "webapp.login.views.logic.get_stores", return_value=[]
+        ), patch(
+            "webapp.login.views.publisher_gateway"
+            ".exchange_dashboard_macaroons",
+            return_value="exchanged-macaroon",
+        ) as mock_exchange:
+            with self.client.session_transaction() as s:
+                s["macaroon_root"] = self.root_macaroon
+
+            response = self.client.get("/_test_after_login")
+
+            assert response.status_code == 302
+            with self.client.session_transaction() as s:
+                assert s["macaroon_exchanged"] == "exchanged-macaroon"
+                assert "macaroon_root" not in s
+                assert "macaroon_discharge" not in s
+
+            mock_exchange.assert_called_once()

--- a/tests/publisher/endpoint_testing.py
+++ b/tests/publisher/endpoint_testing.py
@@ -2,7 +2,6 @@ from unittest.mock import patch
 
 import requests
 
-import pymacaroons
 import responses
 from flask_testing import TestCase
 from webapp.app import create_app
@@ -42,16 +41,12 @@ class BaseTestCases:
         def _log_in(self, client):
             """Emulates test client login in the store.
 
-            Fill current session with `openid`, `macaroon_root` and
-            `macaroon_discharge`.
+            Fill current session with `openid` and `macaroon_exchanged`.
 
             Return the expected `Authorization` header for further verification
             in API requests.
             """
-            # Basic root/discharge macaroons pair.
-            root = pymacaroons.Macaroon("test", "testing", "a_key")
-            root.add_third_party_caveat("3rd", "a_caveat-key", "a_ident")
-            discharge = pymacaroons.Macaroon("3rd", "a_ident", "a_caveat_key")
+            exchanged_macaroon = "test-exchanged-macaroon"
 
             with client.session_transaction() as s:
                 s["publisher"] = {
@@ -61,12 +56,9 @@ class BaseTestCases:
                     "email": "testing@testing.com",
                     "stores": [],
                 }
-                s["macaroon_root"] = root.serialize()
-                s["macaroon_discharge"] = discharge.serialize()
+                s["macaroon_exchanged"] = exchanged_macaroon
 
-            return get_authorization_header(
-                root.serialize(), discharge.serialize()
-            )
+            return get_authorization_header(exchanged_macaroon)
 
         def check_call_by_api_url(self, calls):
             found = False
@@ -246,13 +238,6 @@ class BaseTestCases:
                     headers={"WWW-Authenticate": "Macaroon needs_refresh=1"},
                 )
             )
-            responses.add(
-                responses.POST,
-                "https://login.ubuntu.com/api/v2/tokens/refresh",
-                json={"discharge_macaroon": "macaroon"},
-                status=200,
-            )
-
             if self.method_endpoint == "GET":
                 response = self.client.get(self.endpoint_url)
             else:
@@ -265,14 +250,8 @@ class BaseTestCases:
                         self.endpoint_url, json=self.json
                     )
 
-            called = responses.calls[len(responses.calls) - 1]
-            self.assertEqual(
-                "https://login.ubuntu.com/api/v2/tokens/refresh",
-                called.request.url,
-            )
-
             assert response.status_code == 302
-            assert response.location == self._get_location()
+            assert response.location == (f"/login?next={self.endpoint_url}")
 
     class EndpointLoggedInErrorHandling(EndpointLoggedIn):
         @responses.activate

--- a/tests/publisher/tests_publisher.py
+++ b/tests/publisher/tests_publisher.py
@@ -1,6 +1,5 @@
 from requests.exceptions import ConnectionError
 
-import pymacaroons
 import responses
 from flask_testing import TestCase
 from tests.publisher.endpoint_testing import BaseTestCases
@@ -61,16 +60,12 @@ class PublisherPage(TestCase):
     def _log_in(self, client):
         """Emulates test client login in the store.
 
-        Fill current session with `openid`, `macaroon_root` and
-        `macaroon_discharge`.
+        Fill current session with `openid` and `macaroon_exchanged`.
 
         Return the expected `Authorization` header for further verification in
         API requests.
         """
-        # Basic root/discharge macaroons pair.
-        root = pymacaroons.Macaroon("test", "testing", "a_key")
-        root.add_third_party_caveat("3rd", "a_caveat-key", "a_ident")
-        discharge = pymacaroons.Macaroon("3rd", "a_ident", "a_caveat_key")
+        exchanged_macaroon = "test-exchanged-macaroon"
 
         with client.session_transaction() as s:
             s["publisher"] = {
@@ -79,12 +74,9 @@ class PublisherPage(TestCase):
                 "fullname": "El Toto",
                 "email": "test@example.com",
             }
-            s["macaroon_root"] = root.serialize()
-            s["macaroon_discharge"] = discharge.serialize()
+            s["macaroon_exchanged"] = exchanged_macaroon
 
-        return get_authorization_header(
-            root.serialize(), discharge.serialize()
-        )
+        return get_authorization_header(exchanged_macaroon)
 
     def test_username_not_logged_in(self):
         response = self.client.get("/account/username")

--- a/tests/store/tests_details.py
+++ b/tests/store/tests_details.py
@@ -411,8 +411,7 @@ class GetDetailsPageTest(TestCase):
         with self.client.session_transaction() as s:
             # make test session 'authenticated'
             s["publisher"] = {"nickname": "toto", "fullname": "Totinio"}
-            s["macaroon_root"] = "test"
-            s["macaroon_discharge"] = "test"
+            s["macaroon_exchanged"] = "test"
             # mock test user snaps list
             s["user_snaps"] = {"toto": {"snap-id": "test"}}
 

--- a/tests/store/tests_github_badge.py
+++ b/tests/store/tests_github_badge.py
@@ -232,8 +232,7 @@ class GetGitHubBadgeTest(TestCase):
         with self.client.session_transaction() as s:
             # make test session 'authenticated'
             s["publisher"] = {"nickname": "toto", "fullname": "Totinio"}
-            s["macaroon_root"] = "test"
-            s["macaroon_discharge"] = "test"
+            s["macaroon_exchanged"] = "test"
             # mock test user snaps list
             s["user_snaps"] = {"toto": {"snap-id": "test"}}
 

--- a/tests/tests_authentication.py
+++ b/tests/tests_authentication.py
@@ -5,6 +5,8 @@ from webapp.authentication import (
     SESSION_INTEGRATION_KEYS,
     SESSION_DATA_KEYS,
     empty_session,
+    get_authorization_header,
+    is_authenticated,
     reset_auth_session,
 )
 
@@ -38,4 +40,30 @@ class TestResetAuthSession(unittest.TestCase):
         self.assertEqual(
             set(SESSION_AUTH_KEYS).intersection(set(SESSION_INTEGRATION_KEYS)),
             set(),
+        )
+
+    def test_get_authorization_header_uses_single_exchanged_macaroon(self):
+        self.assertEqual(
+            get_authorization_header("test-macaroon"),
+            "Macaroon test-macaroon",
+        )
+
+    def test_is_authenticated_with_exchanged_macaroon(self):
+        self.assertTrue(
+            is_authenticated(
+                {
+                    "publisher": {"nickname": "test"},
+                    "macaroon_exchanged": "test-macaroon",
+                }
+            )
+        )
+
+    def test_is_authenticated_with_legacy_macaroons(self):
+        self.assertTrue(
+            is_authenticated(
+                {
+                    "publisher": {"nickname": "test"},
+                    "macaroons": "legacy-macaroon",
+                }
+            )
         )

--- a/webapp/authentication.py
+++ b/webapp/authentication.py
@@ -2,6 +2,8 @@ import os
 
 from urllib.parse import urlparse
 
+from canonicalwebteam.store_api import dashboard as store_api_dashboard
+from canonicalwebteam.store_api import publishergw as store_api_publishergw
 from pymacaroons import Macaroon
 from webapp.api import sso
 
@@ -22,6 +24,7 @@ PERMISSIONS = [
 # keys for session data that should be cleared on auth refresh
 SESSION_AUTH_KEYS = [
     "macaroons",
+    "macaroon_exchanged",
     "macaroon_root",
     "macaroon_discharge",
     "publisher",
@@ -38,16 +41,42 @@ SESSION_INTEGRATION_KEYS = [
 SESSION_DATA_KEYS = SESSION_AUTH_KEYS + SESSION_INTEGRATION_KEYS
 
 
-def get_authorization_header(root, discharge):
+def get_authorization_header(macaroon):
     """
-    Bind root and discharge macaroons and return the authorization header.
+    Return the authorization header value for an exchanged macaroon.
     """
+    return f"Macaroon {macaroon}"
 
-    bound = Macaroon.deserialize(root).prepare_for_request(
-        Macaroon.deserialize(discharge)
-    )
 
-    return "macaroon root={}, discharge={}".format(root, bound.serialize())
+def get_session_authorization_headers(session):
+    """
+    Return the correct authorization headers for the current session.
+    """
+    if "macaroon_exchanged" in session:
+        return {
+            "Authorization": get_authorization_header(
+                session["macaroon_exchanged"]
+            )
+        }
+
+    if "macaroon_root" in session and "macaroon_discharge" in session:
+        root = session["macaroon_root"]
+        discharge = session["macaroon_discharge"]
+
+        bound = Macaroon.deserialize(root).prepare_for_request(
+            Macaroon.deserialize(discharge)
+        )
+
+        return {
+            "Authorization": (
+                f"macaroon root={root}, discharge={bound.serialize()}"
+            )
+        }
+
+    if "macaroons" in session:
+        return {"Macaroons": session["macaroons"]}
+
+    return {"Macaroons": ""}
 
 
 def get_publishergw_authorization_header(developer_token):
@@ -60,10 +89,14 @@ def is_authenticated(session):
     Returns True if the user is authenticated
     """
     return (
-        "publisher" in session
-        and "macaroon_discharge" in session
-        and "macaroon_root" in session
-    ) or ("publisher" in session and "macaroons" in session)
+        ("publisher" in session and "macaroon_exchanged" in session)
+        or (
+            "publisher" in session
+            and "macaroon_discharge" in session
+            and "macaroon_root" in session
+        )
+        or ("publisher" in session and "macaroons" in session)
+    )
 
 
 def empty_session(session):
@@ -124,3 +157,15 @@ def is_macaroon_expired(headers):
     the header response.
     """
     return headers.get("WWW-Authenticate") == ("Macaroon needs_refresh=1")
+
+
+def _store_api_authorization_header(_self, session):
+    return get_session_authorization_headers(session)
+
+
+store_api_dashboard.Dashboard._get_authorization_header = (
+    _store_api_authorization_header
+)
+store_api_publishergw.dashboard_authorization_header = (
+    get_session_authorization_headers
+)

--- a/webapp/decorators.py
+++ b/webapp/decorators.py
@@ -133,10 +133,15 @@ def exchange_required(func):
     @functools.wraps(func)
     def is_exchanged(*args, **kwargs):
         if "exchanged_developer_token" not in flask.session:
-            result = publisher_gateway.exchange_dashboard_macaroons(
-                flask.session
-            )
-            flask.session["developer_token"] = result
+            if "macaroon_exchanged" in flask.session:
+                flask.session["developer_token"] = flask.session[
+                    "macaroon_exchanged"
+                ]
+            else:
+                result = publisher_gateway.exchange_dashboard_macaroons(
+                    flask.session
+                )
+                flask.session["developer_token"] = result
             flask.session["exchanged_developer_token"] = True
         return func(*args, **kwargs)
 

--- a/webapp/handlers.py
+++ b/webapp/handlers.py
@@ -138,6 +138,12 @@ if IS_DEVELOPMENT:
 
 
 def refresh_redirect():
+    if "macaroon_exchanged" in flask.session:
+        authentication.reset_auth_session(flask.session)
+        return flask.redirect(
+            flask.url_for("login.login_handler", next=flask.request.path)
+        )
+
     try:
         macaroon_discharge = authentication.get_refreshed_discharge(
             flask.session["macaroon_discharge"]

--- a/webapp/handlers.py
+++ b/webapp/handlers.py
@@ -141,7 +141,10 @@ def refresh_redirect():
     if "macaroon_exchanged" in flask.session:
         authentication.reset_auth_session(flask.session)
         return flask.redirect(
-            flask.url_for("login.login_handler", next=flask.request.path)
+            flask.url_for(
+                "login.login_handler",
+                next=flask.request.full_path.rstrip("?"),
+            )
         )
 
     try:

--- a/webapp/login/views.py
+++ b/webapp/login/views.py
@@ -77,6 +77,9 @@ def after_login(resp):
     discharge_macaroon = resp.extensions["macaroon"].discharge
     flask.session["macaroon_discharge"] = discharge_macaroon
 
+    if not resp.nickname:
+        return flask.redirect(LOGIN_URL)
+
     # Exchange root + discharge for a single dashboard token.
     # Both keys are in the session here, so exchange_dashboard_macaroons
     # can read them directly. We then drop them to keep the cookie small.
@@ -85,9 +88,6 @@ def after_login(resp):
     )
     flask.session.pop("macaroon_root", None)
     flask.session.pop("macaroon_discharge", None)
-
-    if not resp.nickname:
-        return flask.redirect(LOGIN_URL)
 
     account = dashboard.get_account(flask.session)
     validation_sets = dashboard.get_validation_sets(flask.session)

--- a/webapp/login/views.py
+++ b/webapp/login/views.py
@@ -74,7 +74,17 @@ def login_handler():
 
 @open_id.after_login
 def after_login(resp):
-    flask.session["macaroon_discharge"] = resp.extensions["macaroon"].discharge
+    discharge_macaroon = resp.extensions["macaroon"].discharge
+    flask.session["macaroon_discharge"] = discharge_macaroon
+
+    # Exchange root + discharge for a single dashboard token.
+    # Both keys are in the session here, so exchange_dashboard_macaroons
+    # can read them directly. We then drop them to keep the cookie small.
+    flask.session["macaroon_exchanged"] = (
+        publisher_gateway.exchange_dashboard_macaroons(flask.session)
+    )
+    flask.session.pop("macaroon_root", None)
+    flask.session.pop("macaroon_discharge", None)
 
     if not resp.nickname:
         return flask.redirect(LOGIN_URL)


### PR DESCRIPTION
## Done
- Fix the login approach to exchange the raw root + discharge macaroons for a single  store token at login time, then discard both originals. (instead of storing the exchange and discharge one, we only keep the store one, reducing cookie size)

## How to QA
- Login with demo link
- Compare the `session` cookie size with what you get in snapcraft.io
- hopefully its less
- Make sure all auth routes work fine, no 401s, weird errors etc

## Issue / Card

Fixes WD-37297

