### PR TITLE
Pass publisher: search terms to the store API publisher filter

### DIFF
--- a/tests/packages/tests_logic.py
+++ b/tests/packages/tests_logic.py
@@ -1,0 +1,67 @@
+import unittest
+from unittest.mock import patch
+
+from webapp.packages.logic import extract_publisher, fetch_packages
+
+
+class TestExtractPublisher(unittest.TestCase):
+    def test_publisher_only_query(self):
+        publisher, query = extract_publisher("publisher:snapcrafters")
+        self.assertEqual(publisher, "snapcrafters")
+        self.assertEqual(query, "")
+
+    def test_publisher_with_text_query(self):
+        publisher, query = extract_publisher("publisher:snapcrafters terminal")
+        self.assertEqual(publisher, "snapcrafters")
+        self.assertEqual(query, "terminal")
+
+    def test_no_publisher_term(self):
+        publisher, query = extract_publisher("terminal emulator")
+        self.assertIsNone(publisher)
+        self.assertEqual(query, "terminal emulator")
+
+    def test_prefix_is_case_insensitive(self):
+        publisher, query = extract_publisher("Publisher:snapcrafters")
+        self.assertEqual(publisher, "snapcrafters")
+        self.assertEqual(query, "")
+
+    def test_empty_publisher_value_is_kept_as_text(self):
+        publisher, query = extract_publisher("publisher:")
+        self.assertIsNone(publisher)
+        self.assertEqual(query, "publisher:")
+
+    def test_colon_in_other_terms_is_untouched(self):
+        publisher, query = extract_publisher("category:games chess")
+        self.assertIsNone(publisher)
+        self.assertEqual(query, "category:games chess")
+
+    def test_empty_query(self):
+        publisher, query = extract_publisher("")
+        self.assertIsNone(publisher)
+        self.assertEqual(query, "")
+
+
+class TestFetchPackagesPublisherFilter(unittest.TestCase):
+    @patch("webapp.packages.logic.device_gateway")
+    def test_publisher_term_is_passed_as_filter(self, mock_device_gateway):
+        mock_device_gateway.find.return_value = {"results": []}
+
+        fetch_packages(["title"], {"q": "publisher:snapcrafters"})
+
+        _, kwargs = mock_device_gateway.find.call_args
+        self.assertEqual(kwargs["publisher"], "snapcrafters")
+        self.assertEqual(kwargs["query"], "")
+
+    @patch("webapp.packages.logic.device_gateway")
+    def test_plain_query_has_no_publisher_filter(self, mock_device_gateway):
+        mock_device_gateway.find.return_value = {"results": []}
+
+        fetch_packages(["title"], {"q": "terminal"})
+
+        _, kwargs = mock_device_gateway.find.call_args
+        self.assertNotIn("publisher", kwargs)
+        self.assertEqual(kwargs["query"], "terminal")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/webapp/packages/logic.py
+++ b/webapp/packages/logic.py
@@ -35,6 +35,27 @@ Package = TypedDict(
 )
 
 
+def extract_publisher(query: str):
+    """
+    Extracts a `publisher:<username>` term from a search query.
+
+    :param: query: The raw search query string.
+
+    :returns: a tuple of (publisher or None, remaining query text).
+    """
+    publisher = None
+    remaining_terms = []
+
+    for term in query.split():
+        prefix, _, value = term.partition(":")
+        if prefix.lower() == "publisher" and value:
+            publisher = value
+        else:
+            remaining_terms.append(term)
+
+    return publisher, " ".join(remaining_terms)
+
+
 def fetch_packages(fields: List[str], query_params) -> Packages:
     """
     Fetches packages from the store API based on the specified fields.
@@ -57,11 +78,21 @@ def fetch_packages(fields: List[str], query_params) -> Packages:
     if package_type == "all":
         package_type = None
 
+    # `publisher:<username>` terms scope results to that publisher via the
+    # store API's publisher filter instead of being matched as free text,
+    # which returns unrelated snaps. Publisher pages link to
+    # /search?q=publisher:<username>, so this keeps those links accurate.
+    # See https://github.com/canonical/snapcraft.io/issues/5757.
+    publisher, query = extract_publisher(query)
+
     args = {
         "category": category,
         "fields": fields,
         "query": query,
     }
+
+    if publisher:
+        args["publisher"] = publisher
 
     if package_type:
         args["type"] = package_type


### PR DESCRIPTION
### Done

Fixes #5757.

Searching `publisher:<name>` — the syntax linked from the bottom of publisher pages (e.g. Snapcrafters) — passed the entire string as free text to the store API's find endpoint. The API matched it fuzzily, so results were incomplete and mixed with other publishers' snaps.

`fetch_packages` now extracts `publisher:<username>` terms from the query and passes them through the store API's `publisher` parameter — the same parameter the community publisher pages already use (`webapp/store/views.py`), which returns accurate results. Any remaining terms are kept as the text query, so:

- `?q=publisher:snapcrafters` → exactly Snapcrafters' snaps
- `?q=publisher:kde terminal` → text search for "terminal" scoped to KDE

The prefix match is case-insensitive; a bare `publisher:` (no value) and other `foo:bar` terms are left untouched as free text.

### QA

1. Run the site with `dotrun`
2. Visit `/search?q=publisher%3Asnapcrafters` — all results should be from the snapcrafters publisher (previously: mixed/incomplete)
3. Visit `/search?q=terminal` — unchanged behavior
4. Unit tests: `tests/packages/tests_logic.py` covers the term extraction (7 cases) and that the publisher filter reaches `device_gateway.find` (2 cases)