### PR TITLE
chore: Update Thunderbird screenshot on homepage

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -127,10 +127,10 @@
     <div class="u-fixed-width">
       {{
         image(
-          url="https://assets.ubuntu.com/v1/a0501ed2-thunderbird_snap_page.png",
+          url="https://assets.ubuntu.com/v1/60360b3d-thunderbird_snap_page.png",
           alt="Snap details page",
-          width="2216",
-          height="1591",
+          width="2664",
+          height="1832",
           hi_def=True,
           attrs={"class": "u-full-width"}
         ) | safe


### PR DESCRIPTION
## Done

Updates the Thunderbird screenshot on the homepage as the current crop blends in too much with the page and could be confusing to visitors.

## How to QA
- Go to https://snapcraft-io-5781.demos.haus/
- Scroll down to the "Showcase to millions" section and check that the Thunderbird screenshot shows within a browser frame

## Testing

- [ ] This PR has tests
- [x] No testing required (explain why): Visual change

## Security

- [ ] Security considerations for review (list them):
  - [ ] Examples:
  - [ ] Access control: users can only access their own data
  - [ ] Input: user input is validated and sanitised
  - [ ] Sensitive data: secret or private data is not exposed in any way
  - [ ] ...
- [x] This PR has no security considerations (explain why): Visual change

## Issue / Card

n/a

## Screenshots

n/a

## UX Approval

- [x] This PR does not require UX approval
- [ ] This PR does require UX approval (add context):
