### PR TITLE
Fix agreement onboarding redirect

### DIFF
--- a/tests/login/tests_login_handler.py
+++ b/tests/login/tests_login_handler.py
@@ -3,7 +3,10 @@ import requests
 import responses
 from flask_testing import TestCase
 from pymacaroons import Macaroon
-from canonicalwebteam.exceptions import PublisherAgreementNotSigned
+from canonicalwebteam.exceptions import (
+    PublisherAgreementNotSigned,
+    StoreApiResponseErrorList,
+)
 from webapp.app import create_app
 
 from unittest.mock import patch, MagicMock
@@ -312,3 +315,79 @@ class AfterLoginHandlerTest(TestCase):
             assert publisher["nickname"] == self.mock_resp.nickname
             assert publisher["email"] == self.mock_resp.email
             assert s["macaroon_exchanged"] == "exchanged-macaroon"
+
+    @patch("webapp.login.views.dashboard.get_validation_sets")
+    @patch("webapp.login.views.dashboard.get_account")
+    @patch("webapp.login.views.publisher_gateway.exchange_dashboard_macaroons")
+    def test_after_login_account_not_found_redirects_to_agreement(
+        self,
+        mock_exchange,
+        _mock_get_account,
+        _mock_validation_sets,
+    ):
+        # Regression test for issue #5788: a brand-new publisher who has never
+        # accepted the developer Terms & Conditions has no publisher account
+        # yet, so the macaroon exchange fails with "account-not-found".
+        # Instead of returning a 404, the user must be redirected to the
+        # agreement page with an authenticated session and the dashboard
+        # macaroons preserved, so accepting the agreement can create the
+        # account.
+        self.prepare_mock_response(MagicMock(), groups=[])
+        mock_exchange.side_effect = StoreApiResponseErrorList(
+            "The api returned a list of errors",
+            404,
+            [
+                {
+                    "code": "account-not-found",
+                    "message": (
+                        "The account specified in the dashboard "
+                        "macaroons was not found"
+                    ),
+                }
+            ],
+        )
+
+        with self.client.session_transaction() as s:
+            s["macaroon_root"] = self.root_macaroon
+
+        response = self.client.get("/_test_after_login")
+
+        assert response.status_code == 302
+        assert response.location == "/account/agreement"
+
+        with self.client.session_transaction() as s:
+            publisher = s.get("publisher")
+            assert publisher is not None
+            assert publisher["nickname"] == self.mock_resp.nickname
+            # Dashboard macaroons must be preserved so the agreement POST is
+            # authorized and can onboard the account.
+            assert "macaroon_root" in s
+            assert "macaroon_discharge" in s
+            assert "macaroon_exchanged" not in s
+
+    @patch("webapp.login.views.dashboard.get_validation_sets")
+    @patch("webapp.login.views.dashboard.get_account")
+    @patch("webapp.login.views.publisher_gateway.exchange_dashboard_macaroons")
+    def test_after_login_reraises_other_exchange_errors(
+        self,
+        mock_exchange,
+        _mock_get_account,
+        _mock_validation_sets,
+    ):
+        # Exchange failures unrelated to onboarding must not be swallowed as
+        # an agreement redirect; they should surface as a server error.
+        self.prepare_mock_response(MagicMock(), groups=[])
+        mock_exchange.side_effect = StoreApiResponseErrorList(
+            "The api returned a list of errors",
+            500,
+            [{"code": "some-other-error", "message": "boom"}],
+        )
+
+        with self.client.session_transaction() as s:
+            s["macaroon_root"] = self.root_macaroon
+
+        response = self.client.get("/_test_after_login")
+
+        assert response.status_code != 302
+        with self.client.session_transaction() as s:
+            assert "publisher" not in s

--- a/tests/login/tests_login_handler.py
+++ b/tests/login/tests_login_handler.py
@@ -3,6 +3,7 @@ import requests
 import responses
 from flask_testing import TestCase
 from pymacaroons import Macaroon
+from canonicalwebteam.exceptions import PublisherAgreementNotSigned
 from webapp.app import create_app
 
 from unittest.mock import patch, MagicMock
@@ -277,3 +278,37 @@ class AfterLoginHandlerTest(TestCase):
                 assert "macaroon_discharge" not in s
 
             mock_exchange.assert_called_once()
+
+    @patch("webapp.login.views.dashboard.get_validation_sets")
+    @patch("webapp.login.views.dashboard.get_account")
+    @patch(
+        "webapp.login.views.publisher_gateway" ".exchange_dashboard_macaroons",
+        return_value="exchanged-macaroon",
+    )
+    def test_after_login_agreement_not_signed_keeps_user_authenticated(
+        self,
+        _mock_exchange,
+        mock_get_account,
+        _mock_validation_sets,
+    ):
+        # Regression test for issue #5788: a publisher who has not yet
+        # accepted the developer Terms & Conditions must still end up with an
+        # authenticated session and be guided to the agreement page, rather
+        # than dead-ending in a redirect loop / 404.
+        self.prepare_mock_response(MagicMock(), groups=[])
+        mock_get_account.side_effect = PublisherAgreementNotSigned
+
+        with self.client.session_transaction() as s:
+            s["macaroon_root"] = self.root_macaroon
+
+        response = self.client.get("/_test_after_login")
+
+        assert response.status_code == 302
+        assert response.location == "/account/agreement"
+
+        with self.client.session_transaction() as s:
+            publisher = s.get("publisher")
+            assert publisher is not None
+            assert publisher["nickname"] == self.mock_resp.nickname
+            assert publisher["email"] == self.mock_resp.email
+            assert s["macaroon_exchanged"] == "exchanged-macaroon"

--- a/webapp/login/views.py
+++ b/webapp/login/views.py
@@ -14,6 +14,7 @@ from webapp.api.exceptions import ApiResponseError
 from webapp.extensions import csrf
 from webapp.login.macaroon import MacaroonRequest, MacaroonResponse
 from webapp.publisher.snaps import logic
+from canonicalwebteam.exceptions import StoreApiResponseErrorList
 
 login = flask.Blueprint(
     "login", __name__, template_folder="/templates", static_folder="/static"
@@ -83,20 +84,35 @@ def after_login(resp):
     # Exchange root + discharge for a single dashboard token.
     # Both keys are in the session here, so exchange_dashboard_macaroons
     # can read them directly. We then drop them to keep the cookie small.
-    flask.session["macaroon_exchanged"] = (
-        publisher_gateway.exchange_dashboard_macaroons(flask.session)
-    )
+    try:
+        flask.session["macaroon_exchanged"] = (
+            publisher_gateway.exchange_dashboard_macaroons(flask.session)
+        )
+    except StoreApiResponseErrorList as api_error:
+        # A brand-new publisher who has never accepted the developer Terms &
+        # Conditions has no publisher account yet, so the macaroon exchange
+        # fails with "account-not-found". Rather than returning a 404, keep
+        # the dashboard (root + discharge) macaroons, establish a minimal
+        # authenticated session and guide the user to the agreement page.
+        # Accepting the agreement creates the account, after which the
+        # exchange succeeds on the next request. See issue #5788.
+        if any(
+            error.get("code") == "account-not-found"
+            for error in api_error.errors
+        ):
+            flask.session["publisher"] = {
+                "identity_url": resp.identity_url,
+                "nickname": resp.nickname,
+                "fullname": resp.fullname,
+                "image": resp.image,
+                "email": resp.email,
+            }
+            return flask.redirect(flask.url_for("account.get_agreement"))
+        raise
+
     flask.session.pop("macaroon_root", None)
     flask.session.pop("macaroon_discharge", None)
 
-    # Establish a minimal authenticated session from the OpenID response
-    # before querying the dashboard. New publishers who have not yet accepted
-    # the developer Terms & Conditions (or set a username) cause get_account
-    # to raise PublisherAgreementNotSigned / PublisherMissingUsername. Those
-    # are handled by redirecting to the relevant onboarding page, but the
-    # redirect only guides the user correctly if they are already
-    # authenticated. Without this, onboarding dead-ends in a redirect loop
-    # and the store returns a 404. See issue #5788.
     flask.session["publisher"] = {
         "identity_url": resp.identity_url,
         "nickname": resp.nickname,

--- a/webapp/login/views.py
+++ b/webapp/login/views.py
@@ -89,6 +89,22 @@ def after_login(resp):
     flask.session.pop("macaroon_root", None)
     flask.session.pop("macaroon_discharge", None)
 
+    # Establish a minimal authenticated session from the OpenID response
+    # before querying the dashboard. New publishers who have not yet accepted
+    # the developer Terms & Conditions (or set a username) cause get_account
+    # to raise PublisherAgreementNotSigned / PublisherMissingUsername. Those
+    # are handled by redirecting to the relevant onboarding page, but the
+    # redirect only guides the user correctly if they are already
+    # authenticated. Without this, onboarding dead-ends in a redirect loop
+    # and the store returns a 404. See issue #5788.
+    flask.session["publisher"] = {
+        "identity_url": resp.identity_url,
+        "nickname": resp.nickname,
+        "fullname": resp.fullname,
+        "image": resp.image,
+        "email": resp.email,
+    }
+
     account = dashboard.get_account(flask.session)
     validation_sets = dashboard.get_validation_sets(flask.session)
 
@@ -123,14 +139,6 @@ def after_login(resp):
             validation_sets is not None
             and len(validation_sets["assertions"]) > 0
         )
-    else:
-        flask.session["publisher"] = {
-            "identity_url": resp.identity_url,
-            "nickname": resp.nickname,
-            "fullname": resp.fullname,
-            "image": resp.image,
-            "email": resp.email,
-        }
 
     response = flask.make_response(
         flask.redirect(


### PR DESCRIPTION
## Done
- Fix agreement onboarding redirect if the user didn't sign it
## How to QA
- click sign in
- create a new user (use tempmail or `youremail+randomtext@canonical.com`)
- get redirected to dev agreement.
- Try the same on snapcraft.io, get redirected to 404
## Testing

- [x] This PR has tests
- [ ] No testing required (explain why):

Fixes #5788
