### PR TITLE
fix: Fix issues with publisher settings form

### DIFF
--- a/static/js/publisher/pages/PublisherSettings/PublisherSettingsForm.tsx
+++ b/static/js/publisher/pages/PublisherSettings/PublisherSettingsForm.tsx
@@ -66,8 +66,44 @@ function PublisherSettingsForm({ settings }: Props) {
     name: "blacklist_country_keys",
   });
 
+  const visibilityValue = useWatch({
+    control,
+    name: "visibility",
+  });
+
+  const territoryDistributionStatusValue = useWatch({
+    control,
+    name: "territory_distribution_status",
+  });
+
+  const countryKeysStatusValue = useWatch({
+    control,
+    name: "country_keys_status",
+  });
+
+  const selectedTerritoryDistributionStatus =
+    territoryDistributionStatusValue ??
+    settingsData.territory_distribution_status;
+  const selectedCountryKeysStatus =
+    countryKeysStatusValue ?? settingsData.country_keys_status;
+
+  const dirtyFieldKeys = Object.keys(dirtyFields).filter(
+    (key) => dirtyFields[key],
+  );
+  const onlyVisibilityChanged =
+    dirtyFieldKeys.length === 1 && dirtyFieldKeys[0] === "visibility";
+
   const onSubmit = (data: FieldValues) => {
-    if (getValues("update_metadata_on_release") && dirtyFields.visibility) {
+    const isDisablingMetadataUpdates =
+      dirtyFields.update_metadata_on_release &&
+      !data.update_metadata_on_release;
+
+    if (
+      (getValues("update_metadata_on_release") &&
+        dirtyFields.visibility &&
+        !onlyVisibilityChanged) ||
+      isDisablingMetadataUpdates
+    ) {
       setShowMetadataWarningModal(true);
       setFormData(data);
     } else {
@@ -209,7 +245,9 @@ function PublisherSettingsForm({ settings }: Props) {
                     className="p-radio__input"
                     value="public"
                     disabled={settingsData?.visibility_locked}
-                    defaultChecked={settingsData.visibility === "public"}
+                    checked={
+                      (visibilityValue ?? settingsData.visibility) === "public"
+                    }
                     {...register("visibility")}
                   />
                   <span className="p-radio__label">Public</span>
@@ -227,7 +265,10 @@ function PublisherSettingsForm({ settings }: Props) {
                     className="p-radio__input"
                     value="unlisted"
                     disabled={settingsData?.visibility_locked}
-                    defaultChecked={settingsData.visibility === "unlisted"}
+                    checked={
+                      (visibilityValue ?? settingsData.visibility) ===
+                      "unlisted"
+                    }
                     {...register("visibility")}
                   />
                   <span className="p-radio__label">Unlisted</span>
@@ -246,7 +287,9 @@ function PublisherSettingsForm({ settings }: Props) {
                     className="p-radio__input"
                     value="private"
                     disabled={settingsData?.visibility_locked}
-                    defaultChecked={settingsData.visibility === "private"}
+                    checked={
+                      (visibilityValue ?? settingsData.visibility) === "private"
+                    }
                     {...register("visibility")}
                   />
                   <span className="p-radio__label">Private</span>
@@ -284,9 +327,7 @@ function PublisherSettingsForm({ settings }: Props) {
                       type="radio"
                       className="p-radio__input"
                       value="all"
-                      defaultChecked={
-                        settingsData.territory_distribution_status === "all"
-                      }
+                      checked={selectedTerritoryDistributionStatus === "all"}
                       {...register("territory_distribution_status")}
                     />
                     <span className="p-radio__label">All territories</span>
@@ -301,9 +342,7 @@ function PublisherSettingsForm({ settings }: Props) {
                       type="radio"
                       className="p-radio__input"
                       value="custom"
-                      defaultChecked={
-                        settingsData.territory_distribution_status === "custom"
-                      }
+                      checked={selectedTerritoryDistributionStatus === "custom"}
                       {...register("territory_distribution_status")}
                     />
                     <span className="p-radio__label">Selected territories</span>
@@ -311,16 +350,14 @@ function PublisherSettingsForm({ settings }: Props) {
                 </li>
               </ul>
 
-              {getValues("territory_distribution_status") === "custom" && (
+              {selectedTerritoryDistributionStatus === "custom" && (
                 <>
                   <label className="p-radio">
                     <input
                       type="radio"
                       className="p-radio__input"
                       value="include"
-                      defaultChecked={
-                        settingsData.country_keys_status === "include"
-                      }
+                      checked={selectedCountryKeysStatus === "include"}
                       {...register("country_keys_status")}
                     />
                     <span className="p-radio__label">
@@ -336,7 +373,7 @@ function PublisherSettingsForm({ settings }: Props) {
                     setValue={setValue}
                     getValues={getValues}
                     control={control}
-                    disabled={getValues("country_keys_status") === "exclude"}
+                    disabled={selectedCountryKeysStatus === "exclude"}
                   />
 
                   <label className="p-radio">
@@ -344,9 +381,7 @@ function PublisherSettingsForm({ settings }: Props) {
                       type="radio"
                       className="p-radio__input"
                       value="exclude"
-                      defaultChecked={
-                        settingsData.country_keys_status === "exclude"
-                      }
+                      checked={selectedCountryKeysStatus === "exclude"}
                       {...register("country_keys_status")}
                     />
                     <span className="p-radio__label">
@@ -362,7 +397,7 @@ function PublisherSettingsForm({ settings }: Props) {
                     setValue={setValue}
                     getValues={getValues}
                     control={control}
-                    disabled={getValues("country_keys_status") === "include"}
+                    disabled={selectedCountryKeysStatus === "include"}
                   />
                 </>
               )}

--- a/static/js/publisher/pages/PublisherSettings/__tests__/PublisherSettingsForm.test.tsx
+++ b/static/js/publisher/pages/PublisherSettings/__tests__/PublisherSettingsForm.test.tsx
@@ -1,6 +1,6 @@
 import { BrowserRouter } from "react-router-dom";
 import { QueryClient, QueryClientProvider } from "react-query";
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom";
 
@@ -32,12 +32,14 @@ const mockSettings = {
 
 const updateMetadataOnReleaseNotification =
   "This snap is set to have its metadata updated when a new revision is published in the stable channel. Any changes you make here will be overwritten by the contents of any snap published. If this is not desirable, please disable “Update metadata on release” for this snap.";
+const updateMetadataModalText =
+  "Making these changes means that the snap will no longer use the data from snapcraft.yaml.";
 
-function renderComponent() {
+function renderComponent(settings = {}) {
   render(
     <BrowserRouter>
       <QueryClientProvider client={queryClient}>
-        <PublisherSettingsForm settings={mockSettings} />
+        <PublisherSettingsForm settings={{ ...mockSettings, ...settings }} />
       </QueryClientProvider>
     </BrowserRouter>,
   );
@@ -100,6 +102,217 @@ describe("PublisherSettingsForm", () => {
     expect(screen.getByRole("button", { name: "Save" })).not.toHaveAttribute(
       "aria-disabled",
     );
+  });
+
+  test("reverting visibility restores the original option", async () => {
+    const user = userEvent.setup();
+    renderComponent();
+
+    await user.click(screen.getByLabelText(/Unlisted/));
+
+    expect(screen.getByLabelText(/Unlisted/)).toBeChecked();
+    expect(screen.getByLabelText(/Public/)).not.toBeChecked();
+
+    await user.click(screen.getByRole("button", { name: "Revert" }));
+
+    expect(screen.getByLabelText(/Public/)).toBeChecked();
+    expect(screen.getByLabelText(/Unlisted/)).not.toBeChecked();
+  });
+
+  test("saved visibility remains selected after save completes", async () => {
+    const user = userEvent.setup();
+    const fetchMock = vi.fn((input: RequestInfo | URL) => {
+      const url = input.toString();
+
+      if (url === "/snap_info/user_snap/test-snap") {
+        return Promise.resolve(
+          new Response(JSON.stringify({ is_users_snap: true }), {
+            status: 200,
+          }),
+        );
+      }
+
+      if (url === "/api/test-snap/settings") {
+        return Promise.resolve(
+          new Response(JSON.stringify({ private: false, unlisted: true }), {
+            status: 200,
+          }),
+        );
+      }
+
+      return Promise.resolve(new Response(null, { status: 404 }));
+    });
+    const scrollToMock = vi
+      .spyOn(window, "scrollTo")
+      .mockImplementation(() => undefined);
+
+    vi.stubGlobal("fetch", fetchMock);
+    renderComponent({ update_metadata_on_release: false });
+
+    await user.click(screen.getByLabelText(/Unlisted/));
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/api/test-snap/settings",
+        expect.objectContaining({ method: "POST" }),
+      );
+    });
+
+    expect(screen.getByLabelText(/Unlisted/)).toBeChecked();
+    expect(screen.getByLabelText(/Public/)).not.toBeChecked();
+
+    scrollToMock.mockRestore();
+    vi.unstubAllGlobals();
+  });
+
+  test("saved distribution remains selected after save completes", async () => {
+    const user = userEvent.setup();
+    const fetchMock = vi.fn((input: RequestInfo | URL) => {
+      const url = input.toString();
+
+      if (url === "/snap_info/user_snap/test-snap") {
+        return Promise.resolve(
+          new Response(JSON.stringify({ is_users_snap: true }), {
+            status: 200,
+          }),
+        );
+      }
+
+      if (url === "/api/test-snap/settings") {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              blacklist_countries: [],
+              whitelist_countries: [],
+            }),
+            { status: 200 },
+          ),
+        );
+      }
+
+      return Promise.resolve(new Response(null, { status: 404 }));
+    });
+    const scrollToMock = vi
+      .spyOn(window, "scrollTo")
+      .mockImplementation(() => undefined);
+
+    vi.stubGlobal("fetch", fetchMock);
+    renderComponent();
+
+    await user.click(screen.getByLabelText("All territories"));
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/api/test-snap/settings",
+        expect.objectContaining({ method: "POST" }),
+      );
+    });
+
+    expect(screen.getByLabelText("All territories")).toBeChecked();
+    expect(screen.getByLabelText("Selected territories")).not.toBeChecked();
+
+    scrollToMock.mockRestore();
+    vi.unstubAllGlobals();
+  });
+
+  test("saves visibility-only changes without showing update metadata modal", async () => {
+    const user = userEvent.setup();
+    const fetchMock = vi.fn((input: RequestInfo | URL) => {
+      const url = input.toString();
+
+      if (url === "/snap_info/user_snap/test-snap") {
+        return Promise.resolve(
+          new Response(JSON.stringify({ is_users_snap: true }), {
+            status: 200,
+          }),
+        );
+      }
+
+      if (url === "/api/test-snap/settings") {
+        return Promise.resolve(
+          new Response(JSON.stringify({ private: false, unlisted: true }), {
+            status: 200,
+          }),
+        );
+      }
+
+      return Promise.resolve(new Response(null, { status: 404 }));
+    });
+    const scrollToMock = vi
+      .spyOn(window, "scrollTo")
+      .mockImplementation(() => undefined);
+
+    vi.stubGlobal("fetch", fetchMock);
+    renderComponent();
+
+    await user.click(screen.getByLabelText(/Unlisted/));
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(screen.queryByText(updateMetadataModalText)).not.toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/api/test-snap/settings",
+        expect.objectContaining({ method: "POST" }),
+      );
+    });
+
+    scrollToMock.mockRestore();
+    vi.unstubAllGlobals();
+  });
+
+  test("shows update metadata modal when disabling metadata updates", async () => {
+    const user = userEvent.setup();
+    const fetchMock = vi.fn((input: RequestInfo | URL) => {
+      const url = input.toString();
+
+      if (url === "/snap_info/user_snap/test-snap") {
+        return Promise.resolve(
+          new Response(JSON.stringify({ is_users_snap: true }), {
+            status: 200,
+          }),
+        );
+      }
+
+      if (url === "/api/test-snap/settings") {
+        return Promise.resolve(
+          new Response(JSON.stringify({ update_metadata_on_release: false }), {
+            status: 200,
+          }),
+        );
+      }
+
+      return Promise.resolve(new Response(null, { status: 404 }));
+    });
+    const scrollToMock = vi
+      .spyOn(window, "scrollTo")
+      .mockImplementation(() => undefined);
+
+    vi.stubGlobal("fetch", fetchMock);
+    renderComponent();
+
+    await user.click(screen.getByLabelText("Update metadata on release:"));
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(screen.getByText(updateMetadataModalText)).toBeInTheDocument();
+    expect(fetchMock).not.toHaveBeenCalledWith(
+      "/api/test-snap/settings",
+      expect.objectContaining({ method: "POST" }),
+    );
+
+    await user.click(screen.getByRole("button", { name: "Save changes" }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/api/test-snap/settings",
+        expect.objectContaining({ method: "POST" }),
+      );
+    });
+
+    scrollToMock.mockRestore();
+    vi.unstubAllGlobals();
   });
 
   test("'Update metadata on release' shows warning if selected", () => {

--- a/static/js/publisher/utils/__tests__/getSettingsFormData.test.ts
+++ b/static/js/publisher/utils/__tests__/getSettingsFormData.test.ts
@@ -64,4 +64,30 @@ describe("getSettingsFormData", () => {
     expect(formData.get("territories_custom_type")).toEqual("whitelist");
     expect(formData.get("blacklist_countries")).toEqual("");
   });
+
+  test("does not include update metadata on release for visibility-only changes", () => {
+    const formData = getSettingsFormData(
+      settingsData,
+      { visibility: true },
+      {
+        ...data,
+        update_metadata_on_release: true,
+        visibility: "unlisted",
+      },
+    );
+    const changes = JSON.parse(formData.get("changes") as string);
+
+    expect(changes).toEqual({ private: false, unlisted: true });
+  });
+
+  test("includes update metadata on release when it has changed", () => {
+    const formData = getSettingsFormData(
+      settingsData,
+      { update_metadata_on_release: true },
+      { ...data, update_metadata_on_release: true },
+    );
+    const changes = JSON.parse(formData.get("changes") as string);
+
+    expect(changes).toEqual({ update_metadata_on_release: "on" });
+  });
 });

--- a/static/js/publisher/utils/getSettingsFormData.ts
+++ b/static/js/publisher/utils/getSettingsFormData.ts
@@ -40,12 +40,6 @@ function getSettingsFormData(
     formData.set("blacklist_countries", "");
   }
 
-  // Forcefully send the state of update_metadata_on_release in an attempt
-  // to ensure it doesn't get disabled when other fields are changed.
-  // This hasn't worked:
-  // https://chat.canonical.com/canonical/pl/67rcgxrtmfyufr9fjd46oit87r
-  changes["update_metadata_on_release"] = data?.update_metadata_on_release;
-
   formData.set("changes", JSON.stringify(changes));
 
   return formData;


### PR DESCRIPTION
## Done
Fixes issues with the revert button, option state and metadata warning modal on a snaps publisher settings page.

## How to QA

### 'Revert' button not working correctly
- Go to a snaps settings page, e.g https://snapcraft-io-5794.demos.haus/steve-test-snap/settings
- Change the visibility of a snap
- Save
- Change the visibility back to its previous state
- Revert
- The visibility should go back to what was previously selected

### Warning for "snapcraft.yaml not being used" appears with unrelated changes
- Go to a snaps settings page, e.g https://snapcraft-io-5794.demos.haus/steve-test-snap/settings
- Make sure "Update metadata on release" is checked
- Change the visibility
- When you try and save, you should not get a warning modal

### Warning for "snapcraft.yaml not being used" doesn't appear when unchecking option
- Go to a snaps settings page, e.g https://snapcraft-io-5794.demos.haus/steve-test-snap/settings
- Make sure "Update metadata on release" is checked
- Uncheck it and save
- You should get a warning modal

## Testing

- [x] This PR has tests
- [ ] No testing required (explain why):

## Security

- [ ] Security considerations for review (list them):
  - [ ] Examples:
  - [ ] Access control: users can only access their own data
  - [ ] Input: user input is validated and sanitised
  - [ ] Sensitive data: secret or private data is not exposed in any way
  - [ ] ...
- [ ] This PR has no security considerations (explain why):

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-36263

## Screenshots
n/a

## UX Approval

- [x] This PR does not require UX approval
- [ ] This PR does require UX approval (add context):
