### PR TITLE
feat: Add bulk delete to remodels table

### DIFF
--- a/static/js/publisher/pages/Remodel/Remodel.tsx
+++ b/static/js/publisher/pages/Remodel/Remodel.tsx
@@ -8,7 +8,7 @@ import {
   useLocation,
   useSearchParams,
 } from "react-router-dom";
-import { Notification, Icon, Row, Col } from "@canonical/react-components";
+import { Notification, Icon, Button, Modal } from "@canonical/react-components";
 
 import { useRemodels } from "../../hooks";
 import { remodelsListState } from "../../state/remodelsState";
@@ -63,11 +63,13 @@ function Remodel(): React.JSX.Element {
   );
   const [showErrorNotification, setShowErrorNotification] = useState(false);
   const [errorMessage, setErrorMessage] = useState("");
-  const [isDeleting, setIsDeleting] = useState(false);
   const [isSavingEdit, setIsSavingEdit] = useState(false);
   const [editedDescriptions, setEditedDescriptions] = useState<
     Record<string, string>
   >({});
+  const [remodelsToDelete, setRemodelsToDelete] = useState<Remodel[]>([]);
+  const [showBulkDeleteModal, setShowBulkDeleteModal] = useState(false);
+  const [isBulkDeleting, setIsBulkDeleting] = useState(false);
   const brandStore = useAtomValue(brandStoreState(id));
   const navigate = useNavigate();
 
@@ -86,13 +88,14 @@ function Remodel(): React.JSX.Element {
     });
   };
 
-  const handleDeleteRemodel = async (remodel: Remodel) => {
-    setIsDeleting(true);
-    const deletePayload = {
+  const handleBulkDeleteRemodels = async () => {
+    setIsBulkDeleting(true);
+
+    const deletePayload = remodelsToDelete.map((remodel) => ({
       "from-model": remodel["from-model"],
       "to-model": remodel["to-model"],
       "from-serial": remodel["from-serial"],
-    };
+    }));
 
     try {
       const response = await fetch(
@@ -109,11 +112,14 @@ function Remodel(): React.JSX.Element {
       const responseData = await response.json();
 
       if (!response.ok || !responseData.success) {
-        throw new Error(responseData.message || "Unable to delete remodel");
+        throw new Error(responseData.message || "Unable to delete remodels");
       }
 
-      setNotificationMessage("Remodel deleted");
+      const count = remodelsToDelete.length;
+      setNotificationMessage(`${count} remodel${count > 1 ? "s" : ""} deleted`);
       setShowNotification(true);
+      setRemodelsToDelete([]);
+      setShowBulkDeleteModal(false);
 
       await queryClient.invalidateQueries({ queryKey: ["remodels"] });
 
@@ -122,16 +128,14 @@ function Remodel(): React.JSX.Element {
       }, 5000);
     } catch (error) {
       setErrorMessage(
-        error instanceof Error ? error.message : "Unable to delete remodel",
+        error instanceof Error ? error.message : "Unable to delete remodels",
       );
       setShowErrorNotification(true);
       setTimeout(() => {
         setShowErrorNotification(false);
       }, 5000);
-
-      throw error;
     } finally {
-      setIsDeleting(false);
+      setIsBulkDeleting(false);
     }
   };
 
@@ -247,16 +251,35 @@ function Remodel(): React.JSX.Element {
           </Notification>
         ) : (
           <>
-            <Row>
-              <Col size={12} className="u-align--right">
-                <Link
-                  className={`p-button--positive ${isError && !data ? "is-disabled" : ""}`}
-                  to={`/admin/${id}/models/${modelId}/remodel/configure`}
-                >
-                  Configure remodels
-                </Link>
-              </Col>
-            </Row>
+            <div className="u-fixed-width u-align--right">
+              <Button
+                disabled={remodelsToDelete.length === 0 || isBulkDeleting}
+                onClick={() => setShowBulkDeleteModal(true)}
+                className={isBulkDeleting ? "has-icon" : ""}
+              >
+                {isBulkDeleting ? (
+                  <>
+                    <Icon
+                      name="spinner"
+                      className="u-animation--spin is-light"
+                    />
+                    &nbsp;Deleting...
+                  </>
+                ) : remodelsToDelete.length > 1 ? (
+                  `Delete ${remodelsToDelete.length} remodels`
+                ) : (
+                  "Delete remodel"
+                )}
+              </Button>
+
+              <Link
+                className={`p-button--positive ${isError && !data ? "is-disabled" : ""}`}
+                to={`/admin/${id}/models/${modelId}/remodel/configure`}
+              >
+                Configure remodels
+              </Link>
+            </div>
+
             <div className="u-flex-column u-flex-grow">
               {data && (
                 <RemodelTable
@@ -269,13 +292,13 @@ function Remodel(): React.JSX.Element {
                     cursorHistory.current.length < 1 || currentCursor === null
                   }
                   pageSize={pageSize}
-                  isDeleting={isDeleting}
                   isSavingEdit={isSavingEdit}
                   editedDescriptions={editedDescriptions}
-                  onDeleteRemodel={handleDeleteRemodel}
                   onEditChange={handleEditChange}
                   onEditSave={handleUpdateRemodel}
                   onEditCancel={handleEditCancel}
+                  remodelsToDelete={remodelsToDelete}
+                  setRemodelsToDelete={setRemodelsToDelete}
                 />
               )}
             </div>
@@ -310,7 +333,77 @@ function Remodel(): React.JSX.Element {
           </div>
         )}
       </PortalEntrance>
-
+      <PortalEntrance name="modal">
+        {showBulkDeleteModal && (
+          <Modal
+            close={() => {
+              if (!isBulkDeleting) {
+                setShowBulkDeleteModal(false);
+              }
+            }}
+            title={
+              remodelsToDelete.length > 1
+                ? `Delete ${remodelsToDelete.length} remodels`
+                : "Delete remodel"
+            }
+            buttonRow={
+              <>
+                <Button
+                  className="u-no-margin--bottom"
+                  disabled={isBulkDeleting}
+                  onClick={() => setShowBulkDeleteModal(false)}
+                >
+                  Cancel
+                </Button>
+                <Button
+                  className="u-no-margin--bottom u-no-margin--right"
+                  appearance="negative"
+                  disabled={isBulkDeleting}
+                  onClick={() => {
+                    handleBulkDeleteRemodels();
+                  }}
+                >
+                  {isBulkDeleting ? (
+                    <>
+                      <Icon
+                        name="spinner"
+                        className="u-animation--spin is-light"
+                      />
+                      &nbsp;Deleting...
+                    </>
+                  ) : (
+                    "Delete"
+                  )}
+                </Button>
+              </>
+            }
+          >
+            {remodelsToDelete.length > 1 && (
+              <ul>
+                {remodelsToDelete.map((remodel) => {
+                  const rowId = getRemodelRowId(remodel);
+                  return (
+                    <li key={rowId}>
+                      <strong>
+                        {remodel["from-model"]} → {remodel["to-model"]}
+                      </strong>
+                      {remodel["from-serial"] && (
+                        <> (Serial: {remodel["from-serial"]})</>
+                      )}
+                    </li>
+                  );
+                })}
+              </ul>
+            )}
+            <p>
+              Are you sure you want to delete{" "}
+              {remodelsToDelete.length > 1 ? "these remodels" : "this remodel"}?
+              <br />
+              This action cannot be undone.
+            </p>
+          </Modal>
+        )}
+      </PortalEntrance>
       <PortalEntrance name="aside">
         <div
           className={`l-aside__overlay ${

--- a/static/js/publisher/pages/Remodel/RemodelTable.tsx
+++ b/static/js/publisher/pages/Remodel/RemodelTable.tsx
@@ -1,11 +1,11 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import {
   Button,
   Icon,
   MainTable,
-  Modal,
   TablePaginationControls,
   Input,
+  CheckboxInput,
 } from "@canonical/react-components";
 import { format } from "date-fns";
 
@@ -19,13 +19,13 @@ type Props = {
   forwardDisabled: boolean;
   backDisabled: boolean;
   pageSize: number;
-  isDeleting: boolean;
   isSavingEdit: boolean;
   editedDescriptions: Record<string, string>;
-  onDeleteRemodel: (remodel: Remodel) => Promise<void>;
   onEditChange: (rowId: string, value: string) => void;
   onEditSave: (remodel: Remodel) => Promise<void>;
   onEditCancel: (rowId: string) => void;
+  remodelsToDelete: Remodel[];
+  setRemodelsToDelete: (remodels: Remodel[]) => void;
 };
 
 const getRemodelRowId = (remodel: Remodel): string => {
@@ -41,33 +41,66 @@ function RemodelTable({
   forwardDisabled,
   backDisabled,
   pageSize,
-  isDeleting,
   isSavingEdit,
   editedDescriptions,
-  onDeleteRemodel,
   onEditChange,
   onEditSave,
   onEditCancel,
+  remodelsToDelete,
+  setRemodelsToDelete,
 }: Props): React.JSX.Element {
-  const [showDeleteModal, setShowDeleteModal] = useState(false);
-  const [selectedRemodel, setSelectedRemodel] = useState<Remodel | null>(null);
-  const isBusy = isDeleting || isSavingEdit;
+  const [isChecked, setIsChecked] = useState(false);
+  const [isIndeterminate, setIsIndeterminate] = useState(false);
+  const isBusy = isSavingEdit;
 
-  const handleDeleteConfirm = async () => {
-    if (!selectedRemodel) {
-      return;
+  useEffect(() => {
+    if (remodelsToDelete.length) {
+      if (remodelsToDelete.length === remodels.length) {
+        setIsChecked(true);
+        setIsIndeterminate(false);
+      } else {
+        setIsChecked(false);
+        setIsIndeterminate(true);
+      }
+    } else {
+      setIsChecked(false);
+      setIsIndeterminate(false);
     }
+  }, [remodelsToDelete, remodels.length]);
 
-    try {
-      await onDeleteRemodel(selectedRemodel);
-      setShowDeleteModal(false);
-      setSelectedRemodel(null);
-    } catch {
-      // Keep modal open so user can retry or cancel.
-    }
+  const withCheckboxStyles = {
+    paddingBottom: 0,
+    width: "2rem",
   };
 
   const headers = [
+    {
+      style: withCheckboxStyles,
+      content: (
+        <div
+          style={{
+            position: "relative",
+            top: "-9px",
+          }}
+        >
+          <CheckboxInput
+            labelClassName="u-no-margin--bottom"
+            onChange={(e) => {
+              if (e.target.checked) {
+                setRemodelsToDelete(remodels);
+                setIsChecked(true);
+              } else {
+                setRemodelsToDelete([]);
+                setIsChecked(false);
+              }
+            }}
+            checked={isChecked}
+            indeterminate={isIndeterminate}
+            label=<span className="table-cell-checkbox__label">Name</span>
+          />
+        </div>
+      ),
+    },
     {
       content: "Target model",
       style: { width: "250px" },
@@ -84,11 +117,6 @@ function RemodelTable({
       style: { width: "130px" },
     },
     { content: "Note", className: "u-truncate" },
-    {
-      content: "Actions",
-      style: { width: "100px" },
-      className: "u-align--right",
-    },
   ];
 
   const rows = remodels.map((remodel: Remodel) => {
@@ -99,9 +127,34 @@ function RemodelTable({
     const isDirty =
       editedDescriptions[rowId] !== undefined &&
       editedDescriptions[rowId] !== originalValue;
+    const isRowChecked = remodelsToDelete.some(
+      (item) => getRemodelRowId(item) === rowId,
+    );
 
     return {
       columns: [
+        {
+          content: (
+            <CheckboxInput
+              labelClassName="u-no-margin--bottom u-no-padding--top"
+              onChange={(e) => {
+                if (e.target.checked) {
+                  setRemodelsToDelete([...remodelsToDelete, remodel]);
+                } else {
+                  setRemodelsToDelete(
+                    remodelsToDelete.filter(
+                      (item) => getRemodelRowId(item) !== rowId,
+                    ),
+                  );
+                }
+              }}
+              checked={isRowChecked}
+              label=<span className="table-cell-checkbox__label">
+                {remodel["to-model"]}
+              </span>
+            />
+          ),
+        },
         { content: remodel["to-model"], className: "u-truncate" },
         {
           content: remodel["from-serial"] || "All serial policies",
@@ -153,23 +206,6 @@ function RemodelTable({
             </>
           ),
         },
-        {
-          className: "u-align--right",
-          content: (
-            <Button
-              className="u-no-margin--bottom u-no-margin--right"
-              appearance="base"
-              disabled={isBusy}
-              onClick={() => {
-                setSelectedRemodel(remodel);
-                setShowDeleteModal(true);
-              }}
-            >
-              <Icon name="delete" />
-              <span className="u-off-screen">Delete</span>
-            </Button>
-          ),
-        },
       ],
     };
   });
@@ -206,57 +242,6 @@ function RemodelTable({
         visibleCount={rows.length}
         className="table-pagination-controls"
       />
-      {showDeleteModal && selectedRemodel && (
-        <Modal
-          close={() => {
-            if (!isBusy) {
-              setShowDeleteModal(false);
-              setSelectedRemodel(null);
-            }
-          }}
-          title="Delete remodel"
-          buttonRow={
-            <>
-              <Button
-                className="u-no-margin--bottom"
-                disabled={isBusy}
-                onClick={() => {
-                  setShowDeleteModal(false);
-                  setSelectedRemodel(null);
-                }}
-              >
-                Cancel
-              </Button>
-              <Button
-                className="u-no-margin--bottom u-no-margin--right"
-                appearance="negative"
-                disabled={isBusy}
-                onClick={() => {
-                  void handleDeleteConfirm();
-                }}
-              >
-                {isDeleting ? (
-                  <>
-                    <Icon
-                      name="spinner"
-                      className="u-animation--spin is-light"
-                    />
-                    &nbsp;Deleting...
-                  </>
-                ) : (
-                  "Delete"
-                )}
-              </Button>
-            </>
-          }
-        >
-          <p>
-            Are you sure you want to delete this remodel?
-            <br />
-            This action cannot be undone.
-          </p>
-        </Modal>
-      )}
     </>
   );
 }

--- a/static/js/publisher/pages/Remodel/__tests__/Remodel.test.tsx
+++ b/static/js/publisher/pages/Remodel/__tests__/Remodel.test.tsx
@@ -96,6 +96,49 @@ const useRemodelsWithData = {
   isError: false,
 } as unknown as UseQueryResult<ApiResponse<RemodelResponse>, Error>;
 
+const useRemodelsWithMultipleData = {
+  data: {
+    data: {
+      allowlist: [
+        {
+          "created-at": "2026-03-27T14:34:23.666Z",
+          "created-by": "test-user",
+          "from-model": "from-model-a",
+          "from-serial": "serial-1",
+          "modified-at": null,
+          "modified-by": null,
+          "to-model": "to-model-a",
+          description: "test remodel",
+        },
+        {
+          "created-at": "2026-03-28T14:34:23.666Z",
+          "created-by": "test-user",
+          "from-model": "from-model-b",
+          "from-serial": "serial-2",
+          "modified-at": null,
+          "modified-by": null,
+          "to-model": "to-model-b",
+          description: "second remodel",
+        },
+        {
+          "created-at": "2026-03-29T14:34:23.666Z",
+          "created-by": "test-user",
+          "from-model": "from-model-c",
+          "from-serial": null,
+          "modified-at": null,
+          "modified-by": null,
+          "to-model": "to-model-c",
+          description: "third remodel",
+        },
+      ],
+      "next-cursor": null,
+    },
+    success: true,
+  },
+  isLoading: false,
+  isError: false,
+} as unknown as UseQueryResult<ApiResponse<RemodelResponse>, Error>;
+
 const mockUseModels = vi.mocked(useModels);
 mockUseModels.mockReturnValue({
   data: [],
@@ -156,64 +199,6 @@ describe("Remodel", () => {
     expect(
       screen.getByRole("link", { name: "Configure remodels" }),
     ).toBeInTheDocument();
-  });
-
-  it("deletes remodel and shows success notification", async () => {
-    const invalidateQueriesSpy = vi
-      .spyOn(queryClient, "invalidateQueries")
-      .mockResolvedValue(undefined);
-    const fetchMock = vi.fn(async () => ({
-      ok: true,
-      json: async () => ({ success: true }),
-    }));
-    vi.stubGlobal("fetch", fetchMock);
-
-    mockUseRemodels.mockReturnValue(useRemodelsWithData);
-    renderComponent();
-    const user = userEvent.setup();
-
-    await user.click(screen.getByRole("button", { name: "Delete" }));
-    await user.click(screen.getAllByRole("button", { name: "Delete" })[1]);
-
-    await waitFor(() => {
-      expect(fetchMock).toHaveBeenCalledWith(
-        expect.stringContaining("/models/remodel-allowlist"),
-        expect.objectContaining({
-          method: "DELETE",
-          body: JSON.stringify({
-            "from-model": "from-model-a",
-            "to-model": "to-model-a",
-            "from-serial": "serial-1",
-          }),
-          headers: {
-            "Content-Type": "application/json",
-            "X-CSRF-Token": undefined,
-          },
-        }),
-      );
-    });
-    expect(await screen.findByText("Remodel deleted")).toBeInTheDocument();
-    expect(invalidateQueriesSpy).toHaveBeenCalledWith({
-      queryKey: ["remodels"],
-    });
-  });
-
-  it("shows error notification when delete fails", async () => {
-    const errorMessage = "Unable to delete remodel from API";
-    const fetchMock = vi.fn(async () => ({
-      ok: true,
-      json: async () => ({ success: false, message: errorMessage }),
-    }));
-    vi.stubGlobal("fetch", fetchMock);
-
-    mockUseRemodels.mockReturnValue(useRemodelsWithData);
-    renderComponent();
-    const user = userEvent.setup();
-
-    await user.click(screen.getByRole("button", { name: "Delete" }));
-    await user.click(screen.getAllByRole("button", { name: "Delete" })[1]);
-
-    expect(await screen.findByText(errorMessage)).toBeInTheDocument();
   });
 
   it("updates remodel and shows success notification", async () => {
@@ -295,5 +280,296 @@ describe("Remodel", () => {
     await user.click(screen.getByRole("button", { name: "Save" }));
 
     expect(await screen.findByText(errorMessage)).toBeInTheDocument();
+  });
+
+  it("shows bulk delete button as disabled when no items are selected", () => {
+    mockUseRemodels.mockReturnValue(useRemodelsWithData);
+    renderComponent();
+
+    const deleteButton = screen.getByRole("button", { name: "Delete remodel" });
+    expect(deleteButton).toBeInTheDocument();
+    expect(deleteButton).toHaveAttribute("aria-disabled", "true");
+  });
+
+  it("enables bulk delete button with correct text for single item", async () => {
+    mockUseRemodels.mockReturnValue(useRemodelsWithData);
+    renderComponent();
+    const user = userEvent.setup();
+
+    // Click the checkbox for the first row
+    const checkboxes = screen.getAllByRole("checkbox");
+    await user.click(checkboxes[1]);
+
+    const deleteButton = screen.getByRole("button", { name: "Delete remodel" });
+    expect(deleteButton).toBeInTheDocument();
+    expect(deleteButton).not.toHaveAttribute("aria-disabled", "true");
+  });
+
+  it("enables bulk delete button with correct text for multiple items", async () => {
+    mockUseRemodels.mockReturnValue(useRemodelsWithMultipleData);
+    renderComponent();
+    const user = userEvent.setup();
+
+    // Click checkboxes for first two rows
+    const checkboxes = screen.getAllByRole("checkbox");
+    await user.click(checkboxes[1]);
+    await user.click(checkboxes[2]);
+
+    const deleteButton = screen.getByRole("button", {
+      name: "Delete 2 remodels",
+    });
+    expect(deleteButton).toBeInTheDocument();
+    expect(deleteButton).not.toHaveAttribute("aria-disabled", "true");
+  });
+
+  it("opens bulk delete modal when bulk delete button is clicked", async () => {
+    mockUseRemodels.mockReturnValue(useRemodelsWithData);
+    renderComponent();
+    const user = userEvent.setup();
+
+    // Select an item
+    const checkboxes = screen.getAllByRole("checkbox");
+    await user.click(checkboxes[1]);
+
+    // Click bulk delete button
+    await user.click(screen.getByRole("button", { name: "Delete remodel" }));
+
+    // Modal should be visible
+    expect(
+      screen.getByRole("heading", { name: "Delete remodel" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/Are you sure you want to delete this remodel\?/),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/This action cannot be undone\./),
+    ).toBeInTheDocument();
+  });
+
+  it("closes bulk delete modal when cancel is clicked", async () => {
+    mockUseRemodels.mockReturnValue(useRemodelsWithData);
+    renderComponent();
+    const user = userEvent.setup();
+
+    // Select an item and open modal
+    const checkboxes = screen.getAllByRole("checkbox");
+    await user.click(checkboxes[1]);
+    await user.click(screen.getByRole("button", { name: "Delete remodel" }));
+
+    // Click cancel in modal
+    const cancelButtons = screen.getAllByRole("button", { name: "Cancel" });
+    await user.click(cancelButtons[cancelButtons.length - 1]);
+
+    // Modal should be closed
+    await waitFor(() => {
+      expect(
+        screen.queryByText("Are you sure you want to delete this remodel?"),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  it("shows list of remodels in bulk delete modal for multiple items", async () => {
+    mockUseRemodels.mockReturnValue(useRemodelsWithMultipleData);
+    renderComponent();
+    const user = userEvent.setup();
+
+    // Select two items
+    const checkboxes = screen.getAllByRole("checkbox");
+    await user.click(checkboxes[1]);
+    await user.click(checkboxes[2]);
+
+    // Click bulk delete button
+    await user.click(screen.getByRole("button", { name: "Delete 2 remodels" }));
+
+    // Modal should show list of remodels
+    expect(
+      screen.getByRole("heading", { name: "Delete 2 remodels" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("from-model-a → to-model-a")).toBeInTheDocument();
+    expect(screen.getByText("(Serial: serial-1)")).toBeInTheDocument();
+    expect(screen.getByText("from-model-b → to-model-b")).toBeInTheDocument();
+    expect(screen.getByText("(Serial: serial-2)")).toBeInTheDocument();
+  });
+
+  it("bulk deletes remodels and shows success notification", async () => {
+    const invalidateQueriesSpy = vi
+      .spyOn(queryClient, "invalidateQueries")
+      .mockResolvedValue(undefined);
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ success: true }),
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    mockUseRemodels.mockReturnValue(useRemodelsWithMultipleData);
+    renderComponent();
+    const user = userEvent.setup();
+
+    // Select two items
+    const checkboxes = screen.getAllByRole("checkbox");
+    await user.click(checkboxes[1]);
+    await user.click(checkboxes[2]);
+
+    // Click bulk delete button
+    await user.click(screen.getByRole("button", { name: "Delete 2 remodels" }));
+
+    // Click delete in modal
+    const deleteButtons = screen.getAllByRole("button", { name: "Delete" });
+    await user.click(deleteButtons[deleteButtons.length - 1]);
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        expect.stringContaining("/models/remodel-allowlist"),
+        expect.objectContaining({
+          method: "DELETE",
+          body: JSON.stringify([
+            {
+              "from-model": "from-model-a",
+              "to-model": "to-model-a",
+              "from-serial": "serial-1",
+            },
+            {
+              "from-model": "from-model-b",
+              "to-model": "to-model-b",
+              "from-serial": "serial-2",
+            },
+          ]),
+          headers: {
+            "Content-Type": "application/json",
+            "X-CSRF-Token": undefined,
+          },
+        }),
+      );
+    });
+    expect(await screen.findByText("2 remodels deleted")).toBeInTheDocument();
+    expect(invalidateQueriesSpy).toHaveBeenCalledWith({
+      queryKey: ["remodels"],
+    });
+  });
+
+  it("shows correct success message for single remodel bulk delete", async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ success: true }),
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    mockUseRemodels.mockReturnValue(useRemodelsWithData);
+    renderComponent();
+    const user = userEvent.setup();
+
+    // Select one item
+    const checkboxes = screen.getAllByRole("checkbox");
+    await user.click(checkboxes[1]);
+
+    // Click bulk delete button and confirm
+    await user.click(screen.getByRole("button", { name: "Delete remodel" }));
+    const deleteButtons = screen.getAllByRole("button", { name: "Delete" });
+    await user.click(deleteButtons[deleteButtons.length - 1]);
+
+    expect(await screen.findByText("1 remodel deleted")).toBeInTheDocument();
+  });
+
+  it("shows error notification when bulk delete fails", async () => {
+    const errorMessage = "Unable to delete remodels from API";
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ success: false, message: errorMessage }),
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    mockUseRemodels.mockReturnValue(useRemodelsWithMultipleData);
+    renderComponent();
+    const user = userEvent.setup();
+
+    // Select items
+    const checkboxes = screen.getAllByRole("checkbox");
+    await user.click(checkboxes[1]);
+    await user.click(checkboxes[2]);
+
+    // Click bulk delete button and confirm
+    await user.click(screen.getByRole("button", { name: "Delete 2 remodels" }));
+    const deleteButtons = screen.getAllByRole("button", { name: "Delete" });
+    await user.click(deleteButtons[deleteButtons.length - 1]);
+
+    expect(await screen.findByText(errorMessage)).toBeInTheDocument();
+  });
+
+  it("disables bulk delete button while deleting", async () => {
+    let resolvePromise: (value: unknown) => void;
+    const promise = new Promise((resolve) => {
+      resolvePromise = resolve;
+    });
+
+    const fetchMock = vi.fn(async () => promise);
+    vi.stubGlobal("fetch", fetchMock);
+
+    mockUseRemodels.mockReturnValue(useRemodelsWithData);
+    renderComponent();
+    const user = userEvent.setup();
+
+    // Select an item
+    const checkboxes = screen.getAllByRole("checkbox");
+    await user.click(checkboxes[1]);
+
+    // Click bulk delete button
+    await user.click(screen.getByRole("button", { name: "Delete remodel" }));
+
+    // Click delete in modal
+    const deleteButtons = screen.getAllByRole("button", { name: "Delete" });
+    await user.click(deleteButtons[deleteButtons.length - 1]);
+
+    // Check that the modal Delete button is disabled while deleting
+    await waitFor(() => {
+      const modalDeleteButtons = screen.getAllByRole("button", {
+        name: /Delete|Deleting/,
+      });
+      // The last button should be the modal button
+      const modalButton = modalDeleteButtons[modalDeleteButtons.length - 1];
+      expect(modalButton).toHaveAttribute("aria-disabled", "true");
+    });
+
+    // Resolve the promise to complete the test
+    resolvePromise!({
+      ok: true,
+      json: async () => ({ success: true }),
+    });
+  });
+
+  it("clears selection after successful bulk delete", async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ success: true }),
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    mockUseRemodels.mockReturnValue(useRemodelsWithData);
+    renderComponent();
+    const user = userEvent.setup();
+
+    // Select an item
+    const checkboxes = screen.getAllByRole("checkbox");
+    await user.click(checkboxes[1]);
+
+    // Confirm bulk delete button is visible
+    expect(
+      screen.getByRole("button", { name: "Delete remodel" }),
+    ).toBeInTheDocument();
+
+    // Click bulk delete button and confirm
+    await user.click(screen.getByRole("button", { name: "Delete remodel" }));
+    const deleteButtons = screen.getAllByRole("button", { name: "Delete" });
+    await user.click(deleteButtons[deleteButtons.length - 1]);
+
+    // Wait for success notification
+    await screen.findByText("1 remodel deleted");
+
+    // Bulk delete button should be disabled (selection cleared)
+    await waitFor(() => {
+      const deleteButton = screen.getByRole("button", {
+        name: "Delete remodel",
+      });
+      expect(deleteButton).toHaveAttribute("aria-disabled", "true");
+    });
   });
 });

--- a/static/js/publisher/pages/Remodel/__tests__/RemodelTable.test.tsx
+++ b/static/js/publisher/pages/Remodel/__tests__/RemodelTable.test.tsx
@@ -42,24 +42,23 @@ const remodels: Remodel[] = [
 const firstRowId = "from-model-a:to-model-a:serial-1";
 const secondRowId = "from-model-b:to-model-b:serial-2";
 
-const renderComponent = (
-  onDeleteRemodel: (remodel: Remodel) => Promise<void> = vi.fn(async () => {}),
-  {
-    isDeleting = false,
-    isSavingEdit = false,
-    editedDescriptions = {},
-    onEditChange = vi.fn(),
-    onEditSave = vi.fn(async () => {}),
-    onEditCancel = vi.fn(),
-  }: {
-    isDeleting?: boolean;
-    isSavingEdit?: boolean;
-    editedDescriptions?: Record<string, string>;
-    onEditChange?: (rowId: string, value: string) => void;
-    onEditSave?: (remodel: Remodel) => Promise<void>;
-    onEditCancel?: (rowId: string) => void;
-  } = {},
-) => {
+const renderComponent = ({
+  isSavingEdit = false,
+  editedDescriptions = {},
+  onEditChange = vi.fn(),
+  onEditSave = vi.fn(async () => {}),
+  onEditCancel = vi.fn(),
+  remodelsToDelete = [],
+  setRemodelsToDelete = vi.fn(),
+}: {
+  isSavingEdit?: boolean;
+  editedDescriptions?: Record<string, string>;
+  onEditChange?: (rowId: string, value: string) => void;
+  onEditSave?: (remodel: Remodel) => Promise<void>;
+  onEditCancel?: (rowId: string) => void;
+  remodelsToDelete?: Remodel[];
+  setRemodelsToDelete?: (remodels: Remodel[]) => void;
+} = {}) => {
   return render(
     <BrowserRouter>
       <QueryClientProvider client={queryClient}>
@@ -71,13 +70,13 @@ const renderComponent = (
           forwardDisabled={false}
           backDisabled={true}
           pageSize={10}
-          isDeleting={isDeleting}
           isSavingEdit={isSavingEdit}
           editedDescriptions={editedDescriptions}
-          onDeleteRemodel={onDeleteRemodel}
           onEditChange={onEditChange}
           onEditSave={onEditSave}
           onEditCancel={onEditCancel}
+          remodelsToDelete={remodelsToDelete}
+          setRemodelsToDelete={setRemodelsToDelete}
         />
       </QueryClientProvider>
     </BrowserRouter>,
@@ -108,38 +107,6 @@ describe("RemodelTable", () => {
     expect(
       screen.getByRole("columnheader", { name: "Note" }),
     ).toBeInTheDocument();
-
-    expect(
-      screen.getByRole("columnheader", { name: "Actions" }),
-    ).toBeInTheDocument();
-  });
-
-  it("opens the delete modal and closes it when cancel is clicked", async () => {
-    renderComponent();
-    const user = userEvent.setup();
-
-    await user.click(screen.getAllByRole("button", { name: "Delete" })[0]);
-
-    expect(screen.getByText("Delete remodel")).toBeInTheDocument();
-    expect(
-      screen.getByText(/Are you sure you want to delete this remodel/),
-    ).toBeInTheDocument();
-
-    await user.click(screen.getByRole("button", { name: "Cancel" }));
-
-    expect(screen.queryByText("Delete remodel")).not.toBeInTheDocument();
-  });
-
-  it("calls onDeleteRemodel with the selected remodel", async () => {
-    const onDeleteRemodel = vi.fn(async () => {});
-    renderComponent(onDeleteRemodel);
-    const user = userEvent.setup();
-
-    await user.click(screen.getAllByRole("button", { name: "Delete" })[0]);
-    const deleteButtons = screen.getAllByRole("button", { name: "Delete" });
-    await user.click(deleteButtons[deleteButtons.length - 1]);
-
-    expect(onDeleteRemodel).toHaveBeenCalledWith(remodels[0]);
   });
 
   it("shows input fields for all descriptions", () => {
@@ -163,7 +130,7 @@ describe("RemodelTable", () => {
   });
 
   it("shows save/cancel buttons when value differs from original", () => {
-    renderComponent(undefined, {
+    renderComponent({
       editedDescriptions: { [firstRowId]: "modified description" },
     });
 
@@ -172,7 +139,7 @@ describe("RemodelTable", () => {
   });
 
   it("supports multiple rows with pending edits simultaneously", () => {
-    renderComponent(undefined, {
+    renderComponent({
       editedDescriptions: {
         [firstRowId]: "modified first",
         [secondRowId]: "modified second",
@@ -194,7 +161,7 @@ describe("RemodelTable", () => {
     const user = userEvent.setup();
     const onEditSave = vi.fn(async () => {});
 
-    renderComponent(undefined, {
+    renderComponent({
       editedDescriptions: { [firstRowId]: "modified description" },
       onEditSave,
     });
@@ -208,7 +175,7 @@ describe("RemodelTable", () => {
     const user = userEvent.setup();
     const onEditChange = vi.fn();
 
-    renderComponent(undefined, {
+    renderComponent({
       onEditChange,
     });
 
@@ -223,7 +190,7 @@ describe("RemodelTable", () => {
     const user = userEvent.setup();
     const onEditCancel = vi.fn();
 
-    renderComponent(undefined, {
+    renderComponent({
       editedDescriptions: { [firstRowId]: "modified description" },
       onEditCancel,
     });
@@ -233,21 +200,105 @@ describe("RemodelTable", () => {
     expect(onEditCancel).toHaveBeenCalledWith(firstRowId);
   });
 
-  it("delete buttons are always visible", () => {
+  it("renders checkboxes for each row", () => {
     renderComponent();
 
-    const deleteButtons = screen.getAllByRole("button", { name: "Delete" });
-    expect(deleteButtons).toHaveLength(2);
+    // Should have checkbox for each remodel row (2) plus header checkbox
+    const checkboxes = screen.getAllByRole("checkbox");
+    expect(checkboxes).toHaveLength(3);
   });
 
-  it("disables delete buttons when busy", () => {
-    renderComponent(undefined, {
-      isDeleting: true,
+  it("calls setRemodelsToDelete when individual checkbox is clicked", async () => {
+    const user = userEvent.setup();
+    const setRemodelsToDelete = vi.fn();
+
+    renderComponent({
+      setRemodelsToDelete,
     });
 
-    const deleteButtons = screen.getAllByRole("button", { name: "Delete" });
-    deleteButtons.forEach((button) => {
-      expect(button).toHaveAttribute("aria-disabled", "true");
+    const checkboxes = screen.getAllByRole("checkbox");
+    // First checkbox is the header, second is first row
+    await user.click(checkboxes[1]);
+
+    expect(setRemodelsToDelete).toHaveBeenCalledWith([remodels[0]]);
+  });
+
+  it("calls setRemodelsToDelete to remove item when checkbox is unchecked", async () => {
+    const user = userEvent.setup();
+    const setRemodelsToDelete = vi.fn();
+
+    renderComponent({
+      remodelsToDelete: [remodels[0]],
+      setRemodelsToDelete,
     });
+
+    const checkboxes = screen.getAllByRole("checkbox");
+    // First checkbox is the header, second is first row (which is checked)
+    await user.click(checkboxes[1]);
+
+    expect(setRemodelsToDelete).toHaveBeenCalledWith([]);
+  });
+
+  it("selects all remodels when header checkbox is clicked", async () => {
+    const user = userEvent.setup();
+    const setRemodelsToDelete = vi.fn();
+
+    renderComponent({
+      setRemodelsToDelete,
+    });
+
+    const checkboxes = screen.getAllByRole("checkbox");
+    // First checkbox is the header
+    await user.click(checkboxes[0]);
+
+    expect(setRemodelsToDelete).toHaveBeenCalledWith(remodels);
+  });
+
+  it("deselects all remodels when header checkbox is unchecked", async () => {
+    const user = userEvent.setup();
+    const setRemodelsToDelete = vi.fn();
+
+    renderComponent({
+      remodelsToDelete: remodels,
+      setRemodelsToDelete,
+    });
+
+    const checkboxes = screen.getAllByRole("checkbox");
+    // First checkbox is the header
+    await user.click(checkboxes[0]);
+
+    expect(setRemodelsToDelete).toHaveBeenCalledWith([]);
+  });
+
+  it("shows header checkbox as checked when all items selected", () => {
+    renderComponent({
+      remodelsToDelete: remodels,
+    });
+
+    const checkboxes = screen.getAllByRole("checkbox");
+    // Header checkbox should be checked
+    expect(checkboxes[0]).toBeChecked();
+  });
+
+  it("shows header checkbox as indeterminate when some items selected", () => {
+    renderComponent({
+      remodelsToDelete: [remodels[0]],
+    });
+
+    const checkboxes = screen.getAllByRole("checkbox");
+    // Header checkbox should be indeterminate
+    expect(checkboxes[0]).toHaveProperty("indeterminate", true);
+  });
+
+  it("shows individual row checkbox as checked when row is selected", () => {
+    renderComponent({
+      remodelsToDelete: [remodels[0]],
+    });
+
+    const checkboxes = screen.getAllByRole("checkbox");
+    // Second checkbox (first row) should be checked
+    expect(checkboxes[1]).toBeChecked();
+    // Third checkbox (second row) should not be checked
+    expect(checkboxes[2]).not.toBeChecked();
   });
 });


### PR DESCRIPTION
## Done
Adds the ability to bulk delete remodels

## How to QA
- Go to https://snapcraft-io-5772.demos.haus/admin/ahnuP3quahti9vis8aiw/models/testing-model-new-2/remodel
- Click the checkbox by the "Target model" column and see that it selects all of the remodels
- Uncheck some of the table rows and see that the header checkbox shows indeterminate
- Check that you can delete a selection of remodels at once

## Testing

- [x] This PR has tests
- [ ] No testing required (explain why):

## Security

- [ ] Security considerations for review (list them):
  - [ ] Examples:
  - [ ] Access control: users can only access their own data
  - [ ] Input: user input is validated and sanitised
  - [ ] Sensitive data: secret or private data is not exposed in any way
  - [ ] ...
- [x] This PR has no security considerations (explain why): No user input

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-37250

## Screenshots

n/a

## UX Approval

- [ ] This PR does not require UX approval
- [x] This PR does require UX approval (add context):
