### PR TITLE
feat: Improve usability of serial log filters

### DIFF
--- a/static/js/publisher/pages/SerialLog/SerialLog.tsx
+++ b/static/js/publisher/pages/SerialLog/SerialLog.tsx
@@ -95,6 +95,7 @@ function SerialLog(): React.JSX.Element {
             Error: {error.message}
           </Notification>
         )}
+        <SerialLogDateSelectors onApplyDateRange={handleDateRangeApply} />
         {isLoading ? (
           <p>
             <Icon name="spinner" className="u-animation--spin" />
@@ -107,7 +108,6 @@ function SerialLog(): React.JSX.Element {
                 {data.message || "Unable to fetch serial logs"}
               </Notification>
             )}
-            <SerialLogDateSelectors onApplyDateRange={handleDateRangeApply} />
             {data && data.success !== false && (
               <SerialLogTable
                 handlePageForward={handlePageForward}

--- a/static/js/publisher/pages/SerialLog/SerialLog.tsx
+++ b/static/js/publisher/pages/SerialLog/SerialLog.tsx
@@ -10,6 +10,7 @@ import { setPageTitle } from "../../utils";
 
 import SerialLogDateSelectors from "./SerialLogDateSelectors";
 import SerialLogTable from "./SerialLogTable";
+import { getPresetTimestampRange } from "./dateRange";
 
 import type { UseQueryResult } from "react-query";
 import type { SerialLogResponse, ApiResponse } from "../../types/shared";
@@ -27,10 +28,14 @@ function SerialLog(): React.JSX.Element {
   const startTime = searchParams.get("start-time");
   const endTime = searchParams.get("end-time");
   const pageSize = Number.isInteger(parsedPageSize) ? parsedPageSize : 25;
+  const interval =
+    startTime && endTime
+      ? { startTime, endTime }
+      : getPresetTimestampRange("last-30-days");
   const params = {
     pageSize,
     page: currentCursor,
-    ...(startTime && endTime && { interval: { startTime, endTime } }),
+    ...(interval && { interval }),
   };
 
   const {

--- a/static/js/publisher/pages/SerialLog/SerialLog.tsx
+++ b/static/js/publisher/pages/SerialLog/SerialLog.tsx
@@ -10,7 +10,6 @@ import { setPageTitle } from "../../utils";
 
 import SerialLogDateSelectors from "./SerialLogDateSelectors";
 import SerialLogTable from "./SerialLogTable";
-import { getPresetTimestampRange } from "./dateRange";
 
 import type { UseQueryResult } from "react-query";
 import type { SerialLogResponse, ApiResponse } from "../../types/shared";
@@ -28,14 +27,10 @@ function SerialLog(): React.JSX.Element {
   const startTime = searchParams.get("start-time");
   const endTime = searchParams.get("end-time");
   const pageSize = Number.isInteger(parsedPageSize) ? parsedPageSize : 25;
-  const interval =
-    startTime && endTime
-      ? { startTime, endTime }
-      : getPresetTimestampRange("last-30-days");
   const params = {
     pageSize,
     page: currentCursor,
-    ...(interval && { interval }),
+    ...(startTime && endTime && { interval: { startTime, endTime } }),
   };
 
   const {

--- a/static/js/publisher/pages/SerialLog/SerialLogDateSelectors.tsx
+++ b/static/js/publisher/pages/SerialLog/SerialLogDateSelectors.tsx
@@ -7,59 +7,24 @@ import {
   Col,
   Select,
 } from "@canonical/react-components";
-import { differenceInCalendarDays, format, parseISO, subDays } from "date-fns";
+import { differenceInCalendarDays, parseISO } from "date-fns";
+
+import {
+  DEFAULT_END_TIME,
+  DEFAULT_START_TIME,
+  buildTimestampRange,
+  formatDateInputValue,
+  formatReadableDate,
+  formatTimeInputValue,
+  getDefaultDateRange,
+  getPresetDateRange,
+} from "./dateRange";
+
+import type { DatePreset } from "./dateRange";
 
 type Props = {
   onApplyDateRange: () => void;
 };
-
-type DatePreset =
-  | "today"
-  | "yesterday"
-  | "last-7-days"
-  | "last-30-days"
-  | "custom";
-
-const DEFAULT_START_TIME = "00:00:00";
-const DEFAULT_END_TIME = "23:59:59";
-
-function formatDateInputValue(date: Date): string {
-  return format(date, "yyyy-MM-dd");
-}
-
-function formatTimeInputValue(date: Date): string {
-  return format(date, "HH:mm:ss");
-}
-
-function getDefaultDateRange(): { startDate: string; endDate: string } {
-  const today = new Date();
-
-  return {
-    startDate: formatDateInputValue(subDays(today, 29)),
-    endDate: formatDateInputValue(today),
-  };
-}
-
-function formatReadableDate(dateValue: string): string {
-  const date = parseISO(dateValue);
-
-  return format(date, "d MMMM, yyyy");
-}
-
-function buildTimestampRange(
-  startDate: string,
-  startTime: string,
-  endDate: string,
-  endTime: string,
-): {
-  startTime: string;
-  endTime: string;
-} {
-  const startTimeValue = parseISO(`${startDate}T${startTime}`).toISOString();
-  const endTimeValue = parseISO(`${endDate}T${endTime}`).toISOString();
-
-  return { startTime: startTimeValue, endTime: endTimeValue };
-}
 
 function buildSearchString(searchParams: URLSearchParams): string[] {
   const preservedParams = Array.from(searchParams.entries()).filter(
@@ -84,48 +49,10 @@ function buildAppliedSearchString(
   return `?${queryParts.join("&")}`;
 }
 
-function getPresetDateRange(preset: DatePreset): {
-  startDate: string;
-  endDate: string;
-  startTime: string;
-  endTime: string;
-} | null {
-  const today = new Date();
+function buildClearedSearchString(searchParams: URLSearchParams): string {
+  const queryParts = buildSearchString(searchParams);
 
-  switch (preset) {
-    case "today":
-      return {
-        startDate: formatDateInputValue(today),
-        endDate: formatDateInputValue(today),
-        startTime: DEFAULT_START_TIME,
-        endTime: DEFAULT_END_TIME,
-      };
-    case "yesterday": {
-      const yesterday = subDays(today, 1);
-      return {
-        startDate: formatDateInputValue(yesterday),
-        endDate: formatDateInputValue(yesterday),
-        startTime: DEFAULT_START_TIME,
-        endTime: DEFAULT_END_TIME,
-      };
-    }
-    case "last-7-days":
-      return {
-        startDate: formatDateInputValue(subDays(today, 6)),
-        endDate: formatDateInputValue(today),
-        startTime: DEFAULT_START_TIME,
-        endTime: DEFAULT_END_TIME,
-      };
-    case "last-30-days":
-      return {
-        startDate: formatDateInputValue(subDays(today, 29)),
-        endDate: formatDateInputValue(today),
-        startTime: DEFAULT_START_TIME,
-        endTime: DEFAULT_END_TIME,
-      };
-    default:
-      return null;
-  }
+  return queryParts.length > 0 ? `?${queryParts.join("&")}` : "";
 }
 
 function detectActivePreset(
@@ -322,13 +249,6 @@ function SerialLogDateSelectors({
     const range = getPresetDateRange("last-30-days");
     if (!range) return;
 
-    const { startTime, endTime } = buildTimestampRange(
-      range.startDate,
-      range.startTime,
-      range.endDate,
-      range.endTime,
-    );
-
     setSelectedPreset("last-30-days");
     setStartDate(range.startDate);
     setEndDate(range.endDate);
@@ -339,7 +259,7 @@ function SerialLogDateSelectors({
     onApplyDateRange();
     navigate({
       pathname,
-      search: buildAppliedSearchString(searchParams, startTime, endTime),
+      search: buildClearedSearchString(searchParams),
     });
   };
 

--- a/static/js/publisher/pages/SerialLog/SerialLogDateSelectors.tsx
+++ b/static/js/publisher/pages/SerialLog/SerialLogDateSelectors.tsx
@@ -151,7 +151,10 @@ function SerialLogDateSelectors({
   useEffect(() => {
     const detectedPreset = detectActivePreset(queryStartTime, queryEndTime);
     setSelectedPreset(detectedPreset);
-    setIsCustomPanelOpen(detectedPreset === "custom");
+
+    if (detectedPreset !== "custom") {
+      setIsCustomPanelOpen(false);
+    }
 
     if (queryStartTime && queryEndTime) {
       setStartDate(formatDateInputValue(parseISO(queryStartTime)));
@@ -253,7 +256,7 @@ function SerialLogDateSelectors({
     setIsCustomPanelOpen(false);
   };
 
-  const handleClear = (): void => {
+  const handleReset = (): void => {
     const range = getPresetDateRange("last-30-days");
     if (!range) return;
 
@@ -274,8 +277,9 @@ function SerialLogDateSelectors({
   return (
     <>
       <Row>
-        <Col size={6} medium={3}>
+        <Col size={4} medium={3}>
           <Select
+            labelClassName="u-off-screen"
             id="date-range-preset"
             name="date-range-preset"
             label={selectedDateRangeLabel}
@@ -291,11 +295,14 @@ function SerialLogDateSelectors({
               { label: "Custom", value: "custom" },
             ]}
           />
+        </Col>
+        <Col size={2}>
           {selectedPreset === "custom" && (
             <Button onClick={() => setIsCustomPanelOpen(true)}>Edit</Button>
           )}
         </Col>
       </Row>
+      <p className="p-form-help-text">{selectedDateRangeLabel}</p>
       {isCustomPanelOpen && (
         <div className="p-strip is-shallow u-no-padding--top">
           {showValidationError && (
@@ -363,7 +370,7 @@ function SerialLogDateSelectors({
             >
               Apply date range
             </Button>
-            <Button onClick={handleClear}>Clear</Button>
+            <Button onClick={handleReset}>Reset</Button>
             <Button onClick={handleClose}>Close</Button>
           </div>
         </div>

--- a/static/js/publisher/pages/SerialLog/SerialLogDateSelectors.tsx
+++ b/static/js/publisher/pages/SerialLog/SerialLogDateSelectors.tsx
@@ -17,6 +17,7 @@ import {
   formatReadableDate,
   formatTimeInputValue,
   getDefaultDateRange,
+  getMaxEndDate,
   getPresetDateRange,
 } from "./dateRange";
 
@@ -184,6 +185,7 @@ function SerialLogDateSelectors({
   const exceedsThirtyDays =
     hasValidDateOrder &&
     differenceInCalendarDays(parseISO(endDate), parseISO(startDate)) > 29;
+  const maxEndDate = startDate ? getMaxEndDate(startDate) : undefined;
   const showValidationError =
     hasBothDates && (!hasValidOrder || exceedsThirtyDays);
   const selectedDateRangeLabel =
@@ -298,7 +300,12 @@ function SerialLogDateSelectors({
         </Col>
         <Col size={2}>
           {selectedPreset === "custom" && (
-            <Button onClick={() => setIsCustomPanelOpen(true)}>Edit</Button>
+            <Button
+              onClick={() => setIsCustomPanelOpen(true)}
+              disabled={isCustomPanelOpen}
+            >
+              Edit
+            </Button>
           )}
         </Col>
       </Row>
@@ -346,6 +353,7 @@ function SerialLogDateSelectors({
                   type="date"
                   value={endDate}
                   min={startDate}
+                  max={maxEndDate}
                   onChange={(event) => setEndDate(event.target.value)}
                 />
               </Col>

--- a/static/js/publisher/pages/SerialLog/SerialLogDateSelectors.tsx
+++ b/static/js/publisher/pages/SerialLog/SerialLogDateSelectors.tsx
@@ -1,11 +1,24 @@
 import { useEffect, useState } from "react";
 import { useLocation, useNavigate, useSearchParams } from "react-router-dom";
-import { Button, Notification, Row, Col } from "@canonical/react-components";
+import {
+  Button,
+  Notification,
+  Row,
+  Col,
+  Select,
+} from "@canonical/react-components";
 import { differenceInCalendarDays, format, parseISO, subDays } from "date-fns";
 
 type Props = {
   onApplyDateRange: () => void;
 };
+
+type DatePreset =
+  | "today"
+  | "yesterday"
+  | "last-7-days"
+  | "last-30-days"
+  | "custom";
 
 const DEFAULT_START_TIME = "00:00:00";
 const DEFAULT_END_TIME = "23:59:59";
@@ -71,10 +84,108 @@ function buildAppliedSearchString(
   return `?${queryParts.join("&")}`;
 }
 
-function buildClearedSearchString(searchParams: URLSearchParams): string {
-  const queryParts = buildSearchString(searchParams);
+function getPresetDateRange(preset: DatePreset): {
+  startDate: string;
+  endDate: string;
+  startTime: string;
+  endTime: string;
+} | null {
+  const today = new Date();
 
-  return queryParts.length > 0 ? `?${queryParts.join("&")}` : "";
+  switch (preset) {
+    case "today":
+      return {
+        startDate: formatDateInputValue(today),
+        endDate: formatDateInputValue(today),
+        startTime: DEFAULT_START_TIME,
+        endTime: DEFAULT_END_TIME,
+      };
+    case "yesterday": {
+      const yesterday = subDays(today, 1);
+      return {
+        startDate: formatDateInputValue(yesterday),
+        endDate: formatDateInputValue(yesterday),
+        startTime: DEFAULT_START_TIME,
+        endTime: DEFAULT_END_TIME,
+      };
+    }
+    case "last-7-days":
+      return {
+        startDate: formatDateInputValue(subDays(today, 6)),
+        endDate: formatDateInputValue(today),
+        startTime: DEFAULT_START_TIME,
+        endTime: DEFAULT_END_TIME,
+      };
+    case "last-30-days":
+      return {
+        startDate: formatDateInputValue(subDays(today, 29)),
+        endDate: formatDateInputValue(today),
+        startTime: DEFAULT_START_TIME,
+        endTime: DEFAULT_END_TIME,
+      };
+    default:
+      return null;
+  }
+}
+
+function detectActivePreset(
+  startTime: string | null,
+  endTime: string | null,
+): DatePreset {
+  if (!startTime || !endTime) {
+    return "last-30-days";
+  }
+
+  const presets: DatePreset[] = [
+    "today",
+    "yesterday",
+    "last-7-days",
+    "last-30-days",
+  ];
+
+  for (const preset of presets) {
+    const range = getPresetDateRange(preset);
+    if (!range) continue;
+
+    const presetStart = parseISO(
+      `${range.startDate}T${range.startTime}`,
+    ).toISOString();
+    const presetEnd = parseISO(
+      `${range.endDate}T${range.endTime}`,
+    ).toISOString();
+
+    // Compare with a small tolerance for date matching
+    const startMatch =
+      Math.abs(
+        parseISO(startTime).getTime() - parseISO(presetStart).getTime(),
+      ) < 1000;
+    const endMatch =
+      Math.abs(parseISO(endTime).getTime() - parseISO(presetEnd).getTime()) <
+      1000;
+
+    if (startMatch && endMatch) {
+      return preset;
+    }
+  }
+
+  return "custom";
+}
+
+function getPresetLabel(preset: DatePreset): string {
+  switch (preset) {
+    case "today":
+      return "today";
+    case "yesterday":
+      return "yesterday";
+    case "last-7-days":
+      return "the last 7 days";
+    case "last-30-days":
+      return "the last 30 days";
+    case "custom":
+      return "a custom date range";
+    default:
+      return "the last 30 days";
+  }
 }
 
 function SerialLogDateSelectors({
@@ -85,9 +196,14 @@ function SerialLogDateSelectors({
   const [searchParams] = useSearchParams();
   const queryStartTime = searchParams.get("start-time");
   const queryEndTime = searchParams.get("end-time");
-  const shouldStartOpen = Boolean(queryStartTime && queryEndTime);
   const defaultDateRange = getDefaultDateRange();
-  const [isOpen, setIsOpen] = useState(shouldStartOpen);
+  const [selectedPreset, setSelectedPreset] = useState<DatePreset>(() =>
+    detectActivePreset(queryStartTime, queryEndTime),
+  );
+  const [isCustomPanelOpen, setIsCustomPanelOpen] = useState(() => {
+    const preset = detectActivePreset(queryStartTime, queryEndTime);
+    return preset === "custom";
+  });
   const [startDate, setStartDate] = useState(
     (queryStartTime ? formatDateInputValue(parseISO(queryStartTime)) : "") ||
       defaultDateRange.startDate,
@@ -106,12 +222,24 @@ function SerialLogDateSelectors({
   );
 
   useEffect(() => {
+    const detectedPreset = detectActivePreset(queryStartTime, queryEndTime);
+    setSelectedPreset(detectedPreset);
+    setIsCustomPanelOpen(detectedPreset === "custom");
+
     if (queryStartTime && queryEndTime) {
-      setIsOpen(true);
       setStartDate(formatDateInputValue(parseISO(queryStartTime)));
       setEndDate(formatDateInputValue(parseISO(queryEndTime)));
       setStartTimeValue(formatTimeInputValue(parseISO(queryStartTime)));
       setEndTimeValue(formatTimeInputValue(parseISO(queryEndTime)));
+    } else {
+      // Set default 30-day range if no dates in URL
+      const range = getPresetDateRange("last-30-days");
+      if (range) {
+        setStartDate(range.startDate);
+        setEndDate(range.endDate);
+        setStartTimeValue(range.startTime);
+        setEndTimeValue(range.endTime);
+      }
     }
   }, [queryStartTime, queryEndTime]);
 
@@ -129,9 +257,40 @@ function SerialLogDateSelectors({
   const showValidationError =
     hasBothDates && (!hasValidOrder || exceedsThirtyDays);
   const selectedDateRangeLabel =
-    hasBothDates && hasValidOrder
+    selectedPreset === "custom" && hasBothDates && hasValidOrder
       ? `Showing serial logs between ${formatReadableDate(startDate)} and ${formatReadableDate(endDate)}`
-      : "Showing serial logs between selected dates";
+      : `Showing serial logs for ${getPresetLabel(selectedPreset)}`;
+
+  const handlePresetChange = (preset: DatePreset): void => {
+    setSelectedPreset(preset);
+
+    if (preset === "custom") {
+      setIsCustomPanelOpen(true);
+      return;
+    }
+
+    const range = getPresetDateRange(preset);
+    if (!range) return;
+
+    const { startTime, endTime } = buildTimestampRange(
+      range.startDate,
+      range.startTime,
+      range.endDate,
+      range.endTime,
+    );
+
+    setStartDate(range.startDate);
+    setEndDate(range.endDate);
+    setStartTimeValue(range.startTime);
+    setEndTimeValue(range.endTime);
+    setIsCustomPanelOpen(false);
+
+    onApplyDateRange();
+    navigate({
+      pathname,
+      search: buildAppliedSearchString(searchParams, startTime, endTime),
+    });
+  };
 
   const handleApply = (): void => {
     if (!hasBothDates || !hasBothTimes || !hasValidOrder || exceedsThirtyDays) {
@@ -145,6 +304,9 @@ function SerialLogDateSelectors({
       endTimeValue,
     );
 
+    setSelectedPreset("custom");
+    setIsCustomPanelOpen(false);
+
     onApplyDateRange();
     navigate({
       pathname,
@@ -153,34 +315,61 @@ function SerialLogDateSelectors({
   };
 
   const handleClose = (): void => {
-    setIsOpen(false);
-    setStartDate(defaultDateRange.startDate);
-    setEndDate(defaultDateRange.endDate);
-    setStartTimeValue(DEFAULT_START_TIME);
-    setEndTimeValue(DEFAULT_END_TIME);
+    setIsCustomPanelOpen(false);
+  };
+
+  const handleClear = (): void => {
+    const range = getPresetDateRange("last-30-days");
+    if (!range) return;
+
+    const { startTime, endTime } = buildTimestampRange(
+      range.startDate,
+      range.startTime,
+      range.endDate,
+      range.endTime,
+    );
+
+    setSelectedPreset("last-30-days");
+    setStartDate(range.startDate);
+    setEndDate(range.endDate);
+    setStartTimeValue(range.startTime);
+    setEndTimeValue(range.endTime);
+    setIsCustomPanelOpen(false);
+
     onApplyDateRange();
     navigate({
       pathname,
-      search: buildClearedSearchString(searchParams),
+      search: buildAppliedSearchString(searchParams, startTime, endTime),
     });
   };
 
   return (
     <>
-      {!isOpen ? (
-        <Row>
-          <Col size={6} medium={3}>
-            <p>Showing serial logs for the past 30 days</p>
-          </Col>
-          <Col size={6} medium={3} className="u-align--right">
-            <Button onClick={() => setIsOpen(true)}>
-              Select custom date range
-            </Button>
-          </Col>
-        </Row>
-      ) : (
+      <Row>
+        <Col size={6} medium={3}>
+          <Select
+            id="date-range-preset"
+            name="date-range-preset"
+            label={selectedDateRangeLabel}
+            value={selectedPreset}
+            onChange={(event) =>
+              handlePresetChange(event.target.value as DatePreset)
+            }
+            options={[
+              { label: "Today", value: "today" },
+              { label: "Yesterday", value: "yesterday" },
+              { label: "Last 7 days", value: "last-7-days" },
+              { label: "Last 30 days", value: "last-30-days" },
+              { label: "Custom", value: "custom" },
+            ]}
+          />
+          {selectedPreset === "custom" && (
+            <Button onClick={() => setIsCustomPanelOpen(true)}>Edit</Button>
+          )}
+        </Col>
+      </Row>
+      {isCustomPanelOpen && (
         <div className="p-strip is-shallow u-no-padding--top">
-          <p>{selectedDateRangeLabel}</p>
           {showValidationError && (
             <Notification severity="caution">
               {exceedsThirtyDays
@@ -246,6 +435,7 @@ function SerialLogDateSelectors({
             >
               Apply date range
             </Button>
+            <Button onClick={handleClear}>Clear</Button>
             <Button onClick={handleClose}>Close</Button>
           </div>
         </div>

--- a/static/js/publisher/pages/SerialLog/SerialLogDateSelectors.tsx
+++ b/static/js/publisher/pages/SerialLog/SerialLogDateSelectors.tsx
@@ -199,13 +199,6 @@ function SerialLogDateSelectors({
     const range = getPresetDateRange(preset);
     if (!range) return;
 
-    const { startTime, endTime } = buildTimestampRange(
-      range.startDate,
-      range.startTime,
-      range.endDate,
-      range.endTime,
-    );
-
     setStartDate(range.startDate);
     setEndDate(range.endDate);
     setStartTimeValue(range.startTime);
@@ -213,6 +206,21 @@ function SerialLogDateSelectors({
     setIsCustomPanelOpen(false);
 
     onApplyDateRange();
+    if (preset === "last-30-days") {
+      navigate({
+        pathname,
+        search: buildClearedSearchString(searchParams),
+      });
+      return;
+    }
+
+    const { startTime, endTime } = buildTimestampRange(
+      range.startDate,
+      range.startTime,
+      range.endDate,
+      range.endTime,
+    );
+
     navigate({
       pathname,
       search: buildAppliedSearchString(searchParams, startTime, endTime),

--- a/static/js/publisher/pages/SerialLog/__tests__/SerialLog.test.tsx
+++ b/static/js/publisher/pages/SerialLog/__tests__/SerialLog.test.tsx
@@ -2,7 +2,7 @@ import { BrowserRouter } from "react-router-dom";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { vi } from "vitest";
 import { format, parseISO } from "date-fns";
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import "@testing-library/jest-dom";
@@ -157,7 +157,7 @@ describe("SerialLog", () => {
     expect(screen.getByTestId("serial-log-table")).toBeInTheDocument();
   });
 
-  it("passes default page size and date range to useSerialLogs when none is set", () => {
+  it("passes default page size without a date range to useSerialLogs when none is set", () => {
     mockuseSerialLogs.mockReturnValue(useSerialLogsPermissions);
 
     renderWithSearchParams();
@@ -166,10 +166,6 @@ describe("SerialLog", () => {
     expect(mockuseSerialLogs.mock.calls[0][2]).toEqual({
       pageSize: 25,
       page: null,
-      interval: {
-        startTime: "2026-05-04T00:00:00.000Z",
-        endTime: "2026-06-02T23:59:59.000Z",
-      },
     });
   });
 
@@ -241,6 +237,69 @@ describe("SerialLog", () => {
 
     expect(screen.getByLabelText("Start time")).toHaveValue("00:00:00");
     expect(screen.getByLabelText("End time")).toHaveValue("23:59:59");
+  });
+
+  it("detects an active preset date range from URL params", () => {
+    mockuseSerialLogs.mockReturnValue(useSerialLogsPermissions);
+
+    renderWithSearchParams({
+      "start-time": "2026-05-27T00:00:00.000Z",
+      "end-time": "2026-06-02T23:59:59.000Z",
+    });
+
+    const select = document.getElementById(
+      "date-range-preset",
+    ) as HTMLSelectElement;
+    expect(select).toHaveValue("last-7-days");
+    expect(
+      screen.getByText("Showing serial logs for the last 7 days"),
+    ).toBeInTheDocument();
+    expect(screen.queryByLabelText("Start date")).not.toBeInTheDocument();
+  });
+
+  it("applies a selected preset date range and clears pagination params", () => {
+    mockuseSerialLogs.mockReturnValue(useSerialLogsPermissions);
+
+    renderWithSearchParams({
+      filter: mockFilterQuery,
+      page: "cursor",
+      "page-size": "50",
+    });
+
+    const select = document.getElementById(
+      "date-range-preset",
+    ) as HTMLSelectElement;
+    fireEvent.change(select, { target: { value: "today" } });
+
+    expect(mockNavigate).toHaveBeenCalledWith({
+      pathname: mockPathname,
+      search:
+        `?filter=${mockFilterQuery}` +
+        "&start-time=2026-06-02T00:00:00.000Z" +
+        "&end-time=2026-06-02T23:59:59.000Z",
+    });
+  });
+
+  it("clears date range params when selecting the default last 30 days preset", () => {
+    mockuseSerialLogs.mockReturnValue(useSerialLogsPermissions);
+
+    renderWithSearchParams({
+      filter: mockFilterQuery,
+      page: "cursor",
+      "page-size": "50",
+      "start-time": "2026-05-01T00:00:00.000Z",
+      "end-time": "2026-05-10T23:59:59.000Z",
+    });
+
+    const select = document.getElementById(
+      "date-range-preset",
+    ) as HTMLSelectElement;
+    fireEvent.change(select, { target: { value: "last-30-days" } });
+
+    expect(mockNavigate).toHaveBeenCalledWith({
+      pathname: mockPathname,
+      search: `?filter=${mockFilterQuery}`,
+    });
   });
 
   it("shows a default date range of exactly 30 inclusive days", async () => {

--- a/static/js/publisher/pages/SerialLog/__tests__/SerialLog.test.tsx
+++ b/static/js/publisher/pages/SerialLog/__tests__/SerialLog.test.tsx
@@ -71,6 +71,10 @@ function renderWithSearchParams(searchParams: Record<string, string> = {}) {
   return renderComponent();
 }
 
+function getVisibleDateRangeSummary(text: string): HTMLElement {
+  return screen.getByText(text, { selector: ".p-form-help-text" });
+}
+
 const useSerialLogsNoPermissions = {
   data: {
     message: "There was a problem fetching serial logs",
@@ -88,6 +92,12 @@ const useSerialLogsPermissions = {
   isLoading: false,
   isError: false,
 } as unknown as UseQueryResult<ApiResponse<SerialLogResponse>, Error>;
+
+const useSerialLogsLoading = {
+  data: undefined,
+  isLoading: true,
+  isError: false,
+} as UseQueryResult<ApiResponse<SerialLogResponse>, Error>;
 
 const mockUseModels = vi.mocked(useModels);
 mockUseModels.mockReturnValue({
@@ -134,7 +144,22 @@ describe("SerialLog", () => {
     renderComponent();
 
     expect(
-      screen.getByText("Showing serial logs for the last 30 days"),
+      getVisibleDateRangeSummary("Showing serial logs for the last 30 days"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("combobox", {
+        name: "Showing serial logs for the last 30 days",
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it("keeps date selector controls visible while fetching serial logs", () => {
+    mockuseSerialLogs.mockReturnValue(useSerialLogsLoading);
+    renderComponent();
+
+    expect(screen.getByText("Fetching serial logs...")).toBeInTheDocument();
+    expect(
+      getVisibleDateRangeSummary("Showing serial logs for the last 30 days"),
     ).toBeInTheDocument();
     expect(
       screen.getByRole("combobox", {
@@ -175,7 +200,7 @@ describe("SerialLog", () => {
     renderWithSearchParams();
 
     expect(
-      screen.getByText("Showing serial logs for the last 30 days"),
+      getVisibleDateRangeSummary("Showing serial logs for the last 30 days"),
     ).toBeInTheDocument();
     const select = document.getElementById(
       "date-range-preset",
@@ -217,7 +242,7 @@ describe("SerialLog", () => {
       format(parseISO(endTime), "HH:mm:ss"),
     );
     expect(
-      screen.getByText(
+      getVisibleDateRangeSummary(
         "Showing serial logs between 1 May, 2026 and 10 May, 2026",
       ),
     ).toBeInTheDocument();
@@ -252,7 +277,7 @@ describe("SerialLog", () => {
     ) as HTMLSelectElement;
     expect(select).toHaveValue("last-7-days");
     expect(
-      screen.getByText("Showing serial logs for the last 7 days"),
+      getVisibleDateRangeSummary("Showing serial logs for the last 7 days"),
     ).toBeInTheDocument();
     expect(screen.queryByLabelText("Start date")).not.toBeInTheDocument();
   });
@@ -432,7 +457,7 @@ describe("SerialLog", () => {
     expect(mockNavigate).not.toHaveBeenCalled();
   });
 
-  it("removes date range query params when clicking Clear", async () => {
+  it("removes date range query params when clicking Reset", async () => {
     mockuseSerialLogs.mockReturnValue(useSerialLogsPermissions);
 
     renderWithSearchParams({
@@ -445,7 +470,7 @@ describe("SerialLog", () => {
     vi.useRealTimers();
     const user = userEvent.setup();
 
-    await user.click(screen.getByRole("button", { name: "Clear" }));
+    await user.click(screen.getByRole("button", { name: "Reset" }));
 
     expect(mockNavigate).toHaveBeenCalledWith({
       pathname: mockPathname,

--- a/static/js/publisher/pages/SerialLog/__tests__/SerialLog.test.tsx
+++ b/static/js/publisher/pages/SerialLog/__tests__/SerialLog.test.tsx
@@ -267,9 +267,27 @@ describe("SerialLog", () => {
   it("detects an active preset date range from URL params", () => {
     mockuseSerialLogs.mockReturnValue(useSerialLogsPermissions);
 
+    const today = new Date();
+    const startTime = new Date(
+      today.getFullYear(),
+      today.getMonth(),
+      today.getDate() - 6,
+      0,
+      0,
+      0,
+    ).toISOString();
+    const endTime = new Date(
+      today.getFullYear(),
+      today.getMonth(),
+      today.getDate(),
+      23,
+      59,
+      59,
+    ).toISOString();
+
     renderWithSearchParams({
-      "start-time": "2026-05-27T00:00:00.000Z",
-      "end-time": "2026-06-02T23:59:59.000Z",
+      "start-time": startTime,
+      "end-time": endTime,
     });
 
     const select = document.getElementById(

--- a/static/js/publisher/pages/SerialLog/__tests__/SerialLog.test.tsx
+++ b/static/js/publisher/pages/SerialLog/__tests__/SerialLog.test.tsx
@@ -157,7 +157,7 @@ describe("SerialLog", () => {
     expect(screen.getByTestId("serial-log-table")).toBeInTheDocument();
   });
 
-  it("passes default page size 25 to useSerialLogs when none is set", () => {
+  it("passes default page size and date range to useSerialLogs when none is set", () => {
     mockuseSerialLogs.mockReturnValue(useSerialLogsPermissions);
 
     renderWithSearchParams();
@@ -166,6 +166,10 @@ describe("SerialLog", () => {
     expect(mockuseSerialLogs.mock.calls[0][2]).toEqual({
       pageSize: 25,
       page: null,
+      interval: {
+        startTime: "2026-05-04T00:00:00.000Z",
+        endTime: "2026-06-02T23:59:59.000Z",
+      },
     });
   });
 
@@ -367,5 +371,26 @@ describe("SerialLog", () => {
     expect(screen.queryByLabelText("Start date")).not.toBeInTheDocument();
     // URL params should not change
     expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it("removes date range query params when clicking Clear", async () => {
+    mockuseSerialLogs.mockReturnValue(useSerialLogsPermissions);
+
+    renderWithSearchParams({
+      filter: mockFilterQuery,
+      "start-time": "2026-05-01T00:00:00.000Z",
+      "end-time": "2026-05-10T23:59:59.000Z",
+      "page-size": "50",
+      page: "cursor",
+    });
+    vi.useRealTimers();
+    const user = userEvent.setup();
+
+    await user.click(screen.getByRole("button", { name: "Clear" }));
+
+    expect(mockNavigate).toHaveBeenCalledWith({
+      pathname: mockPathname,
+      search: `?filter=${mockFilterQuery}`,
+    });
   });
 });

--- a/static/js/publisher/pages/SerialLog/__tests__/SerialLog.test.tsx
+++ b/static/js/publisher/pages/SerialLog/__tests__/SerialLog.test.tsx
@@ -374,6 +374,30 @@ describe("SerialLog", () => {
 
     expect(screen.getByLabelText("Start date")).toHaveValue("2026-05-04");
     expect(screen.getByLabelText("End date")).toHaveValue("2026-06-02");
+    expect(screen.getByLabelText("End date")).toHaveAttribute(
+      "max",
+      "2026-06-02",
+    );
+  });
+
+  it("limits the end date picker to 30 inclusive days from the start date", async () => {
+    mockuseSerialLogs.mockReturnValue(useSerialLogsPermissions);
+
+    renderWithSearchParams();
+    vi.useRealTimers();
+    const user = userEvent.setup();
+
+    const select = document.getElementById(
+      "date-range-preset",
+    ) as HTMLSelectElement;
+    await user.selectOptions(select, "custom");
+    await user.clear(screen.getByLabelText("Start date"));
+    await user.type(screen.getByLabelText("Start date"), "2026-05-01");
+
+    expect(screen.getByLabelText("End date")).toHaveAttribute(
+      "max",
+      "2026-05-30",
+    );
   });
 
   it("applies a valid custom date range", async () => {

--- a/static/js/publisher/pages/SerialLog/__tests__/SerialLog.test.tsx
+++ b/static/js/publisher/pages/SerialLog/__tests__/SerialLog.test.tsx
@@ -296,12 +296,27 @@ describe("SerialLog", () => {
     ) as HTMLSelectElement;
     fireEvent.change(select, { target: { value: "today" } });
 
+    const today = new Date();
+    const expectedStart = new Date(
+      today.getFullYear(),
+      today.getMonth(),
+      today.getDate(),
+      0,
+      0,
+      0,
+    ).toISOString();
+    const expectedEnd = new Date(
+      today.getFullYear(),
+      today.getMonth(),
+      today.getDate(),
+      23,
+      59,
+      59,
+    ).toISOString();
+
     expect(mockNavigate).toHaveBeenCalledWith({
       pathname: mockPathname,
-      search:
-        `?filter=${mockFilterQuery}` +
-        "&start-time=2026-06-02T00:00:00.000Z" +
-        "&end-time=2026-06-02T23:59:59.000Z",
+      search: `?filter=${mockFilterQuery}&start-time=${expectedStart}&end-time=${expectedEnd}`,
     });
   });
 

--- a/static/js/publisher/pages/SerialLog/__tests__/SerialLog.test.tsx
+++ b/static/js/publisher/pages/SerialLog/__tests__/SerialLog.test.tsx
@@ -134,10 +134,12 @@ describe("SerialLog", () => {
     renderComponent();
 
     expect(
-      screen.getByText("Showing serial logs for the past 30 days"),
+      screen.getByText("Showing serial logs for the last 30 days"),
     ).toBeInTheDocument();
     expect(
-      screen.getByRole("button", { name: "Select custom date range" }),
+      screen.getByRole("combobox", {
+        name: "Showing serial logs for the last 30 days",
+      }),
     ).toBeInTheDocument();
   });
 
@@ -173,11 +175,12 @@ describe("SerialLog", () => {
     renderWithSearchParams();
 
     expect(
-      screen.getByText("Showing serial logs for the past 30 days"),
+      screen.getByText("Showing serial logs for the last 30 days"),
     ).toBeInTheDocument();
-    expect(
-      screen.getByRole("button", { name: "Select custom date range" }),
-    ).toBeInTheDocument();
+    const select = document.getElementById(
+      "date-range-preset",
+    ) as HTMLSelectElement;
+    expect(select).toHaveValue("last-30-days");
     expect(screen.queryByLabelText("Start date")).not.toBeInTheDocument();
     expect(screen.queryByLabelText("End date")).not.toBeInTheDocument();
   });
@@ -193,6 +196,10 @@ describe("SerialLog", () => {
       "end-time": endTime,
     });
 
+    const select = document.getElementById(
+      "date-range-preset",
+    ) as HTMLSelectElement;
+    expect(select).toHaveValue("custom");
     expect(screen.getByLabelText("Start date")).toHaveAttribute("type", "date");
     expect(screen.getByLabelText("Start date")).toHaveValue(
       format(parseISO(startTime), "yyyy-MM-dd"),
@@ -223,9 +230,10 @@ describe("SerialLog", () => {
     vi.useRealTimers();
     const user = userEvent.setup();
 
-    await user.click(
-      screen.getByRole("button", { name: "Select custom date range" }),
-    );
+    const select = document.getElementById(
+      "date-range-preset",
+    ) as HTMLSelectElement;
+    await user.selectOptions(select, "custom");
 
     expect(screen.getByLabelText("Start time")).toHaveValue("00:00:00");
     expect(screen.getByLabelText("End time")).toHaveValue("23:59:59");
@@ -238,9 +246,10 @@ describe("SerialLog", () => {
     vi.useRealTimers();
     const user = userEvent.setup();
 
-    await user.click(
-      screen.getByRole("button", { name: "Select custom date range" }),
-    );
+    const select = document.getElementById(
+      "date-range-preset",
+    ) as HTMLSelectElement;
+    await user.selectOptions(select, "custom");
 
     expect(screen.getByLabelText("Start date")).toHaveValue("2026-05-04");
     expect(screen.getByLabelText("End date")).toHaveValue("2026-06-02");
@@ -253,9 +262,10 @@ describe("SerialLog", () => {
     vi.useRealTimers();
     const user = userEvent.setup();
 
-    await user.click(
-      screen.getByRole("button", { name: "Select custom date range" }),
-    );
+    const select = document.getElementById(
+      "date-range-preset",
+    ) as HTMLSelectElement;
+    await user.selectOptions(select, "custom");
     await user.clear(screen.getByLabelText("Start date"));
     await user.type(screen.getByLabelText("Start date"), "2026-05-01");
     await user.clear(screen.getByLabelText("End date"));
@@ -276,9 +286,10 @@ describe("SerialLog", () => {
     vi.useRealTimers();
     const user = userEvent.setup();
 
-    await user.click(
-      screen.getByRole("button", { name: "Select custom date range" }),
-    );
+    const select = document.getElementById(
+      "date-range-preset",
+    ) as HTMLSelectElement;
+    await user.selectOptions(select, "custom");
     await user.clear(screen.getByLabelText("Start date"));
     await user.type(screen.getByLabelText("Start date"), "2026-05-01");
     await user.clear(screen.getByLabelText("End date"));
@@ -300,9 +311,10 @@ describe("SerialLog", () => {
     vi.useRealTimers();
     const user = userEvent.setup();
 
-    await user.click(
-      screen.getByRole("button", { name: "Select custom date range" }),
-    );
+    const select = document.getElementById(
+      "date-range-preset",
+    ) as HTMLSelectElement;
+    await user.selectOptions(select, "custom");
     await user.clear(screen.getByLabelText("Start date"));
     await user.type(screen.getByLabelText("Start date"), "2026-05-02");
     await user.clear(screen.getByLabelText("End date"));
@@ -337,7 +349,7 @@ describe("SerialLog", () => {
     expect(mockNavigate).not.toHaveBeenCalled();
   });
 
-  it("removes date range query params when closing the panel", async () => {
+  it("closes the date panel without changing URL params when clicking Close", async () => {
     mockuseSerialLogs.mockReturnValue(useSerialLogsPermissions);
 
     renderWithSearchParams({
@@ -351,9 +363,9 @@ describe("SerialLog", () => {
 
     await user.click(screen.getByRole("button", { name: "Close" }));
 
-    expect(mockNavigate).toHaveBeenCalledWith({
-      pathname: mockPathname,
-      search: "",
-    });
+    // Panel should be closed
+    expect(screen.queryByLabelText("Start date")).not.toBeInTheDocument();
+    // URL params should not change
+    expect(mockNavigate).not.toHaveBeenCalled();
   });
 });

--- a/static/js/publisher/pages/SerialLog/__tests__/dateRange.test.ts
+++ b/static/js/publisher/pages/SerialLog/__tests__/dateRange.test.ts
@@ -6,6 +6,7 @@ import {
   formatReadableDate,
   formatTimeInputValue,
   getDefaultDateRange,
+  getMaxEndDate,
   getPresetDateRange,
   getPresetTimestampRange,
 } from "../dateRange";
@@ -33,6 +34,10 @@ describe("dateRange", () => {
       startDate: "2026-05-04",
       endDate: "2026-06-02",
     });
+  });
+
+  it("returns the latest valid end date for an inclusive 30 day range", () => {
+    expect(getMaxEndDate("2026-05-01")).toBe("2026-05-30");
   });
 
   it("returns date ranges for supported presets", () => {

--- a/static/js/publisher/pages/SerialLog/__tests__/dateRange.test.ts
+++ b/static/js/publisher/pages/SerialLog/__tests__/dateRange.test.ts
@@ -13,7 +13,7 @@ import {
 describe("dateRange", () => {
   beforeEach(() => {
     vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-06-02T14:34:23.666Z"));
+    vi.setSystemTime(new Date(2026, 5, 2, 14, 34, 23, 666));
   });
 
   afterEach(() => {
@@ -21,7 +21,7 @@ describe("dateRange", () => {
   });
 
   it("formats date and time input values", () => {
-    const date = new Date("2026-05-01T12:13:14.000Z");
+    const date = new Date(2026, 4, 1, 12, 13, 14);
 
     expect(formatDateInputValue(date)).toBe("2026-05-01");
     expect(formatTimeInputValue(date)).toBe("12:13:14");
@@ -67,15 +67,15 @@ describe("dateRange", () => {
     expect(
       buildTimestampRange("2026-05-01", "12:13:14", "2026-05-10", "20:21:22"),
     ).toEqual({
-      startTime: "2026-05-01T12:13:14.000Z",
-      endTime: "2026-05-10T20:21:22.000Z",
+      startTime: new Date(2026, 4, 1, 12, 13, 14).toISOString(),
+      endTime: new Date(2026, 4, 10, 20, 21, 22).toISOString(),
     });
   });
 
   it("returns timestamp ranges for supported presets", () => {
     expect(getPresetTimestampRange("last-7-days")).toEqual({
-      startTime: "2026-05-27T00:00:00.000Z",
-      endTime: "2026-06-02T23:59:59.000Z",
+      startTime: new Date(2026, 4, 27, 0, 0, 0).toISOString(),
+      endTime: new Date(2026, 5, 2, 23, 59, 59).toISOString(),
     });
     expect(getPresetTimestampRange("custom")).toBeNull();
   });

--- a/static/js/publisher/pages/SerialLog/__tests__/dateRange.test.ts
+++ b/static/js/publisher/pages/SerialLog/__tests__/dateRange.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  buildTimestampRange,
+  formatDateInputValue,
+  formatReadableDate,
+  formatTimeInputValue,
+  getDefaultDateRange,
+  getPresetDateRange,
+  getPresetTimestampRange,
+} from "../dateRange";
+
+describe("dateRange", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-02T14:34:23.666Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("formats date and time input values", () => {
+    const date = new Date("2026-05-01T12:13:14.000Z");
+
+    expect(formatDateInputValue(date)).toBe("2026-05-01");
+    expect(formatTimeInputValue(date)).toBe("12:13:14");
+    expect(formatReadableDate("2026-05-01")).toBe("1 May, 2026");
+  });
+
+  it("returns the default inclusive 30 day date range", () => {
+    expect(getDefaultDateRange()).toEqual({
+      startDate: "2026-05-04",
+      endDate: "2026-06-02",
+    });
+  });
+
+  it("returns date ranges for supported presets", () => {
+    expect(getPresetDateRange("today")).toEqual({
+      startDate: "2026-06-02",
+      endDate: "2026-06-02",
+      startTime: "00:00:00",
+      endTime: "23:59:59",
+    });
+    expect(getPresetDateRange("yesterday")).toEqual({
+      startDate: "2026-06-01",
+      endDate: "2026-06-01",
+      startTime: "00:00:00",
+      endTime: "23:59:59",
+    });
+    expect(getPresetDateRange("last-7-days")).toEqual({
+      startDate: "2026-05-27",
+      endDate: "2026-06-02",
+      startTime: "00:00:00",
+      endTime: "23:59:59",
+    });
+    expect(getPresetDateRange("last-30-days")).toEqual({
+      startDate: "2026-05-04",
+      endDate: "2026-06-02",
+      startTime: "00:00:00",
+      endTime: "23:59:59",
+    });
+    expect(getPresetDateRange("custom")).toBeNull();
+  });
+
+  it("builds ISO timestamp ranges", () => {
+    expect(
+      buildTimestampRange("2026-05-01", "12:13:14", "2026-05-10", "20:21:22"),
+    ).toEqual({
+      startTime: "2026-05-01T12:13:14.000Z",
+      endTime: "2026-05-10T20:21:22.000Z",
+    });
+  });
+
+  it("returns timestamp ranges for supported presets", () => {
+    expect(getPresetTimestampRange("last-7-days")).toEqual({
+      startTime: "2026-05-27T00:00:00.000Z",
+      endTime: "2026-06-02T23:59:59.000Z",
+    });
+    expect(getPresetTimestampRange("custom")).toBeNull();
+  });
+});

--- a/static/js/publisher/pages/SerialLog/dateRange.ts
+++ b/static/js/publisher/pages/SerialLog/dateRange.ts
@@ -1,0 +1,111 @@
+import { format, parseISO, subDays } from "date-fns";
+
+export type DatePreset =
+  | "today"
+  | "yesterday"
+  | "last-7-days"
+  | "last-30-days"
+  | "custom";
+
+export const DEFAULT_START_TIME = "00:00:00";
+export const DEFAULT_END_TIME = "23:59:59";
+
+export function formatDateInputValue(date: Date): string {
+  return format(date, "yyyy-MM-dd");
+}
+
+export function formatTimeInputValue(date: Date): string {
+  return format(date, "HH:mm:ss");
+}
+
+export function getDefaultDateRange(): { startDate: string; endDate: string } {
+  const today = new Date();
+
+  return {
+    startDate: formatDateInputValue(subDays(today, 29)),
+    endDate: formatDateInputValue(today),
+  };
+}
+
+export function formatReadableDate(dateValue: string): string {
+  const date = parseISO(dateValue);
+
+  return format(date, "d MMMM, yyyy");
+}
+
+export function buildTimestampRange(
+  startDate: string,
+  startTime: string,
+  endDate: string,
+  endTime: string,
+): {
+  startTime: string;
+  endTime: string;
+} {
+  const startTimeValue = parseISO(`${startDate}T${startTime}`).toISOString();
+  const endTimeValue = parseISO(`${endDate}T${endTime}`).toISOString();
+
+  return { startTime: startTimeValue, endTime: endTimeValue };
+}
+
+export function getPresetDateRange(preset: DatePreset): {
+  startDate: string;
+  endDate: string;
+  startTime: string;
+  endTime: string;
+} | null {
+  const today = new Date();
+
+  switch (preset) {
+    case "today":
+      return {
+        startDate: formatDateInputValue(today),
+        endDate: formatDateInputValue(today),
+        startTime: DEFAULT_START_TIME,
+        endTime: DEFAULT_END_TIME,
+      };
+    case "yesterday": {
+      const yesterday = subDays(today, 1);
+      return {
+        startDate: formatDateInputValue(yesterday),
+        endDate: formatDateInputValue(yesterday),
+        startTime: DEFAULT_START_TIME,
+        endTime: DEFAULT_END_TIME,
+      };
+    }
+    case "last-7-days":
+      return {
+        startDate: formatDateInputValue(subDays(today, 6)),
+        endDate: formatDateInputValue(today),
+        startTime: DEFAULT_START_TIME,
+        endTime: DEFAULT_END_TIME,
+      };
+    case "last-30-days":
+      return {
+        startDate: formatDateInputValue(subDays(today, 29)),
+        endDate: formatDateInputValue(today),
+        startTime: DEFAULT_START_TIME,
+        endTime: DEFAULT_END_TIME,
+      };
+    default:
+      return null;
+  }
+}
+
+export function getPresetTimestampRange(preset: DatePreset): {
+  startTime: string;
+  endTime: string;
+} | null {
+  const range = getPresetDateRange(preset);
+
+  if (!range) {
+    return null;
+  }
+
+  return buildTimestampRange(
+    range.startDate,
+    range.startTime,
+    range.endDate,
+    range.endTime,
+  );
+}

--- a/static/js/publisher/pages/SerialLog/dateRange.ts
+++ b/static/js/publisher/pages/SerialLog/dateRange.ts
@@ -1,4 +1,4 @@
-import { format, parseISO, subDays } from "date-fns";
+import { addDays, format, parseISO, subDays } from "date-fns";
 
 export type DatePreset =
   | "today"
@@ -25,6 +25,10 @@ export function getDefaultDateRange(): { startDate: string; endDate: string } {
     startDate: formatDateInputValue(subDays(today, 29)),
     endDate: formatDateInputValue(today),
   };
+}
+
+export function getMaxEndDate(startDate: string): string {
+  return formatDateInputValue(addDays(parseISO(startDate), 29));
 }
 
 export function formatReadableDate(dateValue: string): string {


### PR DESCRIPTION
## Done
Improves the usability of the serial log date and time filters by including presets and making the custom panel more intuitive

## How to QA
- Go to https://snapcraft-io-5780.demos.haus/admin/ahnuP3quahti9vis8aiw/models/test-superalpaca-00/serial-log
- Check that the last 30 days are selected by default (there aren't logs for this period so there will be no results)
- Check that selecting other filters such as "Today", "Yesterday" and "Last 7 days" update the start and end time parameters in the URL (there aren't logs for this period so there will be no results)
- Select "Custom" and check that a panel for selecting the date and time appears
- Set the date range to cover the 23rd March 2026, click "Apply date range" and check that there are some serial logs
- Click "Edit" and check that the panel appears
- Click "Reset" and check that the panel closes and the filter resets to its default view of "Last 30 days"

## Testing

- [x] This PR has tests
- [ ] No testing required (explain why):

## Security

- [ ] Security considerations for review (list them):
  - [ ] Examples:
  - [ ] Access control: users can only access their own data
  - [ ] Input: user input is validated and sanitised
  - [ ] Sensitive data: secret or private data is not exposed in any way
  - [ ] ...
- [x] This PR has no security considerations (explain why): No new user inputs introduced

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-37251

## Screenshots

## UX Approval

- [ ] This PR does not require UX approval
- [x] This PR does require UX approval (add context):
