### PR TITLE
chore: repath docs sitemap

### DIFF
--- a/templates/sitemap/sitemap-index.xml
+++ b/templates/sitemap/sitemap-index.xml
@@ -10,7 +10,7 @@
     <loc>{{ base_url }}/blog/sitemap.xml</loc>
   </sitemap>
   <sitemap>
-    <loc>{{ base_url }}/docs/sitemap.xml</loc>
+    <loc>{{ base_url }}/docs/doc-sitemap.xml</loc>
   </sitemap>
   <sitemap>
     <loc>{{ base_url }}/tutorials/sitemap.xml</loc>


### PR DESCRIPTION
Because the docs don't use a version or language slug, RTD defaults to the sitemap at the site root. There's a bug with RTD where this path is unavailable after our builds, so we need to rename it.

Downstream of https://github.com/canonical/snap-docs/pull/437

## Done

## How to QA

## Testing

- [ ] This PR has tests
- [x] No testing required (explain why):

## Security

- [ ] Security considerations for review (list them):
  - [ ] Examples:
  - [ ] Access control: users can only access their own data
  - [ ] Input: user input is validated and sanitised
  - [ ] Sensitive data: secret or private data is not exposed in any way
  - [ ] ...
- [x] This PR has no security considerations (explain why): Change to a publicly-available path on an external service

## UX Approval

- [x] This PR does not require UX approval
- [ ] This PR does require UX approval (add context):
