### PR TITLE
Revert "chore: refactor login and macaroon auth (#5771)"

### DIFF
--- a/tests/login/tests_login_handler.py
+++ b/tests/login/tests_login_handler.py
@@ -3,10 +3,6 @@ import requests
 import responses
 from flask_testing import TestCase
 from pymacaroons import Macaroon
-from canonicalwebteam.exceptions import (
-    PublisherAgreementNotSigned,
-    StoreApiResponseErrorList,
-)
 from webapp.app import create_app
 
 from unittest.mock import patch, MagicMock

--- a/tests/login/tests_login_handler.py
+++ b/tests/login/tests_login_handler.py
@@ -27,7 +27,8 @@ class LoginHandlerTest(TestCase):
     def test_redirect_user_logged_in(self):
         with self.client.session_transaction() as s:
             s["publisher"] = "openid"
-            s["macaroon_exchanged"] = "macaroon_exchanged"
+            s["macaroon_root"] = "macaroon_root"
+            s["macaroon_discharge"] = "macaroon_discharge"
 
         response = self.client.get(self.endpoint_url)
         assert response.status_code == 302
@@ -36,7 +37,8 @@ class LoginHandlerTest(TestCase):
     def test_redirect_user_logged_in_next_url(self):
         with self.client.session_transaction() as s:
             s["publisher"] = "openid"
-            s["macaroon_exchanged"] = "macaroon_exchanged"
+            s["macaroon_root"] = "macaroon_root"
+            s["macaroon_discharge"] = "macaroon_discharge"
 
         response = self.client.get(self.endpoint_url + "?next=/test")
         assert response.status_code == 302
@@ -121,17 +123,6 @@ class AfterLoginHandlerTest(TestCase):
     def prepare_mock_response(
         self, mock_get_account, email="test@test.com", groups=[]
     ):
-        root = Macaroon(location="store", identifier="root", key="root-key")
-        root.add_third_party_caveat(
-            "login.ubuntu.com", "caveat-key", "caveat-id"
-        )
-        self.root_macaroon = root.serialize()
-        discharge = Macaroon(
-            location="login.ubuntu.com",
-            identifier="caveat-id",
-            key="caveat-key",
-        ).serialize()
-
         self.mock_resp = MagicMock()
         self.mock_resp.nickname = "test"
         self.mock_resp.identity_url = "https://login.ubuntu.com/test"
@@ -139,7 +130,7 @@ class AfterLoginHandlerTest(TestCase):
         self.mock_resp.image = "test.png"
         self.mock_resp.email = email
         self.mock_resp.extensions = {
-            "macaroon": MagicMock(discharge=discharge),
+            "macaroon": MagicMock(discharge="some-discharge"),
             "lp": MagicMock(is_member=groups),
         }
 
@@ -156,10 +147,6 @@ class AfterLoginHandlerTest(TestCase):
     @patch(
         "webapp.login.views.dashboard.get_validation_sets", return_value=None
     )
-    @patch(
-        "webapp.login.views.publisher_gateway.exchange_dashboard_macaroons",
-        return_value="exchanged-macaroon",
-    )
     @patch("webapp.login.views.dashboard.get_account")
     def test_is_canonical_true_if_email_ends_with_canonical_on_staging(
         self,
@@ -172,27 +159,18 @@ class AfterLoginHandlerTest(TestCase):
             mock_get_account, email="test@canonical.com", groups=[]
         )
 
-        with self.client.session_transaction() as s:
-            s["macaroon_root"] = self.root_macaroon
         self.client.get("/_test_after_login")
 
         with self.client.session_transaction() as s:
             publisher = s.get("publisher")
             assert publisher is not None
             assert publisher["is_canonical"] is True
-            assert s["macaroon_exchanged"] == "exchanged-macaroon"
-            assert "macaroon_root" not in s
-            assert "macaroon_discharge" not in s
 
     @patch("webapp.login.views.ENVIRONMENT", "production")
     @patch("webapp.login.views.dashboard.get_stores", return_value=[])
     @patch("webapp.login.views.logic.get_stores", return_value=[])
     @patch(
         "webapp.login.views.dashboard.get_validation_sets", return_value=None
-    )
-    @patch(
-        "webapp.login.views.publisher_gateway.exchange_dashboard_macaroons",
-        return_value="exchanged-macaroon",
     )
     @patch("webapp.login.views.dashboard.get_account")
     def test_is_canonical_true_if_member_of_team_on_production(
@@ -204,8 +182,6 @@ class AfterLoginHandlerTest(TestCase):
         # if they are a member of the canonical team
         self.prepare_mock_response(mock_get_account, groups=["canonical"])
 
-        with self.client.session_transaction() as s:
-            s["macaroon_root"] = self.root_macaroon
         self.client.get("/_test_after_login")
 
         with self.client.session_transaction() as s:
@@ -218,10 +194,6 @@ class AfterLoginHandlerTest(TestCase):
     @patch("webapp.login.views.logic.get_stores", return_value=[])
     @patch(
         "webapp.login.views.dashboard.get_validation_sets", return_value=None
-    )
-    @patch(
-        "webapp.login.views.publisher_gateway.exchange_dashboard_macaroons",
-        return_value="exchanged-macaroon",
     )
     @patch("webapp.login.views.dashboard.get_account")
     def test_is_canonical_false_if_not_member_of_team_on_production(
@@ -235,159 +207,9 @@ class AfterLoginHandlerTest(TestCase):
             mock_get_account, email="test@canonical.com", groups=[]
         )
 
-        with self.client.session_transaction() as s:
-            s["macaroon_root"] = self.root_macaroon
         self.client.get("/_test_after_login")
 
         with self.client.session_transaction() as s:
             publisher = s.get("publisher")
             assert publisher is not None
             assert publisher["is_canonical"] is False
-
-    def test_after_login_exchanges_macaroons_and_clears_root_and_discharge(
-        self,
-    ):
-        self.prepare_mock_response(MagicMock(), groups=["canonical"])
-
-        with patch(
-            "webapp.login.views.dashboard.get_account",
-            return_value={
-                "username": "test",
-                "displayname": "Test",
-                "email": "test@test.com",
-                "stores": [],
-            },
-        ), patch(
-            "webapp.login.views.dashboard.get_validation_sets",
-            return_value=None,
-        ), patch(
-            "webapp.login.views.dashboard.get_stores", return_value=[]
-        ), patch(
-            "webapp.login.views.logic.get_stores", return_value=[]
-        ), patch(
-            "webapp.login.views.publisher_gateway"
-            ".exchange_dashboard_macaroons",
-            return_value="exchanged-macaroon",
-        ) as mock_exchange:
-            with self.client.session_transaction() as s:
-                s["macaroon_root"] = self.root_macaroon
-
-            response = self.client.get("/_test_after_login")
-
-            assert response.status_code == 302
-            with self.client.session_transaction() as s:
-                assert s["macaroon_exchanged"] == "exchanged-macaroon"
-                assert "macaroon_root" not in s
-                assert "macaroon_discharge" not in s
-
-            mock_exchange.assert_called_once()
-
-    @patch("webapp.login.views.dashboard.get_validation_sets")
-    @patch("webapp.login.views.dashboard.get_account")
-    @patch(
-        "webapp.login.views.publisher_gateway" ".exchange_dashboard_macaroons",
-        return_value="exchanged-macaroon",
-    )
-    def test_after_login_agreement_not_signed_keeps_user_authenticated(
-        self,
-        _mock_exchange,
-        mock_get_account,
-        _mock_validation_sets,
-    ):
-        # Regression test for issue #5788: a publisher who has not yet
-        # accepted the developer Terms & Conditions must still end up with an
-        # authenticated session and be guided to the agreement page, rather
-        # than dead-ending in a redirect loop / 404.
-        self.prepare_mock_response(MagicMock(), groups=[])
-        mock_get_account.side_effect = PublisherAgreementNotSigned
-
-        with self.client.session_transaction() as s:
-            s["macaroon_root"] = self.root_macaroon
-
-        response = self.client.get("/_test_after_login")
-
-        assert response.status_code == 302
-        assert response.location == "/account/agreement"
-
-        with self.client.session_transaction() as s:
-            publisher = s.get("publisher")
-            assert publisher is not None
-            assert publisher["nickname"] == self.mock_resp.nickname
-            assert publisher["email"] == self.mock_resp.email
-            assert s["macaroon_exchanged"] == "exchanged-macaroon"
-
-    @patch("webapp.login.views.dashboard.get_validation_sets")
-    @patch("webapp.login.views.dashboard.get_account")
-    @patch("webapp.login.views.publisher_gateway.exchange_dashboard_macaroons")
-    def test_after_login_account_not_found_redirects_to_agreement(
-        self,
-        mock_exchange,
-        _mock_get_account,
-        _mock_validation_sets,
-    ):
-        # Regression test for issue #5788: a brand-new publisher who has never
-        # accepted the developer Terms & Conditions has no publisher account
-        # yet, so the macaroon exchange fails with "account-not-found".
-        # Instead of returning a 404, the user must be redirected to the
-        # agreement page with an authenticated session and the dashboard
-        # macaroons preserved, so accepting the agreement can create the
-        # account.
-        self.prepare_mock_response(MagicMock(), groups=[])
-        mock_exchange.side_effect = StoreApiResponseErrorList(
-            "The api returned a list of errors",
-            404,
-            [
-                {
-                    "code": "account-not-found",
-                    "message": (
-                        "The account specified in the dashboard "
-                        "macaroons was not found"
-                    ),
-                }
-            ],
-        )
-
-        with self.client.session_transaction() as s:
-            s["macaroon_root"] = self.root_macaroon
-
-        response = self.client.get("/_test_after_login")
-
-        assert response.status_code == 302
-        assert response.location == "/account/agreement"
-
-        with self.client.session_transaction() as s:
-            publisher = s.get("publisher")
-            assert publisher is not None
-            assert publisher["nickname"] == self.mock_resp.nickname
-            # Dashboard macaroons must be preserved so the agreement POST is
-            # authorized and can onboard the account.
-            assert "macaroon_root" in s
-            assert "macaroon_discharge" in s
-            assert "macaroon_exchanged" not in s
-
-    @patch("webapp.login.views.dashboard.get_validation_sets")
-    @patch("webapp.login.views.dashboard.get_account")
-    @patch("webapp.login.views.publisher_gateway.exchange_dashboard_macaroons")
-    def test_after_login_reraises_other_exchange_errors(
-        self,
-        mock_exchange,
-        _mock_get_account,
-        _mock_validation_sets,
-    ):
-        # Exchange failures unrelated to onboarding must not be swallowed as
-        # an agreement redirect; they should surface as a server error.
-        self.prepare_mock_response(MagicMock(), groups=[])
-        mock_exchange.side_effect = StoreApiResponseErrorList(
-            "The api returned a list of errors",
-            500,
-            [{"code": "some-other-error", "message": "boom"}],
-        )
-
-        with self.client.session_transaction() as s:
-            s["macaroon_root"] = self.root_macaroon
-
-        response = self.client.get("/_test_after_login")
-
-        assert response.status_code != 302
-        with self.client.session_transaction() as s:
-            assert "publisher" not in s

--- a/tests/publisher/endpoint_testing.py
+++ b/tests/publisher/endpoint_testing.py
@@ -2,6 +2,7 @@ from unittest.mock import patch
 
 import requests
 
+import pymacaroons
 import responses
 from flask_testing import TestCase
 from webapp.app import create_app
@@ -41,12 +42,16 @@ class BaseTestCases:
         def _log_in(self, client):
             """Emulates test client login in the store.
 
-            Fill current session with `openid` and `macaroon_exchanged`.
+            Fill current session with `openid`, `macaroon_root` and
+            `macaroon_discharge`.
 
             Return the expected `Authorization` header for further verification
             in API requests.
             """
-            exchanged_macaroon = "test-exchanged-macaroon"
+            # Basic root/discharge macaroons pair.
+            root = pymacaroons.Macaroon("test", "testing", "a_key")
+            root.add_third_party_caveat("3rd", "a_caveat-key", "a_ident")
+            discharge = pymacaroons.Macaroon("3rd", "a_ident", "a_caveat_key")
 
             with client.session_transaction() as s:
                 s["publisher"] = {
@@ -56,9 +61,12 @@ class BaseTestCases:
                     "email": "testing@testing.com",
                     "stores": [],
                 }
-                s["macaroon_exchanged"] = exchanged_macaroon
+                s["macaroon_root"] = root.serialize()
+                s["macaroon_discharge"] = discharge.serialize()
 
-            return get_authorization_header(exchanged_macaroon)
+            return get_authorization_header(
+                root.serialize(), discharge.serialize()
+            )
 
         def check_call_by_api_url(self, calls):
             found = False
@@ -238,6 +246,13 @@ class BaseTestCases:
                     headers={"WWW-Authenticate": "Macaroon needs_refresh=1"},
                 )
             )
+            responses.add(
+                responses.POST,
+                "https://login.ubuntu.com/api/v2/tokens/refresh",
+                json={"discharge_macaroon": "macaroon"},
+                status=200,
+            )
+
             if self.method_endpoint == "GET":
                 response = self.client.get(self.endpoint_url)
             else:
@@ -250,8 +265,14 @@ class BaseTestCases:
                         self.endpoint_url, json=self.json
                     )
 
+            called = responses.calls[len(responses.calls) - 1]
+            self.assertEqual(
+                "https://login.ubuntu.com/api/v2/tokens/refresh",
+                called.request.url,
+            )
+
             assert response.status_code == 302
-            assert response.location == (f"/login?next={self.endpoint_url}")
+            assert response.location == self._get_location()
 
     class EndpointLoggedInErrorHandling(EndpointLoggedIn):
         @responses.activate

--- a/tests/publisher/tests_publisher.py
+++ b/tests/publisher/tests_publisher.py
@@ -1,5 +1,6 @@
 from requests.exceptions import ConnectionError
 
+import pymacaroons
 import responses
 from flask_testing import TestCase
 from tests.publisher.endpoint_testing import BaseTestCases
@@ -60,12 +61,16 @@ class PublisherPage(TestCase):
     def _log_in(self, client):
         """Emulates test client login in the store.
 
-        Fill current session with `openid` and `macaroon_exchanged`.
+        Fill current session with `openid`, `macaroon_root` and
+        `macaroon_discharge`.
 
         Return the expected `Authorization` header for further verification in
         API requests.
         """
-        exchanged_macaroon = "test-exchanged-macaroon"
+        # Basic root/discharge macaroons pair.
+        root = pymacaroons.Macaroon("test", "testing", "a_key")
+        root.add_third_party_caveat("3rd", "a_caveat-key", "a_ident")
+        discharge = pymacaroons.Macaroon("3rd", "a_ident", "a_caveat_key")
 
         with client.session_transaction() as s:
             s["publisher"] = {
@@ -74,9 +79,12 @@ class PublisherPage(TestCase):
                 "fullname": "El Toto",
                 "email": "test@example.com",
             }
-            s["macaroon_exchanged"] = exchanged_macaroon
+            s["macaroon_root"] = root.serialize()
+            s["macaroon_discharge"] = discharge.serialize()
 
-        return get_authorization_header(exchanged_macaroon)
+        return get_authorization_header(
+            root.serialize(), discharge.serialize()
+        )
 
     def test_username_not_logged_in(self):
         response = self.client.get("/account/username")

--- a/tests/store/tests_details.py
+++ b/tests/store/tests_details.py
@@ -419,7 +419,8 @@ class GetDetailsPageTest(TestCase):
         with self.client.session_transaction() as s:
             # make test session 'authenticated'
             s["publisher"] = {"nickname": "toto", "fullname": "Totinio"}
-            s["macaroon_exchanged"] = "test"
+            s["macaroon_root"] = "test"
+            s["macaroon_discharge"] = "test"
             # mock test user snaps list
             s["user_snaps"] = {"toto": {"snap-id": "test"}}
 

--- a/tests/store/tests_github_badge.py
+++ b/tests/store/tests_github_badge.py
@@ -232,7 +232,8 @@ class GetGitHubBadgeTest(TestCase):
         with self.client.session_transaction() as s:
             # make test session 'authenticated'
             s["publisher"] = {"nickname": "toto", "fullname": "Totinio"}
-            s["macaroon_exchanged"] = "test"
+            s["macaroon_root"] = "test"
+            s["macaroon_discharge"] = "test"
             # mock test user snaps list
             s["user_snaps"] = {"toto": {"snap-id": "test"}}
 

--- a/tests/tests_authentication.py
+++ b/tests/tests_authentication.py
@@ -5,8 +5,6 @@ from webapp.authentication import (
     SESSION_INTEGRATION_KEYS,
     SESSION_DATA_KEYS,
     empty_session,
-    get_authorization_header,
-    is_authenticated,
     reset_auth_session,
 )
 
@@ -40,30 +38,4 @@ class TestResetAuthSession(unittest.TestCase):
         self.assertEqual(
             set(SESSION_AUTH_KEYS).intersection(set(SESSION_INTEGRATION_KEYS)),
             set(),
-        )
-
-    def test_get_authorization_header_uses_single_exchanged_macaroon(self):
-        self.assertEqual(
-            get_authorization_header("test-macaroon"),
-            "Macaroon test-macaroon",
-        )
-
-    def test_is_authenticated_with_exchanged_macaroon(self):
-        self.assertTrue(
-            is_authenticated(
-                {
-                    "publisher": {"nickname": "test"},
-                    "macaroon_exchanged": "test-macaroon",
-                }
-            )
-        )
-
-    def test_is_authenticated_with_legacy_macaroons(self):
-        self.assertTrue(
-            is_authenticated(
-                {
-                    "publisher": {"nickname": "test"},
-                    "macaroons": "legacy-macaroon",
-                }
-            )
         )

--- a/webapp/authentication.py
+++ b/webapp/authentication.py
@@ -2,8 +2,6 @@ import os
 
 from urllib.parse import urlparse
 
-from canonicalwebteam.store_api import dashboard as store_api_dashboard
-from canonicalwebteam.store_api import publishergw as store_api_publishergw
 from pymacaroons import Macaroon
 from webapp.api import sso
 
@@ -24,7 +22,6 @@ PERMISSIONS = [
 # keys for session data that should be cleared on auth refresh
 SESSION_AUTH_KEYS = [
     "macaroons",
-    "macaroon_exchanged",
     "macaroon_root",
     "macaroon_discharge",
     "publisher",
@@ -41,42 +38,16 @@ SESSION_INTEGRATION_KEYS = [
 SESSION_DATA_KEYS = SESSION_AUTH_KEYS + SESSION_INTEGRATION_KEYS
 
 
-def get_authorization_header(macaroon):
+def get_authorization_header(root, discharge):
     """
-    Return the authorization header value for an exchanged macaroon.
+    Bind root and discharge macaroons and return the authorization header.
     """
-    return f"Macaroon {macaroon}"
 
+    bound = Macaroon.deserialize(root).prepare_for_request(
+        Macaroon.deserialize(discharge)
+    )
 
-def get_session_authorization_headers(session):
-    """
-    Return the correct authorization headers for the current session.
-    """
-    if "macaroon_exchanged" in session:
-        return {
-            "Authorization": get_authorization_header(
-                session["macaroon_exchanged"]
-            )
-        }
-
-    if "macaroon_root" in session and "macaroon_discharge" in session:
-        root = session["macaroon_root"]
-        discharge = session["macaroon_discharge"]
-
-        bound = Macaroon.deserialize(root).prepare_for_request(
-            Macaroon.deserialize(discharge)
-        )
-
-        return {
-            "Authorization": (
-                f"macaroon root={root}, discharge={bound.serialize()}"
-            )
-        }
-
-    if "macaroons" in session:
-        return {"Macaroons": session["macaroons"]}
-
-    return {"Macaroons": ""}
+    return "macaroon root={}, discharge={}".format(root, bound.serialize())
 
 
 def get_publishergw_authorization_header(developer_token):
@@ -89,14 +60,10 @@ def is_authenticated(session):
     Returns True if the user is authenticated
     """
     return (
-        ("publisher" in session and "macaroon_exchanged" in session)
-        or (
-            "publisher" in session
-            and "macaroon_discharge" in session
-            and "macaroon_root" in session
-        )
-        or ("publisher" in session and "macaroons" in session)
-    )
+        "publisher" in session
+        and "macaroon_discharge" in session
+        and "macaroon_root" in session
+    ) or ("publisher" in session and "macaroons" in session)
 
 
 def empty_session(session):
@@ -157,15 +124,3 @@ def is_macaroon_expired(headers):
     the header response.
     """
     return headers.get("WWW-Authenticate") == ("Macaroon needs_refresh=1")
-
-
-def _store_api_authorization_header(_self, session):
-    return get_session_authorization_headers(session)
-
-
-store_api_dashboard.Dashboard._get_authorization_header = (
-    _store_api_authorization_header
-)
-store_api_publishergw.dashboard_authorization_header = (
-    get_session_authorization_headers
-)

--- a/webapp/decorators.py
+++ b/webapp/decorators.py
@@ -133,15 +133,10 @@ def exchange_required(func):
     @functools.wraps(func)
     def is_exchanged(*args, **kwargs):
         if "exchanged_developer_token" not in flask.session:
-            if "macaroon_exchanged" in flask.session:
-                flask.session["developer_token"] = flask.session[
-                    "macaroon_exchanged"
-                ]
-            else:
-                result = publisher_gateway.exchange_dashboard_macaroons(
-                    flask.session
-                )
-                flask.session["developer_token"] = result
+            result = publisher_gateway.exchange_dashboard_macaroons(
+                flask.session
+            )
+            flask.session["developer_token"] = result
             flask.session["exchanged_developer_token"] = True
         return func(*args, **kwargs)
 

--- a/webapp/handlers.py
+++ b/webapp/handlers.py
@@ -138,15 +138,6 @@ if IS_DEVELOPMENT:
 
 
 def refresh_redirect():
-    if "macaroon_exchanged" in flask.session:
-        authentication.reset_auth_session(flask.session)
-        return flask.redirect(
-            flask.url_for(
-                "login.login_handler",
-                next=flask.request.full_path.rstrip("?"),
-            )
-        )
-
     try:
         macaroon_discharge = authentication.get_refreshed_discharge(
             flask.session["macaroon_discharge"]

--- a/webapp/login/views.py
+++ b/webapp/login/views.py
@@ -14,7 +14,6 @@ from webapp.api.exceptions import ApiResponseError
 from webapp.extensions import csrf
 from webapp.login.macaroon import MacaroonRequest, MacaroonResponse
 from webapp.publisher.snaps import logic
-from canonicalwebteam.exceptions import StoreApiResponseErrorList
 
 login = flask.Blueprint(
     "login", __name__, template_folder="/templates", static_folder="/static"

--- a/webapp/login/views.py
+++ b/webapp/login/views.py
@@ -75,51 +75,10 @@ def login_handler():
 
 @open_id.after_login
 def after_login(resp):
-    discharge_macaroon = resp.extensions["macaroon"].discharge
-    flask.session["macaroon_discharge"] = discharge_macaroon
+    flask.session["macaroon_discharge"] = resp.extensions["macaroon"].discharge
 
     if not resp.nickname:
         return flask.redirect(LOGIN_URL)
-
-    # Exchange root + discharge for a single dashboard token.
-    # Both keys are in the session here, so exchange_dashboard_macaroons
-    # can read them directly. We then drop them to keep the cookie small.
-    try:
-        flask.session["macaroon_exchanged"] = (
-            publisher_gateway.exchange_dashboard_macaroons(flask.session)
-        )
-    except StoreApiResponseErrorList as api_error:
-        # A brand-new publisher who has never accepted the developer Terms &
-        # Conditions has no publisher account yet, so the macaroon exchange
-        # fails with "account-not-found". Rather than returning a 404, keep
-        # the dashboard (root + discharge) macaroons, establish a minimal
-        # authenticated session and guide the user to the agreement page.
-        # Accepting the agreement creates the account, after which the
-        # exchange succeeds on the next request. See issue #5788.
-        if any(
-            error.get("code") == "account-not-found"
-            for error in api_error.errors
-        ):
-            flask.session["publisher"] = {
-                "identity_url": resp.identity_url,
-                "nickname": resp.nickname,
-                "fullname": resp.fullname,
-                "image": resp.image,
-                "email": resp.email,
-            }
-            return flask.redirect(flask.url_for("account.get_agreement"))
-        raise
-
-    flask.session.pop("macaroon_root", None)
-    flask.session.pop("macaroon_discharge", None)
-
-    flask.session["publisher"] = {
-        "identity_url": resp.identity_url,
-        "nickname": resp.nickname,
-        "fullname": resp.fullname,
-        "image": resp.image,
-        "email": resp.email,
-    }
 
     account = dashboard.get_account(flask.session)
     validation_sets = dashboard.get_validation_sets(flask.session)


### PR DESCRIPTION
This reverts commit 6ffd8e0d8531530ce1ccc98dd65aed40b1c8f27e.

## Done

## How to QA
### needs local QA
you will need a github repo that hosts a snap, a set of launchpad credentials and a github webhook to connect the snap repo to launchpad
- log in
- go to your snap, open the Builds tab
- log into github and connect the repository to the snap; if the snap is already connected, disconnect it first (this is important)
- 1+ builds should be scheduled
- wait for the builds to finish
- the value in the RESULT column should read "Released"
- switch to the Releases tab
- the launchpad build should appear at the top of "Revisions available to release" 


## Testing

- [ ] This PR has tests
- [ ] No testing required (explain why):

## Security

- [ ] Security considerations for review (list them):
  - [ ] Examples:
  - [ ] Access control: users can only access their own data
  - [ ] Input: user input is validated and sanitised
  - [ ] Sensitive data: secret or private data is not exposed in any way
  - [ ] ...
- [ ] This PR has no security considerations (explain why):

## Issue / Card

Fixes #5787

## Screenshots

## UX Approval

- [ ] This PR does not require UX approval
- [ ] This PR does require UX approval (add context):
