### PR TITLE
fix: snap installs graph tooltip cropped 

### DIFF
--- a/static/js/publisher/components/PublishedSnapSection/PublishedSnapSection.tsx
+++ b/static/js/publisher/components/PublishedSnapSection/PublishedSnapSection.tsx
@@ -27,7 +27,7 @@ function PublishedSnapSection({
       {snaps.length > 0 && (
         <>
           <Accordion
-            className="accordion-bold-titles"
+            className="accordion-bold-titles snap-installs-metrics-accordion"
             sections={[
               {
                 key: "publisher-metrics",

--- a/static/sass/_snapcraft-publisher.scss
+++ b/static/sass/_snapcraft-publisher.scss
@@ -4,6 +4,11 @@
     min-height: 35vh;
   }
 
+  // Allow the graph tooltip to overflow the accordion panel boundaries
+  .snap-installs-metrics-accordion .p-accordion__panel {
+    overflow: visible;
+  }
+
   .snap-installs-placeholder {
     height: 100%;
     width: 100%;


### PR DESCRIPTION
## Done
- Fix tooltip cropped (see screenshot)
## How to QA
- https://snapcraft-io-5774.demos.haus/snaps
- hover over the installs graph
- things arent cropped
- compare to snapcraft.io/snaps

## Screenshots
Before
<img width="1806" height="661" alt="image" src="https://github.com/user-attachments/assets/694b5280-69e0-4244-8578-1b3cf63f8f06" />
After
<img width="1806" height="661" alt="image" src="https://github.com/user-attachments/assets/003226d4-3d69-4c68-bc76-88fd8452bb7a" />
